### PR TITLE
Make working files public-read only.

### DIFF
--- a/src/rf/js/src/core/uploads.js
+++ b/src/rf/js/src/core/uploads.js
@@ -40,6 +40,7 @@ var uploadFiles = function(fileDescriptions) {
             name: fileName,
             file: fileDescription.file,
             contentType: fileDescription.file.type,
+            xAmzHeadersAtInitiate: { 'x-amz-acl': 'public-read' },
             complete: function() {
                 console.log('File upload complete');
             },


### PR DESCRIPTION
Uploaded files will be processed by EMR workers and will use curl-like
commands to access the files. This will require the resources to be publicly
readable. When uploading files from the front end set the ACL header to
'public-readonly'.

### To test
 * upload an image via the UI
 * Log in to the AWS panel and check the resource in your S3 bucket.
 * Look at properties and check that it it does not have a lock icon and the permissions mark it as "Everyone - Open/Download"