### PR TITLE
Fix placeholder text issue on Safari.

### DIFF
--- a/src/rf/sass/base/_form.scss
+++ b/src/rf/sass/base/_form.scss
@@ -53,7 +53,6 @@ form {
 .form-control {
 	background: $white;
 	box-shadow: none;
-	height: 40px;
 	border-radius: 4px;
 	border-color: $gray-lightest;
 	transition: .4s ease all;


### PR DESCRIPTION
Connects #167 

The combination of line-height and height for the text boxes was causing the
placeholder text to show up near the button of the input box on Safari.
Removing a forced height resolves this.

### To test:
 * Open uploader modal in safari
 * Check that placeholder text is visible.