### PR TITLE
Make upload work by preventing default action

### DIFF
--- a/src/rf/js/src/home/components/modals.js
+++ b/src/rf/js/src/home/components/modals.js
@@ -46,15 +46,17 @@ var UploadModal = React.createBackboneClass({
         this.setState({fileDescriptions: []});
     },
 
-    handleClickBrowse: function() {
+    handleClickBrowse: function(e) {
         React.findDOMNode(this.refs.hiddenFileInput).click();
+        e.preventDefault();
     },
 
     handleFileInputChange: function(e) {
         this.updateFiles(e.target.files);
     },
 
-    uploadFiles: function() {
+    uploadFiles: function(e) {
+        e.preventDefault();
         uploads.uploadFiles(_.pluck(this.state.fileDescriptions, 'file'));
     },
 


### PR DESCRIPTION
To test, try adding a some files and then hitting continue. This should make the files upload. Then close the modal, and try it again.

Connects #85 