### PR TITLE
Queue EMR handoff and thumbnail job at same time

### DIFF
--- a/src/rf/apps/workers/process.py
+++ b/src/rf/apps/workers/process.py
@@ -176,6 +176,10 @@ class QueueProcessor(object):
                         enums.STATUS_VALIDATED)
 
                     data = {'layer_id': layer_id}
+
+                    log.info('Queue handoff job')
+                    self.queue.add_message(JOB_HANDOFF, data)
+
                     log.info('Queue thumbnail job')
                     self.queue.add_message(JOB_THUMBNAIL, data)
 
@@ -207,9 +211,6 @@ class QueueProcessor(object):
         log.info('Generating thumbnails for layer %d...', layer_id)
 
         if make_thumbs_for_layer(layer_id):
-            data = {'layer_id': layer_id}
-            log.info('Queue handoff job')
-            self.queue.add_message(JOB_HANDOFF, data)
             return True
         else:
             log.info('Failed to thumbnail')

--- a/src/rf/apps/workers/process.py
+++ b/src/rf/apps/workers/process.py
@@ -213,7 +213,7 @@ class QueueProcessor(object):
         if make_thumbs_for_layer(layer_id):
             return True
         else:
-            log.info('Failed to thumbnail')
+            log.info('Failed to thumbnail layer %d', layer_id)
             status_updates.update_layer_status(layer_id,
                                                enums.STATUS_FAILED,
                                                ERROR_MESSAGE_THUMBNAIL_FAILED)
@@ -238,7 +238,7 @@ class QueueProcessor(object):
         layer = Layer.objects.get(id=layer_id)
         status_updates.update_layer_status(layer.id,
                                            enums.STATUS_PROCESSING)
-        log.info('Launching EMR cluster...')
+        log.info('Launching EMR cluster for layer %d', layer_id)
         emr_response = create_cluster(layer)
         self.start_health_check(layer_id, emr_response)
         return True


### PR DESCRIPTION
This alters the workflow to launch the cluster and generate thumbnails in
parallel when there are multiple workers available.