### PR TITLE
Allow blank on source_s3_bucket_key

### DIFF
--- a/src/rf/apps/core/migrations/0027_source_allow_blank.py
+++ b/src/rf/apps/core/migrations/0027_source_allow_blank.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('core', '0026_bucket_key_null'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='layerimage',
+            name='source_s3_bucket_key',
+            field=models.CharField(help_text='S3 <bucket>/<key> for source image (optional)', max_length=255, null=True, blank=True),
+        ),
+    ]

--- a/src/rf/apps/core/models.py
+++ b/src/rf/apps/core/models.py
@@ -281,6 +281,7 @@ class LayerImage(Model):
         help_text='Name of S3 bucket'
     )
     source_s3_bucket_key = CharField(
+        blank=True,
         null=True,
         max_length=255,
         help_text='S3 <bucket>/<key> for source image (optional)'


### PR DESCRIPTION
We need to allow blanks to use the admin interface.