### PR TITLE
Remove extra dot in s3 file name

### DIFF
--- a/src/rf/apps/core/migrations/0021_remove_layerimage_source_uri.py
+++ b/src/rf/apps/core/migrations/0021_remove_layerimage_source_uri.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('core', '0020_layerimage_bucket_name'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='layerimage',
+            name='source_uri',
+        ),
+    ]

--- a/src/rf/apps/core/models.py
+++ b/src/rf/apps/core/models.py
@@ -218,7 +218,6 @@ class LayerImage(Model):
     and will be displayed as-is.
     """
     layer = ForeignKey(Layer, related_name='layer_images')
-    source_uri = URLField(max_length=2000)
     priority = IntegerField(
         default=0,
         help_text='The order which images are layered (starting from 0)'

--- a/src/rf/apps/home/tests.py
+++ b/src/rf/apps/home/tests.py
@@ -47,12 +47,12 @@ class AbstractLayerTestCase(TestCase):
                 {
                     'file_name': 'foo.png',
                     's3_uuid': 'a8098c1a-f86e-11da-bd1a-00112444be1e',
-                    'file_extension': '.png'
+                    'file_extension': 'png'
                 },
                 {
                     'file_name': 'bar.png',
                     's3_uuid': 'a8098c1a-f86e-11da-bd1a-00112444be1e',
-                    'file_extension': '.png'
+                    'file_extension': 'png'
                 },
             ],
             'tags': [

--- a/src/rf/js/src/core/uploads.js
+++ b/src/rf/js/src/core/uploads.js
@@ -52,10 +52,10 @@ var uploadFiles = function(files, uuids, extensions) {
 
 var getExtension = function(file) {
     var mapping = {
-        'image/png': '.png',
-        'image/jpeg': '.jpg',
-        'image/tiff': '.tif',
-        'application/zip': '.zip'
+        'image/png': 'png',
+        'image/jpeg': 'jpg',
+        'image/tiff': 'tif',
+        'application/zip': 'zip'
 
     };
     return mapping[file.type] || '';


### PR DESCRIPTION
Also, remove source_uri field which is no longer used.

To test, make sure that the filename in S3 looks correct for an uploaded file and also check that fields in the LayerImage table look right.