### PR TITLE
Feature/lol/dismiss to delete failed jobs

### DIFF
--- a/src/rf/apps/core/models.py
+++ b/src/rf/apps/core/models.py
@@ -167,6 +167,7 @@ class Layer(Model):
             'url': self.get_absolute_url(),
             'meta_url': self.get_meta_url(),
             'favorite_url': self.get_favorite_url(),
+            'dismiss_url': self.get_dismiss_url(),
 
             # TODO: Replace with actual tiles URL.
             'tile_url': 'https://s3.amazonaws.com/raster-foundry-tiles/test_tiles/{z}/{x}/{y}.png',  # NOQA
@@ -191,6 +192,9 @@ class Layer(Model):
             'layer_id': self.id,
         }
         return reverse('create_or_destroy_favorite', kwargs=kwargs)
+
+    def get_dismiss_url(self):
+        return reverse('layer_dismiss')
 
     def __unicode__(self):
         return '{0} -> {1}'.format(self.user.username, self.name)

--- a/src/rf/apps/home/urls.py
+++ b/src/rf/apps/home/urls.py
@@ -29,6 +29,7 @@ urlpatterns = patterns(
     url('^favorite/(?P<layer_id>\d+)$', views.create_or_destroy_favorite,
         name='create_or_destroy_favorite'),
     url('^catalog.json$', views.all_layers, name='catalog'),
+    url('^layer/dismiss', views.layer_dismiss, name='layer_dismiss'),
 
     # These all route to the home page.
     url('^imports/?$', views.home_page),

--- a/src/rf/js/src/core/models.js
+++ b/src/rf/js/src/core/models.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var _ = require('underscore'),
+    $ = require('jquery'),
     Backbone = require('../../shim/backbone'),
     L = require('leaflet'),
     utils = require('./utils');
@@ -75,6 +76,18 @@ var Layer = Backbone.Model.extend({
         return !(this.isUploading() ||
                  this.isCompleted() ||
                  this.isFailed());
+    },
+
+    isDoneWorking: function() {
+        return this.isCompleted() || this.isFailed();
+    },
+
+    dismiss: function() {
+        $.ajax({
+            url: this.get('dismiss_url'),
+            method: 'POST',
+            data: { layer_id: this.get('id') }
+        });
     }
 });
 
@@ -144,15 +157,15 @@ var BaseLayers = Backbone.Collection.extend({
 });
 
 var MyLayers = BaseLayers.extend({
-    url: '/imports.json?live=true'
+    url: '/imports.json'
 });
 
 var FavoriteLayers = BaseLayers.extend({
-    url: '/favorites.json?live=true'
+    url: '/favorites.json'
 });
 
 var PublicLayers = BaseLayers.extend({
-    url: '/catalog.json?live=true'
+    url: '/catalog.json'
 });
 
 var PendingLayers = BaseLayers.extend({

--- a/src/rf/js/src/core/models.js
+++ b/src/rf/js/src/core/models.js
@@ -144,15 +144,15 @@ var BaseLayers = Backbone.Collection.extend({
 });
 
 var MyLayers = BaseLayers.extend({
-    url: '/imports.json'
+    url: '/imports.json?live=true'
 });
 
 var FavoriteLayers = BaseLayers.extend({
-    url: '/favorites.json'
+    url: '/favorites.json?live=true'
 });
 
 var PublicLayers = BaseLayers.extend({
-    url: '/catalog.json'
+    url: '/catalog.json?live=true'
 });
 
 var PendingLayers = BaseLayers.extend({

--- a/src/rf/js/src/home/components/processing-block.js
+++ b/src/rf/js/src/home/components/processing-block.js
@@ -8,7 +8,8 @@ var LayerStatusComponent = React.createBackboneClass({
             spinnerClass = 'rf-icon-loader animate-spin',
             failedClass = 'rf-icon-cancel text-danger',
             uploadingClass = spinnerClass,
-            processingClass = spinnerClass;
+            processingClass = spinnerClass,
+            actionLink = (<a href="#" className="text-danger">Cancel</a>);
 
         if (this.getModel().isProcessing() ||
             this.getModel().isCompleted()) {
@@ -23,6 +24,10 @@ var LayerStatusComponent = React.createBackboneClass({
             processingClass = failedClass;
         }
 
+        if (this.getModel().isDoneWorking()) {
+            actionLink = (<a onClick={this.dismiss}>Dismiss</a>);
+        }
+
         return (
             <div className="list-group-item">
               <div className="list-group-content">
@@ -34,15 +39,23 @@ var LayerStatusComponent = React.createBackboneClass({
                 </ol>
               </div>
               <div className="list-group-tool">
-                <a href="#" className="text-danger">Cancel</a>
+                { actionLink }
               </div>
             </div>
         );
+    },
+
+    dismiss: function(e) {
+        e.preventDefault();
+        var model = this.getModel();
+        model.dismiss();
+        this.props.removeItem(model);
     }
 });
 
 var ProcessingBlock = React.createBackboneClass({
     render: function() {
+        var self = this;
         if (this.getCollection().length === 0) {
             return null;
         }
@@ -54,12 +67,16 @@ var ProcessingBlock = React.createBackboneClass({
             <div className="collapse" id="processing-content">
               <div className="list-group">
                 {this.getCollection().map(function(layer) {
-                    return <LayerStatusComponent model={layer} key={layer.cid} />;
+                    return <LayerStatusComponent removeItem={self.removeItem} model={layer} key={layer.cid} />;
                 })}
               </div>
             </div>
           </div>
         );
+    },
+
+    removeItem: function(model) {
+        this.getCollection().remove(model);
     }
 });
 


### PR DESCRIPTION
Connects #175

This adds a dismiss button to the processing view. When a layer finishes successfully or fails, we can click this to remove it from the window. This will delete the layer if is has failed.

### To test
 * Create or use an existing layer that is in the "created" or "processing" state
 * Using the admin interface, change the status to "failed" make sure to update the updated timestamp to now.
 * Note that the processing view now shows "dismiss" as an option.
 * Open the network tab.
 * Click dismiss.
 * Note that the api endpoint was requested. In the event of a failed layer, the response should be {"status": "deleted"}
 * The item should be removed.
 * Viewing the data in the admin interface should reveal that the layer was deleted by marking the deleted time.
 * Follow the same process and this time mark the layer as completed.
 * Dismissing should hit the API and return {"status": "dismissed"}
 * The layer should not be deleted.