### PR TITLE
Send images when posting layers

### DIFF
--- a/src/rf/apps/core/decorators.py
+++ b/src/rf/apps/core/decorators.py
@@ -6,7 +6,7 @@ from __future__ import division
 import json
 from functools import wraps
 
-from django.http import HttpResponse, QueryDict
+from django.http import HttpResponse
 from django.http.response import Http404
 
 from apps.core.exceptions import (ApiViewException,
@@ -15,19 +15,6 @@ from apps.core.exceptions import (ApiViewException,
                                   MethodNotAllowed,
                                   Unauthorized)
 from apps.core.models import User
-
-
-class PatchedQueryDict(QueryDict):
-    # Attempts to get key[] out of data
-    # if key doesn't exist to handle
-    # the way jQuery sends arrays.
-    def getlist(self, key):
-        bracket_key = key + '[]'
-        if key in self:
-            return super(QueryDict, self).getlist(key)
-        elif bracket_key in self:
-            return super(QueryDict, self).getlist(bracket_key)
-        return []
 
 
 def api_view(fn):
@@ -54,12 +41,6 @@ def api_view(fn):
                 return create_response(status_code=200, headers=headers)
             elif request.method not in allowed_methods:
                 raise MethodNotAllowed()
-
-            if request.method == 'PUT':
-                request.PUT = PatchedQueryDict(request.PUT.urlencode())
-
-            if request.method == 'POST':
-                request.POST = PatchedQueryDict(request.POST.urlencode())
 
             handle_api_authentication(request)
 

--- a/src/rf/apps/core/migrations/0019_layerimage_file_extension.py
+++ b/src/rf/apps/core/migrations/0019_layerimage_file_extension.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('core', '0018_merge'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='layerimage',
+            name='file_extension',
+            field=models.CharField(default='', help_text='Extension of file', max_length=10),
+        ),
+    ]

--- a/src/rf/apps/core/migrations/0020_layerimage_bucket_name.py
+++ b/src/rf/apps/core/migrations/0020_layerimage_bucket_name.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('core', '0019_layerimage_file_extension'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='layerimage',
+            name='bucket_name',
+            field=models.CharField(default='', help_text='Name of S3 bucket', max_length=255),
+        ),
+    ]

--- a/src/rf/apps/core/models.py
+++ b/src/rf/apps/core/models.py
@@ -248,6 +248,18 @@ class LayerImage(Model):
         default=uuid.uuid4,
         editable=False
     )
+    file_extension = CharField(
+        blank=False,
+        default='',
+        max_length=10,
+        help_text='Extension of file'
+    )
+    bucket_name = CharField(
+        blank=False,
+        default='',
+        max_length=255,
+        help_text='Name of S3 bucket'
+    )
     status = CharField(
         blank=True,
         max_length=12,
@@ -259,11 +271,13 @@ class LayerImage(Model):
     def to_json(self):
         return {
             'id': self.id,
-            'source_uri': self.source_uri,
             'thumb_small': self.thumb_small,
             'thumb_large': self.thumb_large,
             'meta_json': self.meta_json,
             'file_name': self.file_name,
+            's3_uuid': str(self.s3_uuid),
+            'file_extension': self.file_extension,
+            'bucket_name': self.bucket_name,
         }
 
 

--- a/src/rf/apps/home/forms.py
+++ b/src/rf/apps/home/forms.py
@@ -40,7 +40,6 @@ class LayerForm(ModelForm):
         except:
             self.cleaned_data['tags'] = []
 
-        # TODO: Parse images from request (required)
         try:
             self.cleaned_data['images'] = self.data['images']
         except:

--- a/src/rf/apps/home/tests.py
+++ b/src/rf/apps/home/tests.py
@@ -3,6 +3,8 @@ from __future__ import print_function
 from __future__ import unicode_literals
 from __future__ import division
 
+import json
+
 from django.contrib.auth.models import User
 from django.test import TestCase
 from django.test.client import Client
@@ -62,7 +64,9 @@ class AbstractLayerTestCase(TestCase):
 
     def save_layer(self, layer, user):
         url = reverse('create_layer', kwargs={'username': user.username})
-        return self.client.post(url, layer)
+        return self.client.post(url,
+                                json.dumps(layer),
+                                content_type='application/json')
 
     def setup_models(self):
         """
@@ -123,6 +127,28 @@ class LayerTestCase(AbstractLayerTestCase):
         user = self.user_models[self.logged_in_user]
         response = self.save_layer(layer, user)
         self.assertEqual(response.status_code, 403)
+
+    # Modify
+    def test_modify_layer(self):
+        orig_name = 'Test Modify Layer'
+        user = self.user_models[self.logged_in_user]
+        layer = self.make_layer(orig_name, self.logged_in_user)
+        response = self.save_layer(layer, user)
+
+        new_name = 'Test Modify Layer 2'
+        layer = json.loads(response.content)
+        layer['name'] = new_name
+        url = reverse('layer_detail', kwargs={
+            'username': user.username,
+            'layer_id': layer['id']
+        })
+
+        response = self.client.put(url,
+                                   json.dumps(layer),
+                                   content_type='application/json')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(Layer.objects.filter(name=orig_name).count(), 0)
+        self.assertEqual(Layer.objects.filter(name=new_name).count(), 1)
 
     # List
     def test_list_all_layers(self):

--- a/src/rf/apps/home/tests.py
+++ b/src/rf/apps/home/tests.py
@@ -42,8 +42,16 @@ class AbstractLayerTestCase(TestCase):
             'capture_start': '2015-08-15',
             'capture_end': '2015-08-15',
             'images': [
-                'http://www.foo.com',
-                'http://www.bar.com',
+                {
+                    'file_name': 'foo.png',
+                    's3_uuid': 'a8098c1a-f86e-11da-bd1a-00112444be1e',
+                    'file_extension': '.png'
+                },
+                {
+                    'file_name': 'bar.png',
+                    's3_uuid': 'a8098c1a-f86e-11da-bd1a-00112444be1e',
+                    'file_extension': '.png'
+                },
             ],
             'tags': [
                 layer_name

--- a/src/rf/apps/home/views.py
+++ b/src/rf/apps/home/views.py
@@ -5,6 +5,7 @@ from __future__ import division
 
 from urllib import urlencode
 
+from django.conf import settings
 from django.contrib.auth.models import User
 from django.db import transaction
 from django.db.models import Q
@@ -120,8 +121,12 @@ def _save_layer(request, layer, username=None):
     # Update images.
     LayerImage.objects.filter(layer=layer).delete()
     LayerImage.objects.bulk_create([
-        LayerImage(layer=layer, source_uri=uri)
-        for uri in form.cleaned_data['images']
+        LayerImage(layer=layer,
+                   s3_uuid=image['s3_uuid'],
+                   file_extension=image['file_extension'],
+                   file_name=image['file_name'],
+                   bucket_name=settings.AWS_BUCKET_NAME)
+        for image in form.cleaned_data['images']
     ])
 
     return layer.to_json()

--- a/src/rf/apps/home/views.py
+++ b/src/rf/apps/home/views.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 from __future__ import division
 
 from urllib import urlencode
+import json
 
 from django.conf import settings
 from django.contrib.auth.models import User
@@ -84,15 +85,9 @@ def _save_layer(request, layer, username=None):
     """
     Create or update a layer model with data from POST or PUT form fields.
     """
-    if request.method == 'POST':
-        data = request.POST.copy()
-    else:
-        data = request.PUT.copy()
+    body = json.loads(request.body)
 
-    data['tags'] = data.getlist('tags')
-    data['images'] = data.getlist('images')
-
-    form = LayerForm(data, instance=layer)
+    form = LayerForm(body, instance=layer)
 
     if not form.is_valid():
         raise Forbidden(errors=form.errors)

--- a/src/rf/js/src/core/uploads.js
+++ b/src/rf/js/src/core/uploads.js
@@ -2,7 +2,6 @@
 
 var _ = require('underscore'),
     Evaporate = require('evaporate'),
-    uuid = require('node-uuid'),
     settings = require('../settings');
 
 function S3UploadException(message, mimeType, fileName) {
@@ -15,7 +14,7 @@ function S3UploadException(message, mimeType, fileName) {
     };
 }
 
-var uploadFiles = function(files) {
+var uploadFiles = function(files, uuids, extensions) {
     var evap = new Evaporate({
         signerUrl: settings.get('signerUrl'),
         aws_key: settings.get('awsKey'),
@@ -28,16 +27,17 @@ var uploadFiles = function(files) {
         throw new S3UploadException('Invalid file type.', invalidMimes[0].mimeType, invalidMimes[0].fileName);
     }
 
-    _.each(files, function(file) {
-        var user = settings.getUser(),
-            userId = user.get('id');
+    _.each(files, function(file, i) {
+        var userId = settings.getUser().get('id'),
+            fileName = userId + '-' + uuids[i] + '.' + extensions[i];
+
         // TODO Later we'll want to store the id of the file upload. We can use
         // it to cancel the upload if needed.
         // var id = evap.add({ //
         evap.add({
             // TODO - NAMES ARE CURRENTLY JUST FOR TESTING.
             // WE WANT TO USE A UUID FOR FILE NAMES.
-            name: userId + '-' + uuid.v4() + getExtension(file),
+            name: fileName,
             file: file,
             contentType: file.type,
             complete: function() {
@@ -81,6 +81,7 @@ var invalidTypes = function(file) {
 };
 
 module.exports = {
+    getExtension: getExtension,
     uploadFiles: uploadFiles,
     S3UploadException: S3UploadException
 };

--- a/src/rf/js/src/home/components/modals.js
+++ b/src/rf/js/src/home/components/modals.js
@@ -403,7 +403,12 @@ var UploadModal = React.createBackboneClass({
                 images: images
             };
         this.submittedLayerData = layerData;
-        return $.post(url, layer);
+        return $.ajax({
+            url: url,
+            type: 'POST',
+            contentType: 'application/json',
+            data: JSON.stringify(layer)
+        });
     },
 
     renderErrors: function(isVisible, messages) {

--- a/src/rf/js/src/settings.js
+++ b/src/rf/js/src/settings.js
@@ -26,9 +26,14 @@ function getPendingLayers() {
     return pendingLayers;
 }
 
+function getS3UriPrefix() {
+    return get('awsBucketUriPrefix');
+}
+
 module.exports = {
     setUser: setUser,
     getUser: getUser,
     get: get,
-    getPendingLayers: getPendingLayers
+    getPendingLayers: getPendingLayers,
+    getS3UriPrefix: getS3UriPrefix
 };


### PR DESCRIPTION
In preparation for #161, this PR sends image data over when posting layers, switches to using a content type of 'application/json' for the body of the request, and gets PUT requests to work properly.

To test, after importing a layer, check that LayerImage models were added to the DB with the correct source_uri and file_name. You can verify this using pgweb, looking in the network tab, and in the layer details panel.

Built on top of #102 (so, ignore first 3 commits)

Connects #162 