### PR TITLE
Prevent job conflicts

### DIFF
--- a/src/rf/apps/core/enums.py
+++ b/src/rf/apps/core/enums.py
@@ -7,6 +7,7 @@ STATUS_CREATED = 'created'
 STATUS_UPLOADED = 'uploaded'
 STATUS_VALIDATED = 'validated'
 STATUS_THUMBNAILED = 'thumbnailed'
+STATUS_PROCESSING = 'processing'
 STATUS_CHUNKED = 'chunked'
 STATUS_FAILED = 'failed'
 STATUS_COMPLETED = 'completed'
@@ -21,6 +22,7 @@ LAYER_STATUS_CHOICES = (
     (STATUS_UPLOADED, 'Uploaded'),
     (STATUS_VALIDATED, 'Validated'),
     (STATUS_THUMBNAILED, 'Thumbnailed'),
+    (STATUS_PROCESSING, 'Processing'),
     (STATUS_CHUNKING, 'Chunking'),
     (STATUS_CHUNKED, 'Chunked'),
     (STATUS_MOSAICKING, 'Mosaicking'),

--- a/src/rf/apps/core/migrations/0030_processing_status.py
+++ b/src/rf/apps/core/migrations/0030_processing_status.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('core', '0029_add_statuses'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='layer',
+            name='status',
+            field=models.CharField(default='created', help_text='Processing workflow status of the layer', max_length=12, blank=True, choices=[('created', 'Created'), ('uploaded', 'Uploaded'), ('validated', 'Validated'), ('thumbnailed', 'Thumbnailed'), ('processing', 'Processing'), ('chunking', 'Chunking'), ('chunked', 'Chunked'), ('mosaicking', 'Mosaicking'), ('failed', 'Failed'), ('completed', 'Completed')]),
+        ),
+    ]

--- a/src/rf/apps/workers/thumbnail.py
+++ b/src/rf/apps/workers/thumbnail.py
@@ -75,7 +75,7 @@ def s3_make_thumbs(image_key, user_id, thumb_dims, thumb_ext):
     thumb_dims -- a list containing (thumb_width, thumb_height) tuples
     Returns list of thumb keys of the form <user_id>-<uuid>.<thumb_ext>
     """
-    image_filepath = os.path.join(settings.TEMP_DIR, image_key)
+    image_filepath = os.path.join(settings.TEMP_DIR, str(uuid.uuid4()))
     s3_client = boto3.client('s3')
     s3_client.download_file(settings.AWS_BUCKET_NAME,
                             image_key,


### PR DESCRIPTION
To test, stop rf-worker, and manually run two workers in separate tabs, and then submit a layer. Each worker should generate thumbnails without any errors.

Connects #263 