### PR TITLE
Add better support for livereload

### DIFF
--- a/src/rf/npm-shrinkwrap.json
+++ b/src/rf/npm-shrinkwrap.json
@@ -4,103 +4,103 @@
   "dependencies": {
     "backbone": {
       "version": "1.2.1",
-      "from": "https://registry.npmjs.org/backbone/-/backbone-1.2.1.tgz",
+      "from": "backbone@1.2.1",
       "resolved": "https://registry.npmjs.org/backbone/-/backbone-1.2.1.tgz"
     },
     "backbone.marionette": {
       "version": "2.4.2",
-      "from": "https://registry.npmjs.org/backbone.marionette/-/backbone.marionette-2.4.2.tgz",
+      "from": "backbone.marionette@2.4.2",
       "resolved": "https://registry.npmjs.org/backbone.marionette/-/backbone.marionette-2.4.2.tgz",
       "dependencies": {
         "backbone.babysitter": {
-          "version": "0.1.8",
-          "from": "https://registry.npmjs.org/backbone.babysitter/-/backbone.babysitter-0.1.8.tgz",
-          "resolved": "https://registry.npmjs.org/backbone.babysitter/-/backbone.babysitter-0.1.8.tgz"
+          "version": "0.1.10",
+          "from": "backbone.babysitter@>=0.1.0 <0.2.0",
+          "resolved": "https://registry.npmjs.org/backbone.babysitter/-/backbone.babysitter-0.1.10.tgz"
         },
         "backbone.wreqr": {
-          "version": "1.3.3",
-          "from": "https://registry.npmjs.org/backbone.wreqr/-/backbone.wreqr-1.3.3.tgz",
-          "resolved": "https://registry.npmjs.org/backbone.wreqr/-/backbone.wreqr-1.3.3.tgz"
+          "version": "1.3.5",
+          "from": "backbone.wreqr@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/backbone.wreqr/-/backbone.wreqr-1.3.5.tgz"
         }
       }
     },
     "bootstrap": {
       "version": "3.3.4",
-      "from": "https://registry.npmjs.org/bootstrap/-/bootstrap-3.3.4.tgz",
+      "from": "bootstrap@3.3.4",
       "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-3.3.4.tgz"
     },
     "bootstrap-tagsinput": {
       "version": "0.5.0",
-      "from": "bootstrap-tagsinput@*",
+      "from": "bootstrap-tagsinput@0.5.0",
       "resolved": "https://registry.npmjs.org/bootstrap-tagsinput/-/bootstrap-tagsinput-0.5.0.tgz"
     },
     "browserify": {
       "version": "9.0.3",
-      "from": "https://registry.npmjs.org/browserify/-/browserify-9.0.3.tgz",
+      "from": "browserify@9.0.3",
       "resolved": "https://registry.npmjs.org/browserify/-/browserify-9.0.3.tgz",
       "dependencies": {
         "JSONStream": {
           "version": "0.10.0",
-          "from": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.10.0.tgz",
+          "from": "JSONStream@>=0.10.0 <0.11.0",
           "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.10.0.tgz",
           "dependencies": {
             "jsonparse": {
               "version": "0.0.5",
-              "from": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz",
+              "from": "jsonparse@0.0.5",
               "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz"
             },
             "through": {
               "version": "2.3.8",
-              "from": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+              "from": "through@>=2.2.7 <3.0.0",
               "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
             }
           }
         },
         "assert": {
           "version": "1.3.0",
-          "from": "https://registry.npmjs.org/assert/-/assert-1.3.0.tgz",
+          "from": "assert@>=1.3.0 <1.4.0",
           "resolved": "https://registry.npmjs.org/assert/-/assert-1.3.0.tgz"
         },
         "browser-pack": {
           "version": "4.0.4",
-          "from": "https://registry.npmjs.org/browser-pack/-/browser-pack-4.0.4.tgz",
+          "from": "browser-pack@>=4.0.0 <5.0.0",
           "resolved": "https://registry.npmjs.org/browser-pack/-/browser-pack-4.0.4.tgz",
           "dependencies": {
             "JSONStream": {
-              "version": "1.0.4",
-              "from": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.0.4.tgz",
-              "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.0.4.tgz",
+              "version": "1.0.6",
+              "from": "JSONStream@>=1.0.3 <2.0.0",
+              "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.0.6.tgz",
               "dependencies": {
                 "jsonparse": {
-                  "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.0.0.tgz"
+                  "version": "1.1.0",
+                  "from": "jsonparse@>=1.1.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.1.0.tgz"
                 },
                 "through": {
                   "version": "2.3.8",
-                  "from": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+                  "from": "through@>=2.2.7 <3.0.0",
                   "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
                 }
               }
             },
             "combine-source-map": {
               "version": "0.3.0",
-              "from": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.3.0.tgz",
+              "from": "combine-source-map@>=0.3.0 <0.4.0",
               "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.3.0.tgz",
               "dependencies": {
                 "inline-source-map": {
                   "version": "0.3.1",
-                  "from": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.3.1.tgz",
+                  "from": "inline-source-map@>=0.3.0 <0.4.0",
                   "resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.3.1.tgz",
                   "dependencies": {
                     "source-map": {
                       "version": "0.3.0",
-                      "from": "https://registry.npmjs.org/source-map/-/source-map-0.3.0.tgz",
+                      "from": "source-map@>=0.3.0 <0.4.0",
                       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.3.0.tgz",
                       "dependencies": {
                         "amdefine": {
                           "version": "1.0.0",
-                          "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
+                          "from": "amdefine@>=0.0.4",
                           "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
                         }
                       }
@@ -109,17 +109,17 @@
                 },
                 "convert-source-map": {
                   "version": "0.3.5",
-                  "from": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-0.3.5.tgz",
+                  "from": "convert-source-map@>=0.3.0 <0.4.0",
                   "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-0.3.5.tgz"
                 },
                 "source-map": {
                   "version": "0.1.43",
-                  "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+                  "from": "source-map@>=0.1.31 <0.2.0",
                   "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                   "dependencies": {
                     "amdefine": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
+                      "from": "amdefine@>=0.0.4",
                       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
                     }
                   }
@@ -128,22 +128,22 @@
             },
             "defined": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+              "from": "defined@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz"
             },
             "through2": {
               "version": "0.5.1",
-              "from": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
+              "from": "through2@>=0.5.1 <0.6.0",
               "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
               "dependencies": {
                 "readable-stream": {
                   "version": "1.0.33",
-                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                  "from": "readable-stream@>=1.0.17 <1.1.0",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     }
                   }
@@ -152,154 +152,217 @@
             },
             "umd": {
               "version": "3.0.1",
-              "from": "https://registry.npmjs.org/umd/-/umd-3.0.1.tgz",
+              "from": "umd@>=3.0.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/umd/-/umd-3.0.1.tgz"
             }
           }
         },
         "browser-resolve": {
           "version": "1.9.1",
-          "from": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.9.1.tgz",
+          "from": "browser-resolve@>=1.7.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.9.1.tgz"
         },
         "browserify-zlib": {
           "version": "0.1.4",
-          "from": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
+          "from": "browserify-zlib@>=0.1.2 <0.2.0",
           "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
           "dependencies": {
             "pako": {
-              "version": "0.2.7",
-              "from": "https://registry.npmjs.org/pako/-/pako-0.2.7.tgz",
-              "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.7.tgz"
+              "version": "0.2.8",
+              "from": "pako@>=0.2.0 <0.3.0",
+              "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.8.tgz"
             }
           }
         },
         "buffer": {
-          "version": "3.4.2",
-          "from": "https://registry.npmjs.org/buffer/-/buffer-3.4.2.tgz",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-3.4.2.tgz",
+          "version": "3.5.0",
+          "from": "buffer@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-3.5.0.tgz",
           "dependencies": {
             "base64-js": {
               "version": "0.0.8",
-              "from": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
+              "from": "base64-js@0.0.8",
               "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz"
             },
             "ieee754": {
               "version": "1.1.6",
-              "from": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.6.tgz",
+              "from": "ieee754@>=1.1.4 <2.0.0",
               "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.6.tgz"
             },
             "is-array": {
               "version": "1.0.1",
-              "from": "https://registry.npmjs.org/is-array/-/is-array-1.0.1.tgz",
+              "from": "is-array@>=1.0.1 <2.0.0",
               "resolved": "https://registry.npmjs.org/is-array/-/is-array-1.0.1.tgz"
             }
           }
         },
         "builtins": {
           "version": "0.0.7",
-          "from": "https://registry.npmjs.org/builtins/-/builtins-0.0.7.tgz",
+          "from": "builtins@>=0.0.3 <0.1.0",
           "resolved": "https://registry.npmjs.org/builtins/-/builtins-0.0.7.tgz"
         },
         "commondir": {
           "version": "0.0.1",
-          "from": "https://registry.npmjs.org/commondir/-/commondir-0.0.1.tgz",
+          "from": "commondir@0.0.1",
           "resolved": "https://registry.npmjs.org/commondir/-/commondir-0.0.1.tgz"
         },
         "concat-stream": {
           "version": "1.4.10",
-          "from": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.10.tgz",
+          "from": "concat-stream@>=1.4.1 <1.5.0",
           "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.10.tgz",
           "dependencies": {
             "typedarray": {
               "version": "0.0.6",
-              "from": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+              "from": "typedarray@>=0.0.5 <0.1.0",
               "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
             }
           }
         },
         "console-browserify": {
           "version": "1.1.0",
-          "from": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+          "from": "console-browserify@>=1.1.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
           "dependencies": {
             "date-now": {
               "version": "0.1.4",
-              "from": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
+              "from": "date-now@>=0.1.4 <0.2.0",
               "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz"
             }
           }
         },
         "constants-browserify": {
           "version": "0.0.1",
-          "from": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-0.0.1.tgz",
+          "from": "constants-browserify@>=0.0.1 <0.1.0",
           "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-0.0.1.tgz"
         },
         "crypto-browserify": {
-          "version": "3.9.14",
-          "from": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.9.14.tgz",
-          "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.9.14.tgz",
+          "version": "3.10.0",
+          "from": "crypto-browserify@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.10.0.tgz",
           "dependencies": {
-            "browserify-aes": {
-              "version": "1.0.3",
-              "from": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.3.tgz",
-              "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.3.tgz",
+            "browserify-cipher": {
+              "version": "1.0.0",
+              "from": "browserify-cipher@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.0.tgz",
               "dependencies": {
-                "buffer-xor": {
-                  "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.2.tgz"
+                "browserify-aes": {
+                  "version": "1.0.5",
+                  "from": "browserify-aes@>=1.0.4 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.5.tgz",
+                  "dependencies": {
+                    "buffer-xor": {
+                      "version": "1.0.3",
+                      "from": "buffer-xor@>=1.0.2 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz"
+                    },
+                    "cipher-base": {
+                      "version": "1.0.1",
+                      "from": "cipher-base@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.1.tgz"
+                    }
+                  }
+                },
+                "browserify-des": {
+                  "version": "1.0.0",
+                  "from": "browserify-des@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.0.tgz",
+                  "dependencies": {
+                    "cipher-base": {
+                      "version": "1.0.1",
+                      "from": "cipher-base@>=1.0.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.1.tgz"
+                    },
+                    "des.js": {
+                      "version": "1.0.0",
+                      "from": "des.js@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
+                      "dependencies": {
+                        "minimalistic-assert": {
+                          "version": "1.0.0",
+                          "from": "minimalistic-assert@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "evp_bytestokey": {
+                  "version": "1.0.0",
+                  "from": "evp_bytestokey@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.0.tgz"
                 }
               }
             },
             "browserify-sign": {
-              "version": "3.0.3",
-              "from": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-3.0.3.tgz",
-              "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-3.0.3.tgz",
+              "version": "3.0.8",
+              "from": "browserify-sign@>=3.0.1 <4.0.0",
+              "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-3.0.8.tgz",
               "dependencies": {
                 "bn.js": {
                   "version": "2.2.0",
-                  "from": "https://registry.npmjs.org/bn.js/-/bn.js-2.2.0.tgz",
+                  "from": "bn.js@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-2.2.0.tgz"
                 },
                 "browserify-rsa": {
                   "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-2.0.1.tgz",
+                  "from": "browserify-rsa@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-2.0.1.tgz"
                 },
                 "elliptic": {
                   "version": "3.1.0",
-                  "from": "https://registry.npmjs.org/elliptic/-/elliptic-3.1.0.tgz",
+                  "from": "elliptic@>=3.0.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-3.1.0.tgz",
                   "dependencies": {
                     "brorand": {
                       "version": "1.0.5",
-                      "from": "https://registry.npmjs.org/brorand/-/brorand-1.0.5.tgz",
+                      "from": "brorand@>=1.0.1 <2.0.0",
                       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.0.5.tgz"
                     },
                     "hash.js": {
                       "version": "1.0.3",
-                      "from": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.3.tgz",
+                      "from": "hash.js@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.3.tgz"
                     }
                   }
                 },
                 "parse-asn1": {
-                  "version": "3.0.1",
-                  "from": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-3.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-3.0.1.tgz",
+                  "version": "3.0.2",
+                  "from": "parse-asn1@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-3.0.2.tgz",
                   "dependencies": {
                     "asn1.js": {
-                      "version": "2.2.0",
-                      "from": "https://registry.npmjs.org/asn1.js/-/asn1.js-2.2.0.tgz",
-                      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-2.2.0.tgz",
+                      "version": "2.2.1",
+                      "from": "asn1.js@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-2.2.1.tgz",
                       "dependencies": {
                         "minimalistic-assert": {
                           "version": "1.0.0",
-                          "from": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz",
+                          "from": "minimalistic-assert@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz"
                         }
                       }
+                    },
+                    "browserify-aes": {
+                      "version": "1.0.5",
+                      "from": "browserify-aes@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.5.tgz",
+                      "dependencies": {
+                        "buffer-xor": {
+                          "version": "1.0.3",
+                          "from": "buffer-xor@>=1.0.2 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz"
+                        },
+                        "cipher-base": {
+                          "version": "1.0.1",
+                          "from": "cipher-base@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "evp_bytestokey": {
+                      "version": "1.0.0",
+                      "from": "evp_bytestokey@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.0.tgz"
                     }
                   }
                 }
@@ -307,27 +370,27 @@
             },
             "create-ecdh": {
               "version": "2.0.1",
-              "from": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-2.0.1.tgz",
+              "from": "create-ecdh@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-2.0.1.tgz",
               "dependencies": {
                 "bn.js": {
                   "version": "2.2.0",
-                  "from": "https://registry.npmjs.org/bn.js/-/bn.js-2.2.0.tgz",
+                  "from": "bn.js@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-2.2.0.tgz"
                 },
                 "elliptic": {
                   "version": "3.1.0",
-                  "from": "https://registry.npmjs.org/elliptic/-/elliptic-3.1.0.tgz",
+                  "from": "elliptic@>=3.0.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-3.1.0.tgz",
                   "dependencies": {
                     "brorand": {
                       "version": "1.0.5",
-                      "from": "https://registry.npmjs.org/brorand/-/brorand-1.0.5.tgz",
+                      "from": "brorand@>=1.0.1 <2.0.0",
                       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.0.5.tgz"
                     },
                     "hash.js": {
                       "version": "1.0.3",
-                      "from": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.3.tgz",
+                      "from": "hash.js@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.3.tgz"
                     }
                   }
@@ -335,45 +398,50 @@
               }
             },
             "create-hash": {
-              "version": "1.1.1",
-              "from": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.1.tgz",
-              "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.1.tgz",
+              "version": "1.1.2",
+              "from": "create-hash@>=1.1.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.2.tgz",
               "dependencies": {
+                "cipher-base": {
+                  "version": "1.0.1",
+                  "from": "cipher-base@>=1.0.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.1.tgz"
+                },
                 "ripemd160": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/ripemd160/-/ripemd160-1.0.1.tgz",
+                  "from": "ripemd160@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-1.0.1.tgz"
                 },
                 "sha.js": {
-                  "version": "2.4.2",
-                  "from": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.2.tgz",
-                  "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.2.tgz"
+                  "version": "2.4.4",
+                  "from": "sha.js@>=2.3.6 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.4.tgz"
                 }
               }
             },
             "create-hmac": {
-              "version": "1.1.3",
-              "from": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.3.tgz",
-              "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.3.tgz"
+              "version": "1.1.4",
+              "from": "create-hmac@>=1.1.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.4.tgz"
             },
             "diffie-hellman": {
               "version": "3.0.2",
-              "from": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-3.0.2.tgz",
+              "from": "diffie-hellman@>=3.0.1 <4.0.0",
               "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-3.0.2.tgz",
               "dependencies": {
                 "bn.js": {
                   "version": "2.2.0",
-                  "from": "https://registry.npmjs.org/bn.js/-/bn.js-2.2.0.tgz",
+                  "from": "bn.js@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-2.2.0.tgz"
                 },
                 "miller-rabin": {
                   "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-2.0.1.tgz",
+                  "from": "miller-rabin@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-2.0.1.tgz",
                   "dependencies": {
                     "brorand": {
                       "version": "1.0.5",
-                      "from": "https://registry.npmjs.org/brorand/-/brorand-1.0.5.tgz",
+                      "from": "brorand@>=1.0.1 <2.0.0",
                       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.0.5.tgz"
                     }
                   }
@@ -382,40 +450,62 @@
             },
             "pbkdf2": {
               "version": "3.0.4",
-              "from": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.4.tgz",
+              "from": "pbkdf2@>=3.0.3 <4.0.0",
               "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.4.tgz"
             },
             "public-encrypt": {
               "version": "2.0.1",
-              "from": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-2.0.1.tgz",
+              "from": "public-encrypt@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-2.0.1.tgz",
               "dependencies": {
                 "bn.js": {
                   "version": "2.2.0",
-                  "from": "https://registry.npmjs.org/bn.js/-/bn.js-2.2.0.tgz",
+                  "from": "bn.js@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-2.2.0.tgz"
                 },
                 "browserify-rsa": {
                   "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-2.0.1.tgz",
+                  "from": "browserify-rsa@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-2.0.1.tgz"
                 },
                 "parse-asn1": {
-                  "version": "3.0.1",
-                  "from": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-3.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-3.0.1.tgz",
+                  "version": "3.0.2",
+                  "from": "parse-asn1@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-3.0.2.tgz",
                   "dependencies": {
                     "asn1.js": {
-                      "version": "2.2.0",
-                      "from": "https://registry.npmjs.org/asn1.js/-/asn1.js-2.2.0.tgz",
-                      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-2.2.0.tgz",
+                      "version": "2.2.1",
+                      "from": "asn1.js@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-2.2.1.tgz",
                       "dependencies": {
                         "minimalistic-assert": {
                           "version": "1.0.0",
-                          "from": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz",
+                          "from": "minimalistic-assert@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz"
                         }
                       }
+                    },
+                    "browserify-aes": {
+                      "version": "1.0.5",
+                      "from": "browserify-aes@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.5.tgz",
+                      "dependencies": {
+                        "buffer-xor": {
+                          "version": "1.0.3",
+                          "from": "buffer-xor@>=1.0.2 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz"
+                        },
+                        "cipher-base": {
+                          "version": "1.0.1",
+                          "from": "cipher-base@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "evp_bytestokey": {
+                      "version": "1.0.0",
+                      "from": "evp_bytestokey@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.0.tgz"
                     }
                   }
                 }
@@ -423,39 +513,39 @@
             },
             "randombytes": {
               "version": "2.0.1",
-              "from": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.1.tgz",
+              "from": "randombytes@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.1.tgz"
             }
           }
         },
         "deep-equal": {
-          "version": "1.0.0",
-          "from": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.0.tgz"
+          "version": "1.0.1",
+          "from": "deep-equal@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz"
         },
         "defined": {
           "version": "0.0.0",
-          "from": "https://registry.npmjs.org/defined/-/defined-0.0.0.tgz",
+          "from": "defined@>=0.0.0 <0.1.0",
           "resolved": "https://registry.npmjs.org/defined/-/defined-0.0.0.tgz"
         },
         "deps-sort": {
           "version": "1.3.9",
-          "from": "https://registry.npmjs.org/deps-sort/-/deps-sort-1.3.9.tgz",
+          "from": "deps-sort@>=1.3.5 <2.0.0",
           "resolved": "https://registry.npmjs.org/deps-sort/-/deps-sort-1.3.9.tgz",
           "dependencies": {
             "JSONStream": {
-              "version": "1.0.4",
-              "from": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.0.4.tgz",
-              "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.0.4.tgz",
+              "version": "1.0.6",
+              "from": "JSONStream@>=1.0.3 <2.0.0",
+              "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.0.6.tgz",
               "dependencies": {
                 "jsonparse": {
-                  "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.0.0.tgz"
+                  "version": "1.1.0",
+                  "from": "jsonparse@>=1.1.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.1.0.tgz"
                 },
                 "through": {
                   "version": "2.3.8",
-                  "from": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+                  "from": "through@>=2.2.7 <3.0.0",
                   "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
                 }
               }
@@ -464,54 +554,54 @@
         },
         "domain-browser": {
           "version": "1.1.4",
-          "from": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.4.tgz",
+          "from": "domain-browser@>=1.1.0 <1.2.0",
           "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.4.tgz"
         },
         "duplexer2": {
           "version": "0.0.2",
-          "from": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+          "from": "duplexer2@>=0.0.2 <0.1.0",
           "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz"
         },
         "events": {
           "version": "1.0.2",
-          "from": "https://registry.npmjs.org/events/-/events-1.0.2.tgz",
+          "from": "events@>=1.0.0 <1.1.0",
           "resolved": "https://registry.npmjs.org/events/-/events-1.0.2.tgz"
         },
         "glob": {
           "version": "4.5.3",
-          "from": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+          "from": "glob@>=4.0.5 <5.0.0",
           "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
           "dependencies": {
             "inflight": {
               "version": "1.0.4",
-              "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+              "from": "inflight@>=1.0.4 <2.0.0",
               "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                  "from": "wrappy@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                 }
               }
             },
             "minimatch": {
               "version": "2.0.10",
-              "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+              "from": "minimatch@>=2.0.1 <3.0.0",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
               "dependencies": {
                 "brace-expansion": {
-                  "version": "1.1.0",
-                  "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
-                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                  "version": "1.1.1",
+                  "from": "brace-expansion@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz",
                   "dependencies": {
                     "balanced-match": {
                       "version": "0.2.0",
-                      "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz",
+                      "from": "balanced-match@>=0.2.0 <0.3.0",
                       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
                     },
                     "concat-map": {
                       "version": "0.0.1",
-                      "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                      "from": "concat-map@0.0.1",
                       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                     }
                   }
@@ -520,12 +610,12 @@
             },
             "once": {
               "version": "1.3.2",
-              "from": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+              "from": "once@>=1.3.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                  "from": "wrappy@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                 }
               }
@@ -534,107 +624,112 @@
         },
         "has": {
           "version": "1.0.1",
-          "from": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
+          "from": "has@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
           "dependencies": {
             "function-bind": {
               "version": "1.0.2",
-              "from": "https://registry.npmjs.org/function-bind/-/function-bind-1.0.2.tgz",
+              "from": "function-bind@>=1.0.2 <2.0.0",
               "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.0.2.tgz"
             }
           }
         },
         "http-browserify": {
           "version": "1.7.0",
-          "from": "https://registry.npmjs.org/http-browserify/-/http-browserify-1.7.0.tgz",
+          "from": "http-browserify@>=1.4.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/http-browserify/-/http-browserify-1.7.0.tgz",
           "dependencies": {
             "Base64": {
               "version": "0.2.1",
-              "from": "https://registry.npmjs.org/Base64/-/Base64-0.2.1.tgz",
+              "from": "Base64@>=0.2.0 <0.3.0",
               "resolved": "https://registry.npmjs.org/Base64/-/Base64-0.2.1.tgz"
             }
           }
         },
         "https-browserify": {
-          "version": "0.0.0",
-          "from": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.0.tgz"
+          "version": "0.0.1",
+          "from": "https-browserify@>=0.0.0 <0.1.0",
+          "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.1.tgz"
         },
         "inherits": {
           "version": "2.0.1",
-          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+          "from": "inherits@>=2.0.1 <2.1.0",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
         },
         "insert-module-globals": {
-          "version": "6.5.2",
-          "from": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-6.5.2.tgz",
-          "resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-6.5.2.tgz",
+          "version": "6.6.0",
+          "from": "insert-module-globals@>=6.2.0 <7.0.0",
+          "resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-6.6.0.tgz",
           "dependencies": {
             "JSONStream": {
-              "version": "1.0.4",
-              "from": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.0.4.tgz",
-              "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.0.4.tgz",
+              "version": "1.0.6",
+              "from": "JSONStream@>=1.0.3 <2.0.0",
+              "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.0.6.tgz",
               "dependencies": {
                 "jsonparse": {
-                  "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.0.0.tgz"
+                  "version": "1.1.0",
+                  "from": "jsonparse@>=1.1.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.1.0.tgz"
                 },
                 "through": {
                   "version": "2.3.8",
-                  "from": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+                  "from": "through@>=2.2.7 <3.0.0",
                   "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
                 }
               }
             },
             "combine-source-map": {
               "version": "0.6.1",
-              "from": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.6.1.tgz",
+              "from": "combine-source-map@>=0.6.1 <0.7.0",
               "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.6.1.tgz",
               "dependencies": {
                 "convert-source-map": {
                   "version": "1.1.1",
-                  "from": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.1.tgz",
+                  "from": "convert-source-map@>=1.1.0 <1.2.0",
                   "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.1.tgz"
                 },
                 "inline-source-map": {
                   "version": "0.5.0",
-                  "from": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.5.0.tgz",
+                  "from": "inline-source-map@>=0.5.0 <0.6.0",
                   "resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.5.0.tgz"
                 },
                 "lodash.memoize": {
                   "version": "3.0.4",
-                  "from": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-3.0.4.tgz",
+                  "from": "lodash.memoize@>=3.0.3 <3.1.0",
                   "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-3.0.4.tgz"
                 },
                 "source-map": {
                   "version": "0.4.4",
-                  "from": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+                  "from": "source-map@>=0.4.2 <0.5.0",
                   "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
                   "dependencies": {
                     "amdefine": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
+                      "from": "amdefine@>=0.0.4",
                       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
                     }
                   }
                 }
               }
             },
+            "is-buffer": {
+              "version": "1.1.0",
+              "from": "is-buffer@>=1.1.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.0.tgz"
+            },
             "lexical-scope": {
-              "version": "1.1.1",
-              "from": "https://registry.npmjs.org/lexical-scope/-/lexical-scope-1.1.1.tgz",
-              "resolved": "https://registry.npmjs.org/lexical-scope/-/lexical-scope-1.1.1.tgz",
+              "version": "1.2.0",
+              "from": "lexical-scope@>=1.2.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/lexical-scope/-/lexical-scope-1.2.0.tgz",
               "dependencies": {
                 "astw": {
                   "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/astw/-/astw-2.0.0.tgz",
+                  "from": "astw@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/astw/-/astw-2.0.0.tgz",
                   "dependencies": {
                     "acorn": {
                       "version": "1.2.2",
-                      "from": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz",
+                      "from": "acorn@>=1.0.3 <2.0.0",
                       "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz"
                     }
                   }
@@ -642,40 +737,40 @@
               }
             },
             "process": {
-              "version": "0.11.1",
-              "from": "https://registry.npmjs.org/process/-/process-0.11.1.tgz",
-              "resolved": "https://registry.npmjs.org/process/-/process-0.11.1.tgz"
+              "version": "0.11.2",
+              "from": "process@>=0.11.0 <0.12.0",
+              "resolved": "https://registry.npmjs.org/process/-/process-0.11.2.tgz"
             },
             "xtend": {
               "version": "4.0.0",
-              "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz",
+              "from": "xtend@>=4.0.0 <5.0.0",
               "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
             }
           }
         },
         "isarray": {
           "version": "0.0.1",
-          "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "from": "isarray@0.0.1",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
         },
         "labeled-stream-splicer": {
           "version": "1.0.2",
-          "from": "https://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-1.0.2.tgz",
+          "from": "labeled-stream-splicer@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-1.0.2.tgz",
           "dependencies": {
             "stream-splicer": {
               "version": "1.3.2",
-              "from": "https://registry.npmjs.org/stream-splicer/-/stream-splicer-1.3.2.tgz",
+              "from": "stream-splicer@>=1.1.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/stream-splicer/-/stream-splicer-1.3.2.tgz",
               "dependencies": {
                 "readable-wrap": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/readable-wrap/-/readable-wrap-1.0.0.tgz",
+                  "from": "readable-wrap@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/readable-wrap/-/readable-wrap-1.0.0.tgz"
                 },
                 "indexof": {
                   "version": "0.0.1",
-                  "from": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
+                  "from": "indexof@0.0.1",
                   "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
                 }
               }
@@ -683,107 +778,107 @@
           }
         },
         "module-deps": {
-          "version": "3.9.0",
-          "from": "https://registry.npmjs.org/module-deps/-/module-deps-3.9.0.tgz",
-          "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-3.9.0.tgz",
+          "version": "3.9.1",
+          "from": "module-deps@>=3.7.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-3.9.1.tgz",
           "dependencies": {
             "JSONStream": {
-              "version": "1.0.4",
-              "from": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.0.4.tgz",
-              "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.0.4.tgz",
+              "version": "1.0.6",
+              "from": "JSONStream@>=1.0.3 <2.0.0",
+              "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.0.6.tgz",
               "dependencies": {
                 "jsonparse": {
-                  "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.0.0.tgz"
+                  "version": "1.1.0",
+                  "from": "jsonparse@>=1.1.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.1.0.tgz"
                 },
                 "through": {
                   "version": "2.3.8",
-                  "from": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+                  "from": "through@>=2.2.7 <3.0.0",
                   "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
                 }
               }
             },
             "defined": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+              "from": "defined@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz"
             },
             "detective": {
-              "version": "4.1.1",
-              "from": "https://registry.npmjs.org/detective/-/detective-4.1.1.tgz",
-              "resolved": "https://registry.npmjs.org/detective/-/detective-4.1.1.tgz",
+              "version": "4.2.0",
+              "from": "detective@>=4.0.0 <5.0.0",
+              "resolved": "https://registry.npmjs.org/detective/-/detective-4.2.0.tgz",
               "dependencies": {
                 "acorn": {
                   "version": "1.2.2",
-                  "from": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz",
+                  "from": "acorn@>=1.0.3 <2.0.0",
                   "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz"
                 },
                 "escodegen": {
-                  "version": "1.6.1",
-                  "from": "https://registry.npmjs.org/escodegen/-/escodegen-1.6.1.tgz",
-                  "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.6.1.tgz",
+                  "version": "1.7.0",
+                  "from": "escodegen@>=1.4.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.7.0.tgz",
                   "dependencies": {
                     "estraverse": {
                       "version": "1.9.3",
-                      "from": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
+                      "from": "estraverse@>=1.9.1 <2.0.0",
                       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz"
                     },
                     "esutils": {
-                      "version": "1.1.6",
-                      "from": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz",
-                      "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz"
+                      "version": "2.0.2",
+                      "from": "esutils@>=2.0.2 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
                     },
                     "esprima": {
                       "version": "1.2.5",
-                      "from": "https://registry.npmjs.org/esprima/-/esprima-1.2.5.tgz",
+                      "from": "esprima@>=1.2.2 <2.0.0",
                       "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.5.tgz"
                     },
                     "optionator": {
                       "version": "0.5.0",
-                      "from": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
+                      "from": "optionator@>=0.5.0 <0.6.0",
                       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
                       "dependencies": {
                         "prelude-ls": {
                           "version": "1.1.2",
-                          "from": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+                          "from": "prelude-ls@>=1.1.1 <1.2.0",
                           "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
                         },
                         "deep-is": {
                           "version": "0.1.3",
-                          "from": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+                          "from": "deep-is@>=0.1.2 <0.2.0",
                           "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
                         },
                         "wordwrap": {
                           "version": "0.0.3",
-                          "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+                          "from": "wordwrap@>=0.0.2 <0.1.0",
                           "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
                         },
                         "type-check": {
                           "version": "0.3.1",
-                          "from": "https://registry.npmjs.org/type-check/-/type-check-0.3.1.tgz",
+                          "from": "type-check@>=0.3.1 <0.4.0",
                           "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.1.tgz"
                         },
                         "levn": {
                           "version": "0.2.5",
-                          "from": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz",
+                          "from": "levn@>=0.2.5 <0.3.0",
                           "resolved": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz"
                         },
                         "fast-levenshtein": {
                           "version": "1.0.7",
-                          "from": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.7.tgz",
+                          "from": "fast-levenshtein@>=1.0.0 <1.1.0",
                           "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.7.tgz"
                         }
                       }
                     },
                     "source-map": {
-                      "version": "0.1.43",
-                      "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
-                      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+                      "version": "0.2.0",
+                      "from": "source-map@>=0.2.0 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
                       "dependencies": {
                         "amdefine": {
                           "version": "1.0.0",
-                          "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
+                          "from": "amdefine@>=0.0.4",
                           "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
                         }
                       }
@@ -794,29 +889,29 @@
             },
             "stream-combiner2": {
               "version": "1.0.2",
-              "from": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.0.2.tgz",
+              "from": "stream-combiner2@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.0.2.tgz",
               "dependencies": {
                 "through2": {
                   "version": "0.5.1",
-                  "from": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
+                  "from": "through2@>=0.5.1 <0.6.0",
                   "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
                   "dependencies": {
                     "readable-stream": {
                       "version": "1.0.33",
-                      "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                      "from": "readable-stream@>=1.0.17 <1.1.0",
                       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                          "from": "core-util-is@>=1.0.0 <1.1.0",
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                         }
                       }
                     },
                     "xtend": {
                       "version": "3.0.0",
-                      "from": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
+                      "from": "xtend@>=3.0.0 <3.1.0",
                       "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz"
                     }
                   }
@@ -825,221 +920,221 @@
             },
             "xtend": {
               "version": "4.0.0",
-              "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz",
+              "from": "xtend@>=4.0.0 <5.0.0",
               "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
             }
           }
         },
         "os-browserify": {
           "version": "0.1.2",
-          "from": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz",
+          "from": "os-browserify@>=0.1.1 <0.2.0",
           "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz"
         },
         "parents": {
           "version": "1.0.1",
-          "from": "https://registry.npmjs.org/parents/-/parents-1.0.1.tgz",
+          "from": "parents@>=1.0.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/parents/-/parents-1.0.1.tgz",
           "dependencies": {
             "path-platform": {
               "version": "0.11.15",
-              "from": "https://registry.npmjs.org/path-platform/-/path-platform-0.11.15.tgz",
+              "from": "path-platform@>=0.11.15 <0.12.0",
               "resolved": "https://registry.npmjs.org/path-platform/-/path-platform-0.11.15.tgz"
             }
           }
         },
         "path-browserify": {
           "version": "0.0.0",
-          "from": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
+          "from": "path-browserify@>=0.0.0 <0.1.0",
           "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz"
         },
         "process": {
           "version": "0.10.1",
-          "from": "https://registry.npmjs.org/process/-/process-0.10.1.tgz",
+          "from": "process@>=0.10.0 <0.11.0",
           "resolved": "https://registry.npmjs.org/process/-/process-0.10.1.tgz"
         },
         "punycode": {
           "version": "1.2.4",
-          "from": "https://registry.npmjs.org/punycode/-/punycode-1.2.4.tgz",
+          "from": "punycode@>=1.2.3 <1.3.0",
           "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.2.4.tgz"
         },
         "querystring-es3": {
           "version": "0.2.1",
-          "from": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
+          "from": "querystring-es3@>=0.2.0 <0.3.0",
           "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz"
         },
         "readable-stream": {
           "version": "1.1.13",
-          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+          "from": "readable-stream@>=1.1.13 <2.0.0",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
           "dependencies": {
             "core-util-is": {
               "version": "1.0.1",
-              "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+              "from": "core-util-is@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
             }
           }
         },
         "resolve": {
           "version": "1.1.6",
-          "from": "https://registry.npmjs.org/resolve/-/resolve-1.1.6.tgz",
+          "from": "resolve@>=1.1.4 <2.0.0",
           "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.6.tgz"
         },
         "shallow-copy": {
           "version": "0.0.1",
-          "from": "https://registry.npmjs.org/shallow-copy/-/shallow-copy-0.0.1.tgz",
+          "from": "shallow-copy@0.0.1",
           "resolved": "https://registry.npmjs.org/shallow-copy/-/shallow-copy-0.0.1.tgz"
         },
         "shasum": {
           "version": "1.0.1",
-          "from": "https://registry.npmjs.org/shasum/-/shasum-1.0.1.tgz",
+          "from": "shasum@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/shasum/-/shasum-1.0.1.tgz",
           "dependencies": {
             "json-stable-stringify": {
               "version": "0.0.1",
-              "from": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-0.0.1.tgz",
+              "from": "json-stable-stringify@>=0.0.0 <0.1.0",
               "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-0.0.1.tgz",
               "dependencies": {
                 "jsonify": {
                   "version": "0.0.0",
-                  "from": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+                  "from": "jsonify@>=0.0.0 <0.1.0",
                   "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
                 }
               }
             },
             "sha.js": {
               "version": "2.3.6",
-              "from": "https://registry.npmjs.org/sha.js/-/sha.js-2.3.6.tgz",
+              "from": "sha.js@>=2.3.0 <2.4.0",
               "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.3.6.tgz"
             }
           }
         },
         "shell-quote": {
           "version": "0.0.1",
-          "from": "https://registry.npmjs.org/shell-quote/-/shell-quote-0.0.1.tgz",
+          "from": "shell-quote@>=0.0.1 <0.1.0",
           "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-0.0.1.tgz"
         },
         "stream-browserify": {
           "version": "1.0.0",
-          "from": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-1.0.0.tgz",
+          "from": "stream-browserify@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-1.0.0.tgz"
         },
         "string_decoder": {
           "version": "0.10.31",
-          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "from": "string_decoder@>=0.10.0 <0.11.0",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
         },
         "subarg": {
           "version": "1.0.0",
-          "from": "https://registry.npmjs.org/subarg/-/subarg-1.0.0.tgz",
+          "from": "subarg@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/subarg/-/subarg-1.0.0.tgz",
           "dependencies": {
             "minimist": {
-              "version": "1.1.3",
-              "from": "https://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz"
+              "version": "1.2.0",
+              "from": "minimist@>=1.1.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
             }
           }
         },
         "syntax-error": {
           "version": "1.1.4",
-          "from": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.1.4.tgz",
+          "from": "syntax-error@>=1.1.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.1.4.tgz",
           "dependencies": {
             "acorn": {
               "version": "1.2.2",
-              "from": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz",
+              "from": "acorn@>=1.0.3 <2.0.0",
               "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz"
             }
           }
         },
         "through2": {
           "version": "1.1.1",
-          "from": "https://registry.npmjs.org/through2/-/through2-1.1.1.tgz",
+          "from": "through2@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/through2/-/through2-1.1.1.tgz",
           "dependencies": {
             "xtend": {
               "version": "4.0.0",
-              "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz",
+              "from": "xtend@>=4.0.0 <4.1.0-0",
               "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
             }
           }
         },
         "timers-browserify": {
           "version": "1.4.1",
-          "from": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.1.tgz",
+          "from": "timers-browserify@>=1.0.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.1.tgz",
           "dependencies": {
             "process": {
-              "version": "0.11.1",
-              "from": "https://registry.npmjs.org/process/-/process-0.11.1.tgz",
-              "resolved": "https://registry.npmjs.org/process/-/process-0.11.1.tgz"
+              "version": "0.11.2",
+              "from": "process@>=0.11.0 <0.12.0",
+              "resolved": "https://registry.npmjs.org/process/-/process-0.11.2.tgz"
             }
           }
         },
         "tty-browserify": {
           "version": "0.0.0",
-          "from": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
+          "from": "tty-browserify@>=0.0.0 <0.1.0",
           "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz"
         },
         "url": {
           "version": "0.10.3",
-          "from": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+          "from": "url@>=0.10.1 <0.11.0",
           "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
           "dependencies": {
             "punycode": {
               "version": "1.3.2",
-              "from": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+              "from": "punycode@1.3.2",
               "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
             },
             "querystring": {
               "version": "0.2.0",
-              "from": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+              "from": "querystring@0.2.0",
               "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz"
             }
           }
         },
         "util": {
           "version": "0.10.3",
-          "from": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+          "from": "util@>=0.10.1 <0.11.0",
           "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz"
         },
         "vm-browserify": {
           "version": "0.0.4",
-          "from": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
+          "from": "vm-browserify@>=0.0.1 <0.1.0",
           "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
           "dependencies": {
             "indexof": {
               "version": "0.0.1",
-              "from": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
+              "from": "indexof@0.0.1",
               "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
             }
           }
         },
         "xtend": {
           "version": "3.0.0",
-          "from": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
+          "from": "xtend@>=3.0.0 <4.0.0",
           "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz"
         }
       }
     },
     "chai": {
       "version": "1.10.0",
-      "from": "https://registry.npmjs.org/chai/-/chai-1.10.0.tgz",
+      "from": "chai@1.10.0",
       "resolved": "https://registry.npmjs.org/chai/-/chai-1.10.0.tgz",
       "dependencies": {
         "assertion-error": {
           "version": "1.0.0",
-          "from": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.0.tgz",
+          "from": "assertion-error@1.0.0",
           "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.0.tgz"
         },
         "deep-eql": {
           "version": "0.1.3",
-          "from": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
+          "from": "deep-eql@0.1.3",
           "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
           "dependencies": {
             "type-detect": {
               "version": "0.1.1",
-              "from": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
+              "from": "type-detect@0.1.1",
               "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz"
             }
           }
@@ -1048,93 +1143,93 @@
     },
     "eslint": {
       "version": "1.1.0",
-      "from": "https://registry.npmjs.org/eslint/-/eslint-1.1.0.tgz",
+      "from": "eslint@1.1.0",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-1.1.0.tgz",
       "dependencies": {
         "chalk": {
-          "version": "1.1.0",
-          "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.0.tgz",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.0.tgz",
+          "version": "1.1.1",
+          "from": "chalk@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
           "dependencies": {
             "ansi-styles": {
               "version": "2.1.0",
-              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
+              "from": "ansi-styles@>=2.1.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
             },
             "has-ansi": {
               "version": "2.0.0",
-              "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+              "from": "has-ansi@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                  "from": "ansi-regex@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                 }
               }
             },
             "strip-ansi": {
               "version": "3.0.0",
-              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+              "from": "strip-ansi@>=3.0.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                  "from": "ansi-regex@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                 }
               }
             },
             "supports-color": {
               "version": "2.0.0",
-              "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+              "from": "supports-color@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
             }
           }
         },
         "concat-stream": {
           "version": "1.5.0",
-          "from": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.0.tgz",
+          "from": "concat-stream@>=1.4.6 <2.0.0",
           "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.0.tgz",
           "dependencies": {
             "inherits": {
               "version": "2.0.1",
-              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+              "from": "inherits@>=2.0.1 <2.1.0",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             },
             "typedarray": {
               "version": "0.0.6",
-              "from": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+              "from": "typedarray@>=0.0.5 <0.1.0",
               "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
             },
             "readable-stream": {
               "version": "2.0.2",
-              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
+              "from": "readable-stream@>=2.0.0 <2.1.0",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                  "from": "core-util-is@>=1.0.0 <1.1.0",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                 },
                 "isarray": {
                   "version": "0.0.1",
-                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                  "from": "isarray@0.0.1",
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "process-nextick-args": {
-                  "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.2.tgz"
+                  "version": "1.0.3",
+                  "from": "process-nextick-args@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.3.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                  "from": "string_decoder@>=0.10.0 <0.11.0",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "util-deprecate": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz",
+                  "from": "util-deprecate@>=1.0.1 <1.1.0",
                   "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
                 }
               }
@@ -1143,196 +1238,196 @@
         },
         "debug": {
           "version": "2.2.0",
-          "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+          "from": "debug@>=2.1.1 <3.0.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "dependencies": {
             "ms": {
               "version": "0.7.1",
-              "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+              "from": "ms@0.7.1",
               "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
             }
           }
         },
         "doctrine": {
           "version": "0.6.4",
-          "from": "https://registry.npmjs.org/doctrine/-/doctrine-0.6.4.tgz",
+          "from": "doctrine@>=0.6.2 <0.7.0",
           "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-0.6.4.tgz",
           "dependencies": {
             "esutils": {
               "version": "1.1.6",
-              "from": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz",
+              "from": "esutils@>=1.1.6 <2.0.0",
               "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz"
             },
             "isarray": {
               "version": "0.0.1",
-              "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+              "from": "isarray@0.0.1",
               "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
             }
           }
         },
         "escape-string-regexp": {
           "version": "1.0.3",
-          "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
+          "from": "escape-string-regexp@>=1.0.2 <2.0.0",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
         },
         "escope": {
           "version": "3.2.0",
-          "from": "https://registry.npmjs.org/escope/-/escope-3.2.0.tgz",
+          "from": "escope@>=3.2.0 <4.0.0",
           "resolved": "https://registry.npmjs.org/escope/-/escope-3.2.0.tgz",
           "dependencies": {
             "es6-map": {
               "version": "0.1.1",
-              "from": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.1.tgz",
+              "from": "es6-map@>=0.1.1 <0.2.0",
               "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.1.tgz",
               "dependencies": {
                 "d": {
                   "version": "0.1.1",
-                  "from": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
+                  "from": "d@>=0.1.1 <0.2.0",
                   "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
                 },
                 "es5-ext": {
                   "version": "0.10.7",
-                  "from": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.7.tgz",
+                  "from": "es5-ext@>=0.10.4 <0.11.0",
                   "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.7.tgz",
                   "dependencies": {
                     "es6-symbol": {
                       "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz",
+                      "from": "es6-symbol@>=2.0.1 <2.1.0",
                       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
                     }
                   }
                 },
                 "es6-iterator": {
                   "version": "0.1.3",
-                  "from": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz",
+                  "from": "es6-iterator@>=0.1.1 <0.2.0",
                   "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz",
                   "dependencies": {
                     "es6-symbol": {
                       "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz",
+                      "from": "es6-symbol@>=2.0.1 <2.1.0",
                       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
                     }
                   }
                 },
                 "es6-set": {
                   "version": "0.1.1",
-                  "from": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.1.tgz",
+                  "from": "es6-set@>=0.1.1 <0.2.0",
                   "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.1.tgz"
                 },
                 "es6-symbol": {
                   "version": "0.1.1",
-                  "from": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-0.1.1.tgz",
+                  "from": "es6-symbol@>=0.1.1 <0.2.0",
                   "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-0.1.1.tgz"
                 },
                 "event-emitter": {
                   "version": "0.3.3",
-                  "from": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.3.tgz",
+                  "from": "event-emitter@>=0.3.1 <0.4.0",
                   "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.3.tgz"
                 }
               }
             },
             "es6-weak-map": {
               "version": "0.1.4",
-              "from": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-0.1.4.tgz",
+              "from": "es6-weak-map@>=0.1.2 <0.2.0",
               "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-0.1.4.tgz",
               "dependencies": {
                 "d": {
                   "version": "0.1.1",
-                  "from": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
+                  "from": "d@>=0.1.1 <0.2.0",
                   "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
                 },
                 "es5-ext": {
                   "version": "0.10.7",
-                  "from": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.7.tgz",
+                  "from": "es5-ext@>=0.10.6 <0.11.0",
                   "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.7.tgz"
                 },
                 "es6-iterator": {
                   "version": "0.1.3",
-                  "from": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz",
+                  "from": "es6-iterator@>=0.1.3 <0.2.0",
                   "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz"
                 },
                 "es6-symbol": {
                   "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz",
+                  "from": "es6-symbol@>=2.0.1 <2.1.0",
                   "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
                 }
               }
             },
             "esrecurse": {
               "version": "3.1.1",
-              "from": "https://registry.npmjs.org/esrecurse/-/esrecurse-3.1.1.tgz",
+              "from": "esrecurse@>=3.1.1 <4.0.0",
               "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-3.1.1.tgz"
             },
             "estraverse": {
               "version": "3.1.0",
-              "from": "https://registry.npmjs.org/estraverse/-/estraverse-3.1.0.tgz",
+              "from": "estraverse@>=3.1.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-3.1.0.tgz"
             }
           }
         },
         "espree": {
-          "version": "2.2.4",
-          "from": "https://registry.npmjs.org/espree/-/espree-2.2.4.tgz",
-          "resolved": "https://registry.npmjs.org/espree/-/espree-2.2.4.tgz"
+          "version": "2.2.5",
+          "from": "espree@>=2.2.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/espree/-/espree-2.2.5.tgz"
         },
         "estraverse": {
           "version": "4.1.0",
-          "from": "https://registry.npmjs.org/estraverse/-/estraverse-4.1.0.tgz",
+          "from": "estraverse@>=4.1.0 <5.0.0",
           "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.1.0.tgz"
         },
         "estraverse-fb": {
           "version": "1.3.1",
-          "from": "https://registry.npmjs.org/estraverse-fb/-/estraverse-fb-1.3.1.tgz",
+          "from": "estraverse-fb@>=1.3.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/estraverse-fb/-/estraverse-fb-1.3.1.tgz"
         },
         "globals": {
-          "version": "8.3.0",
-          "from": "https://registry.npmjs.org/globals/-/globals-8.3.0.tgz",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-8.3.0.tgz"
+          "version": "8.10.0",
+          "from": "globals@>=8.3.0 <9.0.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-8.10.0.tgz"
         },
         "inquirer": {
           "version": "0.9.0",
-          "from": "https://registry.npmjs.org/inquirer/-/inquirer-0.9.0.tgz",
+          "from": "inquirer@>=0.9.0 <0.10.0",
           "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.9.0.tgz",
           "dependencies": {
             "ansi-regex": {
               "version": "2.0.0",
-              "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+              "from": "ansi-regex@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
             },
             "cli-width": {
               "version": "1.0.1",
-              "from": "https://registry.npmjs.org/cli-width/-/cli-width-1.0.1.tgz",
+              "from": "cli-width@>=1.0.1 <2.0.0",
               "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-1.0.1.tgz"
             },
             "figures": {
-              "version": "1.3.5",
-              "from": "https://registry.npmjs.org/figures/-/figures-1.3.5.tgz",
-              "resolved": "https://registry.npmjs.org/figures/-/figures-1.3.5.tgz"
+              "version": "1.4.0",
+              "from": "figures@>=1.3.5 <2.0.0",
+              "resolved": "https://registry.npmjs.org/figures/-/figures-1.4.0.tgz"
             },
             "lodash": {
               "version": "3.10.1",
-              "from": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+              "from": "lodash@>=3.3.1 <4.0.0",
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
             },
             "readline2": {
               "version": "0.1.1",
-              "from": "https://registry.npmjs.org/readline2/-/readline2-0.1.1.tgz",
+              "from": "readline2@>=0.1.1 <0.2.0",
               "resolved": "https://registry.npmjs.org/readline2/-/readline2-0.1.1.tgz",
               "dependencies": {
                 "mute-stream": {
                   "version": "0.0.4",
-                  "from": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.4.tgz",
+                  "from": "mute-stream@0.0.4",
                   "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.4.tgz"
                 },
                 "strip-ansi": {
                   "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+                  "from": "strip-ansi@>=2.0.1 <3.0.0",
                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "1.1.1",
-                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz",
+                      "from": "ansi-regex@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
                     }
                   }
@@ -1341,17 +1436,17 @@
             },
             "run-async": {
               "version": "0.1.0",
-              "from": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
+              "from": "run-async@>=0.1.0 <0.2.0",
               "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
               "dependencies": {
                 "once": {
                   "version": "1.3.2",
-                  "from": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                  "from": "once@>=1.3.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     }
                   }
@@ -1360,139 +1455,139 @@
             },
             "rx-lite": {
               "version": "2.5.2",
-              "from": "https://registry.npmjs.org/rx-lite/-/rx-lite-2.5.2.tgz",
+              "from": "rx-lite@>=2.5.2 <3.0.0",
               "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-2.5.2.tgz"
             },
             "strip-ansi": {
               "version": "3.0.0",
-              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+              "from": "strip-ansi@>=3.0.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz"
             },
             "through": {
               "version": "2.3.8",
-              "from": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+              "from": "through@>=2.3.6 <3.0.0",
               "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
             }
           }
         },
         "is-my-json-valid": {
-          "version": "2.12.1",
-          "from": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.1.tgz",
-          "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.1.tgz",
+          "version": "2.12.2",
+          "from": "is-my-json-valid@>=2.10.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.2.tgz",
           "dependencies": {
             "generate-function": {
               "version": "2.0.0",
-              "from": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+              "from": "generate-function@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
             },
             "generate-object-property": {
               "version": "1.2.0",
-              "from": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+              "from": "generate-object-property@>=1.1.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
               "dependencies": {
                 "is-property": {
                   "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+                  "from": "is-property@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
                 }
               }
             },
             "jsonpointer": {
-              "version": "1.1.0",
-              "from": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-1.1.0.tgz",
-              "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-1.1.0.tgz"
+              "version": "2.0.0",
+              "from": "jsonpointer@2.0.0",
+              "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
             },
             "xtend": {
               "version": "4.0.0",
-              "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz",
+              "from": "xtend@>=4.0.0 <5.0.0",
               "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
             }
           }
         },
         "js-yaml": {
-          "version": "3.3.1",
-          "from": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.3.1.tgz",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.3.1.tgz",
+          "version": "3.4.2",
+          "from": "js-yaml@>=3.2.5 <4.0.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.4.2.tgz",
           "dependencies": {
             "argparse": {
               "version": "1.0.2",
-              "from": "https://registry.npmjs.org/argparse/-/argparse-1.0.2.tgz",
+              "from": "argparse@>=1.0.2 <1.1.0",
               "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.2.tgz",
               "dependencies": {
                 "lodash": {
                   "version": "3.10.1",
-                  "from": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+                  "from": "lodash@>=3.2.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
                 },
                 "sprintf-js": {
                   "version": "1.0.3",
-                  "from": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+                  "from": "sprintf-js@>=1.0.2 <1.1.0",
                   "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
                 }
               }
             },
             "esprima": {
               "version": "2.2.0",
-              "from": "https://registry.npmjs.org/esprima/-/esprima-2.2.0.tgz",
+              "from": "esprima@>=2.2.0 <2.3.0",
               "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.2.0.tgz"
             }
           }
         },
         "lodash.clonedeep": {
           "version": "3.0.2",
-          "from": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-3.0.2.tgz",
+          "from": "lodash.clonedeep@>=3.0.1 <4.0.0",
           "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-3.0.2.tgz",
           "dependencies": {
             "lodash._baseclone": {
               "version": "3.3.0",
-              "from": "https://registry.npmjs.org/lodash._baseclone/-/lodash._baseclone-3.3.0.tgz",
+              "from": "lodash._baseclone@>=3.0.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/lodash._baseclone/-/lodash._baseclone-3.3.0.tgz",
               "dependencies": {
                 "lodash._arraycopy": {
                   "version": "3.0.0",
-                  "from": "https://registry.npmjs.org/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz",
+                  "from": "lodash._arraycopy@>=3.0.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz"
                 },
                 "lodash._arrayeach": {
                   "version": "3.0.0",
-                  "from": "https://registry.npmjs.org/lodash._arrayeach/-/lodash._arrayeach-3.0.0.tgz",
+                  "from": "lodash._arrayeach@>=3.0.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/lodash._arrayeach/-/lodash._arrayeach-3.0.0.tgz"
                 },
                 "lodash._baseassign": {
                   "version": "3.2.0",
-                  "from": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+                  "from": "lodash._baseassign@>=3.0.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
                   "dependencies": {
                     "lodash._basecopy": {
                       "version": "3.0.1",
-                      "from": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+                      "from": "lodash._basecopy@>=3.0.0 <4.0.0",
                       "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
                     }
                   }
                 },
                 "lodash._basefor": {
                   "version": "3.0.2",
-                  "from": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.2.tgz",
+                  "from": "lodash._basefor@>=3.0.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.2.tgz"
                 },
                 "lodash.isarray": {
                   "version": "3.0.4",
-                  "from": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+                  "from": "lodash.isarray@>=3.0.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
                 },
                 "lodash.keys": {
                   "version": "3.1.2",
-                  "from": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+                  "from": "lodash.keys@>=3.0.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
                   "dependencies": {
                     "lodash._getnative": {
                       "version": "3.9.1",
-                      "from": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+                      "from": "lodash._getnative@>=3.0.0 <4.0.0",
                       "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
                     },
                     "lodash.isarguments": {
                       "version": "3.0.4",
-                      "from": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz",
+                      "from": "lodash.isarguments@>=3.0.0 <4.0.0",
                       "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz"
                     }
                   }
@@ -1501,98 +1596,98 @@
             },
             "lodash._bindcallback": {
               "version": "3.0.1",
-              "from": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
+              "from": "lodash._bindcallback@>=3.0.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz"
             }
           }
         },
         "lodash.merge": {
           "version": "3.3.2",
-          "from": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-3.3.2.tgz",
+          "from": "lodash.merge@>=3.3.2 <4.0.0",
           "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-3.3.2.tgz",
           "dependencies": {
             "lodash._arraycopy": {
               "version": "3.0.0",
-              "from": "https://registry.npmjs.org/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz",
+              "from": "lodash._arraycopy@>=3.0.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz"
             },
             "lodash._arrayeach": {
               "version": "3.0.0",
-              "from": "https://registry.npmjs.org/lodash._arrayeach/-/lodash._arrayeach-3.0.0.tgz",
+              "from": "lodash._arrayeach@>=3.0.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/lodash._arrayeach/-/lodash._arrayeach-3.0.0.tgz"
             },
             "lodash._createassigner": {
               "version": "3.1.1",
-              "from": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
+              "from": "lodash._createassigner@>=3.0.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
               "dependencies": {
                 "lodash._bindcallback": {
                   "version": "3.0.1",
-                  "from": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
+                  "from": "lodash._bindcallback@>=3.0.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz"
                 },
                 "lodash._isiterateecall": {
                   "version": "3.0.9",
-                  "from": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+                  "from": "lodash._isiterateecall@>=3.0.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz"
                 },
                 "lodash.restparam": {
                   "version": "3.6.1",
-                  "from": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+                  "from": "lodash.restparam@>=3.0.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
                 }
               }
             },
             "lodash._getnative": {
               "version": "3.9.1",
-              "from": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+              "from": "lodash._getnative@>=3.0.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
             },
             "lodash.isarguments": {
               "version": "3.0.4",
-              "from": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz",
+              "from": "lodash.isarguments@>=3.0.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz"
             },
             "lodash.isarray": {
               "version": "3.0.4",
-              "from": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+              "from": "lodash.isarray@>=3.0.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
             },
             "lodash.isplainobject": {
               "version": "3.2.0",
-              "from": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-3.2.0.tgz",
+              "from": "lodash.isplainobject@>=3.0.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-3.2.0.tgz",
               "dependencies": {
                 "lodash._basefor": {
                   "version": "3.0.2",
-                  "from": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.2.tgz",
+                  "from": "lodash._basefor@>=3.0.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.2.tgz"
                 }
               }
             },
             "lodash.istypedarray": {
               "version": "3.0.2",
-              "from": "https://registry.npmjs.org/lodash.istypedarray/-/lodash.istypedarray-3.0.2.tgz",
+              "from": "lodash.istypedarray@>=3.0.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/lodash.istypedarray/-/lodash.istypedarray-3.0.2.tgz"
             },
             "lodash.keys": {
               "version": "3.1.2",
-              "from": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+              "from": "lodash.keys@>=3.0.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz"
             },
             "lodash.keysin": {
               "version": "3.0.8",
-              "from": "https://registry.npmjs.org/lodash.keysin/-/lodash.keysin-3.0.8.tgz",
+              "from": "lodash.keysin@>=3.0.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/lodash.keysin/-/lodash.keysin-3.0.8.tgz"
             },
             "lodash.toplainobject": {
               "version": "3.0.0",
-              "from": "https://registry.npmjs.org/lodash.toplainobject/-/lodash.toplainobject-3.0.0.tgz",
+              "from": "lodash.toplainobject@>=3.0.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/lodash.toplainobject/-/lodash.toplainobject-3.0.0.tgz",
               "dependencies": {
                 "lodash._basecopy": {
                   "version": "3.0.1",
-                  "from": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+                  "from": "lodash._basecopy@>=3.0.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
                 }
               }
@@ -1601,37 +1696,37 @@
         },
         "lodash.omit": {
           "version": "3.1.0",
-          "from": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-3.1.0.tgz",
+          "from": "lodash.omit@>=3.1.0 <4.0.0",
           "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-3.1.0.tgz",
           "dependencies": {
             "lodash._arraymap": {
               "version": "3.0.0",
-              "from": "https://registry.npmjs.org/lodash._arraymap/-/lodash._arraymap-3.0.0.tgz",
+              "from": "lodash._arraymap@>=3.0.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/lodash._arraymap/-/lodash._arraymap-3.0.0.tgz"
             },
             "lodash._basedifference": {
               "version": "3.0.3",
-              "from": "https://registry.npmjs.org/lodash._basedifference/-/lodash._basedifference-3.0.3.tgz",
+              "from": "lodash._basedifference@>=3.0.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/lodash._basedifference/-/lodash._basedifference-3.0.3.tgz",
               "dependencies": {
                 "lodash._baseindexof": {
                   "version": "3.1.0",
-                  "from": "https://registry.npmjs.org/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz",
+                  "from": "lodash._baseindexof@>=3.0.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz"
                 },
                 "lodash._cacheindexof": {
                   "version": "3.0.2",
-                  "from": "https://registry.npmjs.org/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz",
+                  "from": "lodash._cacheindexof@>=3.0.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz"
                 },
                 "lodash._createcache": {
                   "version": "3.1.2",
-                  "from": "https://registry.npmjs.org/lodash._createcache/-/lodash._createcache-3.1.2.tgz",
+                  "from": "lodash._createcache@>=3.0.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/lodash._createcache/-/lodash._createcache-3.1.2.tgz",
                   "dependencies": {
                     "lodash._getnative": {
                       "version": "3.9.1",
-                      "from": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+                      "from": "lodash._getnative@>=3.0.0 <4.0.0",
                       "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
                     }
                   }
@@ -1640,85 +1735,85 @@
             },
             "lodash._baseflatten": {
               "version": "3.1.4",
-              "from": "https://registry.npmjs.org/lodash._baseflatten/-/lodash._baseflatten-3.1.4.tgz",
+              "from": "lodash._baseflatten@>=3.0.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/lodash._baseflatten/-/lodash._baseflatten-3.1.4.tgz",
               "dependencies": {
                 "lodash.isarguments": {
                   "version": "3.0.4",
-                  "from": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz",
+                  "from": "lodash.isarguments@>=3.0.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz"
                 },
                 "lodash.isarray": {
                   "version": "3.0.4",
-                  "from": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+                  "from": "lodash.isarray@>=3.0.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
                 }
               }
             },
             "lodash._bindcallback": {
               "version": "3.0.1",
-              "from": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
+              "from": "lodash._bindcallback@>=3.0.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz"
             },
             "lodash._pickbyarray": {
               "version": "3.0.2",
-              "from": "https://registry.npmjs.org/lodash._pickbyarray/-/lodash._pickbyarray-3.0.2.tgz",
+              "from": "lodash._pickbyarray@>=3.0.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/lodash._pickbyarray/-/lodash._pickbyarray-3.0.2.tgz"
             },
             "lodash._pickbycallback": {
               "version": "3.0.0",
-              "from": "https://registry.npmjs.org/lodash._pickbycallback/-/lodash._pickbycallback-3.0.0.tgz",
+              "from": "lodash._pickbycallback@>=3.0.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/lodash._pickbycallback/-/lodash._pickbycallback-3.0.0.tgz",
               "dependencies": {
                 "lodash._basefor": {
                   "version": "3.0.2",
-                  "from": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.2.tgz",
+                  "from": "lodash._basefor@>=3.0.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.2.tgz"
                 }
               }
             },
             "lodash.keysin": {
               "version": "3.0.8",
-              "from": "https://registry.npmjs.org/lodash.keysin/-/lodash.keysin-3.0.8.tgz",
+              "from": "lodash.keysin@>=3.0.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/lodash.keysin/-/lodash.keysin-3.0.8.tgz",
               "dependencies": {
                 "lodash.isarguments": {
                   "version": "3.0.4",
-                  "from": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz",
+                  "from": "lodash.isarguments@>=3.0.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz"
                 },
                 "lodash.isarray": {
                   "version": "3.0.4",
-                  "from": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+                  "from": "lodash.isarray@>=3.0.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
                 }
               }
             },
             "lodash.restparam": {
               "version": "3.6.1",
-              "from": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+              "from": "lodash.restparam@>=3.0.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
             }
           }
         },
         "minimatch": {
           "version": "2.0.10",
-          "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+          "from": "minimatch@>=2.0.1 <3.0.0",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
           "dependencies": {
             "brace-expansion": {
-              "version": "1.1.0",
-              "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
-              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+              "version": "1.1.1",
+              "from": "brace-expansion@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz",
               "dependencies": {
                 "balanced-match": {
                   "version": "0.2.0",
-                  "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz",
+                  "from": "balanced-match@>=0.2.0 <0.3.0",
                   "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
                 },
                 "concat-map": {
                   "version": "0.0.1",
-                  "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                  "from": "concat-map@0.0.1",
                   "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                 }
               }
@@ -1727,269 +1822,170 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "from": "mkdirp@>=0.5.0 <0.6.0",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "dependencies": {
             "minimist": {
               "version": "0.0.8",
-              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+              "from": "minimist@0.0.8",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
             }
           }
         },
         "object-assign": {
           "version": "2.1.1",
-          "from": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
+          "from": "object-assign@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz"
         },
         "optionator": {
           "version": "0.5.0",
-          "from": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
+          "from": "optionator@>=0.5.0 <0.6.0",
           "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
           "dependencies": {
             "prelude-ls": {
               "version": "1.1.2",
-              "from": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+              "from": "prelude-ls@>=1.1.1 <1.2.0",
               "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
             },
             "deep-is": {
               "version": "0.1.3",
-              "from": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+              "from": "deep-is@>=0.1.2 <0.2.0",
               "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
             },
             "wordwrap": {
               "version": "0.0.3",
-              "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+              "from": "wordwrap@>=0.0.2 <0.1.0",
               "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
             },
             "type-check": {
               "version": "0.3.1",
-              "from": "https://registry.npmjs.org/type-check/-/type-check-0.3.1.tgz",
+              "from": "type-check@>=0.3.1 <0.4.0",
               "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.1.tgz"
             },
             "levn": {
               "version": "0.2.5",
-              "from": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz",
+              "from": "levn@>=0.2.5 <0.3.0",
               "resolved": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz"
             },
             "fast-levenshtein": {
               "version": "1.0.7",
-              "from": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.7.tgz",
+              "from": "fast-levenshtein@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.7.tgz"
             }
           }
         },
         "path-is-absolute": {
           "version": "1.0.0",
-          "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+          "from": "path-is-absolute@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
         },
         "path-is-inside": {
           "version": "1.0.1",
-          "from": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.1.tgz",
+          "from": "path-is-inside@>=1.0.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.1.tgz"
         },
         "strip-json-comments": {
           "version": "1.0.4",
-          "from": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
+          "from": "strip-json-comments@>=1.0.1 <1.1.0",
           "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
         },
         "text-table": {
           "version": "0.2.0",
-          "from": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+          "from": "text-table@>=0.2.0 <0.3.0",
           "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
         },
         "user-home": {
           "version": "1.1.1",
-          "from": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
+          "from": "user-home@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
         },
         "xml-escape": {
           "version": "1.0.0",
-          "from": "https://registry.npmjs.org/xml-escape/-/xml-escape-1.0.0.tgz",
+          "from": "xml-escape@>=1.0.0 <1.1.0",
           "resolved": "https://registry.npmjs.org/xml-escape/-/xml-escape-1.0.0.tgz"
         }
       }
     },
     "eslint-plugin-react": {
       "version": "3.2.3",
-      "from": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-3.2.3.tgz",
+      "from": "eslint-plugin-react@3.2.3",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-3.2.3.tgz"
     },
     "evaporate": {
       "version": "0.0.2",
-      "from": "../../tmp/npm-25415-cf44e55b/1440429024174-0.8331851903349161/1d95383813d5e89170846c5fa528ac7bbe032db5",
+      "from": "../../tmp/npm-2399-37dcea7b/1443731731618-0.5089754480868578/1d95383813d5e89170846c5fa528ac7bbe032db5",
       "resolved": "git://github.com/TTLabs/EvaporateJS#1d95383813d5e89170846c5fa528ac7bbe032db5"
     },
     "jquery": {
       "version": "2.1.3",
-      "from": "https://registry.npmjs.org/jquery/-/jquery-2.1.3.tgz",
+      "from": "jquery@2.1.3",
       "resolved": "https://registry.npmjs.org/jquery/-/jquery-2.1.3.tgz"
     },
     "leaflet": {
       "version": "0.7.3",
-      "from": "https://registry.npmjs.org/leaflet/-/leaflet-0.7.3.tgz",
+      "from": "leaflet@0.7.3",
       "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-0.7.3.tgz"
     },
     "leaflet.locatecontrol": {
       "version": "0.43.0",
-      "from": "https://registry.npmjs.org/leaflet.locatecontrol/-/leaflet.locatecontrol-0.43.0.tgz",
+      "from": "leaflet.locatecontrol@0.43.0",
       "resolved": "https://registry.npmjs.org/leaflet.locatecontrol/-/leaflet.locatecontrol-0.43.0.tgz",
       "dependencies": {
         "font-awesome": {
           "version": "4.4.0",
-          "from": "https://registry.npmjs.org/font-awesome/-/font-awesome-4.4.0.tgz",
+          "from": "font-awesome@>=4.2.0 <5.0.0",
           "resolved": "https://registry.npmjs.org/font-awesome/-/font-awesome-4.4.0.tgz"
         }
       }
     },
-    "livereloadify": {
-      "version": "2.0.0",
-      "from": "https://registry.npmjs.org/livereloadify/-/livereloadify-2.0.0.tgz",
-      "resolved": "https://registry.npmjs.org/livereloadify/-/livereloadify-2.0.0.tgz",
+    "livereload": {
+      "version": "0.3.7",
+      "from": "livereload@0.3.7",
+      "resolved": "https://registry.npmjs.org/livereload/-/livereload-0.3.7.tgz",
       "dependencies": {
-        "chalk": {
-          "version": "0.5.1",
-          "from": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
-          "dependencies": {
-            "ansi-styles": {
-              "version": "1.1.0",
-              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
-            },
-            "escape-string-regexp": {
-              "version": "1.0.3",
-              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
-            },
-            "has-ansi": {
-              "version": "0.1.0",
-              "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
-              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "0.2.1",
-                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
-                }
-              }
-            },
-            "strip-ansi": {
-              "version": "0.3.0",
-              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "0.2.1",
-                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
-                }
-              }
-            },
-            "supports-color": {
-              "version": "0.2.0",
-              "from": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
-            }
-          }
+        "opts": {
+          "version": "1.2.2",
+          "from": "opts@>=1.2.0",
+          "resolved": "https://registry.npmjs.org/opts/-/opts-1.2.2.tgz"
         },
-        "gaze": {
-          "version": "0.5.1",
-          "from": "https://registry.npmjs.org/gaze/-/gaze-0.5.1.tgz",
-          "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.1.tgz",
+        "websocket.io": {
+          "version": "0.2.1",
+          "from": "websocket.io@>=0.1.0",
+          "resolved": "https://registry.npmjs.org/websocket.io/-/websocket.io-0.2.1.tgz",
           "dependencies": {
-            "globule": {
-              "version": "0.1.0",
-              "from": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
-              "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
-              "dependencies": {
-                "lodash": {
-                  "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz"
-                },
-                "glob": {
-                  "version": "3.1.21",
-                  "from": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
-                  "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
-                  "dependencies": {
-                    "graceful-fs": {
-                      "version": "1.2.3",
-                      "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
-                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
-                    },
-                    "inherits": {
-                      "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz"
-                    }
-                  }
-                },
-                "minimatch": {
-                  "version": "0.2.14",
-                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
-                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
-                  "dependencies": {
-                    "lru-cache": {
-                      "version": "2.6.5",
-                      "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz",
-                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
-                    },
-                    "sigmund": {
-                      "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "minimist": {
-          "version": "1.1.3",
-          "from": "https://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz"
-        },
-        "tiny-lr-fork": {
-          "version": "0.0.5",
-          "from": "https://registry.npmjs.org/tiny-lr-fork/-/tiny-lr-fork-0.0.5.tgz",
-          "resolved": "https://registry.npmjs.org/tiny-lr-fork/-/tiny-lr-fork-0.0.5.tgz",
-          "dependencies": {
-            "qs": {
-              "version": "0.5.6",
-              "from": "https://registry.npmjs.org/qs/-/qs-0.5.6.tgz",
-              "resolved": "https://registry.npmjs.org/qs/-/qs-0.5.6.tgz"
-            },
-            "faye-websocket": {
-              "version": "0.4.4",
-              "from": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.4.4.tgz",
-              "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.4.4.tgz"
-            },
-            "noptify": {
-              "version": "0.0.3",
-              "from": "https://registry.npmjs.org/noptify/-/noptify-0.0.3.tgz",
-              "resolved": "https://registry.npmjs.org/noptify/-/noptify-0.0.3.tgz",
-              "dependencies": {
-                "nopt": {
-                  "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/nopt/-/nopt-2.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.0.0.tgz",
-                  "dependencies": {
-                    "abbrev": {
-                      "version": "1.0.7",
-                      "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz",
-                      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
-                    }
-                  }
-                }
-              }
-            },
             "debug": {
-              "version": "0.7.4",
-              "from": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
+              "version": "2.2.0",
+              "from": "debug@*",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+              "dependencies": {
+                "ms": {
+                  "version": "0.7.1",
+                  "from": "ms@0.7.1",
+                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                }
+              }
+            },
+            "ws": {
+              "version": "0.4.20",
+              "from": "ws@0.4.20",
+              "resolved": "https://registry.npmjs.org/ws/-/ws-0.4.20.tgz",
+              "dependencies": {
+                "commander": {
+                  "version": "0.6.1",
+                  "from": "commander@>=0.6.1 <0.7.0",
+                  "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz"
+                },
+                "tinycolor": {
+                  "version": "0.0.1",
+                  "from": "tinycolor@>=0.0.0 <1.0.0",
+                  "resolved": "https://registry.npmjs.org/tinycolor/-/tinycolor-0.0.1.tgz"
+                },
+                "options": {
+                  "version": "0.0.6",
+                  "from": "options@latest",
+                  "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz"
+                }
+              }
             }
           }
         }
@@ -1997,52 +1993,52 @@
     },
     "minifyify": {
       "version": "7.0.0",
-      "from": "https://registry.npmjs.org/minifyify/-/minifyify-7.0.0.tgz",
+      "from": "minifyify@7.0.0",
       "resolved": "https://registry.npmjs.org/minifyify/-/minifyify-7.0.0.tgz",
       "dependencies": {
         "concat-stream": {
           "version": "1.5.0",
-          "from": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.0.tgz",
+          "from": "concat-stream@>=1.4.7 <2.0.0",
           "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.0.tgz",
           "dependencies": {
             "inherits": {
               "version": "2.0.1",
-              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+              "from": "inherits@>=2.0.1 <2.1.0",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             },
             "typedarray": {
               "version": "0.0.6",
-              "from": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+              "from": "typedarray@>=0.0.5 <0.1.0",
               "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
             },
             "readable-stream": {
               "version": "2.0.2",
-              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
+              "from": "readable-stream@>=2.0.0 <2.1.0",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                  "from": "core-util-is@>=1.0.0 <1.1.0",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                 },
                 "isarray": {
                   "version": "0.0.1",
-                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                  "from": "isarray@0.0.1",
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "process-nextick-args": {
-                  "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.2.tgz"
+                  "version": "1.0.3",
+                  "from": "process-nextick-args@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.3.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                  "from": "string_decoder@>=0.10.0 <0.11.0",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "util-deprecate": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz",
+                  "from": "util-deprecate@>=1.0.1 <1.1.0",
                   "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
                 }
               }
@@ -2051,100 +2047,100 @@
         },
         "convert-source-map": {
           "version": "1.1.1",
-          "from": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.1.tgz",
+          "from": "convert-source-map@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.1.tgz"
         },
         "lodash.bind": {
           "version": "3.1.0",
-          "from": "https://registry.npmjs.org/lodash.bind/-/lodash.bind-3.1.0.tgz",
+          "from": "lodash.bind@>=3.0.0 <4.0.0",
           "resolved": "https://registry.npmjs.org/lodash.bind/-/lodash.bind-3.1.0.tgz",
           "dependencies": {
             "lodash._createwrapper": {
               "version": "3.0.7",
-              "from": "https://registry.npmjs.org/lodash._createwrapper/-/lodash._createwrapper-3.0.7.tgz",
+              "from": "lodash._createwrapper@>=3.0.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/lodash._createwrapper/-/lodash._createwrapper-3.0.7.tgz",
               "dependencies": {
                 "lodash._arraycopy": {
                   "version": "3.0.0",
-                  "from": "https://registry.npmjs.org/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz",
+                  "from": "lodash._arraycopy@>=3.0.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz"
                 },
                 "lodash._basecreate": {
                   "version": "3.0.3",
-                  "from": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
+                  "from": "lodash._basecreate@>=3.0.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz"
                 }
               }
             },
             "lodash._replaceholders": {
               "version": "3.0.0",
-              "from": "https://registry.npmjs.org/lodash._replaceholders/-/lodash._replaceholders-3.0.0.tgz",
+              "from": "lodash._replaceholders@>=3.0.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/lodash._replaceholders/-/lodash._replaceholders-3.0.0.tgz"
             },
             "lodash.restparam": {
               "version": "3.6.1",
-              "from": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+              "from": "lodash.restparam@>=3.0.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
             }
           }
         },
         "lodash.defaults": {
           "version": "3.1.2",
-          "from": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-3.1.2.tgz",
+          "from": "lodash.defaults@>=3.0.0 <4.0.0",
           "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-3.1.2.tgz",
           "dependencies": {
             "lodash.assign": {
               "version": "3.2.0",
-              "from": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-3.2.0.tgz",
+              "from": "lodash.assign@>=3.0.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-3.2.0.tgz",
               "dependencies": {
                 "lodash._baseassign": {
                   "version": "3.2.0",
-                  "from": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+                  "from": "lodash._baseassign@>=3.0.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
                   "dependencies": {
                     "lodash._basecopy": {
                       "version": "3.0.1",
-                      "from": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+                      "from": "lodash._basecopy@>=3.0.0 <4.0.0",
                       "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
                     }
                   }
                 },
                 "lodash._createassigner": {
                   "version": "3.1.1",
-                  "from": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
+                  "from": "lodash._createassigner@>=3.0.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
                   "dependencies": {
                     "lodash._bindcallback": {
                       "version": "3.0.1",
-                      "from": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
+                      "from": "lodash._bindcallback@>=3.0.0 <4.0.0",
                       "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz"
                     },
                     "lodash._isiterateecall": {
                       "version": "3.0.9",
-                      "from": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+                      "from": "lodash._isiterateecall@>=3.0.0 <4.0.0",
                       "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz"
                     }
                   }
                 },
                 "lodash.keys": {
                   "version": "3.1.2",
-                  "from": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+                  "from": "lodash.keys@>=3.0.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
                   "dependencies": {
                     "lodash._getnative": {
                       "version": "3.9.1",
-                      "from": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+                      "from": "lodash._getnative@>=3.0.0 <4.0.0",
                       "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
                     },
                     "lodash.isarguments": {
                       "version": "3.0.4",
-                      "from": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz",
+                      "from": "lodash.isarguments@>=3.0.0 <4.0.0",
                       "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz"
                     },
                     "lodash.isarray": {
                       "version": "3.0.4",
-                      "from": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+                      "from": "lodash.isarray@>=3.0.0 <4.0.0",
                       "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
                     }
                   }
@@ -2153,39 +2149,39 @@
             },
             "lodash.restparam": {
               "version": "3.6.1",
-              "from": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+              "from": "lodash.restparam@>=3.0.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
             }
           }
         },
         "lodash.foreach": {
           "version": "3.0.3",
-          "from": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-3.0.3.tgz",
+          "from": "lodash.foreach@>=3.0.0 <4.0.0",
           "resolved": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-3.0.3.tgz",
           "dependencies": {
             "lodash._arrayeach": {
               "version": "3.0.0",
-              "from": "https://registry.npmjs.org/lodash._arrayeach/-/lodash._arrayeach-3.0.0.tgz",
+              "from": "lodash._arrayeach@>=3.0.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/lodash._arrayeach/-/lodash._arrayeach-3.0.0.tgz"
             },
             "lodash._baseeach": {
               "version": "3.0.4",
-              "from": "https://registry.npmjs.org/lodash._baseeach/-/lodash._baseeach-3.0.4.tgz",
+              "from": "lodash._baseeach@>=3.0.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/lodash._baseeach/-/lodash._baseeach-3.0.4.tgz",
               "dependencies": {
                 "lodash.keys": {
                   "version": "3.1.2",
-                  "from": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+                  "from": "lodash.keys@>=3.0.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
                   "dependencies": {
                     "lodash._getnative": {
                       "version": "3.9.1",
-                      "from": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+                      "from": "lodash._getnative@>=3.0.0 <4.0.0",
                       "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
                     },
                     "lodash.isarguments": {
                       "version": "3.0.4",
-                      "from": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz",
+                      "from": "lodash.isarguments@>=3.0.0 <4.0.0",
                       "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz"
                     }
                   }
@@ -2194,95 +2190,95 @@
             },
             "lodash._bindcallback": {
               "version": "3.0.1",
-              "from": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
+              "from": "lodash._bindcallback@>=3.0.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz"
             },
             "lodash.isarray": {
               "version": "3.0.4",
-              "from": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+              "from": "lodash.isarray@>=3.0.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
             }
           }
         },
         "mkdirp": {
           "version": "0.5.1",
-          "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "from": "mkdirp@>=0.5.0 <0.6.0",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "dependencies": {
             "minimist": {
               "version": "0.0.8",
-              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+              "from": "minimist@0.0.8",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
             }
           }
         },
         "source-map": {
           "version": "0.4.4",
-          "from": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+          "from": "source-map@>=0.4.2 <0.5.0",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
           "dependencies": {
             "amdefine": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
+              "from": "amdefine@>=0.0.4",
               "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
             }
           }
         },
         "through": {
           "version": "2.3.8",
-          "from": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+          "from": "through@>=2.3.6 <3.0.0",
           "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
         },
         "tmp": {
           "version": "0.0.25",
-          "from": "https://registry.npmjs.org/tmp/-/tmp-0.0.25.tgz",
+          "from": "tmp@>=0.0.25 <0.0.26",
           "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.25.tgz"
         },
         "transform-filter": {
           "version": "0.1.1",
-          "from": "https://registry.npmjs.org/transform-filter/-/transform-filter-0.1.1.tgz",
+          "from": "transform-filter@>=0.1.1 <0.2.0",
           "resolved": "https://registry.npmjs.org/transform-filter/-/transform-filter-0.1.1.tgz",
           "dependencies": {
             "multimatch": {
               "version": "2.0.0",
-              "from": "https://registry.npmjs.org/multimatch/-/multimatch-2.0.0.tgz",
+              "from": "multimatch@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.0.0.tgz",
               "dependencies": {
                 "array-differ": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
+                  "from": "array-differ@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz"
                 },
                 "array-union": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/array-union/-/array-union-1.0.1.tgz",
+                  "from": "array-union@>=1.0.1 <2.0.0",
                   "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.1.tgz",
                   "dependencies": {
                     "array-uniq": {
                       "version": "1.0.2",
-                      "from": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz",
+                      "from": "array-uniq@>=1.0.1 <2.0.0",
                       "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz"
                     }
                   }
                 },
                 "minimatch": {
                   "version": "2.0.10",
-                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+                  "from": "minimatch@>=2.0.1 <3.0.0",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
                   "dependencies": {
                     "brace-expansion": {
-                      "version": "1.1.0",
-                      "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
-                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                      "version": "1.1.1",
+                      "from": "brace-expansion@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz",
                       "dependencies": {
                         "balanced-match": {
                           "version": "0.2.0",
-                          "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz",
+                          "from": "balanced-match@>=0.2.0 <0.3.0",
                           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
                         },
                         "concat-map": {
                           "version": "0.0.1",
-                          "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                          "from": "concat-map@0.0.1",
                           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                         }
                       }
@@ -2295,54 +2291,54 @@
         },
         "uglify-js": {
           "version": "2.4.24",
-          "from": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.24.tgz",
+          "from": "uglify-js@>=2.4.16 <3.0.0",
           "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.24.tgz",
           "dependencies": {
             "async": {
               "version": "0.2.10",
-              "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+              "from": "async@>=0.2.6 <0.3.0",
               "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
             },
             "source-map": {
               "version": "0.1.34",
-              "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz",
+              "from": "source-map@0.1.34",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz",
               "dependencies": {
                 "amdefine": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
+                  "from": "amdefine@>=0.0.4",
                   "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
                 }
               }
             },
             "uglify-to-browserify": {
               "version": "1.0.2",
-              "from": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+              "from": "uglify-to-browserify@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
             },
             "yargs": {
               "version": "3.5.4",
-              "from": "https://registry.npmjs.org/yargs/-/yargs-3.5.4.tgz",
+              "from": "yargs@>=3.5.4 <3.6.0",
               "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.5.4.tgz",
               "dependencies": {
                 "camelcase": {
                   "version": "1.2.1",
-                  "from": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+                  "from": "camelcase@>=1.0.2 <2.0.0",
                   "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
                 },
                 "decamelize": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/decamelize/-/decamelize-1.0.0.tgz",
+                  "from": "decamelize@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.0.0.tgz"
                 },
                 "window-size": {
                   "version": "0.1.0",
-                  "from": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+                  "from": "window-size@0.1.0",
                   "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
                 },
                 "wordwrap": {
                   "version": "0.0.2",
-                  "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+                  "from": "wordwrap@0.0.2",
                   "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
                 }
               }
@@ -2353,100 +2349,100 @@
     },
     "mocha": {
       "version": "2.0.1",
-      "from": "https://registry.npmjs.org/mocha/-/mocha-2.0.1.tgz",
+      "from": "mocha@2.0.1",
       "resolved": "https://registry.npmjs.org/mocha/-/mocha-2.0.1.tgz",
       "dependencies": {
         "commander": {
           "version": "2.3.0",
-          "from": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz",
+          "from": "commander@2.3.0",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz"
         },
         "debug": {
           "version": "2.0.0",
-          "from": "https://registry.npmjs.org/debug/-/debug-2.0.0.tgz",
+          "from": "debug@2.0.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.0.0.tgz",
           "dependencies": {
             "ms": {
               "version": "0.6.2",
-              "from": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz",
+              "from": "ms@0.6.2",
               "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
             }
           }
         },
         "diff": {
           "version": "1.0.8",
-          "from": "https://registry.npmjs.org/diff/-/diff-1.0.8.tgz",
+          "from": "diff@1.0.8",
           "resolved": "https://registry.npmjs.org/diff/-/diff-1.0.8.tgz"
         },
         "escape-string-regexp": {
           "version": "1.0.2",
-          "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
+          "from": "escape-string-regexp@1.0.2",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz"
         },
         "glob": {
           "version": "3.2.3",
-          "from": "https://registry.npmjs.org/glob/-/glob-3.2.3.tgz",
+          "from": "glob@3.2.3",
           "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.3.tgz",
           "dependencies": {
             "minimatch": {
               "version": "0.2.14",
-              "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+              "from": "minimatch@>=0.2.11 <0.3.0",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
               "dependencies": {
                 "lru-cache": {
-                  "version": "2.6.5",
-                  "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz",
-                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
+                  "version": "2.7.0",
+                  "from": "lru-cache@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.0.tgz"
                 },
                 "sigmund": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+                  "from": "sigmund@>=1.0.0 <1.1.0",
                   "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
                 }
               }
             },
             "graceful-fs": {
               "version": "2.0.3",
-              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz",
+              "from": "graceful-fs@>=2.0.0 <2.1.0",
               "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
             },
             "inherits": {
               "version": "2.0.1",
-              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+              "from": "inherits@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             }
           }
         },
         "growl": {
           "version": "1.8.1",
-          "from": "https://registry.npmjs.org/growl/-/growl-1.8.1.tgz",
+          "from": "growl@1.8.1",
           "resolved": "https://registry.npmjs.org/growl/-/growl-1.8.1.tgz"
         },
         "jade": {
           "version": "0.26.3",
-          "from": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
+          "from": "jade@0.26.3",
           "resolved": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
           "dependencies": {
             "commander": {
               "version": "0.6.1",
-              "from": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
+              "from": "commander@0.6.1",
               "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz"
             },
             "mkdirp": {
               "version": "0.3.0",
-              "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
+              "from": "mkdirp@0.3.0",
               "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz"
             }
           }
         },
         "mkdirp": {
           "version": "0.5.0",
-          "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+          "from": "mkdirp@0.5.0",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
           "dependencies": {
             "minimist": {
               "version": "0.0.8",
-              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+              "from": "minimist@0.0.8",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
             }
           }
@@ -2455,110 +2451,110 @@
     },
     "moment": {
       "version": "2.10.6",
-      "from": "https://registry.npmjs.org/moment/-/moment-2.10.6.tgz",
+      "from": "moment@2.10.6",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.10.6.tgz"
     },
     "node-sass": {
       "version": "3.1.1",
-      "from": "https://registry.npmjs.org/node-sass/-/node-sass-3.1.1.tgz",
+      "from": "node-sass@3.1.1",
       "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-3.1.1.tgz",
       "dependencies": {
         "async-foreach": {
           "version": "0.1.3",
-          "from": "https://registry.npmjs.org/async-foreach/-/async-foreach-0.1.3.tgz",
+          "from": "async-foreach@>=0.1.3 <0.2.0",
           "resolved": "https://registry.npmjs.org/async-foreach/-/async-foreach-0.1.3.tgz"
         },
         "chalk": {
-          "version": "1.1.0",
-          "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.0.tgz",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.0.tgz",
+          "version": "1.1.1",
+          "from": "chalk@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
           "dependencies": {
             "ansi-styles": {
               "version": "2.1.0",
-              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
+              "from": "ansi-styles@>=2.1.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
             },
             "escape-string-regexp": {
               "version": "1.0.3",
-              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
+              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
             },
             "has-ansi": {
               "version": "2.0.0",
-              "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+              "from": "has-ansi@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                  "from": "ansi-regex@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                 }
               }
             },
             "strip-ansi": {
               "version": "3.0.0",
-              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+              "from": "strip-ansi@>=3.0.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                  "from": "ansi-regex@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                 }
               }
             },
             "supports-color": {
               "version": "2.0.0",
-              "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+              "from": "supports-color@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
             }
           }
         },
         "gaze": {
           "version": "0.5.1",
-          "from": "https://registry.npmjs.org/gaze/-/gaze-0.5.1.tgz",
+          "from": "gaze@>=0.5.1 <0.6.0",
           "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.1.tgz",
           "dependencies": {
             "globule": {
               "version": "0.1.0",
-              "from": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
+              "from": "globule@>=0.1.0 <0.2.0",
               "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
               "dependencies": {
                 "lodash": {
                   "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz",
+                  "from": "lodash@>=1.0.1 <1.1.0",
                   "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz"
                 },
                 "glob": {
                   "version": "3.1.21",
-                  "from": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
+                  "from": "glob@>=3.1.21 <3.2.0",
                   "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
                   "dependencies": {
                     "graceful-fs": {
                       "version": "1.2.3",
-                      "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
+                      "from": "graceful-fs@>=1.2.0 <1.3.0",
                       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
                     },
                     "inherits": {
-                      "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz"
+                      "version": "1.0.2",
+                      "from": "inherits@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz"
                     }
                   }
                 },
                 "minimatch": {
                   "version": "0.2.14",
-                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+                  "from": "minimatch@>=0.2.11 <0.3.0",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
                   "dependencies": {
                     "lru-cache": {
-                      "version": "2.6.5",
-                      "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz",
-                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
+                      "version": "2.7.0",
+                      "from": "lru-cache@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.0.tgz"
                     },
                     "sigmund": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+                      "from": "sigmund@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
                     }
                   }
@@ -2569,49 +2565,49 @@
         },
         "get-stdin": {
           "version": "4.0.1",
-          "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+          "from": "get-stdin@>=4.0.1 <5.0.0",
           "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
         },
         "glob": {
-          "version": "5.0.14",
-          "from": "https://registry.npmjs.org/glob/-/glob-5.0.14.tgz",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.14.tgz",
+          "version": "5.0.15",
+          "from": "glob@>=5.0.3 <6.0.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
           "dependencies": {
             "inflight": {
               "version": "1.0.4",
-              "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+              "from": "inflight@>=1.0.4 <2.0.0",
               "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                  "from": "wrappy@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                 }
               }
             },
             "inherits": {
               "version": "2.0.1",
-              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+              "from": "inherits@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             },
             "minimatch": {
-              "version": "2.0.10",
-              "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+              "version": "3.0.0",
+              "from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
               "dependencies": {
                 "brace-expansion": {
-                  "version": "1.1.0",
-                  "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
-                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                  "version": "1.1.1",
+                  "from": "brace-expansion@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz",
                   "dependencies": {
                     "balanced-match": {
                       "version": "0.2.0",
-                      "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz",
+                      "from": "balanced-match@>=0.2.0 <0.3.0",
                       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
                     },
                     "concat-map": {
                       "version": "0.0.1",
-                      "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                      "from": "concat-map@0.0.1",
                       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                     }
                   }
@@ -2620,63 +2616,63 @@
             },
             "once": {
               "version": "1.3.2",
-              "from": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+              "from": "once@>=1.3.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                  "from": "wrappy@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                 }
               }
             },
             "path-is-absolute": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+              "from": "path-is-absolute@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
             }
           }
         },
         "meow": {
           "version": "3.3.0",
-          "from": "https://registry.npmjs.org/meow/-/meow-3.3.0.tgz",
+          "from": "meow@>=3.1.0 <4.0.0",
           "resolved": "https://registry.npmjs.org/meow/-/meow-3.3.0.tgz",
           "dependencies": {
             "camelcase-keys": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
+              "from": "camelcase-keys@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
               "dependencies": {
                 "camelcase": {
                   "version": "1.2.1",
-                  "from": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+                  "from": "camelcase@>=1.0.1 <2.0.0",
                   "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
                 },
                 "map-obj": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+                  "from": "map-obj@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
                 }
               }
             },
             "indent-string": {
               "version": "1.2.2",
-              "from": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.2.tgz",
+              "from": "indent-string@>=1.1.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.2.tgz",
               "dependencies": {
                 "repeating": {
                   "version": "1.1.3",
-                  "from": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+                  "from": "repeating@>=1.1.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
                   "dependencies": {
                     "is-finite": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                      "from": "is-finite@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                       "dependencies": {
                         "number-is-nan": {
                           "version": "1.0.0",
-                          "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
+                          "from": "number-is-nan@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                         }
                       }
@@ -2686,161 +2682,166 @@
               }
             },
             "minimist": {
-              "version": "1.1.3",
-              "from": "https://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz"
+              "version": "1.2.0",
+              "from": "minimist@>=1.1.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
             },
             "object-assign": {
               "version": "3.0.0",
-              "from": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
+              "from": "object-assign@>=3.0.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
             }
           }
         },
         "mkdirp": {
           "version": "0.5.1",
-          "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "from": "mkdirp@>=0.5.0 <0.6.0",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "dependencies": {
             "minimist": {
               "version": "0.0.8",
-              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+              "from": "minimist@0.0.8",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
             }
           }
         },
         "nan": {
           "version": "1.9.0",
-          "from": "https://registry.npmjs.org/nan/-/nan-1.9.0.tgz",
+          "from": "nan@>=1.8.4 <2.0.0",
           "resolved": "https://registry.npmjs.org/nan/-/nan-1.9.0.tgz"
         },
         "npmconf": {
           "version": "2.1.2",
-          "from": "https://registry.npmjs.org/npmconf/-/npmconf-2.1.2.tgz",
+          "from": "npmconf@>=2.1.1 <3.0.0",
           "resolved": "https://registry.npmjs.org/npmconf/-/npmconf-2.1.2.tgz",
           "dependencies": {
             "config-chain": {
               "version": "1.1.9",
-              "from": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.9.tgz",
+              "from": "config-chain@>=1.1.8 <1.2.0",
               "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.9.tgz",
               "dependencies": {
                 "proto-list": {
                   "version": "1.2.4",
-                  "from": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+                  "from": "proto-list@>=1.2.1 <1.3.0",
                   "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz"
                 }
               }
             },
             "inherits": {
               "version": "2.0.1",
-              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+              "from": "inherits@>=2.0.0 <2.1.0",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             },
             "ini": {
               "version": "1.3.4",
-              "from": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
+              "from": "ini@>=1.2.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
             },
             "nopt": {
-              "version": "3.0.3",
-              "from": "https://registry.npmjs.org/nopt/-/nopt-3.0.3.tgz",
-              "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.3.tgz",
+              "version": "3.0.4",
+              "from": "nopt@>=3.0.1 <3.1.0",
+              "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.4.tgz",
               "dependencies": {
                 "abbrev": {
                   "version": "1.0.7",
-                  "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz",
+                  "from": "abbrev@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
                 }
               }
             },
             "once": {
               "version": "1.3.2",
-              "from": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+              "from": "once@>=1.3.0 <1.4.0",
               "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                  "from": "wrappy@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                 }
               }
             },
             "osenv": {
               "version": "0.1.3",
-              "from": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
+              "from": "osenv@>=0.1.0 <0.2.0",
               "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
               "dependencies": {
                 "os-homedir": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz",
+                  "from": "os-homedir@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
                 },
                 "os-tmpdir": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz",
+                  "from": "os-tmpdir@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
                 }
               }
             },
             "semver": {
               "version": "4.3.6",
-              "from": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
+              "from": "semver@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0",
               "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
             },
             "uid-number": {
               "version": "0.0.5",
-              "from": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.5.tgz",
+              "from": "uid-number@0.0.5",
               "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.5.tgz"
             }
           }
         },
         "pangyp": {
-          "version": "2.3.0",
-          "from": "https://registry.npmjs.org/pangyp/-/pangyp-2.3.0.tgz",
-          "resolved": "https://registry.npmjs.org/pangyp/-/pangyp-2.3.0.tgz",
+          "version": "2.3.2",
+          "from": "pangyp@>=2.2.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/pangyp/-/pangyp-2.3.2.tgz",
           "dependencies": {
             "fstream": {
-              "version": "1.0.7",
-              "from": "https://registry.npmjs.org/fstream/-/fstream-1.0.7.tgz",
-              "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.7.tgz",
+              "version": "1.0.8",
+              "from": "fstream@>=1.0.3 <1.1.0",
+              "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.8.tgz",
               "dependencies": {
+                "graceful-fs": {
+                  "version": "4.1.2",
+                  "from": "graceful-fs@>=4.1.2 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
+                },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "from": "inherits@>=2.0.0 <2.1.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
             },
             "glob": {
               "version": "4.3.5",
-              "from": "https://registry.npmjs.org/glob/-/glob-4.3.5.tgz",
+              "from": "glob@>=4.3.5 <4.4.0",
               "resolved": "https://registry.npmjs.org/glob/-/glob-4.3.5.tgz",
               "dependencies": {
                 "inflight": {
                   "version": "1.0.4",
-                  "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                  "from": "inflight@>=1.0.4 <2.0.0",
                   "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     }
                   }
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "from": "inherits@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "once": {
                   "version": "1.3.2",
-                  "from": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                  "from": "once@>=1.3.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     }
                   }
@@ -2849,27 +2850,27 @@
             },
             "graceful-fs": {
               "version": "3.0.8",
-              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz",
+              "from": "graceful-fs@>=3.0.5 <3.1.0",
               "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
             },
             "minimatch": {
               "version": "2.0.10",
-              "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+              "from": "minimatch@>=2.0.1 <2.1.0",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
               "dependencies": {
                 "brace-expansion": {
-                  "version": "1.1.0",
-                  "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
-                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                  "version": "1.1.1",
+                  "from": "brace-expansion@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz",
                   "dependencies": {
                     "balanced-match": {
                       "version": "0.2.0",
-                      "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz",
+                      "from": "balanced-match@>=0.2.0 <0.3.0",
                       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
                     },
                     "concat-map": {
                       "version": "0.0.1",
-                      "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                      "from": "concat-map@0.0.1",
                       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                     }
                   }
@@ -2877,60 +2878,60 @@
               }
             },
             "nopt": {
-              "version": "3.0.3",
-              "from": "https://registry.npmjs.org/nopt/-/nopt-3.0.3.tgz",
-              "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.3.tgz",
+              "version": "3.0.4",
+              "from": "nopt@>=3.0.1 <3.1.0",
+              "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.4.tgz",
               "dependencies": {
                 "abbrev": {
                   "version": "1.0.7",
-                  "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz",
+                  "from": "abbrev@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
                 }
               }
             },
             "npmlog": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/npmlog/-/npmlog-1.0.0.tgz",
+              "from": "npmlog@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-1.0.0.tgz",
               "dependencies": {
                 "ansi": {
                   "version": "0.3.0",
-                  "from": "https://registry.npmjs.org/ansi/-/ansi-0.3.0.tgz",
+                  "from": "ansi@>=0.3.0 <0.4.0",
                   "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.0.tgz"
                 },
                 "are-we-there-yet": {
                   "version": "1.0.4",
-                  "from": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.0.4.tgz",
+                  "from": "are-we-there-yet@>=1.0.0 <1.1.0",
                   "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.0.4.tgz",
                   "dependencies": {
                     "delegates": {
                       "version": "0.1.0",
-                      "from": "https://registry.npmjs.org/delegates/-/delegates-0.1.0.tgz",
+                      "from": "delegates@>=0.1.0 <0.2.0",
                       "resolved": "https://registry.npmjs.org/delegates/-/delegates-0.1.0.tgz"
                     },
                     "readable-stream": {
                       "version": "1.1.13",
-                      "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                      "from": "readable-stream@>=1.1.13 <2.0.0",
                       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                          "from": "core-util-is@>=1.0.0 <1.1.0",
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                         },
                         "isarray": {
                           "version": "0.0.1",
-                          "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                          "from": "isarray@0.0.1",
                           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                         },
                         "string_decoder": {
                           "version": "0.10.31",
-                          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                          "from": "string_decoder@>=0.10.0 <0.11.0",
                           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                         },
                         "inherits": {
                           "version": "2.0.1",
-                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                          "from": "inherits@>=2.0.1 <2.1.0",
                           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                         }
                       }
@@ -2939,12 +2940,12 @@
                 },
                 "gauge": {
                   "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/gauge/-/gauge-1.0.2.tgz",
+                  "from": "gauge@>=1.0.2 <1.1.0",
                   "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.0.2.tgz",
                   "dependencies": {
                     "has-unicode": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/has-unicode/-/has-unicode-1.0.0.tgz",
+                      "from": "has-unicode@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-1.0.0.tgz"
                     }
                   }
@@ -2953,54 +2954,54 @@
             },
             "osenv": {
               "version": "0.1.3",
-              "from": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
+              "from": "osenv@>=0.0.0 <1.0.0",
               "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
               "dependencies": {
                 "os-homedir": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz",
+                  "from": "os-homedir@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
                 },
                 "os-tmpdir": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz",
+                  "from": "os-tmpdir@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
                 }
               }
             },
             "request": {
               "version": "2.51.0",
-              "from": "https://registry.npmjs.org/request/-/request-2.51.0.tgz",
+              "from": "request@>=2.51.0 <2.52.0",
               "resolved": "https://registry.npmjs.org/request/-/request-2.51.0.tgz",
               "dependencies": {
                 "bl": {
                   "version": "0.9.4",
-                  "from": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
+                  "from": "bl@>=0.9.0 <0.10.0",
                   "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
                   "dependencies": {
                     "readable-stream": {
                       "version": "1.0.33",
-                      "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                      "from": "readable-stream@>=1.0.26 <1.1.0",
                       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                          "from": "core-util-is@>=1.0.0 <1.1.0",
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                         },
                         "isarray": {
                           "version": "0.0.1",
-                          "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                          "from": "isarray@0.0.1",
                           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                         },
                         "string_decoder": {
                           "version": "0.10.31",
-                          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                          "from": "string_decoder@>=0.10.0 <0.11.0",
                           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                         },
                         "inherits": {
                           "version": "2.0.1",
-                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                          "from": "inherits@>=2.0.1 <2.1.0",
                           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                         }
                       }
@@ -3009,32 +3010,32 @@
                 },
                 "caseless": {
                   "version": "0.8.0",
-                  "from": "https://registry.npmjs.org/caseless/-/caseless-0.8.0.tgz",
+                  "from": "caseless@>=0.8.0 <0.9.0",
                   "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.8.0.tgz"
                 },
                 "forever-agent": {
                   "version": "0.5.2",
-                  "from": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz",
+                  "from": "forever-agent@>=0.5.0 <0.6.0",
                   "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
                 },
                 "form-data": {
                   "version": "0.2.0",
-                  "from": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
+                  "from": "form-data@>=0.2.0 <0.3.0",
                   "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
                   "dependencies": {
                     "async": {
                       "version": "0.9.2",
-                      "from": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+                      "from": "async@>=0.9.0 <0.10.0",
                       "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
                     },
                     "mime-types": {
                       "version": "2.0.14",
-                      "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
+                      "from": "mime-types@>=2.0.3 <2.1.0",
                       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
                       "dependencies": {
                         "mime-db": {
                           "version": "1.12.0",
-                          "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz",
+                          "from": "mime-db@>=1.12.0 <1.13.0",
                           "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz"
                         }
                       }
@@ -3043,106 +3044,101 @@
                 },
                 "json-stringify-safe": {
                   "version": "5.0.1",
-                  "from": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+                  "from": "json-stringify-safe@>=5.0.0 <5.1.0",
                   "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
                 },
                 "mime-types": {
                   "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz",
+                  "from": "mime-types@>=1.0.1 <1.1.0",
                   "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
-                },
-                "node-uuid": {
-                  "version": "1.4.3",
-                  "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz",
-                  "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
                 },
                 "qs": {
                   "version": "2.3.3",
-                  "from": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz",
+                  "from": "qs@>=2.3.1 <2.4.0",
                   "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
                 },
                 "tunnel-agent": {
                   "version": "0.4.1",
-                  "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz",
+                  "from": "tunnel-agent@>=0.4.0 <0.5.0",
                   "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz"
                 },
                 "tough-cookie": {
                   "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.0.0.tgz",
+                  "from": "tough-cookie@>=0.12.0",
                   "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.0.0.tgz"
                 },
                 "http-signature": {
                   "version": "0.10.1",
-                  "from": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+                  "from": "http-signature@>=0.10.0 <0.11.0",
                   "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
                   "dependencies": {
                     "assert-plus": {
                       "version": "0.1.5",
-                      "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
+                      "from": "assert-plus@>=0.1.5 <0.2.0",
                       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
                     },
                     "asn1": {
                       "version": "0.1.11",
-                      "from": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
+                      "from": "asn1@0.1.11",
                       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
                     },
                     "ctype": {
                       "version": "0.5.3",
-                      "from": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
+                      "from": "ctype@0.5.3",
                       "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
                     }
                   }
                 },
                 "oauth-sign": {
                   "version": "0.5.0",
-                  "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.5.0.tgz",
+                  "from": "oauth-sign@>=0.5.0 <0.6.0",
                   "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.5.0.tgz"
                 },
                 "hawk": {
                   "version": "1.1.1",
-                  "from": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
+                  "from": "hawk@1.1.1",
                   "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
                   "dependencies": {
                     "hoek": {
                       "version": "0.9.1",
-                      "from": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz",
+                      "from": "hoek@>=0.9.0 <0.10.0",
                       "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
                     },
                     "boom": {
                       "version": "0.4.2",
-                      "from": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz",
+                      "from": "boom@>=0.4.0 <0.5.0",
                       "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
                     },
                     "cryptiles": {
                       "version": "0.2.2",
-                      "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz",
+                      "from": "cryptiles@>=0.2.0 <0.3.0",
                       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
                     },
                     "sntp": {
                       "version": "0.2.4",
-                      "from": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz",
+                      "from": "sntp@>=0.2.0 <0.3.0",
                       "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
                     }
                   }
                 },
                 "aws-sign2": {
                   "version": "0.5.0",
-                  "from": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
+                  "from": "aws-sign2@>=0.5.0 <0.6.0",
                   "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
                 },
                 "stringstream": {
                   "version": "0.0.4",
-                  "from": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz",
+                  "from": "stringstream@>=0.0.4 <0.1.0",
                   "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
                 },
                 "combined-stream": {
                   "version": "0.0.7",
-                  "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+                  "from": "combined-stream@>=0.0.5 <0.1.0",
                   "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
                   "dependencies": {
                     "delayed-stream": {
                       "version": "0.0.5",
-                      "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
+                      "from": "delayed-stream@0.0.5",
                       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
                     }
                   }
@@ -3151,81 +3147,81 @@
             },
             "rimraf": {
               "version": "2.2.8",
-              "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+              "from": "rimraf@>=2.2.8 <2.3.0",
               "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
             },
             "semver": {
               "version": "4.3.6",
-              "from": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
+              "from": "semver@>=4.3.6 <4.4.0",
               "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
             },
             "tar": {
               "version": "1.0.3",
-              "from": "https://registry.npmjs.org/tar/-/tar-1.0.3.tgz",
+              "from": "tar@>=1.0.3 <1.1.0",
               "resolved": "https://registry.npmjs.org/tar/-/tar-1.0.3.tgz",
               "dependencies": {
                 "block-stream": {
                   "version": "0.0.8",
-                  "from": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.8.tgz",
+                  "from": "block-stream@*",
                   "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.8.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "from": "inherits@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
             },
             "which": {
               "version": "1.0.9",
-              "from": "https://registry.npmjs.org/which/-/which-1.0.9.tgz",
+              "from": "which@>=1.0.8 <1.1.0",
               "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz"
             }
           }
         },
         "request": {
-          "version": "2.60.0",
-          "from": "https://registry.npmjs.org/request/-/request-2.60.0.tgz",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.60.0.tgz",
+          "version": "2.64.0",
+          "from": "request@>=2.55.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.64.0.tgz",
           "dependencies": {
             "bl": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/bl/-/bl-1.0.0.tgz",
+              "from": "bl@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.0.tgz",
               "dependencies": {
                 "readable-stream": {
                   "version": "2.0.2",
-                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
+                  "from": "readable-stream@>=2.0.0 <2.1.0",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "from": "inherits@>=2.0.1 <2.1.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "isarray": {
                       "version": "0.0.1",
-                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                      "from": "isarray@0.0.1",
                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "process-nextick-args": {
-                      "version": "1.0.2",
-                      "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.2.tgz",
-                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.2.tgz"
+                      "version": "1.0.3",
+                      "from": "process-nextick-args@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.3.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                      "from": "string_decoder@>=0.10.0 <0.11.0",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "util-deprecate": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz",
+                      "from": "util-deprecate@>=1.0.1 <1.1.0",
                       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
                     }
                   }
@@ -3234,201 +3230,196 @@
             },
             "caseless": {
               "version": "0.11.0",
-              "from": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
+              "from": "caseless@>=0.11.0 <0.12.0",
               "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
             },
             "extend": {
               "version": "3.0.0",
-              "from": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
+              "from": "extend@>=3.0.0 <3.1.0",
               "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
             },
             "forever-agent": {
               "version": "0.6.1",
-              "from": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+              "from": "forever-agent@>=0.6.0 <0.7.0",
               "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
             },
             "form-data": {
               "version": "1.0.0-rc3",
-              "from": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz",
+              "from": "form-data@>=1.0.0-rc1 <1.1.0",
               "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz",
               "dependencies": {
                 "async": {
                   "version": "1.4.2",
-                  "from": "https://registry.npmjs.org/async/-/async-1.4.2.tgz",
+                  "from": "async@>=1.4.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/async/-/async-1.4.2.tgz"
                 }
               }
             },
             "json-stringify-safe": {
               "version": "5.0.1",
-              "from": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+              "from": "json-stringify-safe@>=5.0.0 <5.1.0",
               "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
             },
             "mime-types": {
-              "version": "2.1.4",
-              "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.4.tgz",
-              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.4.tgz",
+              "version": "2.1.7",
+              "from": "mime-types@>=2.1.2 <2.2.0",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.7.tgz",
               "dependencies": {
                 "mime-db": {
-                  "version": "1.16.0",
-                  "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.16.0.tgz",
-                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.16.0.tgz"
+                  "version": "1.19.0",
+                  "from": "mime-db@>=1.19.0 <1.20.0",
+                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.19.0.tgz"
                 }
               }
             },
-            "node-uuid": {
-              "version": "1.4.3",
-              "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz",
-              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
-            },
             "qs": {
-              "version": "4.0.0",
-              "from": "https://registry.npmjs.org/qs/-/qs-4.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/qs/-/qs-4.0.0.tgz"
+              "version": "5.1.0",
+              "from": "qs@>=5.1.0 <5.2.0",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-5.1.0.tgz"
             },
             "tunnel-agent": {
               "version": "0.4.1",
-              "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz",
+              "from": "tunnel-agent@>=0.4.0 <0.5.0",
               "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz"
             },
             "tough-cookie": {
               "version": "2.0.0",
-              "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.0.0.tgz",
+              "from": "tough-cookie@>=0.12.0",
               "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.0.0.tgz"
             },
             "http-signature": {
               "version": "0.11.0",
-              "from": "https://registry.npmjs.org/http-signature/-/http-signature-0.11.0.tgz",
+              "from": "http-signature@>=0.11.0 <0.12.0",
               "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.11.0.tgz",
               "dependencies": {
                 "assert-plus": {
                   "version": "0.1.5",
-                  "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
+                  "from": "assert-plus@>=0.1.5 <0.2.0",
                   "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
                 },
                 "asn1": {
                   "version": "0.1.11",
-                  "from": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
+                  "from": "asn1@0.1.11",
                   "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
                 },
                 "ctype": {
                   "version": "0.5.3",
-                  "from": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
+                  "from": "ctype@0.5.3",
                   "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
                 }
               }
             },
             "oauth-sign": {
               "version": "0.8.0",
-              "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz",
+              "from": "oauth-sign@>=0.8.0 <0.9.0",
               "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz"
             },
             "hawk": {
               "version": "3.1.0",
-              "from": "https://registry.npmjs.org/hawk/-/hawk-3.1.0.tgz",
+              "from": "hawk@>=3.1.0 <3.2.0",
               "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.0.tgz",
               "dependencies": {
                 "hoek": {
-                  "version": "2.14.0",
-                  "from": "https://registry.npmjs.org/hoek/-/hoek-2.14.0.tgz",
-                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.14.0.tgz"
+                  "version": "2.16.3",
+                  "from": "hoek@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
                 },
                 "boom": {
-                  "version": "2.8.0",
-                  "from": "https://registry.npmjs.org/boom/-/boom-2.8.0.tgz",
-                  "resolved": "https://registry.npmjs.org/boom/-/boom-2.8.0.tgz"
+                  "version": "2.9.0",
+                  "from": "boom@>=2.8.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/boom/-/boom-2.9.0.tgz"
                 },
                 "cryptiles": {
-                  "version": "2.0.4",
-                  "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz",
-                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz"
+                  "version": "2.0.5",
+                  "from": "cryptiles@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
                 },
                 "sntp": {
                   "version": "1.0.9",
-                  "from": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+                  "from": "sntp@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
                 }
               }
             },
             "aws-sign2": {
               "version": "0.5.0",
-              "from": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
+              "from": "aws-sign2@>=0.5.0 <0.6.0",
               "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
             },
             "stringstream": {
               "version": "0.0.4",
-              "from": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz",
+              "from": "stringstream@>=0.0.4 <0.1.0",
               "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
             },
             "combined-stream": {
               "version": "1.0.5",
-              "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+              "from": "combined-stream@>=1.0.1 <1.1.0",
               "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
               "dependencies": {
                 "delayed-stream": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+                  "from": "delayed-stream@>=1.0.0 <1.1.0",
                   "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
                 }
               }
             },
             "isstream": {
               "version": "0.1.2",
-              "from": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+              "from": "isstream@>=0.1.1 <0.2.0",
               "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
             },
             "har-validator": {
               "version": "1.8.0",
-              "from": "https://registry.npmjs.org/har-validator/-/har-validator-1.8.0.tgz",
+              "from": "har-validator@>=1.6.1 <2.0.0",
               "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-1.8.0.tgz",
               "dependencies": {
                 "bluebird": {
-                  "version": "2.9.34",
-                  "from": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.34.tgz",
-                  "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.34.tgz"
+                  "version": "2.10.1",
+                  "from": "bluebird@>=2.9.30 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.1.tgz"
                 },
                 "commander": {
                   "version": "2.8.1",
-                  "from": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
+                  "from": "commander@>=2.8.1 <3.0.0",
                   "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
                   "dependencies": {
                     "graceful-readlink": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+                      "from": "graceful-readlink@>=1.0.0",
                       "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
                     }
                   }
                 },
                 "is-my-json-valid": {
-                  "version": "2.12.1",
-                  "from": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.1.tgz",
-                  "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.1.tgz",
+                  "version": "2.12.2",
+                  "from": "is-my-json-valid@>=2.12.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.2.tgz",
                   "dependencies": {
                     "generate-function": {
                       "version": "2.0.0",
-                      "from": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+                      "from": "generate-function@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
                     },
                     "generate-object-property": {
                       "version": "1.2.0",
-                      "from": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+                      "from": "generate-object-property@>=1.1.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
                       "dependencies": {
                         "is-property": {
                           "version": "1.0.2",
-                          "from": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+                          "from": "is-property@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
                         }
                       }
                     },
                     "jsonpointer": {
-                      "version": "1.1.0",
-                      "from": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-1.1.0.tgz",
-                      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-1.1.0.tgz"
+                      "version": "2.0.0",
+                      "from": "jsonpointer@2.0.0",
+                      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
                     },
                     "xtend": {
                       "version": "4.0.0",
-                      "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz",
+                      "from": "xtend@>=4.0.0 <5.0.0",
                       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
                     }
                   }
@@ -3439,52 +3430,59 @@
         },
         "sass-graph": {
           "version": "2.0.1",
-          "from": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.0.1.tgz",
+          "from": "sass-graph@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.0.1.tgz",
           "dependencies": {
             "lodash": {
               "version": "3.10.1",
-              "from": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+              "from": "lodash@>=3.8.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
             },
             "yargs": {
-              "version": "3.19.0",
-              "from": "https://registry.npmjs.org/yargs/-/yargs-3.19.0.tgz",
-              "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.19.0.tgz",
+              "version": "3.26.0",
+              "from": "yargs@>=3.8.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.26.0.tgz",
               "dependencies": {
                 "camelcase": {
                   "version": "1.2.1",
-                  "from": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+                  "from": "camelcase@>=1.2.1 <2.0.0",
                   "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
                 },
                 "cliui": {
                   "version": "2.1.0",
-                  "from": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+                  "from": "cliui@>=2.1.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
                   "dependencies": {
                     "center-align": {
                       "version": "0.1.1",
-                      "from": "https://registry.npmjs.org/center-align/-/center-align-0.1.1.tgz",
+                      "from": "center-align@>=0.1.1 <0.2.0",
                       "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.1.tgz",
                       "dependencies": {
                         "align-text": {
                           "version": "0.1.3",
-                          "from": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
+                          "from": "align-text@>=0.1.0 <0.2.0",
                           "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
                           "dependencies": {
                             "kind-of": {
-                              "version": "2.0.0",
-                              "from": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.0.tgz",
-                              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.0.tgz"
+                              "version": "2.0.1",
+                              "from": "kind-of@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
+                              "dependencies": {
+                                "is-buffer": {
+                                  "version": "1.1.0",
+                                  "from": "is-buffer@>=1.0.2 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.0.tgz"
+                                }
+                              }
                             },
                             "longest": {
                               "version": "1.0.1",
-                              "from": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+                              "from": "longest@>=1.0.1 <2.0.0",
                               "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
                             },
                             "repeat-string": {
                               "version": "1.5.2",
-                              "from": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz",
+                              "from": "repeat-string@>=1.5.2 <2.0.0",
                               "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
                             }
                           }
@@ -3493,27 +3491,34 @@
                     },
                     "right-align": {
                       "version": "0.1.3",
-                      "from": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+                      "from": "right-align@>=0.1.1 <0.2.0",
                       "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
                       "dependencies": {
                         "align-text": {
                           "version": "0.1.3",
-                          "from": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
+                          "from": "align-text@>=0.1.0 <0.2.0",
                           "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
                           "dependencies": {
                             "kind-of": {
-                              "version": "2.0.0",
-                              "from": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.0.tgz",
-                              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.0.tgz"
+                              "version": "2.0.1",
+                              "from": "kind-of@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
+                              "dependencies": {
+                                "is-buffer": {
+                                  "version": "1.1.0",
+                                  "from": "is-buffer@>=1.0.2 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.0.tgz"
+                                }
+                              }
                             },
                             "longest": {
                               "version": "1.0.1",
-                              "from": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+                              "from": "longest@>=1.0.1 <2.0.0",
                               "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
                             },
                             "repeat-string": {
                               "version": "1.5.2",
-                              "from": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz",
+                              "from": "repeat-string@>=1.5.2 <2.0.0",
                               "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
                             }
                           }
@@ -3522,25 +3527,44 @@
                     },
                     "wordwrap": {
                       "version": "0.0.2",
-                      "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+                      "from": "wordwrap@0.0.2",
                       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
                     }
                   }
                 },
                 "decamelize": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/decamelize/-/decamelize-1.0.0.tgz",
+                  "from": "decamelize@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.0.0.tgz"
+                },
+                "os-locale": {
+                  "version": "1.4.0",
+                  "from": "os-locale@>=1.4.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+                  "dependencies": {
+                    "lcid": {
+                      "version": "1.0.0",
+                      "from": "lcid@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+                      "dependencies": {
+                        "invert-kv": {
+                          "version": "1.0.0",
+                          "from": "invert-kv@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
                 },
                 "window-size": {
                   "version": "0.1.2",
-                  "from": "https://registry.npmjs.org/window-size/-/window-size-0.1.2.tgz",
+                  "from": "window-size@>=0.1.2 <0.2.0",
                   "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.2.tgz"
                 },
                 "y18n": {
-                  "version": "3.0.0",
-                  "from": "https://registry.npmjs.org/y18n/-/y18n-3.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.0.0.tgz"
+                  "version": "3.2.0",
+                  "from": "y18n@>=3.2.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.0.tgz"
                 }
               }
             }
@@ -3550,47 +3574,47 @@
     },
     "node-uuid": {
       "version": "1.4.3",
-      "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz",
+      "from": "node-uuid@1.4.3",
       "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
     },
     "react": {
       "version": "0.13.3",
-      "from": "https://registry.npmjs.org/react/-/react-0.13.3.tgz",
+      "from": "react@0.13.3",
       "resolved": "https://registry.npmjs.org/react/-/react-0.13.3.tgz",
       "dependencies": {
         "envify": {
           "version": "3.4.0",
-          "from": "https://registry.npmjs.org/envify/-/envify-3.4.0.tgz",
+          "from": "envify@>=3.0.0 <4.0.0",
           "resolved": "https://registry.npmjs.org/envify/-/envify-3.4.0.tgz",
           "dependencies": {
             "through": {
               "version": "2.3.8",
-              "from": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+              "from": "through@>=2.3.4 <2.4.0",
               "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
             },
             "jstransform": {
               "version": "10.1.0",
-              "from": "https://registry.npmjs.org/jstransform/-/jstransform-10.1.0.tgz",
+              "from": "jstransform@>=10.1.0 <11.0.0",
               "resolved": "https://registry.npmjs.org/jstransform/-/jstransform-10.1.0.tgz",
               "dependencies": {
                 "base62": {
                   "version": "0.1.1",
-                  "from": "https://registry.npmjs.org/base62/-/base62-0.1.1.tgz",
+                  "from": "base62@0.1.1",
                   "resolved": "https://registry.npmjs.org/base62/-/base62-0.1.1.tgz"
                 },
                 "esprima-fb": {
                   "version": "13001.1001.0-dev-harmony-fb",
-                  "from": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-13001.1001.0-dev-harmony-fb.tgz",
+                  "from": "esprima-fb@13001.1001.0-dev-harmony-fb",
                   "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-13001.1001.0-dev-harmony-fb.tgz"
                 },
                 "source-map": {
                   "version": "0.1.31",
-                  "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.31.tgz",
+                  "from": "source-map@0.1.31",
                   "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.31.tgz",
                   "dependencies": {
                     "amdefine": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
+                      "from": "amdefine@>=0.0.4",
                       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
                     }
                   }
@@ -3603,120 +3627,113 @@
     },
     "react.backbone": {
       "version": "0.6.0",
-      "from": "https://registry.npmjs.org/react.backbone/-/react.backbone-0.6.0.tgz",
+      "from": "react.backbone@0.6.0",
       "resolved": "https://registry.npmjs.org/react.backbone/-/react.backbone-0.6.0.tgz"
     },
     "reactify": {
       "version": "1.1.1",
-      "from": "https://registry.npmjs.org/reactify/-/reactify-1.1.1.tgz",
+      "from": "reactify@1.1.1",
       "resolved": "https://registry.npmjs.org/reactify/-/reactify-1.1.1.tgz",
       "dependencies": {
         "through": {
           "version": "2.3.8",
-          "from": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+          "from": "through@>=2.3.4 <2.4.0",
           "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
         },
         "react-tools": {
           "version": "0.13.3",
-          "from": "https://registry.npmjs.org/react-tools/-/react-tools-0.13.3.tgz",
+          "from": "react-tools@>=0.13.0 <0.14.0",
           "resolved": "https://registry.npmjs.org/react-tools/-/react-tools-0.13.3.tgz",
           "dependencies": {
             "commoner": {
               "version": "0.10.3",
-              "from": "https://registry.npmjs.org/commoner/-/commoner-0.10.3.tgz",
+              "from": "commoner@>=0.10.0 <0.11.0",
               "resolved": "https://registry.npmjs.org/commoner/-/commoner-0.10.3.tgz",
               "dependencies": {
                 "q": {
                   "version": "1.1.2",
-                  "from": "https://registry.npmjs.org/q/-/q-1.1.2.tgz",
+                  "from": "q@>=1.1.2 <1.2.0",
                   "resolved": "https://registry.npmjs.org/q/-/q-1.1.2.tgz"
                 },
                 "recast": {
-                  "version": "0.10.29",
-                  "from": "https://registry.npmjs.org/recast/-/recast-0.10.29.tgz",
-                  "resolved": "https://registry.npmjs.org/recast/-/recast-0.10.29.tgz",
+                  "version": "0.10.33",
+                  "from": "recast@>=0.10.0 <0.11.0",
+                  "resolved": "https://registry.npmjs.org/recast/-/recast-0.10.33.tgz",
                   "dependencies": {
                     "esprima-fb": {
                       "version": "15001.1001.0-dev-harmony-fb",
-                      "from": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz",
+                      "from": "esprima-fb@>=15001.1001.0-dev-harmony-fb <15001.1002.0",
                       "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz"
                     },
                     "source-map": {
-                      "version": "0.4.4",
-                      "from": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-                      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-                      "dependencies": {
-                        "amdefine": {
-                          "version": "1.0.0",
-                          "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
-                          "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
-                        }
-                      }
+                      "version": "0.5.1",
+                      "from": "source-map@>=0.5.0 <0.6.0",
+                      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.1.tgz"
                     },
                     "ast-types": {
-                      "version": "0.8.9",
-                      "from": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.9.tgz",
-                      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.9.tgz"
+                      "version": "0.8.12",
+                      "from": "ast-types@0.8.12",
+                      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.12.tgz"
                     }
                   }
                 },
                 "commander": {
                   "version": "2.5.1",
-                  "from": "https://registry.npmjs.org/commander/-/commander-2.5.1.tgz",
+                  "from": "commander@>=2.5.0 <2.6.0",
                   "resolved": "https://registry.npmjs.org/commander/-/commander-2.5.1.tgz"
                 },
                 "graceful-fs": {
                   "version": "3.0.8",
-                  "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz",
+                  "from": "graceful-fs@>=3.0.4 <3.1.0",
                   "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
                 },
                 "glob": {
                   "version": "4.2.2",
-                  "from": "https://registry.npmjs.org/glob/-/glob-4.2.2.tgz",
+                  "from": "glob@>=4.2.1 <4.3.0",
                   "resolved": "https://registry.npmjs.org/glob/-/glob-4.2.2.tgz",
                   "dependencies": {
                     "inflight": {
                       "version": "1.0.4",
-                      "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                      "from": "inflight@>=1.0.4 <2.0.0",
                       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                          "from": "wrappy@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                         }
                       }
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "from": "inherits@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "minimatch": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
+                      "from": "minimatch@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
                       "dependencies": {
                         "lru-cache": {
-                          "version": "2.6.5",
-                          "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz",
-                          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
+                          "version": "2.7.0",
+                          "from": "lru-cache@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.0.tgz"
                         },
                         "sigmund": {
                           "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+                          "from": "sigmund@>=1.0.0 <1.1.0",
                           "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
                         }
                       }
                     },
                     "once": {
                       "version": "1.3.2",
-                      "from": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                      "from": "once@>=1.3.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                          "from": "wrappy@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                         }
                       }
@@ -3725,56 +3742,56 @@
                 },
                 "mkdirp": {
                   "version": "0.5.1",
-                  "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                  "from": "mkdirp@>=0.5.0 <0.6.0",
                   "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
                   "dependencies": {
                     "minimist": {
                       "version": "0.0.8",
-                      "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                      "from": "minimist@0.0.8",
                       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
                     }
                   }
                 },
                 "private": {
                   "version": "0.1.6",
-                  "from": "https://registry.npmjs.org/private/-/private-0.1.6.tgz",
+                  "from": "private@>=0.1.6 <0.2.0",
                   "resolved": "https://registry.npmjs.org/private/-/private-0.1.6.tgz"
                 },
                 "install": {
                   "version": "0.1.8",
-                  "from": "https://registry.npmjs.org/install/-/install-0.1.8.tgz",
+                  "from": "install@>=0.1.7 <0.2.0",
                   "resolved": "https://registry.npmjs.org/install/-/install-0.1.8.tgz"
                 },
                 "iconv-lite": {
-                  "version": "0.4.11",
-                  "from": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.11.tgz",
-                  "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.11.tgz"
+                  "version": "0.4.12",
+                  "from": "iconv-lite@>=0.4.5 <0.5.0",
+                  "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.12.tgz"
                 }
               }
             },
             "jstransform": {
               "version": "10.1.0",
-              "from": "https://registry.npmjs.org/jstransform/-/jstransform-10.1.0.tgz",
+              "from": "jstransform@>=10.1.0 <11.0.0",
               "resolved": "https://registry.npmjs.org/jstransform/-/jstransform-10.1.0.tgz",
               "dependencies": {
                 "base62": {
                   "version": "0.1.1",
-                  "from": "https://registry.npmjs.org/base62/-/base62-0.1.1.tgz",
+                  "from": "base62@0.1.1",
                   "resolved": "https://registry.npmjs.org/base62/-/base62-0.1.1.tgz"
                 },
                 "esprima-fb": {
                   "version": "13001.1001.0-dev-harmony-fb",
-                  "from": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-13001.1001.0-dev-harmony-fb.tgz",
+                  "from": "esprima-fb@13001.1001.0-dev-harmony-fb",
                   "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-13001.1001.0-dev-harmony-fb.tgz"
                 },
                 "source-map": {
                   "version": "0.1.31",
-                  "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.31.tgz",
+                  "from": "source-map@0.1.31",
                   "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.31.tgz",
                   "dependencies": {
                     "amdefine": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
+                      "from": "amdefine@>=0.0.4",
                       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
                     }
                   }
@@ -3787,43 +3804,43 @@
     },
     "sinon": {
       "version": "1.14.1",
-      "from": "https://registry.npmjs.org/sinon/-/sinon-1.14.1.tgz",
+      "from": "sinon@1.14.1",
       "resolved": "https://registry.npmjs.org/sinon/-/sinon-1.14.1.tgz",
       "dependencies": {
         "formatio": {
           "version": "1.1.1",
-          "from": "https://registry.npmjs.org/formatio/-/formatio-1.1.1.tgz",
+          "from": "formatio@1.1.1",
           "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.1.1.tgz",
           "dependencies": {
             "samsam": {
               "version": "1.1.2",
-              "from": "https://registry.npmjs.org/samsam/-/samsam-1.1.2.tgz",
+              "from": "samsam@>=1.1.0 <1.2.0",
               "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.1.2.tgz"
             }
           }
         },
         "util": {
           "version": "0.10.3",
-          "from": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+          "from": "util@>=0.10.3 <1.0.0",
           "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
           "dependencies": {
             "inherits": {
               "version": "2.0.1",
-              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+              "from": "inherits@2.0.1",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             }
           }
         },
         "lolex": {
           "version": "1.1.0",
-          "from": "https://registry.npmjs.org/lolex/-/lolex-1.1.0.tgz",
+          "from": "lolex@1.1.0",
           "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.1.0.tgz"
         }
       }
     },
     "testem": {
       "version": "0.5.15",
-      "from": "https://registry.npmjs.org/testem/-/testem-0.5.15.tgz",
+      "from": "testem@0.5.15",
       "resolved": "https://registry.npmjs.org/testem/-/testem-0.5.15.tgz",
       "dependencies": {
         "express": {
@@ -3902,64 +3919,64 @@
         },
         "mustache": {
           "version": "0.4.0",
-          "from": "https://registry.npmjs.org/mustache/-/mustache-0.4.0.tgz",
+          "from": "mustache@>=0.4.0 <0.5.0",
           "resolved": "https://registry.npmjs.org/mustache/-/mustache-0.4.0.tgz"
         },
         "socket.io": {
           "version": "0.9.17",
-          "from": "https://registry.npmjs.org/socket.io/-/socket.io-0.9.17.tgz",
+          "from": "socket.io@>=0.9.13 <0.10.0",
           "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-0.9.17.tgz",
           "dependencies": {
             "socket.io-client": {
               "version": "0.9.16",
-              "from": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-0.9.16.tgz",
+              "from": "socket.io-client@0.9.16",
               "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-0.9.16.tgz",
               "dependencies": {
                 "uglify-js": {
                   "version": "1.2.5",
-                  "from": "https://registry.npmjs.org/uglify-js/-/uglify-js-1.2.5.tgz",
+                  "from": "uglify-js@1.2.5",
                   "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-1.2.5.tgz"
                 },
                 "ws": {
                   "version": "0.4.32",
-                  "from": "https://registry.npmjs.org/ws/-/ws-0.4.32.tgz",
+                  "from": "ws@>=0.4.0 <0.5.0",
                   "resolved": "https://registry.npmjs.org/ws/-/ws-0.4.32.tgz",
                   "dependencies": {
                     "commander": {
                       "version": "2.1.0",
-                      "from": "https://registry.npmjs.org/commander/-/commander-2.1.0.tgz",
+                      "from": "commander@>=2.1.0 <2.2.0",
                       "resolved": "https://registry.npmjs.org/commander/-/commander-2.1.0.tgz"
                     },
                     "nan": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/nan/-/nan-1.0.0.tgz",
+                      "from": "nan@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/nan/-/nan-1.0.0.tgz"
                     },
                     "tinycolor": {
                       "version": "0.0.1",
-                      "from": "https://registry.npmjs.org/tinycolor/-/tinycolor-0.0.1.tgz",
+                      "from": "tinycolor@>=0.0.0 <1.0.0",
                       "resolved": "https://registry.npmjs.org/tinycolor/-/tinycolor-0.0.1.tgz"
                     },
                     "options": {
                       "version": "0.0.6",
-                      "from": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
+                      "from": "options@>=0.0.5",
                       "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz"
                     }
                   }
                 },
                 "xmlhttprequest": {
                   "version": "1.4.2",
-                  "from": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.4.2.tgz",
+                  "from": "xmlhttprequest@1.4.2",
                   "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.4.2.tgz"
                 },
                 "active-x-obfuscator": {
                   "version": "0.0.1",
-                  "from": "https://registry.npmjs.org/active-x-obfuscator/-/active-x-obfuscator-0.0.1.tgz",
+                  "from": "active-x-obfuscator@0.0.1",
                   "resolved": "https://registry.npmjs.org/active-x-obfuscator/-/active-x-obfuscator-0.0.1.tgz",
                   "dependencies": {
                     "zeparser": {
                       "version": "0.0.5",
-                      "from": "https://registry.npmjs.org/zeparser/-/zeparser-0.0.5.tgz",
+                      "from": "zeparser@0.0.5",
                       "resolved": "https://registry.npmjs.org/zeparser/-/zeparser-0.0.5.tgz"
                     }
                   }
@@ -3968,59 +3985,59 @@
             },
             "policyfile": {
               "version": "0.0.4",
-              "from": "https://registry.npmjs.org/policyfile/-/policyfile-0.0.4.tgz",
+              "from": "policyfile@0.0.4",
               "resolved": "https://registry.npmjs.org/policyfile/-/policyfile-0.0.4.tgz"
             },
             "base64id": {
               "version": "0.1.0",
-              "from": "https://registry.npmjs.org/base64id/-/base64id-0.1.0.tgz",
+              "from": "base64id@0.1.0",
               "resolved": "https://registry.npmjs.org/base64id/-/base64id-0.1.0.tgz"
             },
             "redis": {
               "version": "0.7.3",
-              "from": "https://registry.npmjs.org/redis/-/redis-0.7.3.tgz",
+              "from": "redis@0.7.3",
               "resolved": "https://registry.npmjs.org/redis/-/redis-0.7.3.tgz"
             }
           }
         },
         "winston": {
           "version": "0.7.3",
-          "from": "https://registry.npmjs.org/winston/-/winston-0.7.3.tgz",
+          "from": "winston@>=0.7.1 <0.8.0",
           "resolved": "https://registry.npmjs.org/winston/-/winston-0.7.3.tgz",
           "dependencies": {
             "cycle": {
               "version": "1.0.3",
-              "from": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
+              "from": "cycle@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz"
             },
             "eyes": {
               "version": "0.1.8",
-              "from": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
+              "from": "eyes@>=0.1.0 <0.2.0",
               "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz"
             },
             "pkginfo": {
               "version": "0.3.0",
-              "from": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.0.tgz",
+              "from": "pkginfo@>=0.3.0 <0.4.0",
               "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.0.tgz"
             },
             "request": {
               "version": "2.16.6",
-              "from": "https://registry.npmjs.org/request/-/request-2.16.6.tgz",
+              "from": "request@>=2.16.0 <2.17.0",
               "resolved": "https://registry.npmjs.org/request/-/request-2.16.6.tgz",
               "dependencies": {
                 "form-data": {
                   "version": "0.0.10",
-                  "from": "https://registry.npmjs.org/form-data/-/form-data-0.0.10.tgz",
+                  "from": "form-data@>=0.0.3 <0.1.0",
                   "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.0.10.tgz",
                   "dependencies": {
                     "combined-stream": {
                       "version": "0.0.7",
-                      "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+                      "from": "combined-stream@>=0.0.4 <0.1.0",
                       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
                       "dependencies": {
                         "delayed-stream": {
                           "version": "0.0.5",
-                          "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
+                          "from": "delayed-stream@0.0.5",
                           "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
                         }
                       }
@@ -4029,174 +4046,169 @@
                 },
                 "mime": {
                   "version": "1.2.11",
-                  "from": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
+                  "from": "mime@>=1.2.7 <1.3.0",
                   "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
                 },
                 "hawk": {
                   "version": "0.10.2",
-                  "from": "https://registry.npmjs.org/hawk/-/hawk-0.10.2.tgz",
+                  "from": "hawk@>=0.10.2 <0.11.0",
                   "resolved": "https://registry.npmjs.org/hawk/-/hawk-0.10.2.tgz",
                   "dependencies": {
                     "hoek": {
                       "version": "0.7.6",
-                      "from": "https://registry.npmjs.org/hoek/-/hoek-0.7.6.tgz",
+                      "from": "hoek@>=0.7.0 <0.8.0",
                       "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.7.6.tgz"
                     },
                     "boom": {
                       "version": "0.3.8",
-                      "from": "https://registry.npmjs.org/boom/-/boom-0.3.8.tgz",
+                      "from": "boom@>=0.3.0 <0.4.0",
                       "resolved": "https://registry.npmjs.org/boom/-/boom-0.3.8.tgz"
                     },
                     "cryptiles": {
                       "version": "0.1.3",
-                      "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.1.3.tgz",
+                      "from": "cryptiles@>=0.1.0 <0.2.0",
                       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.1.3.tgz"
                     },
                     "sntp": {
                       "version": "0.1.4",
-                      "from": "https://registry.npmjs.org/sntp/-/sntp-0.1.4.tgz",
+                      "from": "sntp@>=0.1.0 <0.2.0",
                       "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.1.4.tgz"
                     }
                   }
                 },
-                "node-uuid": {
-                  "version": "1.4.3",
-                  "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz",
-                  "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
-                },
                 "cookie-jar": {
                   "version": "0.2.0",
-                  "from": "https://registry.npmjs.org/cookie-jar/-/cookie-jar-0.2.0.tgz",
+                  "from": "cookie-jar@>=0.2.0 <0.3.0",
                   "resolved": "https://registry.npmjs.org/cookie-jar/-/cookie-jar-0.2.0.tgz"
                 },
                 "aws-sign": {
                   "version": "0.2.0",
-                  "from": "https://registry.npmjs.org/aws-sign/-/aws-sign-0.2.0.tgz",
+                  "from": "aws-sign@>=0.2.0 <0.3.0",
                   "resolved": "https://registry.npmjs.org/aws-sign/-/aws-sign-0.2.0.tgz"
                 },
                 "oauth-sign": {
                   "version": "0.2.0",
-                  "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.2.0.tgz",
+                  "from": "oauth-sign@>=0.2.0 <0.3.0",
                   "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.2.0.tgz"
                 },
                 "forever-agent": {
                   "version": "0.2.0",
-                  "from": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.2.0.tgz",
+                  "from": "forever-agent@>=0.2.0 <0.3.0",
                   "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.2.0.tgz"
                 },
                 "tunnel-agent": {
                   "version": "0.2.0",
-                  "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.2.0.tgz",
+                  "from": "tunnel-agent@>=0.2.0 <0.3.0",
                   "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.2.0.tgz"
                 },
                 "json-stringify-safe": {
                   "version": "3.0.0",
-                  "from": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-3.0.0.tgz",
+                  "from": "json-stringify-safe@>=3.0.0 <3.1.0",
                   "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-3.0.0.tgz"
                 },
                 "qs": {
                   "version": "0.5.6",
-                  "from": "https://registry.npmjs.org/qs/-/qs-0.5.6.tgz",
+                  "from": "qs@>=0.5.4 <0.6.0",
                   "resolved": "https://registry.npmjs.org/qs/-/qs-0.5.6.tgz"
                 }
               }
             },
             "stack-trace": {
               "version": "0.0.9",
-              "from": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz",
+              "from": "stack-trace@>=0.0.0 <0.1.0",
               "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz"
             }
           }
         },
         "charm": {
           "version": "0.0.8",
-          "from": "https://registry.npmjs.org/charm/-/charm-0.0.8.tgz",
+          "from": "charm@>=0.0.5 <0.1.0",
           "resolved": "https://registry.npmjs.org/charm/-/charm-0.0.8.tgz"
         },
         "js-yaml": {
           "version": "2.1.3",
-          "from": "https://registry.npmjs.org/js-yaml/-/js-yaml-2.1.3.tgz",
+          "from": "js-yaml@>=2.1.0 <2.2.0",
           "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-2.1.3.tgz",
           "dependencies": {
             "argparse": {
               "version": "0.1.16",
-              "from": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
+              "from": "argparse@>=0.1.11 <0.2.0",
               "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
               "dependencies": {
                 "underscore": {
                   "version": "1.7.0",
-                  "from": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
+                  "from": "underscore@>=1.7.0 <1.8.0",
                   "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz"
                 },
                 "underscore.string": {
                   "version": "2.4.0",
-                  "from": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz",
+                  "from": "underscore.string@>=2.4.0 <2.5.0",
                   "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz"
                 }
               }
             },
             "esprima": {
               "version": "1.0.4",
-              "from": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
+              "from": "esprima@>=1.0.2 <1.1.0",
               "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
             }
           }
         },
         "tap": {
           "version": "0.4.13",
-          "from": "https://registry.npmjs.org/tap/-/tap-0.4.13.tgz",
+          "from": "tap@>=0.4.4 <0.5.0",
           "resolved": "https://registry.npmjs.org/tap/-/tap-0.4.13.tgz",
           "dependencies": {
             "buffer-equal": {
               "version": "0.0.1",
-              "from": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-0.0.1.tgz",
+              "from": "buffer-equal@>=0.0.0 <0.1.0",
               "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-0.0.1.tgz"
             },
             "deep-equal": {
               "version": "0.0.0",
-              "from": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.0.0.tgz",
+              "from": "deep-equal@>=0.0.0 <0.1.0",
               "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.0.0.tgz"
             },
             "difflet": {
               "version": "0.2.6",
-              "from": "https://registry.npmjs.org/difflet/-/difflet-0.2.6.tgz",
+              "from": "difflet@>=0.2.0 <0.3.0",
               "resolved": "https://registry.npmjs.org/difflet/-/difflet-0.2.6.tgz",
               "dependencies": {
                 "traverse": {
                   "version": "0.6.6",
-                  "from": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
+                  "from": "traverse@>=0.6.0 <0.7.0",
                   "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz"
                 },
                 "charm": {
                   "version": "0.1.2",
-                  "from": "https://registry.npmjs.org/charm/-/charm-0.1.2.tgz",
+                  "from": "charm@>=0.1.0 <0.2.0",
                   "resolved": "https://registry.npmjs.org/charm/-/charm-0.1.2.tgz"
                 },
                 "deep-is": {
                   "version": "0.1.3",
-                  "from": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+                  "from": "deep-is@>=0.1.0 <0.2.0",
                   "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
                 }
               }
             },
             "glob": {
               "version": "3.2.11",
-              "from": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+              "from": "glob@>=3.2.1 <3.3.0",
               "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
               "dependencies": {
                 "minimatch": {
                   "version": "0.3.0",
-                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                  "from": "minimatch@>=0.3.0 <0.4.0",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                   "dependencies": {
                     "lru-cache": {
-                      "version": "2.6.5",
-                      "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz",
-                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
+                      "version": "2.7.0",
+                      "from": "lru-cache@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.0.tgz"
                     },
                     "sigmund": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+                      "from": "sigmund@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
                     }
                   }
@@ -4205,56 +4217,56 @@
             },
             "inherits": {
               "version": "2.0.1",
-              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+              "from": "inherits@*",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             },
             "mkdirp": {
               "version": "0.5.1",
-              "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "from": "mkdirp@>=0.3.0 <0.4.0||>=0.4.0 <0.5.0||>=0.5.0 <0.6.0",
               "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
               "dependencies": {
                 "minimist": {
                   "version": "0.0.8",
-                  "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                  "from": "minimist@0.0.8",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
                 }
               }
             },
             "nopt": {
               "version": "2.2.1",
-              "from": "https://registry.npmjs.org/nopt/-/nopt-2.2.1.tgz",
+              "from": "nopt@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.2.1.tgz",
               "dependencies": {
                 "abbrev": {
                   "version": "1.0.7",
-                  "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz",
+                  "from": "abbrev@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
                 }
               }
             },
             "runforcover": {
               "version": "0.0.2",
-              "from": "https://registry.npmjs.org/runforcover/-/runforcover-0.0.2.tgz",
+              "from": "runforcover@>=0.0.2 <0.1.0",
               "resolved": "https://registry.npmjs.org/runforcover/-/runforcover-0.0.2.tgz",
               "dependencies": {
                 "bunker": {
                   "version": "0.1.2",
-                  "from": "https://registry.npmjs.org/bunker/-/bunker-0.1.2.tgz",
+                  "from": "bunker@>=0.1.0 <0.2.0",
                   "resolved": "https://registry.npmjs.org/bunker/-/bunker-0.1.2.tgz",
                   "dependencies": {
                     "burrito": {
                       "version": "0.2.12",
-                      "from": "https://registry.npmjs.org/burrito/-/burrito-0.2.12.tgz",
+                      "from": "burrito@>=0.2.5 <0.3.0",
                       "resolved": "https://registry.npmjs.org/burrito/-/burrito-0.2.12.tgz",
                       "dependencies": {
                         "traverse": {
                           "version": "0.5.2",
-                          "from": "https://registry.npmjs.org/traverse/-/traverse-0.5.2.tgz",
+                          "from": "traverse@>=0.5.1 <0.6.0",
                           "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.5.2.tgz"
                         },
                         "uglify-js": {
                           "version": "1.1.1",
-                          "from": "https://registry.npmjs.org/uglify-js/-/uglify-js-1.1.1.tgz",
+                          "from": "uglify-js@>=1.1.1 <1.2.0",
                           "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-1.1.1.tgz"
                         }
                       }
@@ -4265,105 +4277,105 @@
             },
             "slide": {
               "version": "1.1.6",
-              "from": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
+              "from": "slide@*",
               "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz"
             },
             "yamlish": {
               "version": "0.0.7",
-              "from": "https://registry.npmjs.org/yamlish/-/yamlish-0.0.7.tgz",
+              "from": "yamlish@*",
               "resolved": "https://registry.npmjs.org/yamlish/-/yamlish-0.0.7.tgz"
             }
           }
         },
         "commander": {
           "version": "2.8.1",
-          "from": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
+          "from": "commander@*",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
           "dependencies": {
             "graceful-readlink": {
               "version": "1.0.1",
-              "from": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+              "from": "graceful-readlink@>=1.0.0",
               "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
             }
           }
         },
         "glob": {
           "version": "3.1.21",
-          "from": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
+          "from": "glob@>=3.1.21 <3.2.0",
           "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
           "dependencies": {
             "minimatch": {
               "version": "0.2.14",
-              "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+              "from": "minimatch@>=0.2.11 <0.3.0",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
               "dependencies": {
                 "lru-cache": {
-                  "version": "2.6.5",
-                  "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz",
-                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
+                  "version": "2.7.0",
+                  "from": "lru-cache@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.0.tgz"
                 },
                 "sigmund": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+                  "from": "sigmund@>=1.0.0 <1.1.0",
                   "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
                 }
               }
             },
             "graceful-fs": {
               "version": "1.2.3",
-              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
+              "from": "graceful-fs@>=1.2.0 <1.3.0",
               "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
             },
             "inherits": {
-              "version": "1.0.0",
-              "from": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz"
+              "version": "1.0.2",
+              "from": "inherits@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz"
             }
           }
         },
         "async": {
           "version": "0.2.10",
-          "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+          "from": "async@>=0.2.7 <0.3.0",
           "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
         },
         "rimraf": {
           "version": "2.2.8",
-          "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+          "from": "rimraf@>=2.2.0 <2.3.0",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
         },
         "backbone": {
           "version": "1.0.0",
-          "from": "https://registry.npmjs.org/backbone/-/backbone-1.0.0.tgz",
+          "from": "backbone@>=1.0.0 <1.1.0",
           "resolved": "https://registry.npmjs.org/backbone/-/backbone-1.0.0.tgz"
         },
         "styled_string": {
           "version": "0.0.1",
-          "from": "https://registry.npmjs.org/styled_string/-/styled_string-0.0.1.tgz",
+          "from": "styled_string@*",
           "resolved": "https://registry.npmjs.org/styled_string/-/styled_string-0.0.1.tgz"
         },
         "colors": {
           "version": "0.6.2",
-          "from": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
+          "from": "colors@>=0.6.0 <0.7.0",
           "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
         },
         "fileset": {
           "version": "0.1.8",
-          "from": "https://registry.npmjs.org/fileset/-/fileset-0.1.8.tgz",
+          "from": "fileset@>=0.1.4 <0.2.0",
           "resolved": "https://registry.npmjs.org/fileset/-/fileset-0.1.8.tgz",
           "dependencies": {
             "minimatch": {
               "version": "0.4.0",
-              "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.4.0.tgz",
+              "from": "minimatch@>=0.0.0 <1.0.0",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.4.0.tgz",
               "dependencies": {
                 "lru-cache": {
-                  "version": "2.6.5",
-                  "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz",
-                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
+                  "version": "2.7.0",
+                  "from": "lru-cache@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.0.tgz"
                 },
                 "sigmund": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+                  "from": "sigmund@>=1.0.0 <1.1.0",
                   "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
                 }
               }
@@ -4372,37 +4384,37 @@
         },
         "growl": {
           "version": "1.7.0",
-          "from": "https://registry.npmjs.org/growl/-/growl-1.7.0.tgz",
+          "from": "growl@>=1.7.0 <1.8.0",
           "resolved": "https://registry.npmjs.org/growl/-/growl-1.7.0.tgz"
         },
         "consolidate": {
           "version": "0.8.0",
-          "from": "https://registry.npmjs.org/consolidate/-/consolidate-0.8.0.tgz",
+          "from": "consolidate@>=0.8.0 <0.9.0",
           "resolved": "https://registry.npmjs.org/consolidate/-/consolidate-0.8.0.tgz"
         },
         "did_it_work": {
           "version": "0.0.6",
-          "from": "https://registry.npmjs.org/did_it_work/-/did_it_work-0.0.6.tgz",
+          "from": "did_it_work@>=0.0.5 <0.1.0",
           "resolved": "https://registry.npmjs.org/did_it_work/-/did_it_work-0.0.6.tgz"
         },
         "fireworm": {
           "version": "0.4.4",
-          "from": "https://registry.npmjs.org/fireworm/-/fireworm-0.4.4.tgz",
+          "from": "fireworm@>=0.4.0 <0.5.0",
           "resolved": "https://registry.npmjs.org/fireworm/-/fireworm-0.4.4.tgz",
           "dependencies": {
             "minimatch": {
               "version": "0.2.14",
-              "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+              "from": "minimatch@>=0.2.9 <0.3.0",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
               "dependencies": {
                 "lru-cache": {
-                  "version": "2.6.5",
-                  "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz",
-                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
+                  "version": "2.7.0",
+                  "from": "lru-cache@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.0.tgz"
                 },
                 "sigmund": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+                  "from": "sigmund@>=1.0.0 <1.1.0",
                   "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
                 }
               }
@@ -4413,207 +4425,220 @@
     },
     "underscore": {
       "version": "1.8.3",
-      "from": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+      "from": "underscore@1.8.3",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz"
     },
     "watchify": {
       "version": "3.1.0",
-      "from": "https://registry.npmjs.org/watchify/-/watchify-3.1.0.tgz",
+      "from": "watchify@3.1.0",
       "resolved": "https://registry.npmjs.org/watchify/-/watchify-3.1.0.tgz",
       "dependencies": {
         "chokidar": {
-          "version": "1.0.5",
-          "from": "https://registry.npmjs.org/chokidar/-/chokidar-1.0.5.tgz",
-          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.0.5.tgz",
+          "version": "1.2.0",
+          "from": "chokidar@>=1.0.0-rc4 <2.0.0",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.2.0.tgz",
           "dependencies": {
             "anymatch": {
               "version": "1.3.0",
-              "from": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
+              "from": "anymatch@>=1.1.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
               "dependencies": {
                 "micromatch": {
                   "version": "2.2.0",
-                  "from": "https://registry.npmjs.org/micromatch/-/micromatch-2.2.0.tgz",
+                  "from": "micromatch@>=2.1.5 <3.0.0",
                   "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.2.0.tgz",
                   "dependencies": {
                     "arr-diff": {
-                      "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/arr-diff/-/arr-diff-1.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-1.0.1.tgz",
+                      "version": "1.1.0",
+                      "from": "arr-diff@>=1.0.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-1.1.0.tgz",
                       "dependencies": {
+                        "arr-flatten": {
+                          "version": "1.0.1",
+                          "from": "arr-flatten@>=1.0.1 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz"
+                        },
                         "array-slice": {
                           "version": "0.2.3",
-                          "from": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz",
+                          "from": "array-slice@>=0.2.3 <0.3.0",
                           "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz"
                         }
                       }
                     },
                     "array-unique": {
                       "version": "0.2.1",
-                      "from": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+                      "from": "array-unique@>=0.2.1 <0.3.0",
                       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz"
                     },
                     "braces": {
-                      "version": "1.8.0",
-                      "from": "https://registry.npmjs.org/braces/-/braces-1.8.0.tgz",
-                      "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.0.tgz",
+                      "version": "1.8.1",
+                      "from": "braces@>=1.8.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.1.tgz",
                       "dependencies": {
                         "expand-range": {
                           "version": "1.8.1",
-                          "from": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.1.tgz",
+                          "from": "expand-range@>=1.8.1 <2.0.0",
                           "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.1.tgz",
                           "dependencies": {
                             "fill-range": {
                               "version": "2.2.2",
-                              "from": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.2.tgz",
+                              "from": "fill-range@>=2.1.0 <3.0.0",
                               "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.2.tgz",
                               "dependencies": {
                                 "is-number": {
                                   "version": "1.1.2",
-                                  "from": "https://registry.npmjs.org/is-number/-/is-number-1.1.2.tgz",
+                                  "from": "is-number@>=1.1.2 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/is-number/-/is-number-1.1.2.tgz"
                                 },
                                 "isobject": {
                                   "version": "1.0.2",
-                                  "from": "https://registry.npmjs.org/isobject/-/isobject-1.0.2.tgz",
+                                  "from": "isobject@>=1.0.0 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/isobject/-/isobject-1.0.2.tgz"
                                 },
                                 "randomatic": {
                                   "version": "1.1.0",
-                                  "from": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.0.tgz",
+                                  "from": "randomatic@>=1.1.0 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.0.tgz"
                                 },
                                 "repeat-string": {
                                   "version": "1.5.2",
-                                  "from": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz",
+                                  "from": "repeat-string@>=1.5.2 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
                                 }
                               }
                             }
                           }
                         },
+                        "lazy-cache": {
+                          "version": "0.2.3",
+                          "from": "lazy-cache@>=0.2.3 <0.3.0",
+                          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.3.tgz"
+                        },
                         "preserve": {
                           "version": "0.2.0",
-                          "from": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+                          "from": "preserve@>=0.2.0 <0.3.0",
                           "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz"
                         },
                         "repeat-element": {
                           "version": "1.1.2",
-                          "from": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
+                          "from": "repeat-element@>=1.1.2 <2.0.0",
                           "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz"
                         }
                       }
                     },
                     "expand-brackets": {
-                      "version": "0.1.3",
-                      "from": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.3.tgz",
-                      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.3.tgz",
-                      "dependencies": {
-                        "is-posix-bracket": {
-                          "version": "0.1.0",
-                          "from": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.0.tgz",
-                          "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.0.tgz"
-                        }
-                      }
+                      "version": "0.1.4",
+                      "from": "expand-brackets@>=0.1.1 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.4.tgz"
                     },
                     "extglob": {
                       "version": "0.3.1",
-                      "from": "https://registry.npmjs.org/extglob/-/extglob-0.3.1.tgz",
+                      "from": "extglob@>=0.3.0 <0.4.0",
                       "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.1.tgz",
                       "dependencies": {
                         "ansi-green": {
                           "version": "0.1.1",
-                          "from": "https://registry.npmjs.org/ansi-green/-/ansi-green-0.1.1.tgz",
+                          "from": "ansi-green@>=0.1.1 <0.2.0",
                           "resolved": "https://registry.npmjs.org/ansi-green/-/ansi-green-0.1.1.tgz",
                           "dependencies": {
                             "ansi-wrap": {
                               "version": "0.1.0",
-                              "from": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
+                              "from": "ansi-wrap@0.1.0",
                               "resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz"
                             }
                           }
                         },
                         "is-extglob": {
                           "version": "1.0.0",
-                          "from": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+                          "from": "is-extglob@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
                         },
                         "success-symbol": {
                           "version": "0.1.0",
-                          "from": "https://registry.npmjs.org/success-symbol/-/success-symbol-0.1.0.tgz",
+                          "from": "success-symbol@>=0.1.0 <0.2.0",
                           "resolved": "https://registry.npmjs.org/success-symbol/-/success-symbol-0.1.0.tgz"
                         }
                       }
                     },
                     "filename-regex": {
                       "version": "2.0.0",
-                      "from": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz",
+                      "from": "filename-regex@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz"
+                    },
+                    "is-glob": {
+                      "version": "1.1.3",
+                      "from": "is-glob@>=1.1.3 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-1.1.3.tgz"
                     },
                     "kind-of": {
                       "version": "1.1.0",
-                      "from": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
+                      "from": "kind-of@>=1.1.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz"
                     },
                     "object.omit": {
                       "version": "1.1.0",
-                      "from": "https://registry.npmjs.org/object.omit/-/object.omit-1.1.0.tgz",
+                      "from": "object.omit@>=1.1.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-1.1.0.tgz",
                       "dependencies": {
                         "for-own": {
                           "version": "0.1.3",
-                          "from": "https://registry.npmjs.org/for-own/-/for-own-0.1.3.tgz",
+                          "from": "for-own@>=0.1.3 <0.2.0",
                           "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.3.tgz",
                           "dependencies": {
                             "for-in": {
                               "version": "0.1.4",
-                              "from": "https://registry.npmjs.org/for-in/-/for-in-0.1.4.tgz",
+                              "from": "for-in@>=0.1.4 <0.2.0",
                               "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.4.tgz"
                             }
                           }
                         },
                         "isobject": {
                           "version": "1.0.2",
-                          "from": "https://registry.npmjs.org/isobject/-/isobject-1.0.2.tgz",
+                          "from": "isobject@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/isobject/-/isobject-1.0.2.tgz"
                         }
                       }
                     },
                     "parse-glob": {
-                      "version": "3.0.2",
-                      "from": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.2.tgz",
-                      "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.2.tgz",
+                      "version": "3.0.4",
+                      "from": "parse-glob@>=3.0.1 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
                       "dependencies": {
                         "glob-base": {
-                          "version": "0.2.0",
-                          "from": "https://registry.npmjs.org/glob-base/-/glob-base-0.2.0.tgz",
-                          "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.2.0.tgz"
+                          "version": "0.3.0",
+                          "from": "glob-base@>=0.3.0 <0.4.0",
+                          "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz"
                         },
                         "is-dotfile": {
                           "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.1.tgz",
+                          "from": "is-dotfile@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.1.tgz"
                         },
                         "is-extglob": {
                           "version": "1.0.0",
-                          "from": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+                          "from": "is-extglob@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
+                        },
+                        "is-glob": {
+                          "version": "2.0.0",
+                          "from": "is-glob@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.0.tgz"
                         }
                       }
                     },
                     "regex-cache": {
                       "version": "0.4.2",
-                      "from": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.2.tgz",
+                      "from": "regex-cache@>=0.4.2 <0.5.0",
                       "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.2.tgz",
                       "dependencies": {
                         "is-equal-shallow": {
                           "version": "0.1.3",
-                          "from": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+                          "from": "is-equal-shallow@>=0.1.1 <0.2.0",
                           "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz"
                         },
                         "is-primitive": {
                           "version": "2.0.0",
-                          "from": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+                          "from": "is-primitive@>=2.0.0 <3.0.0",
                           "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz"
                         }
                       }
@@ -4624,92 +4649,138 @@
             },
             "arrify": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/arrify/-/arrify-1.0.0.tgz",
+              "from": "arrify@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.0.tgz"
             },
             "async-each": {
               "version": "0.1.6",
-              "from": "https://registry.npmjs.org/async-each/-/async-each-0.1.6.tgz",
+              "from": "async-each@>=0.1.5 <0.2.0",
               "resolved": "https://registry.npmjs.org/async-each/-/async-each-0.1.6.tgz"
             },
             "glob-parent": {
-              "version": "1.2.0",
-              "from": "https://registry.npmjs.org/glob-parent/-/glob-parent-1.2.0.tgz",
-              "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-1.2.0.tgz"
+              "version": "2.0.0",
+              "from": "glob-parent@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz"
             },
             "is-binary-path": {
               "version": "1.0.1",
-              "from": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+              "from": "is-binary-path@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
               "dependencies": {
                 "binary-extensions": {
                   "version": "1.3.1",
-                  "from": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.3.1.tgz",
+                  "from": "binary-extensions@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.3.1.tgz"
                 }
               }
             },
             "is-glob": {
-              "version": "1.1.3",
-              "from": "https://registry.npmjs.org/is-glob/-/is-glob-1.1.3.tgz",
-              "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-1.1.3.tgz"
+              "version": "2.0.0",
+              "from": "is-glob@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.0.tgz"
+            },
+            "lodash.flatten": {
+              "version": "3.0.2",
+              "from": "lodash.flatten@>=3.0.2 <4.0.0",
+              "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-3.0.2.tgz",
+              "dependencies": {
+                "lodash._baseflatten": {
+                  "version": "3.1.4",
+                  "from": "lodash._baseflatten@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash._baseflatten/-/lodash._baseflatten-3.1.4.tgz",
+                  "dependencies": {
+                    "lodash.isarguments": {
+                      "version": "3.0.4",
+                      "from": "lodash.isarguments@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz"
+                    },
+                    "lodash.isarray": {
+                      "version": "3.0.4",
+                      "from": "lodash.isarray@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
+                    }
+                  }
+                },
+                "lodash._isiterateecall": {
+                  "version": "3.0.9",
+                  "from": "lodash._isiterateecall@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz"
+                }
+              }
             },
             "path-is-absolute": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+              "from": "path-is-absolute@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
             },
             "readdirp": {
-              "version": "1.4.0",
-              "from": "https://registry.npmjs.org/readdirp/-/readdirp-1.4.0.tgz",
-              "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-1.4.0.tgz",
+              "version": "2.0.0",
+              "from": "readdirp@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.0.0.tgz",
               "dependencies": {
                 "graceful-fs": {
                   "version": "4.1.2",
-                  "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz",
+                  "from": "graceful-fs@>=4.1.2 <5.0.0",
                   "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
                 },
                 "minimatch": {
-                  "version": "0.2.14",
-                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
-                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+                  "version": "2.0.10",
+                  "from": "minimatch@>=2.0.10 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
                   "dependencies": {
-                    "lru-cache": {
-                      "version": "2.6.5",
-                      "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz",
-                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
-                    },
-                    "sigmund": {
-                      "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+                    "brace-expansion": {
+                      "version": "1.1.1",
+                      "from": "brace-expansion@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz",
+                      "dependencies": {
+                        "balanced-match": {
+                          "version": "0.2.0",
+                          "from": "balanced-match@>=0.2.0 <0.3.0",
+                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                        },
+                        "concat-map": {
+                          "version": "0.0.1",
+                          "from": "concat-map@0.0.1",
+                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                        }
+                      }
                     }
                   }
                 },
                 "readable-stream": {
-                  "version": "1.0.33",
-                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                  "version": "2.0.2",
+                  "from": "readable-stream@>=2.0.2 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                    },
-                    "isarray": {
-                      "version": "0.0.1",
-                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31",
-                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "from": "inherits@>=2.0.1 <2.1.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    },
+                    "process-nextick-args": {
+                      "version": "1.0.3",
+                      "from": "process-nextick-args@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.3.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    },
+                    "util-deprecate": {
+                      "version": "1.0.1",
+                      "from": "util-deprecate@>=1.0.1 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
                     }
                   }
                 }
@@ -4719,37 +4790,37 @@
         },
         "defined": {
           "version": "0.0.0",
-          "from": "https://registry.npmjs.org/defined/-/defined-0.0.0.tgz",
+          "from": "defined@>=0.0.0 <0.1.0",
           "resolved": "https://registry.npmjs.org/defined/-/defined-0.0.0.tgz"
         },
         "outpipe": {
           "version": "1.1.1",
-          "from": "https://registry.npmjs.org/outpipe/-/outpipe-1.1.1.tgz",
+          "from": "outpipe@>=1.1.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/outpipe/-/outpipe-1.1.1.tgz",
           "dependencies": {
             "shell-quote": {
               "version": "1.4.3",
-              "from": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.4.3.tgz",
+              "from": "shell-quote@>=1.4.2 <2.0.0",
               "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.4.3.tgz",
               "dependencies": {
                 "jsonify": {
                   "version": "0.0.0",
-                  "from": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+                  "from": "jsonify@>=0.0.0 <0.1.0",
                   "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
                 },
                 "array-filter": {
                   "version": "0.0.1",
-                  "from": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz",
+                  "from": "array-filter@>=0.0.0 <0.1.0",
                   "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz"
                 },
                 "array-reduce": {
                   "version": "0.0.0",
-                  "from": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz",
+                  "from": "array-reduce@>=0.0.0 <0.1.0",
                   "resolved": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz"
                 },
                 "array-map": {
                   "version": "0.0.0",
-                  "from": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz",
+                  "from": "array-map@>=0.0.0 <0.1.0",
                   "resolved": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz"
                 }
               }
@@ -4758,32 +4829,32 @@
         },
         "through2": {
           "version": "0.6.5",
-          "from": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+          "from": "through2@>=0.6.3 <0.7.0",
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
           "dependencies": {
             "readable-stream": {
               "version": "1.0.33",
-              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+              "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                  "from": "core-util-is@>=1.0.0 <1.1.0",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                 },
                 "isarray": {
                   "version": "0.0.1",
-                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                  "from": "isarray@0.0.1",
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                  "from": "string_decoder@>=0.10.0 <0.11.0",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "from": "inherits@>=2.0.1 <2.1.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
@@ -4792,7 +4863,7 @@
         },
         "xtend": {
           "version": "4.0.0",
-          "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz",
+          "from": "xtend@>=4.0.0 <5.0.0",
           "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
         }
       }

--- a/src/rf/package.json
+++ b/src/rf/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "test": "test",
     "lint": "node_modules/.bin/eslint $(find js -name *.js)",
-    "livereload": "node_modules/.bin/livereloadify /var/www/rf/static --glob '**/*.*'"
+    "livereload": "./node_modules/.bin/livereload /var/www/rf/static/css/ -i 200"
   },
   "repository": {
     "type": "git",
@@ -30,7 +30,7 @@
     "jquery": "2.1.3",
     "leaflet": "0.7.3",
     "leaflet.locatecontrol": "0.43.0",
-    "livereloadify": "2.0.0",
+    "livereload": "0.3.7",
     "minifyify": "7.0.0",
     "mocha": "2.0.1",
     "moment": "2.10.6",


### PR DESCRIPTION
This lets you inject CSS changes into the page directly without having
to do a page refresh.

The LiveReload browser extension is required for this to work.

To test, run then following commands:

`./scripts/bundle.sh --watch`

`./scripts/npm.sh run livereload`

Then edit any SASS file.