### PR TITLE
Add support for AMI pruning

### DIFF
--- a/deployment/ec2/amis.py
+++ b/deployment/ec2/amis.py
@@ -1,0 +1,49 @@
+"""Helper functions to handle EC2 related operations with Boto"""
+
+import boto
+import logging
+
+
+LOGGER = logging.getLogger('rf')
+LOGGER.addHandler(logging.StreamHandler())
+LOGGER.setLevel(logging.INFO)
+
+MACHINE_TYPE_MAPPING = {
+    'rf-app': 'Application',
+    'rf-worker': 'Worker',
+}
+
+
+def _prune_ami(ami):
+    """Actually deregister AMI and its associated snapshot"""
+    LOGGER.info('Identified that [%s] is eligible to be pruned..', ami.id)
+
+    ami.deregister(delete_snapshot=True)
+
+    LOGGER.info('Deregistered [%s] and snapshot [%s]..', ami.id,
+                ami.block_device_mapping['/dev/sda1'].snapshot_id)
+
+
+def prune(rf_config, machine_types, keep, aws_profile):
+    """Filter owned AMIs by machine type, environment, and count
+
+    Args:
+      rf_config (dict): Dict of configuration settings
+      machine_types (list): list of machine types to prune
+      keep (int): number of images of this machine type to keep
+      aws_profile (str): aws profile name to use for authentication
+    """
+    stack_type = rf_config['StackType']
+
+    conn = boto.connect_ec2(profile_name=aws_profile)
+    for machine_type in machine_types:
+        images = conn.get_all_images(owners='self', filters={
+            'tag:Service': MACHINE_TYPE_MAPPING[machine_type],
+            'tag:Environment': stack_type
+        })
+
+        if len(images) > keep:
+            map(_prune_ami,
+                list(sorted(images, key=lambda i: i.creationDate))[0:len(images) - keep])  # NOQA
+        else:
+            LOGGER.info('No [%s] AMIs are eligible for pruning', machine_type)


### PR DESCRIPTION
Going through the process of wiring up an AMI builder in Jenkins, which requires support for some level of AMI pruning.

---

**Testing**

Can be tested using the following command, but it'll only work if there are more than one AMIs present:

```bash
$ ./rf_stack.py prune-ami --aws-profile rf-stg --rf-profile staging --keep 1 --machine-type rf-app rf-worker
```

Here is an example of it successfully completing from my machine:

```bash
$ ./rf_stack.py prune-ami --aws-profile rf-stg --rf-profile staging --keep 1 --machine-type rf-app rf-worker
Identified that [ami-a9085fcc] is eligible to be pruned..
Deregistered [ami-a9085fcc] and snapshot [snap-20dd716a]..
Identified that [ami-55095a30] is eligible to be pruned..
Deregistered [ami-55095a30] and snapshot [snap-c527a98b]..
Identified that [ami-d3491ab6] is eligible to be pruned..
Deregistered [ami-d3491ab6] and snapshot [snap-3ca1ef56]..
Identified that [ami-314e1d54] is eligible to be pruned..
Deregistered [ami-314e1d54] and snapshot [snap-0e47f26f]..
Identified that [ami-890c5bec] is eligible to be pruned..
Deregistered [ami-890c5bec] and snapshot [snap-171fb770]..
Identified that [ami-db4e1dbe] is eligible to be pruned..
Deregistered [ami-db4e1dbe] and snapshot [snap-bcb5baf0]..
Identified that [ami-e970228c] is eligible to be pruned..
Deregistered [ami-e970228c] and snapshot [snap-cf785fb4]..
```