### PR TITLE
Make copied images public-read

### DIFF
--- a/src/rf/apps/core/management/commands/createawsresources.py
+++ b/src/rf/apps/core/management/commands/createawsresources.py
@@ -140,7 +140,7 @@ class AwsResources(object):
         )
 
     def create_s3_bucket(self, main_queue, s3_bucket):
-        self.create_bucket(s3_bucket)
+        self.create_readonly_bucket(s3_bucket)
 
         # Setup bucket to notify SQS on object creation.
         waiter = self.s3_client.get_waiter('bucket_exists')

--- a/src/rf/js/src/core/uploads.js
+++ b/src/rf/js/src/core/uploads.js
@@ -40,7 +40,6 @@ var uploadFiles = function(fileDescriptions) {
             name: fileName,
             file: fileDescription.file,
             contentType: fileDescription.file.type,
-            xAmzHeadersAtInitiate: { 'x-amz-acl': 'public-read' },
             complete: function() {
                 console.log('File upload complete');
             },


### PR DESCRIPTION
To test, import from s3 (eg. s3://sample-tiffs/356f564e3a0dc9d15553c17cf4583f21-7.tif) and a local file and check that the copied files are publicly accessible in the AWS console.

Connects #266