### PR TITLE
Remove user ping

### DIFF
--- a/src/rf/apps/core/context_processors.py
+++ b/src/rf/apps/core/context_processors.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import division
+
+import json
+import boto
+
+from django.conf import settings
+from django.core.urlresolvers import reverse
+
+
+def page_context(request):
+    """
+    Context available on every page.
+    """
+    return {
+        'user_data': get_user_data(request),
+        'client_settings': get_client_settings(),
+    }
+
+
+def get_user_data(request):
+    user_data = json.dumps({
+        'id': request.user.id,
+        'username': request.user.username,
+    })
+    return user_data
+
+
+def get_client_settings():
+    conn = boto.connect_s3(profile_name=settings.AWS_PROFILE)
+    aws_key = conn.aws_access_key_id
+
+    client_settings = json.dumps({
+        'signerUrl': reverse('sign_request'),
+        'awsKey': aws_key,
+        'awsBucket': settings.AWS_BUCKET_NAME,
+    })
+    return client_settings

--- a/src/rf/apps/home/templates/base.html
+++ b/src/rf/apps/home/templates/base.html
@@ -20,6 +20,7 @@
 <div id="container"></div>
 <script type="text/javascript">
     window.clientSettings = {{ client_settings | safe }};
+    window.user = {{ user | safe }};
 </script>
 {% block content %}
 {% endblock %}

--- a/src/rf/apps/home/templates/base.html
+++ b/src/rf/apps/home/templates/base.html
@@ -20,7 +20,7 @@
 <div id="container"></div>
 <script type="text/javascript">
     window.clientSettings = {{ client_settings | safe }};
-    window.user = {{ user | safe }};
+    window.user = {{ user_data | safe }};
 </script>
 {% block content %}
 {% endblock %}

--- a/src/rf/apps/home/views.py
+++ b/src/rf/apps/home/views.py
@@ -13,7 +13,6 @@ from django.db import transaction
 from django.db.models import Q
 from django.shortcuts import get_object_or_404, Http404, render_to_response
 from django.utils import timezone
-from django.views.decorators.csrf import csrf_exempt
 
 from apps.core.exceptions import Forbidden
 from apps.core.decorators import (accepts, api_view, login_required,
@@ -46,7 +45,6 @@ def not_found(request):
     raise Http404()
 
 
-@csrf_exempt
 @api_view
 @accepts('GET', 'PUT', 'DELETE')
 def layer_detail(request, username, layer_id):
@@ -78,7 +76,6 @@ def _get_layer_or_404(request, **kwargs):
         raise Http404()
 
 
-@csrf_exempt
 @api_view
 @login_required
 @accepts('POST')
@@ -166,7 +163,6 @@ def my_favorites(request):
     return _get_layers(request, Q(id__in=ids))
 
 
-@csrf_exempt
 @api_view
 @login_required
 @accepts('POST', 'DELETE')

--- a/src/rf/apps/home/views.py
+++ b/src/rf/apps/home/views.py
@@ -23,8 +23,15 @@ from apps.home.filters import LayerFilter
 
 
 def home_page(request):
-    return render_to_response('home/home.html',
-                              {'client_settings': get_client_settings()})
+    user_data = json.dumps({
+        'id': request.user.id,
+        'username': request.user.username,
+    })
+    context = {
+        'user': user_data,
+        'client_settings': get_client_settings(),
+    }
+    return render_to_response('home/home.html', context)
 
 
 def get_client_settings():

--- a/src/rf/apps/home/views.py
+++ b/src/rf/apps/home/views.py
@@ -3,15 +3,11 @@ from __future__ import print_function
 from __future__ import unicode_literals
 from __future__ import division
 
-import json
-import boto
-
 from django.contrib.auth.models import User
-from django.conf import settings
-from django.core.urlresolvers import reverse
 from django.db import transaction
 from django.db.models import Q
 from django.shortcuts import get_object_or_404, Http404, render_to_response
+from django.template import RequestContext
 from django.utils import timezone
 
 from apps.core.exceptions import Forbidden
@@ -23,27 +19,8 @@ from apps.home.filters import LayerFilter
 
 
 def home_page(request):
-    user_data = json.dumps({
-        'id': request.user.id,
-        'username': request.user.username,
-    })
-    context = {
-        'user': user_data,
-        'client_settings': get_client_settings(),
-    }
+    context = RequestContext(request)
     return render_to_response('home/home.html', context)
-
-
-def get_client_settings():
-    conn = boto.connect_s3(profile_name=settings.AWS_PROFILE)
-    aws_key = conn.aws_access_key_id
-
-    client_settings = json.dumps({
-        'signerUrl': reverse('sign_request'),
-        'awsKey': aws_key,
-        'awsBucket': settings.AWS_BUCKET_NAME,
-    })
-    return client_settings
 
 
 @api_view

--- a/src/rf/js/src/app.js
+++ b/src/rf/js/src/app.js
@@ -9,8 +9,16 @@ var $ = require('jquery'),
 
 var App = Marionette.Application.extend({
     initialize: function() {
-        settings.setUser(new userModels.UserModel());
+        this.setupUser();
         this.setupNavigation();
+    },
+
+    setupUser: function() {
+        var model = new userModels.UserModel();
+        if (window.user) {
+            model.set(window.user);
+        }
+        settings.setUser(model);
     },
 
     setupNavigation: function() {

--- a/src/rf/js/src/home/controllers.js
+++ b/src/rf/js/src/home/controllers.js
@@ -14,11 +14,9 @@ var $ = require('jquery'),
 
 function showLoginIfNeeded() {
     var user = settings.getUser();
-    user.fetch().always(function() {
-        if (!user.isAuthenticated()) {
-            router.go('/login');
-        }
-    });
+    if (!user.isAuthenticated()) {
+        router.go('/login');
+    }
 }
 
 var HomeController = {

--- a/src/rf/js/src/home/controllers.js
+++ b/src/rf/js/src/home/controllers.js
@@ -16,12 +16,16 @@ function showLoginIfNeeded() {
     var user = settings.getUser();
     if (!user.isAuthenticated()) {
         router.go('/login');
+        return true;
     }
+    return false;
 }
 
 var HomeController = {
     index: function() {
-        showLoginIfNeeded();
+        if (showLoginIfNeeded()) {
+            return;
+        }
 
         // TODO remove these hard coded test values.
         var layerItem1 = new Layer({

--- a/src/rf/js/src/user/controllers.js
+++ b/src/rf/js/src/user/controllers.js
@@ -9,11 +9,9 @@ var $ = require('jquery'),
 
 function showHomeIfLoggedIn() {
     var user = settings.getUser();
-    user.fetch().always(function() {
-        if (user.isAuthenticated()) {
-            router.go('/');
-        }
-    });
+    if (user.isAuthenticated()) {
+        router.go('/');
+    }
 }
 
 var UserController = {

--- a/src/rf/js/src/user/controllers.js
+++ b/src/rf/js/src/user/controllers.js
@@ -11,12 +11,16 @@ function showHomeIfLoggedIn() {
     var user = settings.getUser();
     if (user.isAuthenticated()) {
         router.go('/');
+        return true;
     }
+    return false;
 }
 
 var UserController = {
     login: function() {
-        showHomeIfLoggedIn();
+        if (showHomeIfLoggedIn()) {
+            return;
+        }
         var model = new models.LoginFormModel();
         this.renderComponent(<components.LoginScreen model={model} />);
     },

--- a/src/rf/rf/settings/base.py
+++ b/src/rf/rf/settings/base.py
@@ -197,6 +197,7 @@ TEMPLATE_CONTEXT_PROCESSORS = (
     'django.core.context_processors.tz',
     'django.contrib.messages.context_processors.messages',
     'django.core.context_processors.request',
+    'apps.core.context_processors.page_context',
 )
 
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#template-loaders


### PR DESCRIPTION
This removes the user fetch request that occurs every time you switch
between views. The delayed fetch would sometimes cause a noticable
"flash" as the Library would load for a split second before being
replaced by the login screen (if not authenticated).

The user model is bootstrapped with data embedded in the HTML harness.