### PR TITLE
Use known EC2 location as temp dir.

### DIFF
--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -26,3 +26,5 @@ postgis_version: "2.1"
 postgis_package_version: "2.1.*.pgdg14.04+1"
 
 nodejs_npm_version: 2.1.17
+
+temp_dir: "/media/ephemeral0"

--- a/deployment/ansible/roles/raster-foundry.base/defaults/main.yml
+++ b/deployment/ansible/roles/raster-foundry.base/defaults/main.yml
@@ -14,6 +14,7 @@ envdir_config:
   RF_SQS_QUEUE: "{{ sqs_queue }}"
   RF_SQS_DEAD_LETTER_QUEUE: "{{ sqs_dead_letter_queue }}"
   RF_SQS_REGION: "{{ sqs_region }}"
+  RF_TEMP_DIR: "{{ temp_dir }}"
 
 django_config:
   DJANGO_TEST_DB_NAME: "{{ django_test_database }}"

--- a/deployment/ansible/roles/raster-foundry.base/tasks/dev-and-test-dependencies.yml
+++ b/deployment/ansible/roles/raster-foundry.base/tasks/dev-and-test-dependencies.yml
@@ -1,3 +1,10 @@
 ---
 - name: Copy AWS Credentials
   copy: src=~/.aws dest=/var/lib/rf owner=rf
+
+- name: Create EC2 style temp directory
+  file: path="{{ temp_dir }}"
+        owner=rf
+        group=rf
+        mode=0755
+        state=directory

--- a/src/rf/rf/settings/base.py
+++ b/src/rf/rf/settings/base.py
@@ -285,3 +285,7 @@ AWS_SQS_QUEUE = environ.get('RF_SQS_QUEUE', 'TestQueue')
 AWS_SQS_REGION = environ.get('RF_SQS_REGION', 'us-east-1')
 
 # END AWS CONFIGURATION
+
+# TEMP DIR
+TEMP_DIR = environ.get('RF_TEMP_DIR', '/tmp')
+# END TEMP DIR


### PR DESCRIPTION
Our application may need to generate temporary files. In EC2 we will have
automatic access to a mounted ephemeral drive. We create a matching directory
for dev and test and supply the directory path as a variable name to django.

Connects #174 

### To test

 * Provision app and worker vms
 * SSH to the machines and check that the folder /media/ephemeral0 exists and is owned and group owned by rf.
 * Permission should be 755.