### PR TITLE
Kill timeout if layer has finished processing

### DIFF
--- a/src/rf/apps/workers/process.py
+++ b/src/rf/apps/workers/process.py
@@ -272,6 +272,9 @@ class QueueProcessor(object):
 
         log.info('Heartbeat for layer %d', layer_id)
 
+        if layer.status in (enums.STATUS_COMPLETED, enums.STATUS_FAILED):
+            return True
+
         if not check_cluster_status(job_id):
             log.info('EMR job for layer %d has failed!', layer_id)
             return status_updates.update_layer_status(layer_id,


### PR DESCRIPTION
Fixes a bug where the timeout would continue to run even after layer
processing had completed.

Connects #257

To test:
1. Set log level to DEBUG
2. Upload layer
3. After the timeout job has been queued, mark the layer as FAILED or COMPLETED in the Django admin
4. You should see the "Ending timeout" debug message in the polling logs and the timeout job will not run again for that layer

You can reduce the `TIMEOUT_DELAY` variable to speed things up.