### PR TITLE
Fix favorited layers not appearing as favorited

### DIFF
--- a/src/rf/apps/core/context_processors.py
+++ b/src/rf/apps/core/context_processors.py
@@ -9,32 +9,25 @@ import boto
 from django.conf import settings
 from django.core.urlresolvers import reverse
 
+from apps.user.views import get_user_data
+
 
 def page_context(request):
     """
     Context available on every page.
     """
     return {
-        'user_data': get_user_data(request),
-        'client_settings': get_client_settings(),
+        'user_data': json.dumps(get_user_data(request)),
+        'client_settings': json.dumps(get_client_settings()),
     }
-
-
-def get_user_data(request):
-    user_data = json.dumps({
-        'id': request.user.id,
-        'username': request.user.username,
-    })
-    return user_data
 
 
 def get_client_settings():
     conn = boto.connect_s3(profile_name=settings.AWS_PROFILE)
     aws_key = conn.aws_access_key_id
-
-    client_settings = json.dumps({
+    client_settings = {
         'signerUrl': reverse('sign_request'),
         'awsKey': aws_key,
         'awsBucket': settings.AWS_BUCKET_NAME,
-    })
+    }
     return client_settings

--- a/src/rf/apps/core/models.py
+++ b/src/rf/apps/core/models.py
@@ -114,11 +114,6 @@ class Layer(Model):
         tags = [m.to_json() for m in self.layer_tags.all()]
         images = [m.to_json() for m in self.layer_images.all()]
 
-        # Iterate over prefetched favorites instead of executing
-        # a new query for each layer by using a queryset filter.
-        favorite = len([row for row in self.favorites.all()
-                        if row.user_id == self.user_id]) > 0
-
         return {
             'id': self.id,
             'name': self.name,
@@ -144,7 +139,6 @@ class Layer(Model):
             # Foreign key fields
             'tags': tags,
             'images': images,
-            'favorite': favorite,
             'username': self.user.username,
 
             # Generated fields

--- a/src/rf/apps/home/views.py
+++ b/src/rf/apps/home/views.py
@@ -152,8 +152,6 @@ def my_layers(request):
 @accepts('GET')
 def my_favorites(request):
     ids = UserFavoriteLayer.objects.filter(user__id=request.user.id) \
-                                   .order_by('-created_at') \
-                                   .select_related('layer') \
                                    .values_list('layer_id', flat=True)
     return _get_layers(request, Q(id__in=ids))
 

--- a/src/rf/apps/user/views.py
+++ b/src/rf/apps/user/views.py
@@ -58,9 +58,12 @@ def _user_info(request):
 
 
 def get_user_data(request):
+    favorites = list(UserFavoriteLayer.objects.filter(user_id=request.user.id)
+                     .values_list('layer_id', flat=True))
     return {
         'id': request.user.id,
         'username': request.user.username,
+        'favorites': favorites,
     }
 
 

--- a/src/rf/apps/user/views.py
+++ b/src/rf/apps/user/views.py
@@ -21,6 +21,7 @@ from registration.backends.default.views import RegistrationView
 
 from apps.core.exceptions import Forbidden
 from apps.core.decorators import accepts, api_view, login_required
+from apps.core.models import UserFavoriteLayer
 
 
 @api_view
@@ -53,6 +54,10 @@ def _authenticate_user(request):
 
 @login_required
 def _user_info(request):
+    return get_user_data(request)
+
+
+def get_user_data(request):
     return {
         'id': request.user.id,
         'username': request.user.username,

--- a/src/rf/js/src/core/models.js
+++ b/src/rf/js/src/core/models.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var _ = require('underscore'),
-    $ = require('jquery'),
     Backbone = require('../../shim/backbone'),
     L = require('leaflet'),
     utils = require('./utils');
@@ -32,19 +31,10 @@ var Layer = Backbone.Model.extend({
 
     initialize: function() {
         this.getLeafletLayer = _.memoize(this.getLeafletLayer);
-        this.on('change:favorite', this.toggleFavorite);
     },
 
     getLeafletLayer: function() {
         return new L.TileLayer(this.get('tile_url'));
-    },
-
-    toggleFavorite: function() {
-        var method = this.get('favorite') ? 'POST' : 'DELETE';
-        $.ajax({
-            url: this.get('favorite_url'),
-            method: method
-        });
     }
 });
 

--- a/src/rf/js/src/home/components/library.js
+++ b/src/rf/js/src/home/components/library.js
@@ -347,7 +347,7 @@ var LayerItem = React.createBackboneClass({
     render: function() {
         var model = this.getModel(),
             currentUser = settings.getUser(),
-            favorite = model.get('favorite'),
+            favorite = currentUser.hasFavorited(model),
             isOwner = model.get('username') === currentUser.get('username');
 
         var actions = '';
@@ -408,8 +408,8 @@ var LayerItem = React.createBackboneClass({
 
     toggleFavorite: function() {
         var model = this.getModel(),
-            favorite = !model.get('favorite');
-        model.set('favorite', favorite);
+            currentUser = settings.getUser();
+        currentUser.toggleFavorite(model);
     }
 });
 

--- a/src/rf/js/src/user/models.js
+++ b/src/rf/js/src/user/models.js
@@ -1,6 +1,8 @@
 'use strict';
 
-var Backbone = require('../../shim/backbone');
+var _ = require('underscore'),
+    $ = require('jquery'),
+    Backbone = require('../../shim/backbone');
 
 // It's difficult to validate email addresses and there's controversy about
 // what constitutes a valid email address. So we err towards the side of
@@ -48,6 +50,35 @@ var UserModel = Backbone.Model.extend({
 
     getCreateLayerURL: function() {
         return '/user/' + this.get('username') + '/layer/create';
+    },
+
+    // Return true if user has favorited layer.
+    hasFavorited: function(layerModel) {
+        return _.contains(this.get('favorites'), layerModel.get('id'));
+    },
+
+    toggleFavorite: function(layerModel) {
+        var favorites = this.get('favorites'),
+            layerId = layerModel.get('id');
+
+        // Needs to happen before we modify the `favorites` attribute.
+        this.syncFavorite(layerModel);
+
+        if (this.hasFavorited(layerModel)) {
+            favorites = _.without(favorites, layerId);
+        } else {
+            favorites = favorites.concat(layerId);
+        }
+        this.set('favorites', favorites);
+    },
+
+    // Sync layer favorite status to backend.
+    syncFavorite: function(layerModel) {
+        var method = this.hasFavorited(layerModel) ? 'DELETE' : 'POST';
+        $.ajax({
+            url: layerModel.get('favorite_url'),
+            method: method
+        });
     }
 });
 


### PR DESCRIPTION
Fixes a bug where favorited layers that were authored by other
users would not appear as favorited.

This inconsistency was caused by erroneous logic that was used to
populate the `favorite` property on layer models. After reflecting on
this issue, I realized that it was a mistake to add this propery to the
layer model. Instead, we now define a list of favorites on the user
model.

The best way to test this is by running the sample data generation
script. On develop, you should see that there are some layers on the
Favorites panel where the star is not illuminated. Switching to this PR
should correctly highlight all favorited layers on this panel,
regardless of the layer author.

Connects #150