### PR TITLE
Feature/lol/new status format

### DIFF
--- a/src/rf/apps/core/admin.py
+++ b/src/rf/apps/core/admin.py
@@ -25,11 +25,23 @@ class LayerMetaInline(admin.TabularInline):
 
 class LayerAdmin(admin.ModelAdmin):
     inlines = [LayerTagInline, LayerImageInline, LayerMetaInline]
-    readonly_fields = ('created_at', 'updated_at')
+    readonly_fields = ('created_at', 'updated_at', 'status_created')
     fieldsets = (
         (None, {
             'fields': (
-                'user', 'name', 'status', 'slug',
+                'user', 'name', 'slug',
+                ('status_created'),
+                ('status_upload_start', 'status_upload_end'),
+                ('status_validate_start', 'status_validate_end'),
+                ('status_thumbnail_start', 'status_thumbnail_end'),
+                ('status_create_cluster_start', 'status_create_cluster_end'),
+                ('status_chunk_start', 'status_chunk_end'),
+                ('status_mosaic_start', 'status_mosaic_end'),
+                ('status_failed', 'status_completed'),
+                ('status_upload_error', 'status_validate_error'),
+                ('status_thumbnail_error', 'status_create_cluster_error'),
+                ('status_chunk_error', 'status_mosaic_error'),
+                'status_failed_error',
                 'description', 'is_public',
                 ('capture_start', 'capture_end'),
                 ('area', 'area_unit'),

--- a/src/rf/apps/core/enums.py
+++ b/src/rf/apps/core/enums.py
@@ -3,40 +3,15 @@ from __future__ import print_function
 from __future__ import unicode_literals
 from __future__ import division
 
-STATUS_CREATED = 'created'
-STATUS_UPLOADED = 'uploaded'
-STATUS_VALIDATED = 'validated'
-STATUS_THUMBNAILED = 'thumbnailed'
-STATUS_PROCESSING = 'processing'
-STATUS_CHUNKED = 'chunked'
-STATUS_FAILED = 'failed'
+STATUS_CHUNK = 'chunk'
 STATUS_COMPLETED = 'completed'
-STATUS_VALID = 'valid'
-STATUS_INVALID = 'invalid'
-STATUS_CHUNKING = 'chunking'
-STATUS_CHUNKED = 'chunked'
-STATUS_MOSAICKING = 'mosaicking'
-
-LAYER_STATUS_CHOICES = (
-    (STATUS_CREATED, 'Created'),
-    (STATUS_UPLOADED, 'Uploaded'),
-    (STATUS_VALIDATED, 'Validated'),
-    (STATUS_THUMBNAILED, 'Thumbnailed'),
-    (STATUS_PROCESSING, 'Processing'),
-    (STATUS_CHUNKING, 'Chunking'),
-    (STATUS_CHUNKED, 'Chunked'),
-    (STATUS_MOSAICKING, 'Mosaicking'),
-    (STATUS_FAILED, 'Failed'),
-    (STATUS_COMPLETED, 'Completed'),
-)
-
-LAYER_IMAGE_STATUS_CHOICES = (
-    (STATUS_CREATED, 'Created'),
-    (STATUS_UPLOADED, 'Uploaded'),
-    (STATUS_VALID, 'Valid'),
-    (STATUS_INVALID, 'Invalid'),
-    (STATUS_THUMBNAILED, 'Thumbnailed'),
-)
+STATUS_CREATE = 'create'
+STATUS_CREATE_CLUSTER = 'cluster'
+STATUS_FAILED = 'failed'
+STATUS_MOSAIC = 'mosaic'
+STATUS_THUMBNAIL = 'thumbnail'
+STATUS_UPLOAD = 'upload'
+STATUS_VALIDATE = 'validate'
 
 SQ_MI = 'sq. mi'
 SQ_KM = 'sq. km'

--- a/src/rf/apps/core/migrations/0031_status_start_end.py
+++ b/src/rf/apps/core/migrations/0031_status_start_end.py
@@ -1,0 +1,194 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import datetime
+from django.utils.timezone import utc
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('core', '0030_processing_status'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='layer',
+            name='error',
+        ),
+        migrations.RemoveField(
+            model_name='layer',
+            name='status',
+        ),
+        migrations.RemoveField(
+            model_name='layerimage',
+            name='error',
+        ),
+        migrations.RemoveField(
+            model_name='layerimage',
+            name='status',
+        ),
+        migrations.AddField(
+            model_name='layer',
+            name='status_chunk_end',
+            field=models.DateTimeField(null=True, blank=True),
+        ),
+        migrations.AddField(
+            model_name='layer',
+            name='status_chunk_error',
+            field=models.CharField(max_length=255, null=True, blank=True),
+        ),
+        migrations.AddField(
+            model_name='layer',
+            name='status_chunk_start',
+            field=models.DateTimeField(null=True, blank=True),
+        ),
+        migrations.AddField(
+            model_name='layer',
+            name='status_completed',
+            field=models.DateTimeField(null=True, blank=True),
+        ),
+        migrations.AddField(
+            model_name='layer',
+            name='status_create_cluster_end',
+            field=models.DateTimeField(null=True, blank=True),
+        ),
+        migrations.AddField(
+            model_name='layer',
+            name='status_create_cluster_error',
+            field=models.CharField(max_length=255, null=True, blank=True),
+        ),
+        migrations.AddField(
+            model_name='layer',
+            name='status_create_cluster_start',
+            field=models.DateTimeField(null=True, blank=True),
+        ),
+        migrations.AddField(
+            model_name='layer',
+            name='status_created',
+            field=models.DateTimeField(default=datetime.datetime(2015, 10, 27, 21, 47, 47, 939776, tzinfo=utc), auto_now_add=True),
+            preserve_default=False,
+        ),
+        migrations.AddField(
+            model_name='layer',
+            name='status_failed',
+            field=models.DateTimeField(null=True, blank=True),
+        ),
+        migrations.AddField(
+            model_name='layer',
+            name='status_failed_error',
+            field=models.CharField(max_length=255, null=True, blank=True),
+        ),
+        migrations.AddField(
+            model_name='layer',
+            name='status_mosaic_end',
+            field=models.DateTimeField(null=True, blank=True),
+        ),
+        migrations.AddField(
+            model_name='layer',
+            name='status_mosaic_error',
+            field=models.CharField(max_length=255, null=True, blank=True),
+        ),
+        migrations.AddField(
+            model_name='layer',
+            name='status_mosaic_start',
+            field=models.DateTimeField(null=True, blank=True),
+        ),
+        migrations.AddField(
+            model_name='layer',
+            name='status_thumbnail_end',
+            field=models.DateTimeField(null=True, blank=True),
+        ),
+        migrations.AddField(
+            model_name='layer',
+            name='status_thumbnail_error',
+            field=models.CharField(max_length=255, null=True, blank=True),
+        ),
+        migrations.AddField(
+            model_name='layer',
+            name='status_thumbnail_start',
+            field=models.DateTimeField(null=True, blank=True),
+        ),
+        migrations.AddField(
+            model_name='layer',
+            name='status_upload_end',
+            field=models.DateTimeField(null=True, blank=True),
+        ),
+        migrations.AddField(
+            model_name='layer',
+            name='status_upload_error',
+            field=models.CharField(max_length=255, null=True, blank=True),
+        ),
+        migrations.AddField(
+            model_name='layer',
+            name='status_upload_start',
+            field=models.DateTimeField(null=True, blank=True),
+        ),
+        migrations.AddField(
+            model_name='layer',
+            name='status_validate_end',
+            field=models.DateTimeField(null=True, blank=True),
+        ),
+        migrations.AddField(
+            model_name='layer',
+            name='status_validate_error',
+            field=models.CharField(max_length=255, null=True, blank=True),
+        ),
+        migrations.AddField(
+            model_name='layer',
+            name='status_validate_start',
+            field=models.DateTimeField(null=True, blank=True),
+        ),
+        migrations.AddField(
+            model_name='layerimage',
+            name='status_created',
+            field=models.DateTimeField(default=datetime.datetime(2015, 10, 27, 21, 47, 54, 763011, tzinfo=utc), auto_now_add=True),
+            preserve_default=False,
+        ),
+        migrations.AddField(
+            model_name='layerimage',
+            name='status_thumbnail_end',
+            field=models.DateTimeField(null=True, blank=True),
+        ),
+        migrations.AddField(
+            model_name='layerimage',
+            name='status_thumbnail_error',
+            field=models.CharField(max_length=255, null=True, blank=True),
+        ),
+        migrations.AddField(
+            model_name='layerimage',
+            name='status_thumbnail_start',
+            field=models.DateTimeField(null=True, blank=True),
+        ),
+        migrations.AddField(
+            model_name='layerimage',
+            name='status_upload_end',
+            field=models.DateTimeField(null=True, blank=True),
+        ),
+        migrations.AddField(
+            model_name='layerimage',
+            name='status_upload_error',
+            field=models.CharField(max_length=255, null=True, blank=True),
+        ),
+        migrations.AddField(
+            model_name='layerimage',
+            name='status_upload_start',
+            field=models.DateTimeField(null=True, blank=True),
+        ),
+        migrations.AddField(
+            model_name='layerimage',
+            name='status_validate_end',
+            field=models.DateTimeField(null=True, blank=True),
+        ),
+        migrations.AddField(
+            model_name='layerimage',
+            name='status_validate_error',
+            field=models.CharField(max_length=255, null=True, blank=True),
+        ),
+        migrations.AddField(
+            model_name='layerimage',
+            name='status_validate_start',
+            field=models.DateTimeField(null=True, blank=True),
+        ),
+    ]

--- a/src/rf/apps/core/models.py
+++ b/src/rf/apps/core/models.py
@@ -47,13 +47,30 @@ class Layer(Model):
     name = CharField(max_length=255)
     slug = SlugField(max_length=255, blank=True)
 
-    status = CharField(
-        blank=True,
-        max_length=12,
-        choices=enums.LAYER_STATUS_CHOICES,
-        default=enums.STATUS_CREATED,
-        help_text='Processing workflow status of the layer',
-    )
+    status_created = DateTimeField(auto_now_add=True)
+    status_upload_start = DateTimeField(null=True, blank=True)
+    status_upload_end = DateTimeField(null=True, blank=True)
+    status_validate_start = DateTimeField(null=True, blank=True)
+    status_validate_end = DateTimeField(null=True, blank=True)
+    status_thumbnail_start = DateTimeField(null=True, blank=True)
+    status_thumbnail_end = DateTimeField(null=True, blank=True)
+    status_create_cluster_start = DateTimeField(null=True, blank=True)
+    status_create_cluster_end = DateTimeField(null=True, blank=True)
+    status_chunk_start = DateTimeField(null=True, blank=True)
+    status_chunk_end = DateTimeField(null=True, blank=True)
+    status_mosaic_start = DateTimeField(null=True, blank=True)
+    status_mosaic_end = DateTimeField(null=True, blank=True)
+    status_failed = DateTimeField(null=True, blank=True)
+    status_completed = DateTimeField(null=True, blank=True)
+
+    status_upload_error = CharField(max_length=255, blank=True, null=True)
+    status_validate_error = CharField(max_length=255, blank=True, null=True)
+    status_thumbnail_error = CharField(max_length=255, blank=True, null=True)
+    status_create_cluster_error = CharField(max_length=255, blank=True,
+                                            null=True)
+    status_chunk_error = CharField(max_length=255, blank=True, null=True)
+    status_mosaic_error = CharField(max_length=255, blank=True, null=True)
+    status_failed_error = CharField(max_length=255, blank=True, null=True)
 
     description = TextField(blank=True)
     organization = CharField(max_length=255, blank=True, null=True)
@@ -122,12 +139,6 @@ class Layer(Model):
     deleted_at = DateTimeField(null=True, blank=True)
     status_updated_at = DateTimeField(default=datetime.now)
 
-    error = CharField(
-        blank=True,
-        null=True,
-        max_length=255,
-        help_text='Error that occured while processing the layer.',
-    )
     thumb_small_key = CharField(max_length=255, blank=True, default='',
                                 help_text='S3 key for small thumbnail')
     thumb_large_key = CharField(max_length=255, blank=True, default='',
@@ -162,7 +173,6 @@ class Layer(Model):
             'id': self.id,
             'name': self.name,
             'slug': self.slug,
-            'status': self.status,
             'description': self.description,
             'organization': self.organization,
             'is_public': self.is_public,
@@ -177,11 +187,36 @@ class Layer(Model):
             'tile_origin': self.tile_origin,
             'resampling': self.resampling,
             'transparency': self.transparency,
-            'status': self.status,
+
+            'status_created': self.status_created is not None,
+            'status_upload_start': self.status_upload_start is not None,
+            'status_upload_end': self.status_upload_end is not None,
+            'status_validate_start': self.status_validate_start is not None,
+            'status_validate_end': self.status_validate_end is not None,
+            'status_thumbnail_start': self.status_thumbnail_start is not None,
+            'status_thumbnail_end': self.status_thumbnail_end is not None,
+            'status_create_cluster_start': (self.status_create_cluster_start
+                                            is not None),
+            'status_create_cluster_end': (self.status_create_cluster_end
+                                          is not None),
+            'status_chunk_start': self.status_chunk_start is not None,
+            'status_chunk_end': self.status_chunk_end is not None,
+            'status_mosaic_start': self.status_mosaic_start is not None,
+            'status_mosaic_end': self.status_mosaic_end is not None,
+            'status_failed': self.status_failed is not None,
+            'status_completed': self.status_completed is not None,
+
+            'status_upload_error': self.status_upload_error,
+            'status_validate_error': self.status_validate_error,
+            'status_thumbnail_error': self.status_thumbnail_error,
+            'status_create_cluster_error': self.status_create_cluster_error,
+            'status_chunk_error': self.status_chunk_error,
+            'status_mosaic_error': self.status_mosaic_error,
+            'status_failed_error': self.status_failed_error,
+
             'created_at': self.created_at.isoformat(),
             'updated_at': self.updated_at.isoformat(),
             'status_updated_at': self.created_at.isoformat(),
-            'error': self.error,
 
             'thumb_small': generate_thumb_url(self.thumb_small_key),
             'thumb_large': generate_thumb_url(self.thumb_large_key),
@@ -296,19 +331,18 @@ class LayerImage(Model):
         max_length=255,
         help_text='S3 <bucket>/<key> for source image (optional)'
     )
-    status = CharField(
-        blank=True,
-        max_length=12,
-        choices=enums.LAYER_IMAGE_STATUS_CHOICES,
-        default=enums.STATUS_CREATED,
-        help_text='Image processing workflow status of the image',
-    )
-    error = CharField(
-        blank=True,
-        null=True,
-        max_length=255,
-        help_text='Error that occured while processing the file.',
-    )
+
+    status_created = DateTimeField(auto_now_add=True)
+    status_upload_start = DateTimeField(null=True, blank=True)
+    status_upload_end = DateTimeField(null=True, blank=True)
+    status_validate_start = DateTimeField(null=True, blank=True)
+    status_validate_end = DateTimeField(null=True, blank=True)
+    status_thumbnail_start = DateTimeField(null=True, blank=True)
+    status_thumbnail_end = DateTimeField(null=True, blank=True)
+
+    status_upload_error = CharField(max_length=255, blank=True, null=True)
+    status_validate_error = CharField(max_length=255, blank=True, null=True)
+    status_thumbnail_error = CharField(max_length=255, blank=True, null=True)
 
     def get_s3_key(self):
         return '%d-%s.%s' % (self.layer.user.id,
@@ -331,8 +365,17 @@ class LayerImage(Model):
             's3_uuid': str(self.s3_uuid),
             'file_extension': self.file_extension,
             'bucket_name': self.bucket_name,
-            'error': self.error,
-            'source_s3_bucket_key': self.source_s3_bucket_key
+            'source_s3_bucket_key': self.source_s3_bucket_key,
+            'status_created': self.status_created is not None,
+            'status_upload_start': self.status_upload_start is not None,
+            'status_upload_end': self.status_upload_end is not None,
+            'status_validate_start': self.status_validate_start is not None,
+            'status_validate_end': self.status_validate_end is not None,
+            'status_thumbnail_start': self.status_thumbnail_start is not None,
+            'status_thumbnail_end': self.status_thumbnail_end is not None,
+            'status_upload_error': self.status_upload_error,
+            'status_validate_error': self.status_validate_error,
+            'status_thumbnail_error': self.status_thumbnail_error
         }
 
 

--- a/src/rf/apps/core/models.py
+++ b/src/rf/apps/core/models.py
@@ -264,6 +264,58 @@ class Layer(Model):
     def get_tile_bucket_path(self):
         return 's3://{}/{}'.format(settings.AWS_TILES_BUCKET, self.id)
 
+    def update_status_start(self, status):
+        value = datetime.now()
+        if status == enums.STATUS_UPLOAD:
+            self.status_upload_start = (value if self.status_upload_start
+                                        is None else self.status_upload_start)
+        elif status == enums.STATUS_VALIDATE:
+            self.status_validate_start = (value if self.status_validate_start
+                                          is None else
+                                          self.status_validate_start)
+        elif status == enums.STATUS_THUMBNAIL:
+            self.status_thumbnail_start = (value if self.status_thumbnail_start
+                                           is None else
+                                           self.status_thumbnail_start)
+        elif status == enums.STATUS_CREATE_CLUSTER:
+            self.status_create_cluster_start = \
+                (value if self.status_create_cluster_start is None else
+                 self.status_create_cluster_start)
+        elif status == enums.STATUS_CHUNK:
+            self.status_chunk_start = (value if self.status_chunk_start
+                                       is None else self.status_chunk_start)
+        elif status == enums.STATUS_MOSAIC:
+            self.status_mosaic_start = (value if self.status_mosaic_start
+                                        is None else self.status_mosaic_start)
+
+    def update_status_end(self, status, error_message=None):
+        value = datetime.now()
+        if status == enums.STATUS_UPLOAD:
+            self.status_upload_end = value
+            self.status_upload_error = error_message
+        elif status == enums.STATUS_VALIDATE:
+            self.status_validate_end = value
+            self.status_validate_error = error_message
+        elif status == enums.STATUS_THUMBNAIL:
+            self.status_thumbnail_end = value
+            self.status_thumbnail_error = error_message
+        elif status == enums.STATUS_CREATE_CLUSTER:
+            self.status_create_cluster_end = value
+            self.status_create_cluster_error = error_message
+        elif status == enums.STATUS_CHUNK:
+            self.status_chunk_end = value
+            self.status_chunk_error = error_message
+        elif status == enums.STATUS_MOSAIC:
+            self.status_mosaic_end = value
+            self.status_mosaic_error = error_message
+        elif status == enums.STATUS_COMPLETED:
+            self.status_completed = value
+        elif status == enums.STATUS_FAILED:
+            self.status_failed_error = error_message
+        # If we had any error message mark the generic failed field.
+        if error_message is not None:
+            self.status_failed = value
+
     def __unicode__(self):
         return '{0} -> {1}'.format(self.user.username, self.name)
 
@@ -377,6 +429,32 @@ class LayerImage(Model):
             'status_validate_error': self.status_validate_error,
             'status_thumbnail_error': self.status_thumbnail_error
         }
+
+    def update_status_start(self, status):
+        value = datetime.now()
+        if status == enums.STATUS_UPLOAD:
+            self.status_upload_start = (value if self.status_upload_start
+                                        is None else self.status_upload_start)
+        elif status == enums.STATUS_VALIDATE:
+            self.status_validate_start = (value if self.status_validate_start
+                                          is None else
+                                          self.status_validate_start)
+        elif status == enums.STATUS_THUMBNAIL:
+            self.status_thumbnail_start = (value if self.status_thumbnail_start
+                                           is None else
+                                           self.status_thumbnail_start)
+
+    def update_status_end(self, status, error_message=None):
+        value = datetime.now()
+        if status == enums.STATUS_UPLOAD:
+            self.status_upload_end = value
+            self.status_upload_error = error_message
+        elif status == enums.STATUS_VALIDATE:
+            self.status_validate_end = value
+            self.status_validate_error = error_message
+        elif status == enums.STATUS_THUMBNAIL:
+            self.status_thumbnail_end = value
+            self.status_thumbnail_error = error_message
 
 
 class LayerMeta(Model):

--- a/src/rf/apps/home/filters.py
+++ b/src/rf/apps/home/filters.py
@@ -11,7 +11,6 @@ from django_filters import MethodFilter
 from django.db.models import Q
 
 from apps.core.models import Layer, LayerTag
-from apps.core import enums
 
 
 class LayerFilter(django_filters.FilterSet):
@@ -44,6 +43,6 @@ class LayerFilter(django_filters.FilterSet):
         value -- the time in milliseconds elapsed since 1/1/1970
         """
         refresh_time = datetime.fromtimestamp(float(value) / 1000.0)
-        return queryset.filter((~Q(status=enums.STATUS_COMPLETED) &
-                                ~Q(status=enums.STATUS_FAILED)) |
+        return queryset.filter((Q(status_completed__isnull=True) &
+                                Q(status_failed__isnull=True)) |
                                Q(status_updated_at__gt=refresh_time))

--- a/src/rf/apps/home/tests.py
+++ b/src/rf/apps/home/tests.py
@@ -5,13 +5,14 @@ from __future__ import division
 
 import json
 
+from datetime import datetime
+
 from django.contrib.auth.models import User
 from django.test import TestCase
 from django.test.client import Client
 from django.core.urlresolvers import reverse
 
 from apps.core.models import Layer, LayerMeta, UserFavoriteLayer
-from apps.core import enums
 
 
 class AbstractLayerTestCase(TestCase):
@@ -68,7 +69,7 @@ class AbstractLayerTestCase(TestCase):
         response = self.client.post(url,
                                     json.dumps(layer),
                                     content_type='application/json')
-        Layer.objects.all().update(status=enums.STATUS_COMPLETED)
+        Layer.objects.all().update(status_completed=datetime.now())
         return response
 
     def setup_models(self):
@@ -100,7 +101,7 @@ class AbstractLayerTestCase(TestCase):
                 layer = self.make_layer(layer_name, is_public=True)
                 self.save_layer(layer, user)
 
-        Layer.objects.all().update(status=enums.STATUS_COMPLETED)
+        Layer.objects.all().update(status_completed=datetime.now())
 
 
 class LayerTestCase(AbstractLayerTestCase):

--- a/src/rf/apps/home/views.py
+++ b/src/rf/apps/home/views.py
@@ -16,7 +16,6 @@ from django.utils import timezone
 from django.views.decorators.csrf import ensure_csrf_cookie
 from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
 
-from apps.core import enums
 from apps.core.exceptions import Forbidden
 from apps.core.decorators import (accepts, api_view, login_required,
                                   owner_required)
@@ -72,7 +71,7 @@ def layer_dismiss(request):
     user_id = request.user.id
     layer_id = request.POST.get('layer_id')
     layer = get_object_or_404(Layer, id=layer_id, user_id=user_id)
-    if layer.status == enums.STATUS_FAILED:
+    if layer.status_failed:
         _delete_layer(request, layer, request.user.username)
     # TODO: Consider returning something indicitive of the result:
     # return {'status': 'deleted'}
@@ -230,7 +229,7 @@ def _get_layer_models(request, crit=None):
         qs = qs.filter(crit)
 
     if request.GET.get('pending') is None:
-        qs = qs.filter(status=enums.STATUS_COMPLETED)
+        qs = qs.filter(status_completed__isnull=False)
 
     filtered_layers = LayerFilter(request.GET, queryset=qs)
 

--- a/src/rf/apps/workers/emr.py
+++ b/src/rf/apps/workers/emr.py
@@ -106,7 +106,7 @@ def create_cluster(layer):
     return response
 
 
-def check_cluster_status(cluster_id):
+def cluster_is_alive(cluster_id):
     alive_instance_statuses = [
         'PROVISIONING',
         'BOOTSTRAPPING',

--- a/src/rf/apps/workers/status_updates.py
+++ b/src/rf/apps/workers/status_updates.py
@@ -10,6 +10,80 @@ from apps.core.models import LayerImage, Layer
 import apps.core.enums as enums
 
 ERROR_MESSAGE_LAYER_IMAGE_INVALID = 'Cannot process invalid images.'
+ERROR_MESSAGE_LAYER_IMAGE_TRANSFER = 'Processing aborted. Missing images.'
+
+
+def mark_image_uploaded(s3_uuid):
+    try:
+        image = LayerImage.objects.get(s3_uuid=s3_uuid)
+    except LayerImage.DoesNotExist:
+        return False
+
+    image = update_layerimage_status_start(image, enums.STATUS_UPLOAD)
+    image = update_layerimage_status_end(image, enums.STATUS_UPLOAD)
+    image.save()
+
+    # It is okay to repeat this. It will not overwrite existing timestamps.
+    if not mark_layer_status_start(image.layer_id, enums.STATUS_UPLOAD):
+        return False
+
+    layer_images = LayerImage.objects.filter(layer_id=image.layer_id)
+    uploaded_layer_images = LayerImage.objects.filter(
+        layer_id=image.layer_id,
+        status_upload_end__isnull=False,
+        status_upload_error__isnull=True)
+
+    # If all images are uploaded, then mark layer upload as complete.
+    if len(layer_images) == len(uploaded_layer_images) and \
+            len(layer_images) > 0:
+        return mark_layer_status_end(image.layer_id, enums.STATUS_UPLOAD)
+
+    return True
+
+
+def mark_image_status_start(s3_uuid, status):
+    try:
+        image = LayerImage.objects.get(s3_uuid=s3_uuid)
+    except LayerImage.DoesNotExist:
+        return False
+
+    image = update_layerimage_status_start(image, status)
+    image.save()
+
+    return mark_layer_status_start(image.layer_id, status)
+
+
+def mark_image_status_end(s3_uuid, status):
+    try:
+        image = LayerImage.objects.get(s3_uuid=s3_uuid)
+    except LayerImage.DoesNotExist:
+        return False
+
+    image = update_layerimage_status_end(image, status)
+    image.save()
+    return True
+
+
+def mark_layer_status_start(layer_id, status):
+    try:
+        layer = Layer.objects.get(id=layer_id)
+    except Layer.DoesNotExist:
+        return False
+
+    layer = update_layer_status_start(layer, status)
+    layer.save()
+    return True
+
+
+def mark_layer_status_end(layer_id, status, error_message=None):
+    try:
+        layer = Layer.objects.get(id=layer_id)
+    except Layer.DoesNotExist:
+        return False
+
+    layer = update_layer_status_end(layer, status, error_message)
+    layer.save()
+    return True
 
 
 def mark_image_valid(s3_uuid):
@@ -18,7 +92,7 @@ def mark_image_valid(s3_uuid):
     except LayerImage.DoesNotExist:
         return False
 
-    image.status = enums.STATUS_VALID
+    image = update_layerimage_status_end(image, enums.STATUS_VALIDATE)
     image.save()
     return True
 
@@ -29,24 +103,38 @@ def mark_image_invalid(s3_uuid, error_message):
     except LayerImage.DoesNotExist:
         return False
 
-    image.status = enums.STATUS_INVALID
-    image.error = error_message
+    image = update_layerimage_status_end(image, enums.STATUS_VALIDATE,
+                                         error_message)
     image.save()
-    layer_id = image.layer_id
-    return update_layer_status(layer_id, enums.STATUS_VALIDATED,
-                               ERROR_MESSAGE_LAYER_IMAGE_INVALID)
+
+    return update_layer_status_end(image.layer_id, enums.STATUS_VALIDATE,
+                                   ERROR_MESSAGE_LAYER_IMAGE_INVALID)
 
 
-def update_layer_status(layer_id, layer_status, error_message=None):
+def mark_image_transfer_start(s3_uuid):
     try:
-        layer = Layer.objects.get(id=layer_id)
-    except Layer.DoesNotExist:
+        image = LayerImage.objects.get(s3_uuid=s3_uuid)
+    except LayerImage.DoesNotExist:
         return False
 
-    layer.status_updated_at = datetime.now()
-    update_status_column_by_enum(layer, layer_status, error_message)
-    layer.save()
-    return True
+    image = update_layerimage_status_start(image, enums.STATUS_UPLOAD)
+    image.save()
+    return mark_layer_status_start(image.layer_id, enums.STATUS_UPLOAD)
+
+
+def mark_image_transfer_failure(s3_uuid, error_message):
+    try:
+        image = LayerImage.objects.get(s3_uuid=s3_uuid)
+    except LayerImage.DoesNotExist:
+        return False
+
+    image = update_layerimage_status_end(image,
+                                         enums.STATUS_UPLOAD,
+                                         error_message)
+    image.save()
+    return mark_layer_status_end(image.layer_id,
+                                 enums.STATUS_UPLOAD,
+                                 ERROR_MESSAGE_LAYER_IMAGE_TRANSFER)
 
 
 def get_layer_id_from_uuid(s3_uuid):
@@ -57,35 +145,90 @@ def get_layer_id_from_uuid(s3_uuid):
         return None
 
 
-def update_status_column_by_enum(layer, status, error_message=None):
+def update_layer_status_start(layer, status):
     value = datetime.now()
-    if status == enums.STATUS_CREATED:
-        layer.status_created = value
-        layer.status_created_error = error_message
-    elif status == enums.STATUS_UPLOADED:
-        layer.status_uploaded = value
-        layer.status_uploaded = error_message
-    elif status == enums.STATUS_VALIDATED:
-        layer.status_validated = value
-        layer.status_validated_error = error_message
-    elif status == enums.STATUS_THUMBNAILED:
-        layer.status_thumbnailed = value
-        layer.status_thumbnailed_error = error_message
-    elif status == enums.STATUS_PROCESSING:
-        layer.status_handed_off = value
-        layer.status_handed_off_error = error_message
-    elif status == enums.STATUS_CHUNKING:
-        layer.status_worker_built = value
-        layer.status_worker_built_error = error_message
-    elif status == enums.STATUS_CHUNKED:
-        layer.status_chunked = value
-        layer.status_chunked_error = error_message
-    elif status == enums.STATUS_MOSAICKING:
-        layer.status_mosaicking = value
-        layer.status_mosaicking_error = error_message
+    if status == enums.STATUS_UPLOAD:
+        layer.status_upload_start = (value if layer.status_upload_start
+                                     is None else layer.status_upload_start)
+
+    elif status == enums.STATUS_VALIDATE:
+        layer.status_validate_start = (value if layer.status_validate_start
+                                       is None else
+                                       layer.status_validate_start)
+
+    elif status == enums.STATUS_THUMBNAIL:
+        layer.status_thumbnail_start = (value if layer.status_thumbnail_start
+                                        is None else
+                                        layer.status_thumbnail_start)
+
+    elif status == enums.STATUS_CREATE_CLUSTER:
+        layer.status_create_cluster_start = (value if
+                                             layer.status_create_cluster_start
+                                             is None else
+                                             layer.status_create_cluster_start)
+
+    elif status == enums.STATUS_CHUNK:
+        layer.status_chunk_start = (value if layer.status_chunk_start
+                                    is None else layer.status_chunk_start)
+
+    elif status == enums.STATUS_MOSAIC:
+        layer.status_mosaic_start = (value if layer.status_mosaic_start
+                                     is None else layer.status_mosaic_start)
+
+    return layer
+
+
+def update_layer_status_end(layer, status, error_message=None):
+    value = datetime.now()
+    if status == enums.STATUS_UPLOAD:
+        layer.status_upload_end = value
+        layer.status_upload_error = error_message
+    elif status == enums.STATUS_VALIDATE:
+        layer.status_validate_end = value
+    elif status == enums.STATUS_THUMBNAIL:
+        layer.status_thumbnail_end = value
+        layer.status_thumbnail_error = error_message
+    elif status == enums.STATUS_CREATE_CLUSTER:
+        layer.status_create_cluster_end = value
+        layer.status_create_cluster_error = error_message
+    elif status == enums.STATUS_CHUNK:
+        layer.status_chunk_end = value
+        layer.status_chunk_error = error_message
+    elif status == enums.STATUS_MOSAIC:
+        layer.status_mosaic_end = value
+        layer.status_mosaic_error = error_message
     elif status == enums.STATUS_COMPLETED:
         layer.status_completed = value
-    elif error_message is not None:
-        layer.status_failed = value
     elif status == enums.STATUS_FAILED:
         layer.status_failed_error = error_message
+
+    # If we had any error message mark the generic failed field.
+    if error_message is not None:
+        layer.status_failed = value
+
+    return layer
+
+
+def update_layerimage_status_start(image, status):
+    value = datetime.now()
+    if status == enums.STATUS_UPLOAD:
+        image.status_upload_start = value
+    elif status == enums.STATUS_VALIDATE:
+        image.status_validate_start = value
+    elif status == enums.STATUS_THUMBNAIL:
+        image.status_thumbnail_start = value
+    return image
+
+
+def update_layerimage_status_end(image, status, error_message=None):
+    value = datetime.now()
+    if status == enums.STATUS_UPLOAD:
+        image.status_upload_end = value
+        image.status_upload_error = error_message
+    elif status == enums.STATUS_VALIDATE:
+        image.status_validate_end = value
+        image.status_validate_error = error_message
+    elif status == enums.STATUS_THUMBNAIL:
+        image.status_thumbnail_end = value
+        image.status_thumbnail_error = error_message
+    return image

--- a/src/rf/apps/workers/status_updates.py
+++ b/src/rf/apps/workers/status_updates.py
@@ -33,7 +33,7 @@ def mark_image_invalid(s3_uuid, error_message):
     image.error = error_message
     image.save()
     layer_id = image.layer_id
-    return update_layer_status(layer_id, enums.STATUS_FAILED,
+    return update_layer_status(layer_id, enums.STATUS_VALIDATED,
                                ERROR_MESSAGE_LAYER_IMAGE_INVALID)
 
 
@@ -43,9 +43,8 @@ def update_layer_status(layer_id, layer_status, error_message=None):
     except Layer.DoesNotExist:
         return False
 
-    layer.status = layer_status
     layer.status_updated_at = datetime.now()
-    layer.error = error_message
+    update_status_column_by_enum(layer, layer_status, error_message)
     layer.save()
     return True
 
@@ -56,3 +55,37 @@ def get_layer_id_from_uuid(s3_uuid):
         return image.layer_id
     except LayerImage.DoesNotExist:
         return None
+
+
+def update_status_column_by_enum(layer, status, error_message=None):
+    value = datetime.now()
+    if status == enums.STATUS_CREATED:
+        layer.status_created = value
+        layer.status_created_error = error_message
+    elif status == enums.STATUS_UPLOADED:
+        layer.status_uploaded = value
+        layer.status_uploaded = error_message
+    elif status == enums.STATUS_VALIDATED:
+        layer.status_validated = value
+        layer.status_validated_error = error_message
+    elif status == enums.STATUS_THUMBNAILED:
+        layer.status_thumbnailed = value
+        layer.status_thumbnailed_error = error_message
+    elif status == enums.STATUS_PROCESSING:
+        layer.status_handed_off = value
+        layer.status_handed_off_error = error_message
+    elif status == enums.STATUS_CHUNKING:
+        layer.status_worker_built = value
+        layer.status_worker_built_error = error_message
+    elif status == enums.STATUS_CHUNKED:
+        layer.status_chunked = value
+        layer.status_chunked_error = error_message
+    elif status == enums.STATUS_MOSAICKING:
+        layer.status_mosaicking = value
+        layer.status_mosaicking_error = error_message
+    elif status == enums.STATUS_COMPLETED:
+        layer.status_completed = value
+    elif error_message is not None:
+        layer.status_failed = value
+    elif status == enums.STATUS_FAILED:
+        layer.status_failed_error = error_message

--- a/src/rf/apps/workers/status_updates.py
+++ b/src/rf/apps/workers/status_updates.py
@@ -4,8 +4,6 @@ from __future__ import unicode_literals
 from __future__ import division
 
 
-from datetime import datetime
-
 from apps.core.models import LayerImage, Layer
 import apps.core.enums as enums
 
@@ -19,8 +17,8 @@ def mark_image_uploaded(s3_uuid):
     except LayerImage.DoesNotExist:
         return False
 
-    image = update_layerimage_status_start(image, enums.STATUS_UPLOAD)
-    image = update_layerimage_status_end(image, enums.STATUS_UPLOAD)
+    image.update_status_start(enums.STATUS_UPLOAD)
+    image.update_status_end(enums.STATUS_UPLOAD)
     image.save()
 
     # It is okay to repeat this. It will not overwrite existing timestamps.
@@ -47,7 +45,7 @@ def mark_image_status_start(s3_uuid, status):
     except LayerImage.DoesNotExist:
         return False
 
-    image = update_layerimage_status_start(image, status)
+    image.update_status_start(status)
     image.save()
 
     return mark_layer_status_start(image.layer_id, status)
@@ -59,7 +57,7 @@ def mark_image_status_end(s3_uuid, status):
     except LayerImage.DoesNotExist:
         return False
 
-    image = update_layerimage_status_end(image, status)
+    image.update_status_end(status)
     image.save()
     return True
 
@@ -70,7 +68,7 @@ def mark_layer_status_start(layer_id, status):
     except Layer.DoesNotExist:
         return False
 
-    layer = update_layer_status_start(layer, status)
+    layer.update_status_start(status)
     layer.save()
     return True
 
@@ -81,7 +79,7 @@ def mark_layer_status_end(layer_id, status, error_message=None):
     except Layer.DoesNotExist:
         return False
 
-    layer = update_layer_status_end(layer, status, error_message)
+    layer.update_status_end(status, error_message)
     layer.save()
     return True
 
@@ -92,7 +90,7 @@ def mark_image_valid(s3_uuid):
     except LayerImage.DoesNotExist:
         return False
 
-    image = update_layerimage_status_end(image, enums.STATUS_VALIDATE)
+    image.update_status_end(enums.STATUS_VALIDATE)
     image.save()
     return True
 
@@ -103,12 +101,11 @@ def mark_image_invalid(s3_uuid, error_message):
     except LayerImage.DoesNotExist:
         return False
 
-    image = update_layerimage_status_end(image, enums.STATUS_VALIDATE,
-                                         error_message)
+    image.update_status_end(enums.STATUS_VALIDATE, error_message)
     image.save()
 
-    return update_layer_status_end(image.layer_id, enums.STATUS_VALIDATE,
-                                   ERROR_MESSAGE_LAYER_IMAGE_INVALID)
+    return mark_layer_status_end(image.layer_id, enums.STATUS_VALIDATE,
+                                 ERROR_MESSAGE_LAYER_IMAGE_INVALID)
 
 
 def mark_image_transfer_start(s3_uuid):
@@ -117,7 +114,7 @@ def mark_image_transfer_start(s3_uuid):
     except LayerImage.DoesNotExist:
         return False
 
-    image = update_layerimage_status_start(image, enums.STATUS_UPLOAD)
+    image.update_status_start(enums.STATUS_UPLOAD)
     image.save()
     return mark_layer_status_start(image.layer_id, enums.STATUS_UPLOAD)
 
@@ -128,9 +125,7 @@ def mark_image_transfer_failure(s3_uuid, error_message):
     except LayerImage.DoesNotExist:
         return False
 
-    image = update_layerimage_status_end(image,
-                                         enums.STATUS_UPLOAD,
-                                         error_message)
+    image.update_status_end(enums.STATUS_UPLOAD, error_message)
     image.save()
     return mark_layer_status_end(image.layer_id,
                                  enums.STATUS_UPLOAD,
@@ -143,92 +138,3 @@ def get_layer_id_from_uuid(s3_uuid):
         return image.layer_id
     except LayerImage.DoesNotExist:
         return None
-
-
-def update_layer_status_start(layer, status):
-    value = datetime.now()
-    if status == enums.STATUS_UPLOAD:
-        layer.status_upload_start = (value if layer.status_upload_start
-                                     is None else layer.status_upload_start)
-
-    elif status == enums.STATUS_VALIDATE:
-        layer.status_validate_start = (value if layer.status_validate_start
-                                       is None else
-                                       layer.status_validate_start)
-
-    elif status == enums.STATUS_THUMBNAIL:
-        layer.status_thumbnail_start = (value if layer.status_thumbnail_start
-                                        is None else
-                                        layer.status_thumbnail_start)
-
-    elif status == enums.STATUS_CREATE_CLUSTER:
-        layer.status_create_cluster_start = (value if
-                                             layer.status_create_cluster_start
-                                             is None else
-                                             layer.status_create_cluster_start)
-
-    elif status == enums.STATUS_CHUNK:
-        layer.status_chunk_start = (value if layer.status_chunk_start
-                                    is None else layer.status_chunk_start)
-
-    elif status == enums.STATUS_MOSAIC:
-        layer.status_mosaic_start = (value if layer.status_mosaic_start
-                                     is None else layer.status_mosaic_start)
-
-    return layer
-
-
-def update_layer_status_end(layer, status, error_message=None):
-    value = datetime.now()
-    if status == enums.STATUS_UPLOAD:
-        layer.status_upload_end = value
-        layer.status_upload_error = error_message
-    elif status == enums.STATUS_VALIDATE:
-        layer.status_validate_end = value
-    elif status == enums.STATUS_THUMBNAIL:
-        layer.status_thumbnail_end = value
-        layer.status_thumbnail_error = error_message
-    elif status == enums.STATUS_CREATE_CLUSTER:
-        layer.status_create_cluster_end = value
-        layer.status_create_cluster_error = error_message
-    elif status == enums.STATUS_CHUNK:
-        layer.status_chunk_end = value
-        layer.status_chunk_error = error_message
-    elif status == enums.STATUS_MOSAIC:
-        layer.status_mosaic_end = value
-        layer.status_mosaic_error = error_message
-    elif status == enums.STATUS_COMPLETED:
-        layer.status_completed = value
-    elif status == enums.STATUS_FAILED:
-        layer.status_failed_error = error_message
-
-    # If we had any error message mark the generic failed field.
-    if error_message is not None:
-        layer.status_failed = value
-
-    return layer
-
-
-def update_layerimage_status_start(image, status):
-    value = datetime.now()
-    if status == enums.STATUS_UPLOAD:
-        image.status_upload_start = value
-    elif status == enums.STATUS_VALIDATE:
-        image.status_validate_start = value
-    elif status == enums.STATUS_THUMBNAIL:
-        image.status_thumbnail_start = value
-    return image
-
-
-def update_layerimage_status_end(image, status, error_message=None):
-    value = datetime.now()
-    if status == enums.STATUS_UPLOAD:
-        image.status_upload_end = value
-        image.status_upload_error = error_message
-    elif status == enums.STATUS_VALIDATE:
-        image.status_validate_end = value
-        image.status_validate_error = error_message
-    elif status == enums.STATUS_THUMBNAIL:
-        image.status_thumbnail_end = value
-        image.status_thumbnail_error = error_message
-    return image

--- a/src/rf/apps/workers/thumbnail.py
+++ b/src/rf/apps/workers/thumbnail.py
@@ -13,6 +13,7 @@ from PIL import Image
 from django.conf import settings
 
 import apps.core.enums as enums
+import apps.workers.status_updates as status_updates
 from apps.core.models import LayerImage, Layer
 
 
@@ -24,6 +25,8 @@ IMAGE_THUMB_LARGE_DIMS = (300, 300)
 LAYER_THUMB_LARGE_DIMS = (400, 150)
 THUMB_EXT = 'png'
 THUMB_CONTENT_TYPE = 'image/png'
+
+ERROR_MESSAGE_THUMBNAIL_FAILED = 'Thumbnail failed for image.'
 
 # Mute warnings about processing large files.
 warnings.simplefilter('ignore', Image.DecompressionBombWarning)
@@ -122,13 +125,18 @@ def make_thumbs_for_layer(layer_id):
     for image in layer_images:
         thumb_dims = [IMAGE_THUMB_SMALL_DIMS, IMAGE_THUMB_LARGE_DIMS]
         try:
+            image = status_updates.update_layerimage_status_start(
+                image, enums.STATUS_THUMBNAIL)
             image.thumb_small_key, image.thumb_large_key = \
                 s3_make_thumbs(image.get_s3_key(), user_id,
                                thumb_dims, THUMB_EXT)
         except ImageCouldNotOpenError:
+            image = status_updates.update_layerimage_status_end(
+                image, enums.STATUS_THUMBNAIL, ERROR_MESSAGE_THUMBNAIL_FAILED)
             return False
 
-        image.status = enums.STATUS_THUMBNAILED
+        image = status_updates.update_layerimage_status_end(
+            image, enums.STATUS_THUMBNAIL)
         image.save()
 
     # Create thumbnails for the Layer as a whole

--- a/src/rf/apps/workers/thumbnail.py
+++ b/src/rf/apps/workers/thumbnail.py
@@ -13,7 +13,6 @@ from PIL import Image
 from django.conf import settings
 
 import apps.core.enums as enums
-import apps.workers.status_updates as status_updates
 from apps.core.models import LayerImage, Layer
 
 
@@ -125,18 +124,16 @@ def make_thumbs_for_layer(layer_id):
     for image in layer_images:
         thumb_dims = [IMAGE_THUMB_SMALL_DIMS, IMAGE_THUMB_LARGE_DIMS]
         try:
-            image = status_updates.update_layerimage_status_start(
-                image, enums.STATUS_THUMBNAIL)
+            image.update_status_start(enums.STATUS_THUMBNAIL)
             image.thumb_small_key, image.thumb_large_key = \
                 s3_make_thumbs(image.get_s3_key(), user_id,
                                thumb_dims, THUMB_EXT)
         except ImageCouldNotOpenError:
-            image = status_updates.update_layerimage_status_end(
-                image, enums.STATUS_THUMBNAIL, ERROR_MESSAGE_THUMBNAIL_FAILED)
+            image.update_status_end(enums.STATUS_THUMBNAIL,
+                                    ERROR_MESSAGE_THUMBNAIL_FAILED)
             return False
 
-        image = status_updates.update_layerimage_status_end(
-            image, enums.STATUS_THUMBNAIL)
+        image.update_status_end(enums.STATUS_THUMBNAIL)
         image.save()
 
     # Create thumbnails for the Layer as a whole

--- a/src/rf/apps/workers/thumbnail.py
+++ b/src/rf/apps/workers/thumbnail.py
@@ -7,7 +7,6 @@ import os
 import uuid
 import warnings
 import logging
-from datetime import datetime
 
 import boto3
 from PIL import Image
@@ -143,9 +142,6 @@ def make_thumbs_for_layer(layer_id):
     except ImageCouldNotOpenError:
         return False
 
-    layer.status = enums.STATUS_THUMBNAILED
-    layer.status_updated_at = datetime.now()
-    layer.save()
     return True
 
 


### PR DESCRIPTION
Connects #259 

This is a fairly major overhaul of the statuses and errors in layer and layerimage models.
Statuses are now split into two fields a start field and an end field. The UI does not/will not care about these as they are returned as JSON as simple Booleans. Each status also has an associated error message field.

### To test
 * Run migrations and restart the worker.
 * Kick off a normal job flow by uploading a file.
 * In the admin UI refresh the page as the job move through the pipeline.
 * Note that timestamps are added at the start and end of each part of the job. 