### PR TITLE
Add more INFO logging messages

### DIFF
--- a/src/rf/apps/workers/process.py
+++ b/src/rf/apps/workers/process.py
@@ -70,6 +70,9 @@ class QueueProcessor(object):
 
     def handle_message(self, record):
         # Parse record fields.
+        if self.is_test_event(record):
+            return True
+
         try:
             job_type = record['eventName']
             event_source = record['eventSource']
@@ -90,6 +93,9 @@ class QueueProcessor(object):
             return self.copy_image(record)
 
         return False
+
+    def is_test_event(self, record):
+        return 'Event' in record and record['Event'] == 's3:TestEvent'
 
     def validate_image(self, record):
         """

--- a/src/rf/apps/workers/process.py
+++ b/src/rf/apps/workers/process.py
@@ -137,6 +137,7 @@ class QueueProcessor(object):
                 log.info('Image validated %s', key)
                 layer_id = status_updates.get_layer_id_from_uuid(s3_uuid)
                 layer_images = LayerImage.objects.filter(layer_id=layer_id)
+                # TODO: Filter `layer_images` instead of extra query.
                 valid_images = LayerImage.objects.filter(
                     layer_id=layer_id,
                     status=enums.STATUS_VALID)
@@ -180,11 +181,10 @@ class QueueProcessor(object):
             return False
 
         try:
-            int(layer_id)
+            layer_id = int(layer_id)
         except ValueError:
             return False
 
-        layer_id = data['layer_id']
         log.info('Generating thumbnails for layer %d...', layer_id)
 
         if make_thumbs_for_layer(layer_id):
@@ -211,11 +211,12 @@ class QueueProcessor(object):
             return False
 
         try:
-            int(layer_id)
+            layer_id = int(layer_id)
         except ValueError:
             return False
 
         layer_images = LayerImage.objects.filter(layer_id=layer_id)
+        # TODO: Filter `layer_images` instead of extra query.
         valid_images = LayerImage.objects.filter(
             layer_id=layer_id,
             status=enums.STATUS_THUMBNAILED)
@@ -290,7 +291,7 @@ class QueueProcessor(object):
             return False
 
         try:
-            int(image_id)
+            image_id = int(image_id)
         except ValueError:
             return False
 

--- a/src/rf/rf/settings/development.py
+++ b/src/rf/rf/settings/development.py
@@ -53,7 +53,7 @@ LOGGING = {
         },
         'apps': {
             'handlers': ['console'],
-            'level': 'DEBUG',
+            'level': 'INFO',
         },
     }
 }


### PR DESCRIPTION
Sets the default (development) logging level to INFO and adds helpful
logging messages.

The polling log should now display simple output like this:

![image](https://cloud.githubusercontent.com/assets/43062/10741699/7fba1c42-7bff-11e5-9773-fc6a8a072212.png)

Connects #216