### PR TITLE
Display system notifications when bundle.sh updates a file in watch mode

### DIFF
--- a/src/rf/bundle.sh
+++ b/src/rf/bundle.sh
@@ -27,6 +27,8 @@ VENDOR_CSS_FILE="${STATIC_CSS_DIR}vendor.css"
 
 TEST_FILES="./js/src/**/tests.js"
 
+NOTIFY_COMMAND=""
+
 usage() {
     echo -n "$(basename $0) [OPTION]...
 
@@ -65,6 +67,12 @@ if [ -n "$ENABLE_WATCH" ]; then
     # This argument must be a folder in watch mode, but a
     # single file otherwise.
     ENTRY_SASS_FILE="$ENTRY_SASS_DIR"
+
+    # Requires libnotify-bin, inotify-tools, and the Python when-changed
+    # module on the guest VM.
+    # Requires the vagrant-notify plugin on the host VM.
+    NOTIFY_COMMAND="when-changed -r ${DJANGO_STATIC_ROOT} -c \
+        command notify-send \"bundle.sh\" \"Updated\" &"
 fi
 
 if [ -n "$ENABLE_DEBUG" ]; then
@@ -129,7 +137,7 @@ if [ -n "$ENABLE_TESTS" ]; then
             -o ${STATIC_JS_DIR}test.bundle.js $EXTRA_ARGS &"
 fi
 
-VAGRANT_COMMAND="$TEST_COMMAND $VENDOR_COMMAND
+VAGRANT_COMMAND="$NOTIFY_COMMAND $TEST_COMMAND $VENDOR_COMMAND
     $NODE_SASS $ENTRY_SASS_FILE -o ${STATIC_CSS_DIR} &
     $BROWSERIFY $ENTRY_JS_FILES $BROWSERIFY_EXT $REACTIFY_TRANSFORM \
         -o ${STATIC_JS_DIR}main.js $EXTRA_ARGS"

--- a/src/rf/requirements/development.txt
+++ b/src/rf/requirements/development.txt
@@ -4,3 +4,4 @@ flake8==2.4.0
 ipython==2.3.0
 django-debug-toolbar==1.3
 ipdb==0.8
+when-changed==0.2.1


### PR DESCRIPTION
To install:

1. `vagrant plugin install vagrant-notify` (Note: There are additional
steps for OS X. See https://github.com/fgrehm/vagrant-notify#os-x)
2. Reload app VM

To test:

1. Run `./scripts/bundle.sh --watch`
2. Change any JS/CSS file