### PR TITLE
Use correct layer status

### DIFF
--- a/src/rf/apps/workers/process.py
+++ b/src/rf/apps/workers/process.py
@@ -136,7 +136,7 @@ class QueueProcessor(object):
                 if all_valid and some_images:
                     status_updates.update_layer_status(
                         layer_id,
-                        enums.STATUS_VALID)
+                        enums.STATUS_VALIDATED)
 
                     data = {'layer_id': layer_id}
                     self.queue.add_message(JOB_THUMBNAIL, data)


### PR DESCRIPTION
This fixes an issue where the validation step was saving a `LayerImage`
status on a `Layer` record. On `develop`, the layer status briefly
appears as `---------` (unknown) in the Django admin after the
validation step completes.

To test:

1. Upload layer
2. Observe layer status in Django admin