### PR TITLE
Feature/lol/date format error

### DIFF
--- a/src/rf/apps/home/forms.py
+++ b/src/rf/apps/home/forms.py
@@ -45,8 +45,24 @@ class LayerForm(ModelForm):
         except:
             self.cleaned_data['images'] = []
 
-        start = self.cleaned_data['capture_start']
-        end = self.cleaned_data['capture_end']
-        if (end - start).seconds < 0.0:
+        try:
+            start = self.cleaned_data['capture_start']
+        except KeyError:
+            # Improperly formed date string.\
+            start = None
+            self.add_error('capture_start',
+                           'The date is not valid or is not a valid format.')
+
+        try:
+            end = self.cleaned_data['capture_end']
+        except KeyError:
+            # Improperly formed date strings.
+            end = None
+            self.add_error('capture_end',
+                           'The date is not valid or is not a valid format.')
+
+        if start is not None and \
+           end is not None and \
+           (end - start).seconds < 0.0:
             self.add_error('capture_end',
                            'capture_end is before capture_start')


### PR DESCRIPTION
Connects #179 

On browsers that do not support HTML5 input elements, we did not properly handle errors generated from improper date strings being added to the date inputs.

Here we update the API to handle these errors and update the front end to properly display them.

### To test
 * Use Firefox
 * Build and start the process of adding a new layer.
 * Note new placeholder text on date inputs.
 * Type junk date into the date inputs.
 * Attempt to submit.
 * Note errors.
 * Fix one input and attempt to submit.
 * Note errors.
 * Fix both inputs and submit.