### PR TITLE
Add monitoring endpoint.

### DIFF
--- a/deployment/cfn/application.py
+++ b/deployment/cfn/application.py
@@ -266,7 +266,7 @@ class Application(StackNode):
                 )
             ],
             HealthCheck=elb.HealthCheck(
-                Target='HTTP:80/',
+                Target='HTTP:80/health-check/',
                 HealthyThreshold='3',
                 UnhealthyThreshold='2',
                 Interval='30',

--- a/src/rf/apps/monitoring/urls.py
+++ b/src/rf/apps/monitoring/urls.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import division
+
+from django.conf.urls import patterns, url
+from apps.monitoring.views import health_check
+
+
+urlpatterns = patterns(
+    '',
+    url(r'^$', health_check, name='health_check'),
+)

--- a/src/rf/apps/monitoring/views.py
+++ b/src/rf/apps/monitoring/views.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import division
+
+from django.http import JsonResponse
+from django.db import connections
+
+from apps.core.decorators import accepts
+
+
+@accepts('GET')
+def health_check(request):
+    response = {}
+
+    for check in [_check_app_servers, _check_database]:
+        response.update(check())
+
+    if all(map(lambda x: x[0]['default']['ok'], response.values())):
+        return JsonResponse(response, status=200)
+    else:
+        return JsonResponse(response, status=503)
+
+
+def _check_database(database='default'):
+    try:
+        connections[database].introspection.table_names()
+
+        response = {database: {'ok': True}}
+    except Exception as e:
+        response = {
+            database: {
+                'ok': False,
+                'msg': str(e)
+            },
+        }
+
+    return {'databases': [response]}
+
+
+def _check_app_servers():
+    return {'apps': [{'default': {'ok': True}}]}

--- a/src/rf/rf/settings/base.py
+++ b/src/rf/rf/settings/base.py
@@ -261,6 +261,7 @@ ACCOUNT_ACTIVATION_DAYS = 7  # One-week activation window.
 LOCAL_APPS = (
     'apps.core',
     'apps.home',
+    'apps.monitoring',
     'apps.uploads',
     'apps.workers'
 )

--- a/src/rf/rf/urls.py
+++ b/src/rf/rf/urls.py
@@ -9,6 +9,7 @@ from django.contrib import admin
 import registration.backends.default.urls
 
 import apps.home.urls
+import apps.monitoring.urls
 import apps.user.urls
 import apps.uploads.urls
 
@@ -18,8 +19,9 @@ admin.autodiscover()
 urlpatterns = patterns(
     '',
     url(r'^admin/', include(admin.site.urls)),
+    url(r'^accounts/', include(registration.backends.default.urls)),
+    url(r'^health-check/', include(apps.monitoring.urls)),
     url(r'^uploads/', include(apps.uploads.urls)),
     url(r'^user/', include(apps.user.urls)),
-    url(r'^accounts/', include(registration.backends.default.urls)),
     url(r'^', include(apps.home.urls)),
 )


### PR DESCRIPTION
Connects #212 

To help us keep track of service interruptions we add a monitoring endpoint
that lets us know if the application stack and database are working properly.

We currently will only have a single app server, we return 200 OK for the
apps since be default of the fact that our endpoint code is running, the
application server must be ok.

We return a 200 for the database if we can connect to is. Currently we have
and expect to have only one database as well.

Worker servers are not monitored currently.

### To test
 * visit /health-check/
 * ensure you see the follow JSON response
```json
{"apps": [{"default": {"ok": true}}], "databases": [{"default": {"ok": true}}]}
```