### PR TITLE
Show error for failed layer

### DIFF
--- a/src/rf/apps/home/filters.py
+++ b/src/rf/apps/home/filters.py
@@ -37,12 +37,13 @@ class LayerFilter(django_filters.FilterSet):
     def pending_filter(self, queryset, value):
         """
         Gets layers that are uploading or processing, or that
-        have become complete since the time of the last browser refresh.
-        This is so that layers that have become complete since the last refresh
-        will be visible to users on the frontend.
+        have become complete or failed since the time of the last browser
+        refresh. This is so that layers that have become complete or failed
+        since the last refresh will be visible to users on the frontend.
 
         value -- the time in milliseconds elapsed since 1/1/1970
         """
         refresh_time = datetime.fromtimestamp(float(value) / 1000.0)
-        return queryset.filter(~Q(status=enums.STATUS_COMPLETED) |
+        return queryset.filter((~Q(status=enums.STATUS_COMPLETED) &
+                                ~Q(status=enums.STATUS_FAILED)) |
                                Q(status_updated_at__gt=refresh_time))

--- a/src/rf/js/src/app.js
+++ b/src/rf/js/src/app.js
@@ -40,7 +40,8 @@ var App = Marionette.Application.extend({
         }
 
         function poll() {
-            if (pendingLayers.existsProcessing()) {
+            if (pendingLayers.existsUploading() ||
+                pendingLayers.existsProcessing()) {
                 pendingLayers.fetch();
             }
             setTimeout(poll, pollInterval);

--- a/src/rf/js/src/core/models.js
+++ b/src/rf/js/src/core/models.js
@@ -58,9 +58,18 @@ var Layer = Backbone.Model.extend({
         return this.get('status') === STATUS_CREATED;
     },
 
+    isCompleted: function() {
+        return this.get('status') === STATUS_COMPLETED;
+    },
+
+    isFailed: function() {
+        return this.get('status') === STATUS_FAILED;
+    },
+
     isProcessing: function() {
-        var status = this.get('status');
-        return status !== STATUS_COMPLETED && status !== STATUS_FAILED;
+        return !(this.isUploading() ||
+                 this.isCompleted() ||
+                 this.isFailed());
     }
 });
 

--- a/src/rf/js/src/home/components/processing-block.js
+++ b/src/rf/js/src/home/components/processing-block.js
@@ -6,14 +6,21 @@ var LayerStatusComponent = React.createBackboneClass({
     render: function() {
         var checkClass = 'rf-icon-check',
             spinnerClass = 'rf-icon-loader animate-spin',
+            failedClass = 'rf-icon-cancel text-danger',
             uploadingClass = spinnerClass,
             processingClass = spinnerClass;
 
-        if (!this.getModel().isUploading()) {
+        if (this.getModel().isProcessing() ||
+            this.getModel().isCompleted()) {
             uploadingClass = checkClass;
+        } else if (this.getModel().isFailed()) {
+            uploadingClass = failedClass;
         }
-        if (!this.getModel().isProcessing()) {
+
+        if (this.getModel().isCompleted()) {
             processingClass = checkClass;
+        } else if (this.getModel().isFailed()) {
+            processingClass = failedClass;
         }
 
         return (


### PR DESCRIPTION
If the layer has failed since hitting refresh on the page, show a failure icon in the processing block.

Test by changing status of a layer to Failed in the admin view. Check that polling stops and no alert is shown when exiting (assuming there's only one layer pending and it has failed).

Builds on #173 

Connects #153 