### PR TITLE
Add Retry link for failed layers

### DIFF
--- a/src/rf/apps/home/urls.py
+++ b/src/rf/apps/home/urls.py
@@ -30,6 +30,7 @@ urlpatterns = patterns(
         name='create_or_destroy_favorite'),
     url('^catalog.json$', views.all_layers, name='catalog'),
     url('^layer/dismiss', views.layer_dismiss, name='layer_dismiss'),
+    url('^layer/retry', views.layer_retry, name='layer_retry'),
 
     # These all route to the home page.
     url('^imports/?$', views.home_page),

--- a/src/rf/apps/workers/thumbnail.py
+++ b/src/rf/apps/workers/thumbnail.py
@@ -144,6 +144,7 @@ def make_thumbs_for_layer(layer_id):
         layer.thumb_large_key, = s3_make_thumbs(image.get_s3_key(),
                                                 user_id, thumb_dims,
                                                 THUMB_EXT)
+        layer.save()
     except ImageCouldNotOpenError:
         return False
 

--- a/src/rf/js/src/home/components/processing-block.js
+++ b/src/rf/js/src/home/components/processing-block.js
@@ -17,8 +17,9 @@ var LayerStatusComponent = React.createBackboneClass({
             chunkClass = this.pendingClass,
             mosaicClass = this.pendingClass,
             completeClass = this.pendingClass,
-            actionLink = (<a className="text-danger">Cancel</a>),
+            actionLinks = (<a className="text-danger">Cancel</a>),
             uploadErrorsExist = false,
+
             layerError = false,
             layerErrorComponent = (
                 <li>
@@ -52,7 +53,14 @@ var LayerStatusComponent = React.createBackboneClass({
         }
 
         if (this.getModel().isDoneWorking()) {
-            actionLink = (<a onClick={this.dismiss}>Dismiss</a>);
+            actionLinks = (<a onClick={this.dismiss}>Dismiss</a>);
+            if (this.getModel().retryPossible()) {
+                actionLinks = (
+                    <span>
+                        {actionLinks}, <a onClick={this.retry}>Retry</a>
+                    </span>
+                );
+            }
         }
 
         return (
@@ -159,7 +167,7 @@ var LayerStatusComponent = React.createBackboneClass({
                     </ol>
                 </div>
                 <div className="list-group-tool">
-                    { actionLink }
+                    { actionLinks }
                 </div>
             </div>
         );
@@ -185,6 +193,11 @@ var LayerStatusComponent = React.createBackboneClass({
             className = this.successClass;
         }
         return className;
+    },
+
+    retry: function(e) {
+        e.preventDefault();
+        this.getModel().retry();
     }
 });
 

--- a/src/rf/sass/components/_processing-block.scss
+++ b/src/rf/sass/components/_processing-block.scss
@@ -98,9 +98,9 @@
 	.list-group-tool {
 		a {
             cursor: pointer;
-			position: absolute;
-			top: 15px;
-			right: 10px;
 		}
+		position: absolute;
+		top: 15px;
+		right: 10px;
 	}
 }


### PR DESCRIPTION
Adds a retry link to layers that failed.

To test, find or construct a layer that has failed. Click the retry button which should roll things back to the transfer stage for layers with copied images, and the validation stage for layers with only uploaded images.

Connects #220 