### PR TITLE
Feature/lol/only allow tifs

### DIFF
--- a/src/rf/apps/core/migrations/0024_allow_null_errors.py
+++ b/src/rf/apps/core/migrations/0024_allow_null_errors.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('core', '0023_update_thumbs_status'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='layer',
+            name='error',
+            field=models.CharField(help_text='Error that occured while processing the layer.', max_length=255, null=True, blank=True),
+        ),
+        migrations.AlterField(
+            model_name='layerimage',
+            name='error',
+            field=models.CharField(help_text='Error that occured while processing the file.', max_length=255, null=True, blank=True),
+        ),
+    ]

--- a/src/rf/apps/core/models.py
+++ b/src/rf/apps/core/models.py
@@ -124,6 +124,7 @@ class Layer(Model):
 
     error = CharField(
         blank=True,
+        null=True,
         max_length=255,
         help_text='Error that occured while processing the layer.',
     )
@@ -282,6 +283,7 @@ class LayerImage(Model):
     )
     error = CharField(
         blank=True,
+        null=True,
         max_length=255,
         help_text='Error that occured while processing the file.',
     )

--- a/src/rf/apps/workers/image_validator.py
+++ b/src/rf/apps/workers/image_validator.py
@@ -36,7 +36,9 @@ class ImageValidator(object):
             bucket = connection.get_bucket(settings.AWS_BUCKET_NAME)
             s3_key = Key(bucket)
             s3_key.key = key_string
-            self.random_filename = os.path.join(settings.TEMP_DIR, str(uuid.uuid4()))
+            self.random_filename = os.path.join(
+                settings.TEMP_DIR, str(uuid.uuid4()))
+
             with open(self.random_filename, 'w') as tempfile:
                 if byte_range is not None:
                     header_range = {'Range': 'bytes=' + byte_range}
@@ -71,8 +73,8 @@ class ImageValidator(object):
             raster_ok = validator.RasterCount >= band_count
             if not raster_ok:
                 self.error = ERROR_MESSAGE_IMAGE_TOO_FEW_BANDS + \
-                             ' A minimum of ' + str(band_count) + \
-                             ' bands are needed for processing.'
+                    ' A minimum of ' + str(band_count) + \
+                    ' bands are needed for processing.'
         except AttributeError:
             self.error = ERROR_MESSAGE_IMAGE_NOT_VALID
             raster_ok = False
@@ -91,4 +93,4 @@ class ImageValidator(object):
         return supported
 
     def get_error(self):
-        return self.error;
+        return self.error

--- a/src/rf/apps/workers/image_validator.py
+++ b/src/rf/apps/workers/image_validator.py
@@ -5,34 +5,90 @@ from __future__ import division
 
 from django.conf import settings
 
+import imghdr
 import os
 import uuid
 
 from boto.s3.key import Key
 from boto.s3.connection import S3Connection
+from boto.exception import NoAuthHandlerFound, S3ResponseError
 from osgeo import gdal
 
+SUPPORTED_MIMES = [  # See https://docs.python.org/2/library/imghdr.html
+    'tiff',
+]
 
-def ensure_band_count(key_string, byte_range=None):
-    """
-    Gets the first `range` bytes from the s3 resource and uses it to
-    determine the number of bands in the image.
-    """
-    connection = S3Connection()
-    bucket = connection.get_bucket(settings.AWS_BUCKET_NAME)
-    s3_key = Key(bucket)
-    s3_key.key = key_string
-    random_filename = os.path.join(settings.TEMP_DIR, str(uuid.uuid4()))
-    with open(random_filename, 'w') as tempfile:
-        if byte_range is not None:
-            header_range = {'Range': 'bytes=' + byte_range}
-            s3_key.get_contents_to_file(tempfile, headers=header_range)
-        else:
-            s3_key.get_contents_to_file(tempfile)
+ERROR_MESSAGE_UNSUPPORTED_MIME = 'The image format is not supported.' + \
+                                 ' Supported formats are: ' + \
+                                 ', '.join(SUPPORTED_MIMES)
+ERROR_MESSAGE_GENERIC_UNKNOWN = 'The system encountered an error.' + \
+                                ' Please try again later.'
+ERROR_MESSAGE_IMAGE_NOT_VALID = 'Image was not a valid GeoTiff file.'
+ERROR_MESSAGE_IMAGE_TOO_FEW_BANDS = 'Image does not have enough band data.'
 
-    # Throws AttributeError if it cannot be opened.
-    validator = gdal.Open(random_filename)
-    # Tiler needs 3+ bands.
-    raster_ok = validator.RasterCount >= 3
-    os.remove(random_filename)
-    return raster_ok
+
+class ImageValidator(object):
+    def __init__(self, key_string, byte_range=None):
+        self.error = None
+        self.random_filename = None
+        try:
+            connection = S3Connection()
+            bucket = connection.get_bucket(settings.AWS_BUCKET_NAME)
+            s3_key = Key(bucket)
+            s3_key.key = key_string
+            self.random_filename = os.path.join(settings.TEMP_DIR, str(uuid.uuid4()))
+            with open(self.random_filename, 'w') as tempfile:
+                if byte_range is not None:
+                    header_range = {'Range': 'bytes=' + byte_range}
+                    s3_key.get_contents_to_file(tempfile, headers=header_range)
+                else:
+                    s3_key.get_contents_to_file(tempfile)
+        except (NoAuthHandlerFound, S3ResponseError):
+            self.random_filename = None
+            # Set an error but don't let the user know anything scary.
+            self.error = ERROR_MESSAGE_GENERIC_UNKNOWN
+
+    def __del__(self):
+        try:
+            os.remove(self.random_filename)
+        except OSError:
+            # Could not remove the file. Shouldn't be a problem though since
+            # it is ephemeral.
+            pass
+
+    def image_has_min_bands(self, band_count):
+        """
+        Gets the first `range` bytes from the s3 resource and uses it to
+        determine the number of bands in the image.
+        """
+        # Fail fast in case we couldn't get the file.
+        if not self.random_filename:
+            return False
+
+        try:
+            validator = gdal.Open(self.random_filename)
+            # Tiler needs 3+ bands.
+            raster_ok = validator.RasterCount >= band_count
+            if not raster_ok:
+                self.error = ERROR_MESSAGE_IMAGE_TOO_FEW_BANDS + \
+                             ' A minimum of ' + str(band_count) + \
+                             ' bands are needed for processing.'
+        except AttributeError:
+            self.error = ERROR_MESSAGE_IMAGE_NOT_VALID
+            raster_ok = False
+
+        return raster_ok
+
+    def image_format_is_supported(self):
+        # Fail fast in case we couldn't get the file.
+        if not self.random_filename:
+            return False
+
+        supported = imghdr.what(self.random_filename) in SUPPORTED_MIMES
+        if not supported:
+            self.error = ERROR_MESSAGE_UNSUPPORTED_MIME
+
+        return supported
+
+    def get_error(self):
+        return self.error;

--- a/src/rf/apps/workers/image_validator.py
+++ b/src/rf/apps/workers/image_validator.py
@@ -17,7 +17,6 @@ from osgeo import gdal
 SUPPORTED_MIMES = [  # See https://docs.python.org/2/library/imghdr.html
     'tiff',
 ]
-
 ERROR_MESSAGE_UNSUPPORTED_MIME = 'The image format is not supported.' + \
                                  ' Supported formats are: ' + \
                                  ', '.join(SUPPORTED_MIMES)

--- a/src/rf/apps/workers/status_updates.py
+++ b/src/rf/apps/workers/status_updates.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import division
+
+
+from datetime import datetime
+
+from apps.core.models import LayerImage, Layer
+import apps.core.enums as enums
+
+
+def mark_image_valid(s3_uuid):
+    image = LayerImage.objects.get(s3_uuid=s3_uuid)
+    image.status = enums.STATUS_VALID
+    image.save()
+    return True
+
+
+def mark_image_invalid(s3_uuid, error_message):
+    image = LayerImage.objects.get(s3_uuid=s3_uuid)
+    image.status = enums.STATUS_INVALID
+    image.error = error_message
+    image.save()
+    layer_id = image.layer_id
+    update_layer_status(layer_id, enums.STATUS_FAILED, error_message)
+    return True
+
+
+def update_layer_status(layer_id, layer_status, error_message=None):
+    layer = Layer.objects.get(id=layer_id)
+    layer.status = layer_status
+    layer.status_updated_at = datetime.now()
+    layer.error = error_message
+    layer.save()
+
+
+def get_layer_id_from_uuid(s3_uuid):
+    image = LayerImage.objects.get(s3_uuid=s3_uuid)
+    return image.layer_id

--- a/src/rf/apps/workers/status_updates.py
+++ b/src/rf/apps/workers/status_updates.py
@@ -13,40 +13,43 @@ import apps.core.enums as enums
 def mark_image_valid(s3_uuid):
     try:
         image = LayerImage.objects.get(s3_uuid=s3_uuid)
-        image.status = enums.STATUS_VALID
-        image.save()
-        return True
-    except (ValueError, LayerImage.DoesNotExist):
+    except LayerImage.DoesNotExist:
         return False
+
+    image.status = enums.STATUS_VALID
+    image.save()
+    return True
 
 
 def mark_image_invalid(s3_uuid, error_message):
     try:
         image = LayerImage.objects.get(s3_uuid=s3_uuid)
-        image.status = enums.STATUS_INVALID
-        image.error = error_message
-        image.save()
-        layer_id = image.layer_id
-        update_layer_status(layer_id, enums.STATUS_FAILED, error_message)
-        return True
-    except (ValueError, LayerImage.DoesNotExist):
+    except LayerImage.DoesNotExist:
         return False
+
+    image.status = enums.STATUS_INVALID
+    image.error = error_message
+    image.save()
+    layer_id = image.layer_id
+    return update_layer_status(layer_id, enums.STATUS_FAILED, error_message)
 
 
 def update_layer_status(layer_id, layer_status, error_message=None):
     try:
         layer = Layer.objects.get(id=layer_id)
-        layer.status = layer_status
-        layer.status_updated_at = datetime.now()
-        layer.error = error_message
-        layer.save()
-    except (ValueError, Layer.DoesNotExist):
+    except Layer.DoesNotExist:
         return False
+
+    layer.status = layer_status
+    layer.status_updated_at = datetime.now()
+    layer.error = error_message
+    layer.save()
+    return True
 
 
 def get_layer_id_from_uuid(s3_uuid):
     try:
         image = LayerImage.objects.get(s3_uuid=s3_uuid)
         return image.layer_id
-    except (ValueError, LayerImage.DoesNotExist):
+    except LayerImage.DoesNotExist:
         return None

--- a/src/rf/apps/workers/status_updates.py
+++ b/src/rf/apps/workers/status_updates.py
@@ -9,6 +9,8 @@ from datetime import datetime
 from apps.core.models import LayerImage, Layer
 import apps.core.enums as enums
 
+ERROR_MESSAGE_LAYER_IMAGE_INVALID = 'Cannot process invalid images.'
+
 
 def mark_image_valid(s3_uuid):
     try:
@@ -31,7 +33,8 @@ def mark_image_invalid(s3_uuid, error_message):
     image.error = error_message
     image.save()
     layer_id = image.layer_id
-    return update_layer_status(layer_id, enums.STATUS_FAILED, error_message)
+    return update_layer_status(layer_id, enums.STATUS_FAILED,
+                               ERROR_MESSAGE_LAYER_IMAGE_INVALID)
 
 
 def update_layer_status(layer_id, layer_status, error_message=None):

--- a/src/rf/apps/workers/status_updates.py
+++ b/src/rf/apps/workers/status_updates.py
@@ -11,30 +11,42 @@ import apps.core.enums as enums
 
 
 def mark_image_valid(s3_uuid):
-    image = LayerImage.objects.get(s3_uuid=s3_uuid)
-    image.status = enums.STATUS_VALID
-    image.save()
-    return True
+    try:
+        image = LayerImage.objects.get(s3_uuid=s3_uuid)
+        image.status = enums.STATUS_VALID
+        image.save()
+        return True
+    except (ValueError, LayerImage.DoesNotExist):
+        return False
 
 
 def mark_image_invalid(s3_uuid, error_message):
-    image = LayerImage.objects.get(s3_uuid=s3_uuid)
-    image.status = enums.STATUS_INVALID
-    image.error = error_message
-    image.save()
-    layer_id = image.layer_id
-    update_layer_status(layer_id, enums.STATUS_FAILED, error_message)
-    return True
+    try:
+        image = LayerImage.objects.get(s3_uuid=s3_uuid)
+        image.status = enums.STATUS_INVALID
+        image.error = error_message
+        image.save()
+        layer_id = image.layer_id
+        update_layer_status(layer_id, enums.STATUS_FAILED, error_message)
+        return True
+    except (ValueError, LayerImage.DoesNotExist):
+        return False
 
 
 def update_layer_status(layer_id, layer_status, error_message=None):
-    layer = Layer.objects.get(id=layer_id)
-    layer.status = layer_status
-    layer.status_updated_at = datetime.now()
-    layer.error = error_message
-    layer.save()
+    try:
+        layer = Layer.objects.get(id=layer_id)
+        layer.status = layer_status
+        layer.status_updated_at = datetime.now()
+        layer.error = error_message
+        layer.save()
+    except (ValueError, Layer.DoesNotExist):
+        return False
 
 
 def get_layer_id_from_uuid(s3_uuid):
-    image = LayerImage.objects.get(s3_uuid=s3_uuid)
-    return image.layer_id
+    try:
+        image = LayerImage.objects.get(s3_uuid=s3_uuid)
+        return image.layer_id
+    except (ValueError, LayerImage.DoesNotExist):
+        return None


### PR DESCRIPTION
Connects #186
Connects #187 

This provides mimetype checking for uploaded images and hardens the worker pipeline against failing because of bad data.

Much of the worker code has been refactored in an effort to make this more stable.

### To test
 * Start worker
 * Go through normal site checks with varying images including some that will fail.
 * Go to SQS and feed it some junk messages.
 * Check that worker does not crash.
 * Upload a PNG file and ensure it is marked as invalid with appropriate error message.