### PR TITLE
S3 imports

### DIFF
--- a/deployment/ansible/roles/raster-foundry.app/tasks/dependencies.yml
+++ b/deployment/ansible/roles/raster-foundry.app/tasks/dependencies.yml
@@ -13,3 +13,11 @@
   when: "['packer'] | is_in(group_names)"
   notify:
     - Restart rf-app
+
+- name: Install Python dependencies for geoprocessing
+  pip: chdir="{{ django_home }}/requirements" requirements=workers.txt
+  environment:
+    C_INCLUDE_PATH: "/usr/include/gdal"
+    CPLUS_INCLUDE_PATH: "/usr/include/gdal"
+  notify:
+    - Restart rf-app

--- a/src/rf/apps/core/migrations/0025_add_bucket_key.py
+++ b/src/rf/apps/core/migrations/0025_add_bucket_key.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('core', '0024_allow_null_errors'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='layerimage',
+            name='source_s3_bucket_key',
+            field=models.CharField(default='', help_text='S3 <bucket>/<key> for source image (optional)', max_length=255),
+        ),
+        migrations.AlterField(
+            model_name='layer',
+            name='thumb_large_key',
+            field=models.CharField(default='', help_text='S3 key for large thumbnail', max_length=255, blank=True),
+        ),
+        migrations.AlterField(
+            model_name='layer',
+            name='thumb_small_key',
+            field=models.CharField(default='', help_text='S3 key for small thumbnail', max_length=255, blank=True),
+        ),
+        migrations.AlterField(
+            model_name='layerimage',
+            name='thumb_large_key',
+            field=models.CharField(default='', help_text='S3 key for large thumbnail', max_length=255, blank=True),
+        ),
+        migrations.AlterField(
+            model_name='layerimage',
+            name='thumb_small_key',
+            field=models.CharField(default='', help_text='S3 key for small thumbnail', max_length=255, blank=True),
+        ),
+    ]

--- a/src/rf/apps/core/migrations/0026_bucket_key_null.py
+++ b/src/rf/apps/core/migrations/0026_bucket_key_null.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('core', '0025_add_bucket_key'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='layerimage',
+            name='source_s3_bucket_key',
+            field=models.CharField(help_text='S3 <bucket>/<key> for source image (optional)', max_length=255, null=True),
+        ),
+    ]

--- a/src/rf/apps/core/models.py
+++ b/src/rf/apps/core/models.py
@@ -133,6 +133,12 @@ class Layer(Model):
     thumb_large_key = CharField(max_length=255, blank=True, default='',
                                 help_text='S3 key for large thumbnail')
 
+    def has_copied_images(self):
+        for image in self.layer_images.all():
+            if image.source_s3_bucket_key:
+                return True
+        return False
+
     def save(self, *args, **kwargs):
         self.slug = slugify(self.name)
         super(Layer, self).save(*args, **kwargs)
@@ -274,6 +280,11 @@ class LayerImage(Model):
         max_length=255,
         help_text='Name of S3 bucket'
     )
+    source_s3_bucket_key = CharField(
+        null=True,
+        max_length=255,
+        help_text='S3 <bucket>/<key> for source image (optional)'
+    )
     status = CharField(
         blank=True,
         max_length=12,
@@ -304,6 +315,7 @@ class LayerImage(Model):
             'file_extension': self.file_extension,
             'bucket_name': self.bucket_name,
             'error': self.error,
+            'source_s3_bucket_key': self.source_s3_bucket_key
         }
 
 

--- a/src/rf/apps/home/forms.py
+++ b/src/rf/apps/home/forms.py
@@ -41,7 +41,10 @@ class LayerForm(ModelForm):
             self.cleaned_data['tags'] = []
 
         try:
-            self.cleaned_data['images'] = self.data['images']
+            for image in self.data['images']:
+                if 'source_s3_bucket_key' not in image:
+                    image['source_s3_bucket_key'] = None
+                self.cleaned_data['images'] = self.data['images']
         except:
             self.cleaned_data['images'] = []
 

--- a/src/rf/apps/home/tests.py
+++ b/src/rf/apps/home/tests.py
@@ -48,12 +48,12 @@ class AbstractLayerTestCase(TestCase):
                 {
                     'file_name': 'foo.png',
                     's3_uuid': 'a8098c1a-f86e-11da-bd1a-00112444be1e',
-                    'file_extension': 'png'
+                    'file_extension': 'png',
                 },
                 {
                     'file_name': 'bar.png',
                     's3_uuid': 'a8098c1a-f86e-11da-bd1a-00112444be1e',
-                    'file_extension': 'png'
+                    'file_extension': 'png',
                 },
             ],
             'tags': [

--- a/src/rf/apps/workers/copy_images.py
+++ b/src/rf/apps/workers/copy_images.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import division
+
+import boto3
+
+from django.conf import settings
+
+
+def s3_copy(source_s3_bucket_key, destination_key):
+    """
+    Copy a source file to destination_key in AWS_BUCKET_NAME.
+    source_s3_bucket_key -- string of the form <bucket>/<key>
+    """
+
+    session = boto3.session.Session()
+    s3_client = session.client('s3')
+    try:
+        s3_client.copy_object(CopySource=source_s3_bucket_key,
+                              Bucket=settings.AWS_BUCKET_NAME,
+                              Key=destination_key)
+        return True
+    except:
+        return False

--- a/src/rf/js/src/app.js
+++ b/src/rf/js/src/app.js
@@ -41,6 +41,7 @@ var App = Marionette.Application.extend({
 
         function poll() {
             if (pendingLayers.existsUploading() ||
+                pendingLayers.existsTransferring() ||
                 pendingLayers.existsProcessing()) {
                 pendingLayers.fetch();
             }

--- a/src/rf/js/src/home/components/processing-block.js
+++ b/src/rf/js/src/home/components/processing-block.js
@@ -8,26 +8,28 @@ var LayerStatusComponent = React.createBackboneClass({
         var checkClass = 'rf-icon-check',
             spinnerClass = 'rf-icon-loader animate-spin',
             failedClass = 'rf-icon-attention rf-failed text-danger',
-            uploadingClass = spinnerClass,
+            preValidatedClass = spinnerClass,
             processingClass = spinnerClass,
             actionLink = (<a href="#" className="text-danger">Cancel</a>),
-            uploadErrorsExist = false,
+            preValidatedErrorsExist = false,
             layerError = false,
             layerErrorComponent = (
                 <li>
                     {this.getModel().get('error') ? this.getModel().get('error') : 'An unknown error occured.'}
                     <i className="rf-icon-attention"></i>
                 </li>
-            );
+            ),
+            preValidatedLabel = this.getModel().hasCopiedImages() ?
+                'Transferring Images' : 'Uploading Images';
 
         if (this.getModel().isProcessing() ||
             this.getModel().isCompleted()) {
-            uploadingClass = checkClass;
+            preValidatedClass = checkClass;
         } else if (this.getModel().isFailed()) {
-            uploadErrorsExist = _.some(this.getModel().get('images'), function(image) {
-                return !(image.error && image.error !== '');
+            preValidatedErrorsExist = _.some(this.getModel().get('images'), function(image) {
+                return image.error && image.error !== '';
             });
-            uploadingClass = uploadErrorsExist ? failedClass : checkClass;
+            preValidatedClass = preValidatedErrorsExist ? failedClass : checkClass;
         }
 
         if (this.getModel().isCompleted()) {
@@ -47,7 +49,7 @@ var LayerStatusComponent = React.createBackboneClass({
                     <h5>{this.getModel().get('name')}</h5>
                     <ol>
                         <li>
-                            Uploading Images <i className={uploadingClass} />
+                            {preValidatedLabel} <i className={preValidatedClass} />
                             <ul className="notice">
                                 {_.map(this.getModel().get('images'), function(image) {
                                     if (image.error && image.error !== '') {


### PR DESCRIPTION
Allows users to import images from publicly-accessible S3 buckets.

##### Testing
* Try importing from a syntactically invalid bucket/key to test frontend validation (eg. `bkbo-tohu`)
* Try importing from a syntactically valid, but non-existent bucket/key to test backend validation (eg. `sample-tiffs/blah.tif`). Note that the submit button becomes disabled while submit is in progress.
* Import from `sample-tiffs/test.png` which should result in an image validation error
* Import from `sample-tiffs/356f564e3a0dc9d15553c17cf4583f21-7.tif` which should work. Change status to `complete` via `/admin/` to see the generated thumbnails.

##### Known issues
* Imported file names (from file system or S3) need to have extensions. This is because we need to send the extension to the backend, and there's no way to extract the file type on the frontend for S3 imports. We could eliminate this issue by getting rid of the extension field in the DB which isn't necessary, but I don't want to make a drastic change right now.
* ~~Frontend does not enforce the constraint that files are either imported from the file system or S3.~~ This can be considered a feature. The user might want to import some images from the file system and some from S3.
* Backend validation for the copy job could return more detailed error messages (eg. 'Bucket name was invalid).
* ~~Would be nice to put a spinner next to the submit button while it is disabled.~~ The text of the button changes 'Submitting...' while submitting.

Connects #201 