### PR TITLE
Add VPC CloudFormation stack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,5 @@ npm-debug.log
 
 # MacOS
 .DS_Store
+
+deployment/default.yml

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -27,6 +27,14 @@ $ aws configure --profile rf-stg
 
 You will be prompted to enter your AWS credentials, along with a default region. These credentials will be used to authenticate calls to the AWS API when using Boto, Packer, and the AWS CLI.
 
+## Edit the configuration file
+
+A configuration file is required to launch the stack. An example file (`default.yml.example`) is available in the current directory.
+
+## Launch and manage stacks
+
+Stack launching is managed with `rf_stack.py`. This command provides an interface for automatically generating AMIs and launching Raster Foundry stacks.
+
 ### Generating AMIs
 
 Before launching the Raster Foundry stack, AMIs for each service need to be generated:
@@ -34,4 +42,15 @@ Before launching the Raster Foundry stack, AMIs for each service need to be gene
 ```bash
 $ ./rf_stack.py create-ami --aws-profile rf-stg --rf-profile staging \
                             --machine-type rf-{app,worker}
+```
+
+### Launching Stacks
+
+After successfully creating AMIs, you can launch a Raster Foundry stack with the `launch-stacks` subcommand. To view all options for the `launch-stacks` subcommand, you can use the `--help` option.
+
+Using the parameters set in `default.yml`, you can launch a full stack with the following command:
+
+```bash
+$ ./rf_stack.py launch-stacks --aws-profile rf-stg --rf-profile staging \
+                              --rf-config-path default.yml
 ```

--- a/deployment/cfn/stacks.py
+++ b/deployment/cfn/stacks.py
@@ -1,3 +1,7 @@
+from majorkirby import GlobalConfigNode
+
+from vpc import VPC
+
 import ConfigParser
 import sys
 
@@ -22,3 +26,23 @@ def get_config(rf_config_path, profile):
         sys.exit(1)
 
     return {k: v.strip('"').strip("'") for k, v in section}
+
+
+def build_graph(rf_config, aws_profile, **kwargs):
+    """
+    Builds graphs for all of the Raster Foundry stacks
+    Args:
+      rf_config (dict): dictionary representation of `default.yml`
+      aws_profile (str): name of AWS profile to use for authentication
+    """
+    global_config = GlobalConfigNode(**rf_config)
+    vpc = VPC(globalconfig=global_config, aws_profile=aws_profile)
+
+    return vpc
+
+
+def build_stacks(rf_config, aws_profile, **kwargs):
+    """Trigger actual building of graphs"""
+    vpc_graph = build_graph(rf_config, aws_profile, **kwargs)
+
+    vpc_graph.go()

--- a/deployment/cfn/utils/cfn.py
+++ b/deployment/cfn/utils/cfn.py
@@ -1,0 +1,82 @@
+import boto
+
+from boto.ec2 import get_region
+
+
+class AvailabilityZone(object):
+    """Helper class that represents an availability zone
+
+    We often only want 2 things from an AZ - a slug and name.
+    This class keeps those in one location.
+    """
+
+    def __init__(self, availability_zone):
+        """Creates an AvailabilityZoneHelper object
+
+        Args:
+        availability_zone (AvailabilityZone): boto object
+        """
+
+        self.availability_zone = availability_zone
+
+    @property
+    def cfn_name(self):
+        """
+        Utility method to return a string appropriate for CloudFormation
+        name of a resource (e.g. UsEast1a)
+        """
+        return self.availability_zone.name.title().replace('-', '')
+
+    @property
+    def name(self):
+        """Utility function to return the name of an availability zone"""
+        return self.availability_zone.name
+
+
+def get_availability_zones(aws_profile):
+    """Helper function that returns availability zones for a region
+
+    Returns:
+      (list of AvailabilityZone): List of availability zones for a given
+                                  EC2 region
+    """
+    conn = boto.connect_ec2(profile_name=aws_profile)
+    return [AvailabilityZone(az) for az in conn.get_all_zones()]
+
+
+def get_subnet_cidr_block():
+    """Generator to generate unique CIDR block subnets"""
+    current = 0
+    high = 255
+    while current <= high:
+        yield '10.0.%s.0/24' % current
+        current += 1
+
+
+def get_recent_ami(aws_profile, filters={}, region='us-east-1', owner='self',
+                   executable_by='self'):
+    conn = boto.connect_ec2(profile_name=aws_profile,
+                            region=get_region(region))
+
+    # Filter images by owned by self first.
+    images = conn.get_all_images(owners=owner, filters=filters)
+
+    # If no images are owned by self, look for images self can execute.
+    if not images:
+        images = conn.get_all_images(executable_by=executable_by,
+                                     filters=filters)
+
+    # Make sure RC images are omitted from results
+    images = filter(lambda i: True if 'beta' not in i.name else False, images)
+
+    return sorted(images, key=lambda i: i.creationDate, reverse=True)[0].id
+
+
+def read_file(file_name):
+    """Reads an entire file and returns it as a string
+
+    Arguments
+    :param file_name: A path to a file
+    """
+    with open(file_name, 'r') as f:
+        return f.read()

--- a/deployment/cfn/utils/constants.py
+++ b/deployment/cfn/utils/constants.py
@@ -1,0 +1,26 @@
+EC2_INSTANCE_TYPES = [
+    't2.micro',
+    't2.small',
+    't2.medium',
+    't2.large'
+]
+
+RDS_INSTANCE_TYPES = [
+    'db.t2.micro',
+    'db.t2.small',
+    'db.t2.medium',
+    'db.t2.large'
+]
+
+ALLOW_ALL_CIDR = '0.0.0.0/0'
+VPC_CIDR = '10.0.0.0/16'
+
+HTTP = 80
+HTTPS = 443
+POSTGRESQL = 5432
+SSH = 22
+
+AMAZON_ACCOUNT_ID = 'amazon'
+AMAZON_S3_VPC_ENDPOINT = 'com.amazonaws.us-east-1.s3'
+
+CANONICAL_ACCOUNT_ID = '099720109477'

--- a/deployment/cfn/vpc.py
+++ b/deployment/cfn/vpc.py
@@ -1,0 +1,406 @@
+from troposphere import (
+    Parameter,
+    Ref,
+    Output,
+    Tags,
+    Join,
+    ec2
+)
+
+from utils.cfn import (
+    get_availability_zones,
+    get_recent_ami,
+    get_subnet_cidr_block
+)
+
+from utils.constants import (
+    ALLOW_ALL_CIDR,
+    AMAZON_ACCOUNT_ID,
+    AMAZON_S3_VPC_ENDPOINT,
+    CANONICAL_ACCOUNT_ID,
+    EC2_INSTANCE_TYPES,
+    HTTP,
+    HTTPS,
+    POSTGRESQL,
+    SSH,
+    VPC_CIDR
+)
+
+from majorkirby import StackNode, MKUnresolvableInputError
+
+
+cidr_generator = get_subnet_cidr_block()
+
+
+class VPC(StackNode):
+    INPUTS = {
+        'Tags': ['global:Tags'],
+        'Region': ['global:Region'],
+        'StackType': ['global:StackType'],
+        'KeyName': ['global:KeyName'],
+        'IPAccess': ['global:IPAccess'],
+        'AvailabilityZones': ['global:AvailabilityZones'],
+        'NATInstanceType': ['global:NATInstanceType'],
+        'NATInstanceAMI': ['global:NATInstanceAMI'],
+        'BastionHostInstanceType': ['global:BastionHostInstanceType'],
+        'BastionHostAMI': ['global:BastionHostAMI'],
+    }
+
+    DEFAULTS = {
+        'Tags': {},
+        'Region': 'us-east-1',
+        'StackType': 'Staging',
+        'KeyName': 'rf-stg',
+        'IPAccess': ALLOW_ALL_CIDR,
+        'AvailabilityZones': 'us-east-1a,us-east-1b',
+        'NATInstanceType': 't2.micro',
+        'BastionHostInstanceType': 't2.micro',
+    }
+
+    ATTRIBUTES = {'StackType': 'StackType'}
+
+    PUBLIC_SUBNETS = []
+    PRIVATE_SUBNETS = []
+
+    _NAT_SECURITY_GROUP_CACHE = None
+
+    def set_up_stack(self):
+        super(VPC, self).set_up_stack()
+
+        tags = self.get_input('Tags').copy()
+        tags.update({'StackType': 'VPC'})
+
+        self.default_tags = tags
+        self.region = self.get_input('Region')
+        self.availability_zones = get_availability_zones(self.aws_profile)
+
+        self.add_description('VPC stack for Raster Foundry')
+
+        # Parameters
+        self.keyname = self.add_parameter(Parameter(
+            'KeyName', Type='String',
+            Description='Name of an existing EC2 key pair'
+        ), 'KeyName')
+
+        self.ip_access = self.add_parameter(Parameter(
+            'IPAccess', Type='String', Default=self.get_input('IPAccess'),
+            Description='CIDR for allowing SSH access'
+        ), 'IPAccess')
+
+        self.nat_instance_type = self.add_parameter(Parameter(
+            'NATInstanceType', Type='String', Default='t2.micro',
+            Description='NAT EC2 instance type',
+            AllowedValues=EC2_INSTANCE_TYPES,
+            ConstraintDescription='must be a valid EC2 instance type.'
+        ), 'NATInstanceType')
+
+        self.nat_instance_ami = self.add_parameter(Parameter(
+            'NATInstanceAMI', Type='String', Default=self.get_recent_nat_ami(),
+            Description='NAT EC2 Instance AMI'
+        ), 'NATInstanceAMI')
+
+        self.bastion_instance_type = self.add_parameter(Parameter(
+            'BastionHostInstanceType', Type='String', Default='t2.medium',
+            Description='Bastion host EC2 instance type',
+            AllowedValues=EC2_INSTANCE_TYPES,
+            ConstraintDescription='must be a valid EC2 instance type.'
+        ), 'BastionHostInstanceType')
+
+        self.bastion_host_ami = self.add_parameter(Parameter(
+            'BastionHostAMI', Type='String',
+            Default=self.get_recent_bastion_ami(),
+            Description='Bastion host AMI'
+        ), 'BastionHostAMI')
+
+        self.create_vpc()
+        self.create_vpc_endpoint()
+        self.create_bastion()
+
+        self.add_output(Output('AvailabilityZones',
+                               Value=','.join(self.default_azs)))
+        self.add_output(Output('PrivateSubnets',
+                               Value=Join(',', map(Ref, self.default_private_subnets))))  # NOQA
+        self.add_output(Output('PublicSubnets',
+                               Value=Join(',', map(Ref, self.default_public_subnets))))  # NOQA
+
+    def get_recent_nat_ami(self):
+        try:
+            nat_ami_id = self.get_input('NATInstanceAMI')
+        except MKUnresolvableInputError:
+            filters = {'name': '*ami-vpc-nat-hvm*',
+                       'architecture': 'x86_64',
+                       'block-device-mapping.volume-type': 'gp2',
+                       'root-device-type': 'ebs',
+                       'virtualization-type': 'hvm'}
+
+            nat_ami_id = get_recent_ami(self.aws_profile, filters,
+                                        region=self.region,
+                                        owner=AMAZON_ACCOUNT_ID)
+
+        return nat_ami_id
+
+    def get_recent_bastion_ami(self):
+        try:
+            bastion_ami_id = self.get_input('BastionHostAMI')
+        except MKUnresolvableInputError:
+            filters = {'name':
+                       'ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server-*',  # NOQA
+                       'architecture': 'x86_64',
+                       'block-device-mapping.volume-type': 'gp2',
+                       'root-device-type': 'ebs',
+                       'virtualization-type': 'hvm'}
+
+            bastion_ami_id = get_recent_ami(self.aws_profile, filters,
+                                            region=self.region,
+                                            owner=CANONICAL_ACCOUNT_ID)
+
+        return bastion_ami_id
+
+    def create_vpc(self):
+        vpc_name = 'RFVPC'
+
+        self.vpc = self.create_resource(ec2.VPC(
+            vpc_name,
+            CidrBlock=VPC_CIDR, EnableDnsSupport=True,
+            EnableDnsHostnames=True, Tags=self.get_tags(Name=vpc_name)
+        ), output='VpcId')
+
+        self.public_route_table = self.create_routing_resources()
+        self.create_subnets()
+
+    def create_vpc_endpoint(self):
+        self.create_resource(ec2.VPCEndpoint(
+            'S3VPCEndpoint',
+            RouteTableIds=[Ref(self.public_route_table)],
+            ServiceName=AMAZON_S3_VPC_ENDPOINT,
+            VpcId=Ref(self.vpc))
+        )
+
+    def create_routing_resources(self):
+        gateway = self.create_resource(
+            ec2.InternetGateway(
+                'InternetGateway',
+                Tags=self.get_tags()
+            )
+        )
+
+        gateway_attachment = self.create_resource(
+            ec2.VPCGatewayAttachment(
+                'VPCGatewayAttachment',
+                VpcId=Ref(self.vpc),
+                InternetGatewayId=Ref(gateway)
+            )
+        )
+
+        public_route_table = self.create_resource(
+            ec2.RouteTable(
+                'PublicRouteTable',
+                VpcId=Ref(self.vpc))
+        )
+
+        self.create_resource(
+            ec2.Route(
+                'PublicRoute',
+                RouteTableId=Ref(public_route_table),
+                DestinationCidrBlock=ALLOW_ALL_CIDR,
+                DependsOn=gateway_attachment.title,
+                GatewayId=Ref(gateway)
+            )
+        )
+
+        return public_route_table
+
+    def create_subnets(self):
+        self.default_azs = []
+        self.default_private_subnets = []
+        self.default_public_subnets = []
+
+        for num, availability_zone in enumerate(self.availability_zones):
+            public_subnet_name = '{}PublicSubnet'.format(availability_zone.cfn_name)  # NOQA
+
+            public_subnet = self.create_resource(ec2.Subnet(
+                public_subnet_name,
+                VpcId=Ref(self.vpc),
+                CidrBlock=cidr_generator.next(),
+                AvailabilityZone=availability_zone.name,
+                Tags=self.get_tags(Name=public_subnet_name)
+            ))
+
+            self.create_resource(ec2.SubnetRouteTableAssociation(
+                '{}PublicRouteTableAssociation'.format(public_subnet.title),
+                SubnetId=Ref(public_subnet),
+                RouteTableId=Ref(self.public_route_table)
+            ))
+
+            private_subnet_name = '{}PrivateSubnet'.format(availability_zone.cfn_name)  # NOQA
+
+            private_subnet = self.create_resource(ec2.Subnet(
+                private_subnet_name,
+                VpcId=Ref(self.vpc),
+                CidrBlock=cidr_generator.next(),
+                AvailabilityZone=availability_zone.name,
+                Tags=self.get_tags(Name=private_subnet_name)
+                ))
+
+            private_route_table_name = '{}PrivateRouteTable'.format(availability_zone.cfn_name)  # NOQA
+
+            private_route_table = self.create_resource(ec2.RouteTable(
+                private_route_table_name,
+                VpcId=Ref(self.vpc),
+                Tags=self.get_tags(Name=private_route_table_name)
+            ))
+
+            self.create_resource(ec2.SubnetRouteTableAssociation(
+                '{}PrivateSubnetRouteTableAssociation'.format(private_subnet.title),  # NOQA
+                SubnetId=Ref(private_subnet),
+                RouteTableId=Ref(private_route_table)
+            ))
+
+            self.PUBLIC_SUBNETS.append(public_subnet)
+            self.PRIVATE_SUBNETS.append(private_subnet)
+
+            if availability_zone.name in self.get_input('AvailabilityZones').split(','):  # NOQA
+                self.create_nat(availability_zone, public_subnet,
+                                private_route_table)
+                self.default_azs.append(availability_zone.name)
+                self.default_private_subnets.append(private_subnet)
+                self.default_public_subnets.append(public_subnet)
+
+    def create_nat(self, availability_zone, public_subnet,
+                   private_route_table):
+        nat_device_name = '{}NATDevice'.format(availability_zone.cfn_name)
+        nat_device = self.create_resource(ec2.Instance(
+            nat_device_name,
+            InstanceType=Ref(self.nat_instance_type),
+            KeyName=Ref(self.keyname),
+            SourceDestCheck=False,
+            ImageId=Ref(self.nat_instance_ami),
+            NetworkInterfaces=[
+                ec2.NetworkInterfaceProperty(
+                    Description='ENI for NATDevice',
+                    GroupSet=[Ref(self.nat_security_group)],
+                    SubnetId=Ref(public_subnet),
+                    AssociatePublicIpAddress=True,
+                    DeviceIndex=0,
+                    DeleteOnTermination=True,
+                )
+            ],
+            Tags=self.get_tags(Name=nat_device_name)
+        ))
+
+        self.create_resource(ec2.Route(
+            '{}PrivateRoute'.format(availability_zone.cfn_name),
+            RouteTableId=Ref(private_route_table),
+            DestinationCidrBlock=ALLOW_ALL_CIDR,
+            InstanceId=Ref(nat_device))
+        )
+
+    def create_bastion(self):
+        bastion_security_group_name = 'sgBastion'
+
+        bastion_security_group = self.add_resource(ec2.SecurityGroup(
+            bastion_security_group_name,
+            GroupDescription='Enables access to the BastionHost',
+            VpcId=Ref(self.vpc),
+            SecurityGroupIngress=[
+                ec2.SecurityGroupRule(IpProtocol='tcp',
+                                      CidrIp=Ref(self.ip_access),
+                                      FromPort=p, ToPort=p)
+                for p in [SSH]
+            ],
+            SecurityGroupEgress=[
+                ec2.SecurityGroupRule(IpProtocol='tcp',
+                                      CidrIp=VPC_CIDR,
+                                      FromPort=p, ToPort=p)
+                for p in [POSTGRESQL, SSH]
+            ] + [
+                ec2.SecurityGroupRule(IpProtocol='tcp',
+                                      CidrIp=ALLOW_ALL_CIDR,
+                                      FromPort=p, ToPort=p)
+                for p in [HTTP, HTTPS]
+            ],
+            Tags=self.get_tags(Name=bastion_security_group_name)
+        ))
+
+        bastion_host_name = 'BastionHost'
+
+        self.add_resource(ec2.Instance(
+            bastion_host_name,
+            InstanceType=Ref(self.bastion_instance_type),
+            KeyName=Ref(self.keyname),
+            ImageId=Ref(self.bastion_host_ami),
+            NetworkInterfaces=[
+                ec2.NetworkInterfaceProperty(
+                    Description='ENI for BastionHost',
+                    GroupSet=[Ref(bastion_security_group)],
+                    SubnetId=Ref(self.PUBLIC_SUBNETS[0]),
+                    AssociatePublicIpAddress=True,
+                    DeviceIndex=0,
+                    DeleteOnTermination=True
+                )
+            ],
+            Tags=self.get_tags(Name=bastion_host_name)
+        ))
+
+    @property
+    def nat_security_group(self):
+        if self._NAT_SECURITY_GROUP_CACHE:
+            return self._NAT_SECURITY_GROUP_CACHE
+        else:
+            nat_security_group_name = 'sgNAT'
+
+            self._NAT_SECURITY_GROUP_CACHE = self.create_resource(
+                ec2.SecurityGroup(nat_security_group_name,
+                                  GroupDescription='Enables access to the NAT '
+                                                   'devices',
+                                  VpcId=Ref(self.vpc),
+                                  SecurityGroupIngress=[
+                                      ec2.SecurityGroupRule(
+                                          IpProtocol='tcp', CidrIp=VPC_CIDR,
+                                          FromPort=p, ToPort=p
+                                      )
+                                      for p in [HTTP, HTTPS]
+                                  ],
+                                  SecurityGroupEgress=[
+                                      ec2.SecurityGroupRule(
+                                          IpProtocol='tcp',
+                                          CidrIp=ALLOW_ALL_CIDR,
+                                          FromPort=port, ToPort=port
+                                      ) for port in [HTTP, HTTPS]
+                                  ],
+                                  Tags=self.get_tags(Name=nat_security_group_name)),  # NOQA
+                                  'NATSecurityGroup'
+            )
+            return self._NAT_SECURITY_GROUP_CACHE
+
+    def create_resource(self, resource, output=None):
+        """Helper method to attach resource to template and return it
+
+        This helper method is used when adding _any_ CloudFormation resource
+        to the template. It abstracts out the creation of the resource, adding
+        it to the template, and optionally adding it to the outputs as well
+
+        Args:
+          resource: Troposphere resource to create
+          output: Name of output to return this value as
+        """
+        resource = self.add_resource(resource)
+
+        if output:
+            cloudformation_output = Output(
+                output,
+                Value=Ref(resource)
+            )
+
+            self.add_output(cloudformation_output)
+
+        return resource
+
+    def get_tags(self, **kwargs):
+        """Helper method to return Troposphere tags + default tags
+
+        Args:
+          **kwargs: arbitrary keyword arguments to be used as tags
+        """
+        kwargs.update(self.default_tags)
+        return Tags(**kwargs)

--- a/deployment/default.yml.example
+++ b/deployment/default.yml.example
@@ -1,0 +1,11 @@
+[staging]
+Region: 'us-east-1'
+StackType: 'Staging'
+KeyName: 'rf-stg'
+IPAccess: '0.0.0.0/0'
+AvailabilityZones: 'us-east-1a,us-east-1b'
+NATInstanceType: 't2.micro'
+NATInstanceAMI: ''
+BastionHostInstanceType: 't2.micro'
+BastionHostAMI: ''
+GlobalNotificationsARN: 'arn:aws:sns:...'

--- a/deployment/rf_stack.py
+++ b/deployment/rf_stack.py
@@ -4,11 +4,15 @@
 import argparse
 import os
 
-from cfn.stacks import get_config
+from cfn.stacks import build_stacks, get_config
 from packer.driver import run_packer
 
 
 current_file_dir = os.path.dirname(os.path.realpath(__file__))
+
+
+def launch_stacks(rf_config, aws_profile, **kwargs):
+    build_stacks(rf_config, aws_profile, **kwargs)
 
 
 def create_ami(rf_config, aws_profile, machine_type, **kwargs):
@@ -32,6 +36,11 @@ def main():
     parser = argparse.ArgumentParser()
     subparsers = parser.add_subparsers(title='Raster Foundry Stack '
                                              'Commands')
+
+    rf_stacks = subparsers.add_parser('launch-stacks',
+                                      help='Launch Raster Foundry Stack',
+                                      parents=[common_parser])
+    rf_stacks.set_defaults(func=launch_stacks)
 
     rf_ami = subparsers.add_parser('create-ami', help='Create AMI for Raster '
                                                       'Foundry',


### PR DESCRIPTION
Add `launch-stacks` subcommand to `rf-stack.py` with supporting CloudFormation templates for an Amazon VPC with a VPC endpoint for S3.

---

**Testing**

Ensure that `default.yml` has at least the following contents:

```yaml
[staging]
Region: 'us-east-1'
StackType: 'Staging'
KeyName: 'rf-stg'
IPAccess: '216.158.51.82/32'
AvailabilityZones: 'us-east-1a,us-east-1b'
NATInstanceType: 't2.micro'
BastionHostInstanceType: 't2.micro'
```

Then, run the following command:

```bash
$ ./rf_stack.py launch-stacks --aws-profile rf-stg --rf-config-path default.yml --rf-profile staging

```

**Note**: This process makes use of the `rf-stg` API keys, which is different than the API keys associated with `rf-dev`. You can find the `rf-stg` keys on the file share.