### PR TITLE
Add mock-geoprocessing service

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -95,6 +95,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       app.vm.synced_folder "src/rf/apps", "/opt/app/apps"
     else
       app.vm.synced_folder "src/rf", "/opt/app/"
+      app.vm.synced_folder "src/mock-geoprocessing", "/opt/mock-geoprocessing/"      
       if File.directory?("#{ENV['HOME']}/.aws")
         app.vm.synced_folder "#{ENV['HOME']}/.aws", "/home/vagrant/.aws/"
       else

--- a/deployment/ansible/app-servers.yml
+++ b/deployment/ansible/app-servers.yml
@@ -14,6 +14,7 @@
 
   roles:
     - { role: "raster-foundry.app" }
+    - { role: "raster-foundry.mock-geoprocessing", when: "['development', 'test'] | some_are_in(group_names)" }
 
   post_tasks:
     - name: Revert change to /etc/hosts

--- a/deployment/ansible/roles/raster-foundry.mock-geoprocessing/defaults/main.yml
+++ b/deployment/ansible/roles/raster-foundry.mock-geoprocessing/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+mock_geoprocessing_home: /opt/mock-geoprocessing

--- a/deployment/ansible/roles/raster-foundry.mock-geoprocessing/handlers/main.yml
+++ b/deployment/ansible/roles/raster-foundry.mock-geoprocessing/handlers/main.yml
@@ -1,0 +1,3 @@
+---
+- name: Restart rf-mock-geoprocessing
+  service: name=rf-mock-geoprocessing state=restarted

--- a/deployment/ansible/roles/raster-foundry.mock-geoprocessing/meta/main.yml
+++ b/deployment/ansible/roles/raster-foundry.mock-geoprocessing/meta/main.yml
@@ -1,0 +1,4 @@
+---
+dependencies:
+  - { role: "raster-foundry.base" }
+  - { role: "azavea.nodejs" }

--- a/deployment/ansible/roles/raster-foundry.mock-geoprocessing/tasks/configuration.yml
+++ b/deployment/ansible/roles/raster-foundry.mock-geoprocessing/tasks/configuration.yml
@@ -1,0 +1,6 @@
+---
+- name: Configure service definition
+  template: src=upstart-rf-mock-geoprocessing.conf.j2
+            dest=/etc/init/rf-mock-geoprocessing.conf
+  notify:
+    - Restart rf-mock-geoprocessing

--- a/deployment/ansible/roles/raster-foundry.mock-geoprocessing/tasks/main.yml
+++ b/deployment/ansible/roles/raster-foundry.mock-geoprocessing/tasks/main.yml
@@ -1,0 +1,2 @@
+---
+- { include: configuration.yml }

--- a/deployment/ansible/roles/raster-foundry.mock-geoprocessing/templates/upstart-rf-mock-geoprocessing.conf.j2
+++ b/deployment/ansible/roles/raster-foundry.mock-geoprocessing/templates/upstart-rf-mock-geoprocessing.conf.j2
@@ -1,0 +1,15 @@
+description	"rf-mock-geoprocessing"
+
+{% if ['development', 'test'] | some_are_in(group_names) -%}
+start on (vagrant-mounted)
+{% else %}
+start on (local-filesystems and net-device-up IFACE!=lo)
+{% endif %}
+stop on shutdown
+
+respawn
+setuid rf
+chdir {{ mock_geoprocessing_home }}
+env HOME="/var/lib/rf"
+
+exec envdir /etc/rf.d/env node server.js

--- a/src/mock-geoprocessing/server.js
+++ b/src/mock-geoprocessing/server.js
@@ -1,0 +1,31 @@
+var qs = require('querystring'),
+    http = require('http');
+
+var serverPort = 9500;
+
+function handleNewLayer(request, response) {
+    if (request.method == 'POST') {
+        var body = '';
+        request.on('data', function (data) {
+            body += data;
+        });
+        request.on('end', function () {
+            var parsedBody = qs.parse(body),
+                delay = 3000;
+
+            console.log('Received job_id: ' + parsedBody.job_id);
+            setTimeout(function() {
+                // TODO Do something to update status.
+                console.log('Updating status for job_id: ' + parsedBody.job_id);
+            }, delay);
+
+            response.writeHead(200);
+            response.end();
+        });
+    }
+}
+
+var server = http.createServer(handleNewLayer);
+server.listen(serverPort, function() {
+    console.log("Server listening on: http://localhost:%s", serverPort);
+});


### PR DESCRIPTION
This PR adds a service that listens for posts on port 9500. It takes the layer_id in the post body, waits 3 secs, and then posts to the /update-status endpoint on the app server, resulting in the status of that layer changing to complete.

##### Testing
 * Run migrations and provision the app VM.
 * Get the id of a layer in the DB.
 * Then run `vagrant ssh app` and `curl --data "layer_id=<layer_id>" http://localhost:9500`. 
 * Check that the status changes to complete.

Connects #50 

