### PR TITLE
Feature/lol/paginiation

### DIFF
--- a/src/rf/apps/home/filters.py
+++ b/src/rf/apps/home/filters.py
@@ -14,5 +14,5 @@ class LayerFilter(django_filters.FilterSet):
 
     class Meta:
         model = Layer
-        fields = ('username', 'name', 'organization', 'tag')
+        fields = ('username', 'name', 'organization', 'tag', 'created_at')
         order_by = True

--- a/src/rf/apps/home/tests.py
+++ b/src/rf/apps/home/tests.py
@@ -109,19 +109,21 @@ class LayerTestCase(AbstractLayerTestCase):
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         # 2 layers from logged_in_user, and 1 public layer from other_user
-        self.assertEqual(len(response.data), 3)
+        self.assertEqual(response.data['pages'], 1)
+        self.assertEqual(response.data['current_page'], 1)
+        self.assertEqual(len(response.data['layers']), 3)
 
     def test_list_layers_from_logged_in_user(self):
         url = reverse('user_layers', kwargs={'username': self.logged_in_user})
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(response.data), 2)
+        self.assertEqual(len(response.data['layers']), 2)
 
     def test_list_layers_from_other_user(self):
         url = reverse('user_layers', kwargs={'username': self.other_user})
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(response.data), 1)
+        self.assertEqual(len(response.data['layers']), 1)
 
     def test_list_layers_from_invalid_user(self):
         url = reverse('user_layers', kwargs={'username': self.invalid_user})
@@ -134,8 +136,9 @@ class LayerTestCase(AbstractLayerTestCase):
         url += '?name=%s Public Layer' % (self.logged_in_user,)
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(response.data), 1)
-        self.assertEqual(response.data[0]['name'],
+        layers = response.data['layers']
+        self.assertEqual(len(layers), 1)
+        self.assertEqual(layers[0]['name'],
                          '%s Public Layer' % (self.logged_in_user,))
 
     def test_list_layers_with_filter_by_tag_from_logged_in_user(self):
@@ -143,25 +146,27 @@ class LayerTestCase(AbstractLayerTestCase):
         url += '?tag=%s+Public+Layer' % (self.logged_in_user,)
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(response.data), 1)
-        self.assertEqual(response.data[0]['name'],
+        layers = response.data['layers']
+        self.assertEqual(len(layers), 1)
+        self.assertEqual(layers[0]['name'],
                          '%s Public Layer' % (self.logged_in_user,))
 
         url = reverse('user_layers', kwargs={'username': self.logged_in_user})
         url += '?tag=invalid+tag'
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(response.data), 0)
+        self.assertEqual(len(response.data['layers']), 0)
 
     def test_list_layers_with_sorting_from_logged_in_user(self):
         url = reverse('user_layers', kwargs={'username': self.logged_in_user})
         url += '?ordering=name'
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(response.data), 2)
-        self.assertEqual(response.data[0]['name'],
+        layers = response.data['layers']
+        self.assertEqual(len(layers), 2)
+        self.assertEqual(layers[0]['name'],
                          '%s Private Layer' % (self.logged_in_user,))
-        self.assertEqual(response.data[1]['name'],
+        self.assertEqual(layers[1]['name'],
                          '%s Public Layer' % (self.logged_in_user,))
 
     # Retrieve
@@ -312,7 +317,7 @@ class FavoriteTestCase(AbstractLayerTestCase):
         url = reverse('favorites')
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(response.data), 1)
+        self.assertEqual(len(response.data['layers']), 1)
 
     # Destroy
     def test_destroy_favorite_from_logged_in_user(self):

--- a/src/rf/js/src/core/models.js
+++ b/src/rf/js/src/core/models.js
@@ -3,7 +3,8 @@
 var _ = require('underscore'),
     $ = require('jquery'),
     Backbone = require('../../shim/backbone'),
-    L = require('leaflet');
+    L = require('leaflet'),
+    utils = require('./utils');
 
 var MapModel = Backbone.Model.extend({
     defaults: {
@@ -48,9 +49,34 @@ var Layer = Backbone.Model.extend({
     }
 });
 
-// TODO: Paginate
 var BaseLayers = Backbone.Collection.extend({
     model: Layer,
+    currentPage: 1,
+    pages: 1,
+    prevUrl: null,
+    nextUrl: null,
+
+    hasPrev: function() {
+        return this.prevUrl !== null;
+    },
+
+    hasNext: function() {
+        return this.nextUrl !== null;
+    },
+
+    getPrevPage: function() {
+        if (this.prevUrl) {
+            var data = utils.parseQueryData(this.prevUrl);
+            this.fetch({ data: data });
+        }
+    },
+
+    getNextPage: function() {
+        if (this.nextUrl) {
+            var data = utils.parseQueryData(this.nextUrl);
+            this.fetch({ data: data });
+        }
+    },
 
     initialize: function(models, options) {
         options = options || {};
@@ -65,6 +91,14 @@ var BaseLayers = Backbone.Collection.extend({
         } else {
             this.onLayerDeselected(model);
         }
+    },
+
+    parse: function(data) {
+        this.currentPage = data.current_page;
+        this.pages = data.pages;
+        this.prevUrl = data.prev_url;
+        this.nextUrl = data.next_url;
+        return data.layers;
     }
 });
 

--- a/src/rf/js/src/core/utils.js
+++ b/src/rf/js/src/core/utils.js
@@ -4,6 +4,12 @@ function asset(relPath) {
     return '/static/' + relPath;
 }
 
+function parseQueryData(url) {
+    var data = url.split('?');
+    return JSON.parse('{"' + decodeURI(data[1]).replace(/"/g, '\\"').replace(/&/g, '","').replace(/=/g,'":"') + '"}');
+}
+
 module.exports = {
-    asset: asset
+    asset: asset,
+    parseQueryData: parseQueryData
 };

--- a/src/rf/js/src/home/components/library.js
+++ b/src/rf/js/src/home/components/library.js
@@ -217,13 +217,26 @@ var LayerCollection = React.createBackboneClass({
                              .filter(this.state.filterFn)
                              .sort(this.state.sortFn)
                              .map(makeLayerItem),
-            className = 'tab-pane animated fadeInLeft';
+            className = 'tab-pane animated fadeInLeft',
+            pager = '',
+            uploadButton = '';
 
         if (this.props.active) {
             className += ' active';
         }
 
-        var uploadButton = '';
+        if (this.getCollection().pages > 1) {
+            var prev = '',
+                next = '';
+            if (this.getCollection().hasPrev()) {
+                prev = (<a className="prev" onClick={this.prevPage}>&lt;-</a>);
+            }
+            if (this.getCollection().hasNext()) {
+                next = (<a className="next" onClick={this.nextPage}>-&gt;</a>);
+            }
+            pager = (<div>{prev} {next}</div>);
+        }
+
         if (this.props.uploadsEnabled) {
             uploadButton = (
                 <span className="tool-toggle" data-toggle="tooltip" data-placement="bottom" title="Import Imagery Layer">
@@ -298,6 +311,7 @@ var LayerCollection = React.createBackboneClass({
                     </div>
                 </div>
                 <div className="list-group">
+                    { pager }
                     { layerItems }
                 </div>
             </div>
@@ -366,6 +380,14 @@ var LayerCollection = React.createBackboneClass({
             };
         }
         this.setState({ sortFn: sortFn });
+    },
+
+    nextPage: function() {
+        this.getCollection().getNextPage();
+    },
+
+    prevPage: function() {
+        this.getCollection().getPrevPage();
     }
 });
 


### PR DESCRIPTION
Connects #101 

 * Paginates layer endpoints.
 * Allow backbone layer collections to use pagination.
 * Adds a stubbed pagination control to the front end.

To test:
 * Ensure you have more than 50 public layers (use generation script if necessary).
 * Visit the layer catalog (check each tab).
 * On collections that have more than 10 items (public) you should see ascii art arrow (`<-` and `->`)
 * Click next/prev buttons a few times.
 * Items in the collection should change.
 * Ensure that the prev button only shows when you are on pages 2 or greater.
 * Ensure next button does not show on last page.
 * Ensure no buttons show if there are fewer than 10 models in the collection.  