### PR TITLE
Style password screen

### DIFF
--- a/src/rf/apps/home/urls.py
+++ b/src/rf/apps/home/urls.py
@@ -41,6 +41,7 @@ urlpatterns = patterns(
     url('^forgot/?$', views.home_page),
     url('^logout/?$', views.home_page),
     url('^activate/?$', views.home_page),
+    url('^reset-password/\S+/\S+/?', views.home_page),
     url('^keys/?$', views.home_page),
     url('^billing/?$', views.home_page),
     url('^account/?$', views.home_page),

--- a/src/rf/apps/user/urls.py
+++ b/src/rf/apps/user/urls.py
@@ -14,6 +14,7 @@ urlpatterns = patterns(
     url('^sign-up$', views.sign_up, name='sign_up'),
     url('^resend$', views.resend, name='resend'),
     url('^forgot$', views.forgot, name='forgot'),
+    url('^reset-password$', views.reset_password, name='reset_password'),
     url('^activate/(?P<activation_key>[A-z0-9]+)/$', views.activate,
         name='activate'),
 )

--- a/src/rf/js/src/routes.js
+++ b/src/rf/js/src/routes.js
@@ -15,6 +15,7 @@ router.addRoute(/^billing/, UserController, 'billing');
 router.addRoute(/^login/, UserController, 'login');
 router.addRoute(/^sign-up/, UserController, 'signUp');
 router.addRoute(/^send-activation/, UserController, 'sendActivation');
+router.addRoute('reset-password/:uidb64/:token(/)', UserController, 'resetPassword');
 router.addRoute(/^forgot/, UserController, 'forgot');
 router.addRoute(/^logout/, UserController, 'logout');
 router.addRoute(/^activate/, UserController, 'activate');

--- a/src/rf/js/src/user/components.js
+++ b/src/rf/js/src/user/components.js
@@ -346,6 +346,58 @@ var ForgotScreen = React.createBackboneClass({
     }
 });
 
+var ResetPasswordScreen = React.createBackboneClass({
+    mixins: [ModelValidationMixin],
+
+    onValidateFailure: function() {
+        this.refs.new_password1.setFocus();
+    },
+
+    getFormData: function() {
+        return {
+            new_password1: this.refs.new_password1.getValue(),
+            new_password2: this.refs.new_password2.getValue(),
+            uidb64: this.props.uidb64,
+            token: this.props.token
+        };
+    },
+
+    primaryAction: function() {
+        this.getModel()
+            .fetch({
+                method: 'POST',
+                data: this.getFormData()
+            })
+            .done(_.bind(this.handleServerSuccess, this))
+            .fail(_.bind(this.handleServerFailure, this));
+    },
+
+    render: function() {
+        var content = (
+            <div>
+                <div className="user-message">
+                    Password reset was successful.
+                </div>
+                <a href="#" data-url="/login" className="btn btn-secondary btn-block">Login</a>
+            </div>
+        );
+        if (!this.getModel().get('success')) {
+            content = (
+                <form noValidate method="post" onSubmit={this.validate}>
+                    {this.renderErrors()}
+                    <InputField name="new_password1" displayName="Password" type="password" ref="new_password1" value={this.getModel().get('new_password1')}/>
+                    <InputField name="new_password2" displayName="Re-enter Password" type="password" ref="new_password2" value={this.getModel().get('new_password2')}/>
+                    <div className="form-action">
+                        <input type="submit" className="btn btn-secondary btn-block" value="Reset Password" />
+                    </div>
+                </form>
+            );
+        }
+
+        return <UserScreen content={content} />;
+    }
+});
+
 var ActivateScreen = React.createBackboneClass({
     render: function() {
         var content = (
@@ -474,5 +526,6 @@ module.exports = {
     KeysScreen: KeysScreen,
     LoginScreen: LoginScreen,
     SendActivationScreen: SendActivationScreen,
+    ResetPasswordScreen: ResetPasswordScreen,
     SignUpScreen: SignUpScreen
 };

--- a/src/rf/js/src/user/controllers.js
+++ b/src/rf/js/src/user/controllers.js
@@ -63,6 +63,12 @@ var UserController = {
         this.renderComponent(<components.ForgotScreen model={model} />);
     },
 
+    resetPassword: function(uidb64, token) {
+        var model = new models.ResetPasswordFormModel();
+        this.renderComponent(<components.ResetPasswordScreen model={model}
+                                uidb64={uidb64} token={token} />);
+    },
+
     activate: function() {
         this.renderComponent(<components.ActivateScreen />);
     },

--- a/src/rf/js/src/user/models.js
+++ b/src/rf/js/src/user/models.js
@@ -52,6 +52,21 @@ var ModalBaseModel = Backbone.Model.extend({
         success: false,
         client_errors: null,
         server_errors: null
+    },
+
+    setErrors: function(errors) {
+        if (errors.length) {
+            this.set({
+                'client_errors': errors,
+                'server_errors': null
+            });
+            return errors;
+        } else {
+            this.set({
+                'client_errors': null,
+                'server_errors': null
+            });
+        }
     }
 });
 
@@ -74,18 +89,7 @@ var LoginFormModel = ModalBaseModel.extend({
             errors.push('Please enter a password');
         }
 
-        if (errors.length) {
-            this.set({
-                'client_errors': errors,
-                'server_errors': null
-            });
-            return errors;
-        } else {
-            this.set({
-                'client_errors': null,
-                'server_errors': null
-            });
-        }
+        return this.setErrors(errors);
     }
 });
 
@@ -131,18 +135,7 @@ var SignUpFormModel = ModalBaseModel.extend({
             errors.push('Please check the agreement');
         }
 
-        if (errors.length) {
-            this.set({
-                'client_errors': errors,
-                'server_errors': null
-            });
-            return errors;
-        } else {
-            this.set({
-                'client_errors': null,
-                'server_errors': null
-            });
-        }
+        return this.setErrors(errors);
     }
 });
 
@@ -164,17 +157,7 @@ var ForgotFormModel = ModalBaseModel.extend({
             }
         }
 
-        if (errors.length) {
-            this.set({
-                'client_errors': errors,
-                'server_errors': null
-            });
-            return errors;
-        } else {
-            this.set({
-                'client_errors': null,
-                'server_errors': null
-            });
+        return this.setErrors(errors);
         }
     }
 });
@@ -197,18 +180,7 @@ var ResendFormModel = ModalBaseModel.extend({
             }
         }
 
-        if (errors.length) {
-            this.set({
-                'client_errors': errors,
-                'server_errors': null
-            });
-            return errors;
-        } else {
-            this.set({
-                'client_errors': null,
-                'server_errors': null
-            });
-        }
+        return this.setErrors(errors);
     }
 });
 
@@ -217,5 +189,6 @@ module.exports = {
     LoginFormModel: LoginFormModel,
     SignUpFormModel: SignUpFormModel,
     ForgotFormModel: ForgotFormModel,
+    ResetPasswordFormModel: ResetPasswordFormModel,
     ResendFormModel: ResendFormModel
 };

--- a/src/rf/js/src/user/models.js
+++ b/src/rf/js/src/user/models.js
@@ -158,7 +158,33 @@ var ForgotFormModel = ModalBaseModel.extend({
         }
 
         return this.setErrors(errors);
+    }
+});
+
+var ResetPasswordFormModel = ModalBaseModel.extend({
+    defaults: {
+        new_password1: null,
+        new_password2: null
+    },
+
+    url: '/user/reset-password',
+
+    validate: function(attrs) {
+        var errors = [];
+
+        if (!attrs.new_password1) {
+            errors.push('Please enter a password');
         }
+
+        if (!attrs.new_password2) {
+            errors.push('Please repeat the password');
+        }
+
+        if (attrs.new_password1 !== attrs.new_password2) {
+            errors.push('Passwords do not match');
+        }
+
+        return this.setErrors(errors);
     }
 });
 

--- a/src/rf/templates/registration/password_reset_email.html
+++ b/src/rf/templates/registration/password_reset_email.html
@@ -9,7 +9,7 @@ wish to reset your password, please ignore this message.
 To reset your password, please click the following link, or copy and paste it
 into your web browser:
 
-{{ protocol }}://{{ domain }}{% url 'auth_password_reset_confirm' uid token %}
+{{ protocol }}://{{ domain }}/reset-password/{{uid}}/{{token}}
 
 Your username, in case you've forgotten: {{ user.username }}
 


### PR DESCRIPTION
Originally, I was going to just style the templates that come with registration redux. Instead, I created a REST endpoint to reset the password and added a React component ResetPassword screen. It seemed like it would be the same amount of work, and was more consistent with the other account screens.

###### Testing
 * Get URL to reset password by going through the Forgot? screen. 
 * Go to that URL with an extra character at the end. Enter passwords that match and submit, which should lead to an error about the URL being invalid (technically, the token won't be correct).
 * Enter the real URL and try entering passwords that don't match, testing validation.
 * Enter the real URL and enter passwords that do match, which should reset the password.

Connects #67 