### PR TITLE
Fix background video reset on login screens

### DIFF
--- a/src/rf/js/src/user/components.js
+++ b/src/rf/js/src/user/components.js
@@ -140,7 +140,7 @@ var InputField = React.createBackboneClass({
     }
 });
 
-var LoginScreen = React.createBackboneClass({
+var LoginBox = React.createBackboneClass({
     mixins: [ModelValidationMixin],
 
     onValidateFailure: function() {
@@ -169,7 +169,7 @@ var LoginScreen = React.createBackboneClass({
     },
 
     render: function() {
-        var content = (
+        return (
             <div>
                 {this.renderErrors()}
                 <div className="link-block">
@@ -193,12 +193,10 @@ var LoginScreen = React.createBackboneClass({
                 </form>
             </div>
         );
-
-        return <UserScreen content={content} />;
     }
 });
 
-var SignUpScreen = React.createBackboneClass({
+var SignUpBox = React.createBackboneClass({
     mixins: [ModelValidationMixin],
 
     onValidateFailure: function() {
@@ -226,17 +224,19 @@ var SignUpScreen = React.createBackboneClass({
     },
 
     render: function() {
-        var content = (
-            <div>
-                <div className="user-message">
-                    Please check your email to activate your account.
-                </div>
-                <a href="#" data-url="/login" className="btn btn-secondary btn-block">Login</a>
-            </div>
-        );
-        if (!this.getModel().get('success')) {
+        var content = '';
+        if (this.getModel().get('success')) {
             content = (
-                <form noValidate method="post" onSubmit={this.validate}>
+                <div>
+                    <div className="user-message">
+                        Please check your email to activate your account.
+                    </div>
+                    <a href="#" data-url="/login" className="btn btn-secondary btn-block">Login</a>
+                </div>
+            );
+        } else {
+            content = (
+                <form method="post" onSubmit={this.validate} noValidate>
                     {this.renderErrors()}
                     <InputField name="username" displayName="Username" ref="username" value={this.getModel().get('username')}/>
                     <InputField name="email" displayName="Email" ref="email" type="email" value={this.getModel().get('email')}/>
@@ -249,12 +249,11 @@ var SignUpScreen = React.createBackboneClass({
                 </form>
             );
         }
-
-        return <UserScreen content={content} />;
+        return <div>{content}</div>;
     }
 });
 
-var SendActivationScreen = React.createBackboneClass({
+var SendActivationBox = React.createBackboneClass({
     mixins: [ModelValidationMixin],
 
     onValidateFailure: function() {
@@ -278,17 +277,19 @@ var SendActivationScreen = React.createBackboneClass({
     },
 
     render: function() {
-        var content = (
-            <div>
-                <div className="user-message">
-                    Please check your email to activate your account.
-                </div>
-                <a href="#" data-url="/login" className="btn btn-secondary btn-block">Login</a>
-            </div>
-        );
-        if (!this.getModel().get('success')) {
+        var content = '';
+        if (this.getModel().get('success')) {
             content = (
-                <form method="post" onSubmit={this.validate} noValidate >
+                <div>
+                    <div className="user-message">
+                        Please check your email to activate your account.
+                    </div>
+                    <a href="#" data-url="/login" className="btn btn-secondary btn-block">Login</a>
+                </div>
+            );
+        } else {
+            content = (
+                <form method="post" onSubmit={this.validate} noValidate>
                     {this.renderErrors()}
                     <InputField name="email" displayName="Email" type="email" ref="email" value={this.getModel().get('email')}/>
                     <div className="form-action">
@@ -297,12 +298,11 @@ var SendActivationScreen = React.createBackboneClass({
                 </form>
             );
         }
-
-        return <UserScreen content={content} />;
+        return <div>{content}</div>;
     }
 });
 
-var ForgotScreen = React.createBackboneClass({
+var ForgotBox = React.createBackboneClass({
     mixins: [ModelValidationMixin],
 
     onValidateFailure: function() {
@@ -326,8 +326,10 @@ var ForgotScreen = React.createBackboneClass({
     },
 
     render: function() {
-        var content = 'Please check your email to reset your password.';
-        if (!this.getModel().get('success')) {
+        var content = '';
+        if (this.getModel().get('success')) {
+            content = 'Please check your email to reset your password.';
+        } else {
             content = (
                 <form method="post" onSubmit={this.validate} noValidate>
                     {this.renderErrors()}
@@ -341,12 +343,11 @@ var ForgotScreen = React.createBackboneClass({
                 </form>
             );
         }
-
-        return <UserScreen content={content} />;
+        return <div>{content}</div>;
     }
 });
 
-var ResetPasswordScreen = React.createBackboneClass({
+var ResetPasswordBox = React.createBackboneClass({
     mixins: [ModelValidationMixin],
 
     onValidateFailure: function() {
@@ -373,17 +374,19 @@ var ResetPasswordScreen = React.createBackboneClass({
     },
 
     render: function() {
-        var content = (
-            <div>
-                <div className="user-message">
-                    Password reset was successful.
-                </div>
-                <a href="#" data-url="/login" className="btn btn-secondary btn-block">Login</a>
-            </div>
-        );
-        if (!this.getModel().get('success')) {
+        var content = '';
+        if (this.getModel().get('success')) {
             content = (
-                <form noValidate method="post" onSubmit={this.validate}>
+                <div>
+                    <div className="user-message">
+                        Password reset was successful.
+                    </div>
+                    <a href="#" data-url="/login" className="btn btn-secondary btn-block">Login</a>
+                </div>
+            );
+        } else {
+            content = (
+                <form method="post" onSubmit={this.validate} noValidate>
                     {this.renderErrors()}
                     <InputField name="new_password1" displayName="Password" type="password" ref="new_password1" value={this.getModel().get('new_password1')}/>
                     <InputField name="new_password2" displayName="Re-enter Password" type="password" ref="new_password2" value={this.getModel().get('new_password2')}/>
@@ -393,14 +396,13 @@ var ResetPasswordScreen = React.createBackboneClass({
                 </form>
             );
         }
-
-        return <UserScreen content={content} />;
+        return <div>{content}</div>;
     }
 });
 
-var ActivateScreen = React.createBackboneClass({
+var ActivateBox = React.createBackboneClass({
     render: function() {
-        var content = (
+        return (
             <div>
                 <div className="user-message">
                     Activation is complete and you are now logged in.
@@ -408,8 +410,6 @@ var ActivateScreen = React.createBackboneClass({
                 <a href="#" data-url="/" className="btn btn-secondary btn-block">Proceed To Library</a>
             </div>
         );
-
-        return <UserScreen content={content} />;
     }
 });
 
@@ -520,12 +520,13 @@ var BillingScreen = React.createBackboneClass({
 
 module.exports = {
     AccountScreen: AccountScreen,
-    ActivateScreen: ActivateScreen,
+    ActivateBox: ActivateBox,
     BillingScreen: BillingScreen,
-    ForgotScreen: ForgotScreen,
+    ForgotBox: ForgotBox,
     KeysScreen: KeysScreen,
-    LoginScreen: LoginScreen,
-    SendActivationScreen: SendActivationScreen,
-    ResetPasswordScreen: ResetPasswordScreen,
-    SignUpScreen: SignUpScreen
+    LoginBox: LoginBox,
+    SendActivationBox: SendActivationBox,
+    ResetPasswordBox: ResetPasswordBox,
+    SignUpBox: SignUpBox,
+    UserScreen: UserScreen
 };

--- a/src/rf/js/src/user/controllers.js
+++ b/src/rf/js/src/user/controllers.js
@@ -45,32 +45,36 @@ var UserController = {
             return;
         }
         var model = new models.LoginFormModel();
-        this.renderComponent(<components.LoginScreen model={model} />);
+        this.renderUserScreen(<components.LoginBox model={model} />);
     },
 
     signUp: function() {
         var model = new models.SignUpFormModel();
-        this.renderComponent(<components.SignUpScreen model={model} />);
+        this.renderUserScreen(<components.SignUpBox model={model} />);
     },
 
     sendActivation: function() {
         var model = new models.ResendFormModel();
-        this.renderComponent(<components.SendActivationScreen model={model} />);
+        this.renderUserScreen(<components.SendActivationBox model={model} />);
     },
 
     forgot: function() {
         var model = new models.ForgotFormModel();
-        this.renderComponent(<components.ForgotScreen model={model} />);
+        this.renderUserScreen(<components.ForgotBox model={model} />);
     },
 
     resetPassword: function(uidb64, token) {
         var model = new models.ResetPasswordFormModel();
-        this.renderComponent(<components.ResetPasswordScreen model={model}
+        this.renderUserScreen(<components.ResetPasswordBox model={model}
                                 uidb64={uidb64} token={token} />);
     },
 
     activate: function() {
-        this.renderComponent(<components.ActivateScreen />);
+        this.renderUserScreen(<components.ActivateBox />);
+    },
+
+    renderUserScreen: function(content) {
+        this.renderComponent(<components.UserScreen content={content} />);
     },
 
     renderComponent: function(component) {


### PR DESCRIPTION
React will re-render the entire DOM node if you pass in a new kind of
React component, even if they generate nearly identical markup. This is
problematic because of the way our components were using composition to
share common markup.

The solution is to invert the common React components so that only the
inner content is re-rendered for each transition.

After refactoring out `UserScreen` from all these components I started
to receive the following error:

> Invariant Violation: ReactMount: Two valid but unequal nodes with the same `data-reactid`

I think this is triggered by components that return a different kind of
root node depending on the circumstances (ex. sometimes all content is
wrapped in `<div>` and other times `<form>`). I solved this by adding a
wrapper around each component output so the root node is consistent.

Connects #70