### PR TITLE
Remove redis & change django cache to Postgres.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ The `app` virtual machine contains an instance of the Django application, `servi
 
 - PostgreSQL
 - Pgweb
-- Redis
 - Logstash
 - Kibana
 - Graphite
@@ -74,7 +73,6 @@ Graphite Dashboard     | 8080 | [http://localhost:8080](http://localhost:8080)
 Kibana Dashboard       | 5601 | [http://localhost:5601](http://localhost:5601)
 PostgreSQL             | 5432 | `psql -h localhost`
 pgweb                  | 5433 | [http://localhost:5433](http://localhost:5433)
-Redis                  | 6379 | `redis-cli -h localhost 6379`
 Testem                 | 7357 | [http://localhost:7357](http://localhost:7357)
 
 ### Caching

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -57,11 +57,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       guest: 5433,
       host: 5433
     }.merge(VAGRANT_NETWORK_OPTIONS)
-    # Redis
-    services.vm.network "forwarded_port", {
-      guest: 6379,
-      host: 6379
-    }.merge(VAGRANT_NETWORK_OPTIONS)
 
     services.vm.provider "virtualbox" do |v|
       v.memory = 1024
@@ -128,7 +123,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     worker.vm.synced_folder ".", "/vagrant", disabled: true
 
     worker.vm.synced_folder "src/rf", "/opt/app/"
-    
+
     if File.directory?("#{ENV['HOME']}/.aws")
       worker.vm.synced_folder "#{ENV['HOME']}/.aws", "/home/vagrant/.aws/"
     else

--- a/deployment/ansible/filter_plugins/custom_filters.py
+++ b/deployment/ansible/filter_plugins/custom_filters.py
@@ -1,14 +1,22 @@
 class FilterModule(object):
     '''
-    Custom filters to guard specific Ansible task by environment using set-like
-    operations.
+    Custom filters for set operations on lists:
+
+        - is_not_in
+        - is_in
+        - some_are_into
+
+    And dictionary merging:
+
+        - combine
     '''
 
     def filters(self):
         return {
             'is_not_in': self.is_not_in,
             'is_in': self.is_in,
-            'some_are_in': self.some_are_in
+            'some_are_in': self.some_are_in,
+            'combine': self.combine,
         }
 
     def is_not_in(self, x, y):
@@ -17,7 +25,8 @@ class FilterModule(object):
             x | is_not_in(y)
 
         Arguments
-        :param t: A tuple with two elements (x and y)
+        :param x: A list
+        :param y: A list
         """
         return set(x).isdisjoint(set(y))
 
@@ -27,7 +36,8 @@ class FilterModule(object):
             x | is_in(y)
 
         Arguments
-        :param t: A tuple with two elements (x and y)
+        :param x: A list
+        :param y: A list
         """
         return set(x).issubset(set(y))
 
@@ -37,6 +47,20 @@ class FilterModule(object):
             x | some_are_in(y)
 
         Arguments
-        :param t: A tuple with two elements (x and y)
+        :param x: A list
+        :param y: A list
         """
         return len(set(x) & set(y)) > 0
+
+    def combine(self, x, y):
+        """Combines the dictionary x with the key/value pairs from y
+
+            x | combine(y)
+
+        Arguments
+        :param x: A dictionary
+        :param y: A dictionary
+        """
+        x.update(y)
+
+        return x

--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -1,7 +1,6 @@
 ---
 django_test_database: "{{ lookup('env', 'RF_TEST_DB_NAME') | default('test_rf', true) }}"
 
-redis_port: 6379
 postgresql_port: 5432
 
 postgresql_username: rf

--- a/deployment/ansible/group_vars/development
+++ b/deployment/ansible/group_vars/development
@@ -1,8 +1,6 @@
 ---
 django_settings_module: "rf.settings.development"
 
-redis_bind_address: "0.0.0.0"
-
 aws_profile: "{{ lookup('env', 'AWS_PROFILE') | default('rf-dev', true) }}"
 
 postgresql_listen_addresses: "*"
@@ -12,7 +10,6 @@ postgresql_hba_mapping:
 
 services_ip: "{{ lookup('env', 'RF_SERVICES_IP') | default('33.33.40.80', true) }}"
 
-redis_host: "{{ services_ip }}"
 postgresql_host: "{{ services_ip }}"
 
 sqs_queue: "raster-foundry-{{ lookup('env', 'USER') | regex_replace('^(.*\\\\\\)?(.*)$', '\\\\2') }}"

--- a/deployment/ansible/group_vars/test
+++ b/deployment/ansible/group_vars/test
@@ -1,8 +1,6 @@
 ---
 django_settings_module: "rf.settings.test"
 
-redis_bind_address: "0.0.0.0"
-
 aws_profile: "{{ lookup('env', 'AWS_PROFILE') | default('rf-dev', true) }}"
 
 postgresql_listen_addresses: "*"
@@ -11,7 +9,6 @@ postgresql_hba_mapping:
 
 services_ip: "{{ lookup('env', 'RF_SERVICES_IP') | default('33.33.40.80', true) }}"
 
-redis_host: "{{ services_ip }}"
 postgresql_host: "{{ services_ip }}"
 
 sqs_queue: "raster-foundry-jenkins"

--- a/deployment/ansible/roles.txt
+++ b/deployment/ansible/roles.txt
@@ -11,4 +11,3 @@ azavea.pip,0.1.1
 azavea.postgis,0.2.1
 azavea.postgresql,0.3.0
 azavea.postgresql-support,0.2.0
-azavea.redis,0.1.0

--- a/deployment/ansible/roles/raster-foundry.app/tasks/main.yml
+++ b/deployment/ansible/roles/raster-foundry.app/tasks/main.yml
@@ -7,3 +7,4 @@
 - { include: static-files.yml }
 - { include: reverse-proxy.yml }
 - { include: log-rotation.yml }
+- { include: migrate.yml }

--- a/deployment/ansible/roles/raster-foundry.app/tasks/migrate.yml
+++ b/deployment/ansible/roles/raster-foundry.app/tasks/migrate.yml
@@ -1,0 +1,12 @@
+---
+- name: Create Django database cache table
+  django_manage: command=createcachetable app_path="{{ django_home }}"
+  environment: django_config
+  sudo: False
+  when: "['development', 'test'] | some_are_in(group_names)"
+
+- name: Run Django database migrations
+  django_manage: command=migrate app_path="{{ django_home }}"
+  environment: django_config
+  sudo: False
+  when: "['development', 'test'] | some_are_in(group_names)"

--- a/deployment/ansible/roles/raster-foundry.app/tasks/migrate.yml
+++ b/deployment/ansible/roles/raster-foundry.app/tasks/migrate.yml
@@ -1,12 +1,15 @@
 ---
 - name: Create Django database cache table
-  django_manage: command=createcachetable app_path="{{ django_home }}"
-  environment: django_config
+  django_manage: command=createcachetable
+                 cache_table="rf_cache"
+                 app_path="{{ django_home }}"
+  environment: "{{ envdir_config | combine(django_config) }}"
   sudo: False
   when: "['development', 'test'] | some_are_in(group_names)"
 
 - name: Run Django database migrations
-  django_manage: command=migrate app_path="{{ django_home }}"
-  environment: django_config
+  django_manage: command=migrate
+                 app_path="{{ django_home }}"
+  environment: "{{ envdir_config | combine(django_config) }}"
   sudo: False
   when: "['development', 'test'] | some_are_in(group_names)"

--- a/deployment/ansible/roles/raster-foundry.base/defaults/main.yml
+++ b/deployment/ansible/roles/raster-foundry.base/defaults/main.yml
@@ -6,8 +6,6 @@ envdir_config:
   RF_DB_PASSWORD: "{{ postgresql_password }}"
   RF_DB_HOST: "{{ postgresql_host }}"
   RF_DB_PORT: "{{ postgresql_port }}"
-  RF_CACHE_HOST: "{{ redis_host }}"
-  RF_CACHE_PORT: "{{ redis_port }}"
   AWS_PROFILE: "{{ aws_profile }}"
   AWS_DEFAULT_REGION: "{{ aws_region }}"
   RF_S3_BUCKET: "{{ s3_bucket }}"

--- a/deployment/ansible/services.yml
+++ b/deployment/ansible/services.yml
@@ -9,4 +9,3 @@
   roles:
     - { role: "raster-foundry.postgresql", when: "['development', 'test'] | some_are_in(group_names)" }
     - { role: "raster-foundry.pgweb", when: "['development', 'test'] | some_are_in(group_names)" }
-    - { role: "azavea.redis", when: "['development', 'test'] | some_are_in(group_names)" }

--- a/scripts/aws/setupdb.sh
+++ b/scripts/aws/setupdb.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Export settings required to run psql non-interactively
+export PGHOST=$(cat /etc/rf.d/env/RF_DB_HOST)
+export PGDATABASE=$(cat /etc/rf.d/env/RF_DB_NAME)
+export PGUSER=$(cat /etc/rf.d/env/RF_DB_USER)
+export PGPASSWORD=$(cat /etc/mmw.d/env/RF_DB_PASSWORD)
+
+# Ensure that the PostGIS extension exists
+psql -c "CREATE EXTENSION IF NOT EXISTS postgis;"
+
+# Run migrations
+envdir /etc/rf.d/env /opt/app/manage.py migrate
+
+# Enable DB Cache
+envdir /etc/rf.d/env /opt/app/manage.py createcachetable

--- a/src/rf/requirements/base.txt
+++ b/src/rf/requirements/base.txt
@@ -1,7 +1,5 @@
 Django>=1.8,<1.8.99
 gunicorn==19.1.1
-django-redis==3.8.3
-hiredis==0.1.6
 django-registration-redux==1.2
 django-filter==0.10.0
 boto==2.38.0

--- a/src/rf/rf/settings/base.py
+++ b/src/rf/rf/settings/base.py
@@ -59,20 +59,10 @@ DEFAULT_FILE_STORAGE = 'django.core.files.storage.FileSystemStorage'
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#caches
 CACHES = {
     'default': {
-        # The Redis database at index 0 is used by Logstash/Beaver
-        'BACKEND': 'django_redis.cache.RedisCache',
-        'LOCATION': 'redis://{0}:{1}/1'.format(
-            environ.get('RF_CACHE_HOST', 'localhost'),
-            environ.get('RF_CACHE_PORT', 6379)),
-        'OPTIONS': {
-            'PARSER_CLASS': 'redis.connection.HiredisParser',
-            'SOCKET_TIMEOUT': 3,
-        }
+        'BACKEND': 'django.core.cache.backends.db.DatabaseCache',
+        'LOCATION': 'rf_cache',
     }
 }
-
-# Don't throw exceptions if Redis is down.
-DJANGO_REDIS_IGNORE_EXCEPTIONS = True
 # END CACHE CONFIGURATION
 
 


### PR DESCRIPTION
Connects #193 

This relies on work done by @hectcastro in d49a599a213a438d4919af659e36cc9d903046bf.

We do not want to manage Redis for Django caching at this time. Database
caching will be fast enough and reliable enough and requires less effort to
provision.

 * Remove redis as a dependency.
 * Change cache setting in base.py to use database cache.

### To test
 * It is probably best to start from scratch and delete your current VMs as this does not actually remove redis.
 * Provision VMs
 * Check that redis is not installed on any of the machines (`which rediscli` or `netstat -natp` and make sure nothing is on the redis port) 
 * Run the management command to generate cache tables.
 * `python manage.py createcachetable`
 * Navigate around the site.
 * Check the cache tables in the DB. Hopefully you will find some data but it is also likely that you will find none as most of our functionality occurs while logged in and we cannot cache data for logged in users.