### PR TITLE
Strip whitespace from tags.

### DIFF
--- a/src/rf/apps/home/forms.py
+++ b/src/rf/apps/home/forms.py
@@ -35,7 +35,8 @@ class LayerForm(ModelForm):
 
         # TODO: Parse tags from request (optional)
         try:
-            self.cleaned_data['tags'] = self.data['tags']
+            self.cleaned_data['tags'] = [tag.strip()
+                                         for tag in self.data['tags']]
         except:
             self.cleaned_data['tags'] = []
 


### PR DESCRIPTION
When saving tags from the front end we were getting leading and or trailing
spaces as a result of the UI separating the tags. This removes these for
easier filtering in other locations.

Connects #111 

### To Test
 * Create a new layer with several tags. (```this, that, the other, some tag```)
 * Attempt to search for the tag by name in the database. (`SELECT * FROM core_layertag WHERE NAME = 'some tag';`)
 * Ensure that the result is found.
 * Prior to this change you should have to search for ' some tag'.