### PR TITLE
Add support for launching stacks namespaced by color

### DIFF
--- a/deployment/cfn/worker.py
+++ b/deployment/cfn/worker.py
@@ -29,6 +29,7 @@ class Worker(StackNode):
         'Tags': ['global:Tags'],
         'Region': ['global:Region'],
         'StackType': ['global:StackType'],
+        'StackColor': ['global:StackColor'],
         'KeyName': ['global:KeyName'],
         'AvailabilityZones': ['global:AvailabilityZones',
                               'VPC:AvailabilityZones'],
@@ -49,6 +50,7 @@ class Worker(StackNode):
         'Tags': {},
         'Region': 'us-east-1',
         'StackType': 'Staging',
+        'StackColor': 'Green',
         'KeyName': 'rf-stg',
         'IPAccess': ALLOW_ALL_CIDR,
         'WorkerInstanceType': 't2.micro',
@@ -60,6 +62,7 @@ class Worker(StackNode):
 
     ATTRIBUTES = {
         'StackType': 'StackType',
+        'StackColor': 'StackColor',
     }
 
     def set_up_stack(self):
@@ -74,6 +77,11 @@ class Worker(StackNode):
         self.add_description('Worker stack for Raster Foundry')
 
         # Parameters
+        self.color = self.add_parameter(Parameter(
+            'StackColor', Type='String',
+            Description='Stack color', AllowedValues=['Blue', 'Green']
+        ), 'StackColor')
+
         self.keyname = self.add_parameter(Parameter(
             'KeyName', Type='String',
             Description='Name of an existing EC2 key pair'
@@ -240,6 +248,10 @@ class Worker(StackNode):
         return ['#cloud-config\n',
                 '\n',
                 'write_files:\n',
+                '  - path: /etc/rf.d/env/RF_STACK_COLOR\n',
+                '    permissions: 0750\n',
+                '    owner: root:rf\n',
+                '    content: ', Ref(self.color), '\n',
                 '  - path: /etc/rf.d/env/RF_DB_PASSWORD\n',
                 '    permissions: 0750\n',
                 '    owner: root:rf\n',

--- a/deployment/rf_stack.py
+++ b/deployment/rf_stack.py
@@ -4,7 +4,7 @@
 import argparse
 import os
 
-from cfn.stacks import build_stacks, get_config
+from cfn.stacks import build_stacks, destroy_stacks, get_config
 from ec2.amis import prune
 from packer.driver import run_packer
 
@@ -14,6 +14,10 @@ current_file_dir = os.path.dirname(os.path.realpath(__file__))
 
 def launch_stacks(rf_config, aws_profile, **kwargs):
     build_stacks(rf_config, aws_profile, **kwargs)
+
+
+def remove_stacks(rf_config, aws_profile, **kwargs):
+    destroy_stacks(rf_config, aws_profile, **kwargs)
 
 
 def create_ami(rf_config, aws_profile, machine_type, **kwargs):
@@ -45,7 +49,24 @@ def main():
     rf_stacks = subparsers.add_parser('launch-stacks',
                                       help='Launch Raster Foundry Stack',
                                       parents=[common_parser])
+    rf_stacks.add_argument('--stack-color', type=str,
+                           choices=['green', 'blue'],
+                           default=None,
+                           help='One of "green", "blue"')
+    rf_stacks.add_argument('--activate-dns', action='store_true',
+                           default=False,
+                           help='Activate DNS for current stack color')
     rf_stacks.set_defaults(func=launch_stacks)
+
+    rf_remove_stacks = subparsers.add_parser('remove-stacks',
+                                             help='Remove Raster Foundry '
+                                                  'Stack',
+                                             parents=[common_parser])
+    rf_remove_stacks.add_argument('--stack-color', type=str,
+                                  choices=['green', 'blue'],
+                                  required=True,
+                                  help='One of "green", "blue"')
+    rf_remove_stacks.set_defaults(func=remove_stacks)
 
     rf_ami = subparsers.add_parser('create-ami', help='Create AMI for Raster '
                                                       'Foundry',

--- a/scripts/aws/setupdb.sh
+++ b/scripts/aws/setupdb.sh
@@ -4,7 +4,7 @@
 export PGHOST=$(cat /etc/rf.d/env/RF_DB_HOST)
 export PGDATABASE=$(cat /etc/rf.d/env/RF_DB_NAME)
 export PGUSER=$(cat /etc/rf.d/env/RF_DB_USER)
-export PGPASSWORD=$(cat /etc/mmw.d/env/RF_DB_PASSWORD)
+export PGPASSWORD=$(cat /etc/rf.d/env/RF_DB_PASSWORD)
 
 # Ensure that the PostGIS extension exists
 psql -c "CREATE EXTENSION IF NOT EXISTS postgis;"

--- a/scripts/aws/staging-deployment.sh
+++ b/scripts/aws/staging-deployment.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+set -e
+
+if env | grep -q "RF_DEPLOY_DEBUG"; then
+  set -x
+fi
+
+CURRENT_STACK_COLOR=$(aws cloudformation describe-stacks \
+  --profile "${RF_AWS_PROFILE}" \
+  --output text \
+  | egrep "TAGS\s+StackColor" \
+  | egrep "Blue|Green" \
+  | cut -f3 \
+  | uniq \
+  | tr "[:upper:]" "[:lower:]")
+
+STACK_COLOR_COUNT=$(echo "${CURRENT_STACK_COLOR}" \
+  | wc -l \
+  | xargs)
+
+# Determine which color stack to launch
+if [ "${STACK_COLOR_COUNT}" -gt 1 ]; then
+  echo "Both stack colors already exist."
+  exit 1
+elif [ "${CURRENT_STACK_COLOR}" = "blue" ]; then
+  NEW_STACK_COLOR="green"
+elif [ "${CURRENT_STACK_COLOR}" = "green" ]; then
+  NEW_STACK_COLOR="blue"
+fi
+
+pushd deployment
+
+# Attempt to launch a new stack & cutover DNS
+python rf_stack.py launch-stacks \
+  --aws-profile "${RF_AWS_PROFILE}" \
+  --rf-profile "${RF_PROFILE}" \
+  --rf-config-path "${RF_CONFIG_PATH}" \
+  --stack-color "${NEW_STACK_COLOR}" \
+  --activate-dns
+
+# Remove old stack
+python rf_stack.py remove-stacks \
+  --aws-profile "${RF_AWS_PROFILE}" \
+  --rf-profile "${RF_PROFILE}" \
+  --rf-config-path "${RF_CONFIG_PATH}" \
+  --stack-color "${CURRENT_STACK_COLOR}" \

--- a/src/rf/rf/settings/base.py
+++ b/src/rf/rf/settings/base.py
@@ -55,6 +55,11 @@ DEFAULT_FILE_STORAGE = 'django.core.files.storage.FileSystemStorage'
 # END FILE STORAGE CONFIGURATION
 
 
+# STACK COLOR CONFIGURATION
+STACK_COLOR = environ.get('RF_STACK_COLOR', 'Black')
+# END STACK COLOR CONFIGURATION
+
+
 # CACHE CONFIGURATION
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#caches
 CACHES = {


### PR DESCRIPTION
Now each application and worker stack is namespaced by color. In addition, a subcommand was added to `rf_stacks.py` to remove an entire stack by color.

Lastly, a staging deployment script was added to make use of all of the changes to alternate colors during Jenkins deployments.

---

**Testing**

Ensure that `default.yml` has at least the following contents:

```yaml
[staging]
Region: 'us-east-1'
StackType: 'Staging'
KeyName: 'rf-stg'
IPAccess: '216.158.51.82/32'
AvailabilityZones: 'us-east-1a,us-east-1b'
NATInstanceType: 't2.micro'
BastionHostInstanceType: 't2.micro'
PublicHostedZoneName: 'rf.azavea.com'
PrivateHostedZoneName: 'rf.internal'
RDSDbName: 'rasterfoundry'
RDSUsername: 'rasterfoundry'
RDSPassword: 'secretsecret'
GlobalNotificationsARN: 'arn:aws:sns:...'
AppServerInstanceType: 't2.micro'
AppServerInstanceProfile: 'AppServerInstanceProfile'
AppServerAutoScalingDesired: '1'
AppServerAutoScalingMin: '1'
AppServerAutoScalingMax: '1'
SSLCertificateARN: 'arn:aws:iam...'
WorkerInstanceType: 't2.micro'
WorkerInstanceProfile: 'WorkerInstanceProfile'
WorkerAutoScalingDesired: '1'
WorkerAutoScalingMin: '1'
WorkerAutoScalingMax: '1'
```

Then, run the following command:

```bash
$ RF_AWS_PROFILE=rf-stg \
   RF_PROFILE=staging \
   RF_CONFIG_PATH=${PWD}/deployment/default.yml \
   RF_DEPLOY_DEBUG=1 ./scripts/aws/staging-deployment.sh
```