### PR TITLE
Feature/lol/amazon lambda unzip

### DIFF
--- a/src/rf/.eslintrc
+++ b/src/rf/.eslintrc
@@ -2,7 +2,8 @@
     "rules": {
         "indent": [
             2,
-            4
+            4,
+            {"SwitchCase": 1}
         ],
         "quotes": [
             2,

--- a/src/rf/js/src/core/uploads.js
+++ b/src/rf/js/src/core/uploads.js
@@ -59,7 +59,7 @@ var getExtension = function(file) {
 
     };
     return mapping[file.type] || '';
-}
+};
 
 var invalidTypes = function(file) {
     var mimeType = file.type,

--- a/src/rf/js/src/core/uploads.js
+++ b/src/rf/js/src/core/uploads.js
@@ -37,7 +37,7 @@ var uploadFiles = function(files) {
         evap.add({
             // TODO - NAMES ARE CURRENTLY JUST FOR TESTING.
             // WE WANT TO USE A UUID FOR FILE NAMES.
-            name: userId + '-' + uuid.v4(),
+            name: userId + '-' + uuid.v4() + getExtension(file),
             file: file,
             contentType: file.type,
             complete: function() {
@@ -49,6 +49,17 @@ var uploadFiles = function(files) {
         });
     });
 };
+
+var getExtension = function(file) {
+    var mapping = {
+        'image/png': '.png',
+        'image/jpeg': '.jpg',
+        'image/tiff': '.tif',
+        'application/zip': '.zip'
+
+    };
+    return mapping[file.type] || '';
+}
 
 var invalidTypes = function(file) {
     var mimeType = file.type,

--- a/src/rf/js/src/home/components/modals.js
+++ b/src/rf/js/src/home/components/modals.js
@@ -57,7 +57,16 @@ var UploadModal = React.createBackboneClass({
 
     uploadFiles: function(e) {
         e.preventDefault();
-        uploads.uploadFiles(_.pluck(this.state.fileDescriptions, 'file'));
+        try {
+            uploads.uploadFiles(_.pluck(this.state.fileDescriptions, 'file'));
+        } catch (excp) {
+            if (excp instanceof uploads.S3UploadException) {
+                // TODO Show something useful to the user here.
+                console.error(excp);
+            } else {
+                throw excp;
+            }
+        }
     },
 
     updateFiles: function(files) {

--- a/src/upload-functions/index.js
+++ b/src/upload-functions/index.js
@@ -1,0 +1,108 @@
+'use strict';
+
+var AWS = require('aws-sdk'),
+    util = require('util'),
+    unzip = require('unzip');
+
+var DESTINATION_BUCKET = 'raster-foundry-verified-zp0mnkphjtoxakytsoz5gqmwshmx8';
+
+// get reference to S3 client
+var s3 = new AWS.S3();
+
+function isImage(extension) {
+    return extension === 'jpg' || extension === 'png' || extension === 'tif';
+}
+
+function isZip(extension) {
+    return extension === 'zip';
+}
+
+function allowedType(extension) {
+    return isImage(extension) || isZip(extension);
+}
+
+exports.handler = function(event, context) {
+    // Read options from the event.
+    console.log('Reading options from event:\n', util.inspect(event, {depth: 5}));
+    var srcBucket = event.Records[0].s3.bucket.name;
+
+    // We try to prevent this but just in case, get rid of spaces or unicode
+    // non-ASCII characters.
+    var srcKey = decodeURIComponent(event.Records[0].s3.object.key.replace(/\+/g, ' '));
+
+    // Sanity check: validate that source and destination are different buckets.
+    if (srcBucket == DESTINATION_BUCKET) {
+        console.error("Destination bucket must not match source bucket.");
+        return;
+    }
+
+    // Infer the image type.
+    var typeMatch = srcKey.match(/\.([^.]*)$/);
+    if (!typeMatch) {
+        console.error('No file extension on file: ' + srcKey);
+        return;
+    }
+    var fileExtension = typeMatch[1];
+
+    if (!allowedType(fileExtension)) {
+        console.log('Skipping unknown file type: ' + srcKey);
+        return;
+    }
+
+    if (isImage(fileExtension)) {
+        // TODO verify this image is good.
+        var copyParams = {
+            Bucket: DESTINATION_BUCKET,
+            CopySource: srcBucket + '/' + srcKey,
+            Key: srcKey
+        };
+        s3.copyObject(copyParams, function(err, data) {
+            if (err) {
+                console.log('File transfer FAILED.');
+                context.done(err);
+            } else {
+                console.log('File transfer complete!');
+                context.done(null, data);
+            }
+        });
+    } else if (isZip(fileExtension)) {
+        // Unzip and move.
+        // TODO verify file is valid.
+        var sourceParams = {
+            Bucket: srcBucket,
+            Key: srcKey
+        };
+
+        var parseStream = s3.getObject(sourceParams)
+            .createReadStream()
+            .pipe(unzip.Parse());
+
+        parseStream.on('entry', function(entry) {
+            console.log('STARTED ' + entry.path);
+            // TODO check type.
+            // TODO make file names UUIDs and prefix with user id.
+            // TODO replace file extensions with our own after file checks.
+            var fileName = entry.path,
+                type = entry.type,
+                uploadParams = {
+                    Bucket: DESTINATION_BUCKET,
+                    Key: fileName,
+                    Body: entry,
+                    ContentType: 'application/zip'
+                };
+
+            s3.upload(uploadParams, function(err, data) {
+                if (err) {
+                    console.log('File transfer FAILED.');
+                    context.done(err);
+                } else {
+                    console.log('Extracted and moved file: ' + fileName);
+                }
+            });
+        });
+
+        parseStream.on('close', function(err) {
+            context.done(null, 'File extraction complete.');
+        });
+    }
+};

--- a/src/upload-functions/package.json
+++ b/src/upload-functions/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "upload-functions",
+  "version": "1.0.0",
+  "description": "Handle uploaded files in AWS Lambda.",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "Azavea",
+  "license": "Apache",
+  "dependencies": {
+    "unzip": "git+https://github.com/AnkurMali/node-unzip.git#9146a6f"
+  }
+}


### PR DESCRIPTION
Connects #77 

 * Provides some client side validation of the uploaded files.
 * Provide a nodejs module to automatically unzip and transfer files between s3 buckets using lambda.

To test:
 * Open AWS console and select s3.
 * You should find two buckets one for uploads and one for verified files.
 * Using the front end application add a zip file full of images.
 * Wait 30 sec to a minute and refresh the verification bucket.
 * You should see the extracted files.

## Problems:
 * Moving files across the network seems to be the real bottleneck. Node is pretty good and streaming bytes from one place to another. In my early tests, I simply copied the file across from one bucket to the other, using the lambda server as an intermediary. This was about equally slow.
 * Considering this issue, we may not be able to use lambda for the unzipping at all since we have a max timeout of 60 seconds.
 * Image verification should be fast. It looks as though we can stream the first few hundred bytes to do a test and then close the connection.
 * I did see some errors generated by the lower-level zlib when streaming zip files over the network. 