### PR TITLE
Script creation of S3 and SQS resources

### DIFF
--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -1,6 +1,5 @@
 ---
 django_test_database: "{{ lookup('env', 'RF_TEST_DB_NAME') | default('test_rf', true) }}"
-sqs_queue: "{{ lookup('env', 'SQS_QUEUE_NAME') | default('TestQueue', true) }}"
 sqs_region: "{{ lookup('env', 'SQS_QUEUE_REGION') | default('us-east-1', true) }}"
 
 redis_port: 6379
@@ -17,7 +16,6 @@ postgresql_password: rf
 postgresql_database: rf
 
 aws_profile: "{{ lookup('env', 'AWS_PROFILE') | default('rf-dev', true) }}"
-aws_bucket: "{{ lookup('env', 'RF_AWS_BUCKET') | default('', true) }}"
 
 postgresql_version: "9.4"
 postgresql_package_version: "9.4.*-1.pgdg14.04+1"

--- a/deployment/ansible/group_vars/development
+++ b/deployment/ansible/group_vars/development
@@ -15,3 +15,7 @@ postgresql_host: "{{ services_ip }}"
 relp_host: "{{ services_ip }}"
 graphite_host: "{{ services_ip }}"
 statsite_host: "{{ services_ip }}"
+
+sqs_queue: "raster-foundry-{{ lookup('env', 'USER') | regex_replace('^(.*\\\\\\)?(.*)$', '\\\\2') }}"
+sqs_dead_letter_queue: "raster-foundry-{{ lookup('env', 'USER') | regex_replace('^(.*\\\\\\)?(.*)$', '\\\\2') }}-dead-letter"
+s3_bucket: "raster-foundry-{{ lookup('env', 'USER') | regex_replace('^(.*\\\\\\)?(.*)$', '\\\\2') }}"

--- a/deployment/ansible/group_vars/packer
+++ b/deployment/ansible/group_vars/packer
@@ -1,0 +1,3 @@
+sqs_queue: "raster-foundry"
+sqs_dead_letter_queue: "raster-foundry-dead-letter"
+s3_bucket: "raster-foundry"

--- a/deployment/ansible/group_vars/test
+++ b/deployment/ansible/group_vars/test
@@ -14,3 +14,7 @@ postgresql_host: "{{ services_ip }}"
 relp_host: "{{ services_ip }}"
 graphite_host: "{{ services_ip }}"
 statsite_host: "{{ services_ip }}"
+
+sqs_queue: "raster-foundry-jenkins"
+sqs_dead_letter_queue: "raster-foundry-jenkins-dead-letter"
+s3_bucket: "raster-foundry-jenkins"

--- a/deployment/ansible/roles/raster-foundry.app/handlers/main.yml
+++ b/deployment/ansible/roles/raster-foundry.app/handlers/main.yml
@@ -1,3 +1,3 @@
 ---
-- name: Restart rf-django
+- name: Restart rf-app
   service: name=rf-app state=restarted

--- a/deployment/ansible/roles/raster-foundry.app/tasks/configuration.yml
+++ b/deployment/ansible/roles/raster-foundry.app/tasks/configuration.yml
@@ -2,9 +2,9 @@
 - name: Configure Gunicorn settings
   template: src=gunicorn.py.j2 dest=/etc/rf.d/gunicorn.py
   notify:
-    - Restart rf-django
+    - Restart rf-app
 
 - name: Configure service definition
   template: src=upstart-app.conf.j2 dest=/etc/init/rf-app.conf
   notify:
-    - Restart rf-django
+    - Restart rf-app

--- a/deployment/ansible/roles/raster-foundry.app/tasks/dependencies.yml
+++ b/deployment/ansible/roles/raster-foundry.app/tasks/dependencies.yml
@@ -6,10 +6,10 @@
     - test
   when: "['development', 'test'] | some_are_in(group_names)"
   notify:
-    - Restart rf-django
+    - Restart rf-app
 
 - name: Install application Python dependencies for production
   pip: chdir="{{ django_home }}/requirements" requirements=production.txt
   when: "['packer'] | is_in(group_names)"
   notify:
-    - Restart rf-django
+    - Restart rf-app

--- a/deployment/ansible/roles/raster-foundry.app/templates/upstart-app.conf.j2
+++ b/deployment/ansible/roles/raster-foundry.app/templates/upstart-app.conf.j2
@@ -1,4 +1,4 @@
-description "rf-django"
+description "rf-app"
 
 {% if ['development', 'test'] | some_are_in(group_names) -%}
 start on (vagrant-mounted)
@@ -10,5 +10,9 @@ stop on shutdown
 respawn
 setuid rf
 chdir {{ django_home }}
+
+pre-start script
+    envdir /etc/rf.d/env python create-aws-resources.py >> {{ log_path }} 2>&1
+end script
 
 exec envdir /etc/rf.d/env gunicorn --config /etc/rf.d/gunicorn.py rf.wsgi >> {{ log_path }} 2>&1

--- a/deployment/ansible/roles/raster-foundry.base/defaults/main.yml
+++ b/deployment/ansible/roles/raster-foundry.base/defaults/main.yml
@@ -10,7 +10,10 @@ envdir_config:
   RF_CACHE_HOST: "{{ redis_host }}"
   RF_CACHE_PORT: "{{ redis_port }}"
   AWS_PROFILE: "{{ aws_profile }}"
-  RF_AWS_BUCKET: "{{ aws_bucket }}"
+  RF_S3_BUCKET: "{{ s3_bucket }}"
+  RF_SQS_QUEUE: "{{ sqs_queue }}"
+  RF_SQS_DEAD_LETTER_QUEUE: "{{ sqs_dead_letter_queue }}"
+  RF_SQS_REGION: "{{ sqs_region }}"
 
 django_config:
   DJANGO_TEST_DB_NAME: "{{ django_test_database }}"
@@ -19,8 +22,6 @@ django_config:
   DJANGO_MEDIA_ROOT: "{{ django_media_root }}"
   DJANGO_POSTGIS_VERSION: "{{ postgis_version }}"
   DJANGO_SECRET_KEY: "{{ django_secret_key }}"
-  SQS_QUEUE_NAME: "{{ sqs_queue }}"
-  SQS_QUEUE_REGION: "{{ sqs_region }}"
 
 postgis_version: 2.1.3
 deploy_branch: "master"

--- a/deployment/ansible/roles/raster-foundry.base/handlers/main.yml
+++ b/deployment/ansible/roles/raster-foundry.base/handlers/main.yml
@@ -1,4 +1,12 @@
 ---
-- name: Restart rf-django
+- name: Restart Vagrant
+  service: name=vagrant state=restarted
+  when: "['app-servers', 'workers'] | some_are_in(group_names)"
+
+- name: Restart rf-app
   service: name=rf-app state=restarted
-  when: "['app-servers', 'workers'] | is_in(group_names)"
+  when: "['app-servers'] | is_in(group_names)"
+
+- name: Restart rf-worker
+  service: name=rf-worker state=restarted
+  when: "['workers'] | is_in(group_names)"

--- a/deployment/ansible/roles/raster-foundry.base/tasks/configuration.yml
+++ b/deployment/ansible/roles/raster-foundry.base/tasks/configuration.yml
@@ -27,7 +27,7 @@
         mode=0750
   with_dict: envdir_config
   notify:
-    - Restart rf-django
+    - Restart rf-app
 
 - name: Configure django application
   copy: content="{{ item.value }}"
@@ -37,4 +37,5 @@
         mode=0750
   with_dict: django_config
   notify:
-    - Restart rf-django
+    - Restart rf-app
+    - Restart rf-worker

--- a/deployment/ansible/roles/raster-foundry.base/tasks/main.yml
+++ b/deployment/ansible/roles/raster-foundry.base/tasks/main.yml
@@ -1,4 +1,8 @@
 ---
+- include: vagrant-mounted.yml
+  when:
+    - "['development', 'test'] | some_are_in(group_names)"
+    - "['app-servers', 'workers'] | some_are_in(group_names)"
 - { include: chef-and-puppet.yml, when: "['development', 'test'] | some_are_in(group_names)" }
 - { include: configuration.yml }
 - { include: dependencies.yml }

--- a/deployment/ansible/roles/raster-foundry.base/tasks/vagrant-mounted.yml
+++ b/deployment/ansible/roles/raster-foundry.base/tasks/vagrant-mounted.yml
@@ -1,0 +1,6 @@
+---
+- name: Configure Vagrant service definition
+  template: src=vagrant.conf.j2
+            dest=/etc/init/vagrant.conf
+  notify:
+    - Restart Vagrant

--- a/deployment/ansible/roles/raster-foundry.base/templates/vagrant.conf.j2
+++ b/deployment/ansible/roles/raster-foundry.base/templates/vagrant.conf.j2
@@ -1,0 +1,10 @@
+start on filesystem
+
+task
+
+script
+  until mountpoint -q /home/vagrant/.aws; do sleep 1; done
+  until mountpoint -q /opt/app; do sleep 1; done
+
+  /sbin/initctl emit vagrant-mounted
+end script

--- a/deployment/ansible/roles/raster-foundry.worker/defaults/main.yml
+++ b/deployment/ansible/roles/raster-foundry.worker/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-django_home: /opt/worker
+django_home: /opt/app
 
 log_path: /var/log/rf-worker.log
 

--- a/deployment/ansible/roles/raster-foundry.worker/handlers/main.yml
+++ b/deployment/ansible/roles/raster-foundry.worker/handlers/main.yml
@@ -1,3 +1,3 @@
 ---
-- name: Restart rf-django
+- name: Restart rf-worker
   service: name=rf-worker state=restarted

--- a/deployment/ansible/roles/raster-foundry.worker/tasks/configuration.yml
+++ b/deployment/ansible/roles/raster-foundry.worker/tasks/configuration.yml
@@ -2,4 +2,4 @@
 - name: Configure service definition
   template: src=upstart-worker.conf.j2 dest=/etc/init/rf-worker.conf
   notify:
-    - Restart rf-django
+    - Restart rf-worker

--- a/deployment/ansible/roles/raster-foundry.worker/tasks/dependencies.yml
+++ b/deployment/ansible/roles/raster-foundry.worker/tasks/dependencies.yml
@@ -6,10 +6,10 @@
     - test
   when: "['development', 'test'] | some_are_in(group_names)"
   notify:
-    - Restart rf-django
+    - Restart rf-worker
 
 - name: Install Python dependencies for production
   pip: chdir="{{ django_home }}/requirements" requirements=production.txt
   when: "['packer'] | is_in(group_names)"
   notify:
-    - Restart rf-django
+    - Restart rf-worker

--- a/deployment/ansible/roles/raster-foundry.worker/templates/upstart-worker.conf.j2
+++ b/deployment/ansible/roles/raster-foundry.worker/templates/upstart-worker.conf.j2
@@ -1,4 +1,4 @@
-description "rf-django"
+description "rf-worker"
 
 {% if ['development', 'test'] | some_are_in(group_names) -%}
 start on (vagrant-mounted)
@@ -7,8 +7,8 @@ start on (local-filesystems and net-device-up IFACE!=lo)
 {% endif %}
 stop on shutdown
 
-# respawn
+respawn
 setuid rf
 chdir {{ django_home }}
 
-# TODO
+exec python -mSimpleHTTPServer >> {{ log_path }} 2>&1

--- a/scripts/create-aws-resources.sh
+++ b/scripts/create-aws-resources.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# Convenience script for manually running create-aws-resources.py on app VM
+
+set -e
+set -x
+
+vagrant ssh app -c "cd /opt/app && envdir /etc/rf.d/env ./create-aws-resources.py"

--- a/src/rf/create-aws-resources.py
+++ b/src/rf/create-aws-resources.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python
+
+# -*- coding: utf-8 -*-
+from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import division
+
+import json
+from os import environ
+
+import boto3
+import botocore
+
+SQS_REGION = environ.get('RF_SQS_REGION')
+SQS_QUEUE = environ.get('RF_SQS_QUEUE')
+SQS_DEAD_LETTER_QUEUE = environ.get('RF_SQS_DEAD_LETTER_QUEUE')
+S3_BUCKET = environ.get('RF_S3_BUCKET')
+
+VISIBILITY_TIMEOUT = 120
+MAX_RECEIVE_COUNT = 5
+
+
+def make_sqs_policy(queue_arn, bucket_name):
+    """
+    Policy that allows S3 bucket to publish to SQS queue.
+    from http://docs.aws.amazon.com/AmazonS3/latest/dev/
+    ... ways-to-add-notification-config-to-bucket.html
+    """
+
+    return {
+        "Version": "2008-10-17",
+        "Statement": [
+            {
+                "Sid": "Stmt1444351543000",
+                "Effect": "Allow",
+                "Principal": {
+                    "AWS": "*"
+                },
+                "Action": [
+                    "SQS:SendMessage"
+                ],
+                "Resource": queue_arn,
+                "Condition": {
+                    "ArnLike": {
+                        "aws:SourceArn": "arn:aws:s3:*:*:" + bucket_name
+                    }
+                }
+            }
+        ]
+    }
+
+
+class CreateAwsResources(object):
+    """"
+    Encapsulates a process for creating an SQS queue,
+    an attached dead letter queue, and an S3 bucket
+    that sends messages to the SQS queue on object creation.
+    """
+    def __init__(self):
+        print('create-aws-resources.py started')
+
+        self.session = boto3.session.Session(region_name=SQS_REGION)
+
+        self.sqs = self.session.resource('sqs')
+        self.sqs_client = self.session.client('sqs')
+
+        self.s3 = self.session.resource('s3')
+        self.s3_client = self.session.client('s3')
+
+        self.create_resources()
+
+    def create_queue(self, queue_name):
+        try:
+            queue = self.sqs.get_queue_by_name(QueueName=queue_name)
+        except botocore.exceptions.ClientError as e:
+            error_code = e.response['Error']['Code']
+            if error_code == 'AWS.SimpleQueueService.NonExistentQueue':
+                queue = self.sqs.create_queue(QueueName=queue_name)
+            else:
+                raise e
+
+        return queue
+
+    def create_main_queue(self, dead_letter_queue):
+        main_queue = self.create_queue(SQS_QUEUE)
+
+        # Setup dead letter queue and policy so S3 can publish to queue
+        dead_letter_arn = dead_letter_queue.attributes['QueueArn']
+        main_arn = main_queue.attributes['QueueArn']
+        redrive_policy = json.dumps({
+            'maxReceiveCount': MAX_RECEIVE_COUNT,
+            'deadLetterTargetArn': dead_letter_arn,
+        })
+        sqs_policy = json.dumps(make_sqs_policy(main_arn, S3_BUCKET))
+
+        self.sqs_client.set_queue_attributes(
+            QueueUrl=main_queue.url,
+            Attributes={
+                'RedrivePolicy': redrive_policy,
+                'Policy': sqs_policy
+            }
+        )
+
+        return main_queue
+
+    def create_bucket(self, bucket_name):
+        try:
+            bucket = self.s3_client.head_bucket(Bucket=bucket_name)
+        except botocore.exceptions.ClientError as e:
+            error_code = int(e.response['Error']['Code'])
+            if error_code == 404:
+                bucket = self.s3_client.create_bucket(Bucket=bucket_name)
+            else:
+                raise e
+        return bucket
+
+    def create_s3_bucket(self, main_queue):
+        self.create_bucket(S3_BUCKET)
+
+        # Setup bucket to notify SQS on object creation.
+        waiter = self.s3_client.get_waiter('bucket_exists')
+        waiter.wait(Bucket=S3_BUCKET)
+
+        bucket_notification = self.s3.BucketNotification(S3_BUCKET)
+        main_queue_arn = main_queue.attributes['QueueArn']
+        bucket_notification.put(
+            NotificationConfiguration={
+                'QueueConfigurations': [
+                    {
+                        'QueueArn': main_queue_arn,
+                        'Events': [
+                            's3:ObjectCreated:*',
+                        ],
+                    },
+                ],
+            }
+        )
+
+        # Setup CORS config so that frontend can post to the bucket.
+        bucket_cors = self.s3.BucketCors(S3_BUCKET)
+        bucket_cors.put(
+            CORSConfiguration={
+                'CORSRules': [
+                    {
+                        'AllowedHeaders': ['*'],
+                        'AllowedMethods': ['GET', 'PUT', 'POST', 'DELETE'],
+                        'AllowedOrigins': ['*'],
+                        'ExposeHeaders': ['ETag'],
+                        'MaxAgeSeconds': 3000,
+                    },
+                ]
+            }
+        )
+
+    def create_resources(self):
+        dead_letter_queue = self.create_queue(SQS_DEAD_LETTER_QUEUE)
+        main_queue = self.create_main_queue(dead_letter_queue)
+
+        self.create_s3_bucket(main_queue)
+
+CreateAwsResources()

--- a/src/rf/requirements/base.txt
+++ b/src/rf/requirements/base.txt
@@ -6,3 +6,4 @@ hiredis==0.1.6
 django-registration-redux==1.2
 django-filter==0.10.0
 boto==2.38.0
+boto3==1.1.4

--- a/src/rf/rf/settings/base.py
+++ b/src/rf/rf/settings/base.py
@@ -279,9 +279,9 @@ WSGI_APPLICATION = '%s.wsgi.application' % SITE_NAME
 
 # AWS CONFIGURATION
 
-AWS_BUCKET_NAME = environ.get('RF_AWS_BUCKET', 'raster-foundry-test-uploads-67dc48c70b3bcf89eab78dbf5cf7900')  # NOQA
+AWS_BUCKET_NAME = environ.get('RF_S3_BUCKET', 'raster-foundry-test-uploads-67dc48c70b3bcf89eab78dbf5cf7900')  # NOQA
 AWS_PROFILE = environ.get('AWS_PROFILE', 'rf-dev')
-AWS_SQS_QUEUE = environ.get('SQS_QUEUE_NAME', 'TestQueue')
-AWS_SQS_REGION = environ.get('SQS_QUEUE_REGION', 'us-east-1')
+AWS_SQS_QUEUE = environ.get('RF_SQS_QUEUE', 'TestQueue')
+AWS_SQS_REGION = environ.get('RF_SQS_REGION', 'us-east-1')
 
 # END AWS CONFIGURATION


### PR DESCRIPTION
Provisioning the app now creates RF_SQS, RF_SQS_DEAD_LETTER, and RF_S3_BUCKET in /etc/rf.d/env based on the USER, and runs a script to create an SQS queue, an SQS dead letter queue, and an S3 bucket with names specified by these environment variables. The frontend should get the new bucket name and upload there, which should result in messages in the queue.

Connects #116 
