### PR TITLE
Fix dismiss

### DIFF
--- a/src/rf/apps/core/admin.py
+++ b/src/rf/apps/core/admin.py
@@ -42,7 +42,7 @@ class LayerAdmin(admin.ModelAdmin):
                 ('status_thumbnail_error', 'status_create_cluster_error'),
                 ('status_chunk_error', 'status_mosaic_error'),
                 'status_failed_error',
-                'description', 'is_public',
+                'description', 'is_public', 'dismissed',
                 ('capture_start', 'capture_end'),
                 ('area', 'area_unit'),
                 'projection', 'srid',

--- a/src/rf/apps/core/migrations/0032_add_dismissed.py
+++ b/src/rf/apps/core/migrations/0032_add_dismissed.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('core', '0031_status_start_end'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='layer',
+            name='dismissed',
+            field=models.BooleanField(default=False),
+        ),
+    ]

--- a/src/rf/apps/core/models.py
+++ b/src/rf/apps/core/models.py
@@ -134,6 +134,8 @@ class Layer(Model):
         help_text='Hexadecimal (Ex. #00FF00)',
     )
 
+    dismissed = BooleanField(blank=True, default=False)
+
     created_at = DateTimeField(auto_now_add=True)
     updated_at = DateTimeField(auto_now=True)
     deleted_at = DateTimeField(null=True, blank=True)

--- a/src/rf/apps/home/filters.py
+++ b/src/rf/apps/home/filters.py
@@ -3,8 +3,6 @@ from __future__ import print_function
 from __future__ import unicode_literals
 from __future__ import division
 
-from datetime import datetime
-
 import django_filters
 
 from django_filters import MethodFilter
@@ -17,7 +15,6 @@ class LayerFilter(django_filters.FilterSet):
     tag = django_filters.CharFilter(name='layer_tags__name')
     username = django_filters.CharFilter(name='user__username')
     name_search = MethodFilter(action='name_tag_organization_filter')
-    pending = MethodFilter(action='pending_filter')
 
     class Meta:
         model = Layer
@@ -32,17 +29,3 @@ class LayerFilter(django_filters.FilterSet):
         return queryset.filter(Q(id__in=list(layer_values)) |
                                Q(name__icontains=value) |
                                Q(organization__icontains=value))
-
-    def pending_filter(self, queryset, value):
-        """
-        Gets layers that are uploading or processing, or that
-        have become complete or failed since the time of the last browser
-        refresh. This is so that layers that have become complete or failed
-        since the last refresh will be visible to users on the frontend.
-
-        value -- the time in milliseconds elapsed since 1/1/1970
-        """
-        refresh_time = datetime.fromtimestamp(float(value) / 1000.0)
-        return queryset.filter((Q(status_completed__isnull=True) &
-                                Q(status_failed__isnull=True)) |
-                               Q(status_updated_at__gt=refresh_time))

--- a/src/rf/apps/home/views.py
+++ b/src/rf/apps/home/views.py
@@ -73,6 +73,10 @@ def layer_dismiss(request):
     layer = get_object_or_404(Layer, id=layer_id, user_id=user_id)
     if layer.status_failed:
         _delete_layer(request, layer, request.user.username)
+    else:
+        layer.dismissed = True
+        layer.save()
+
     # TODO: Consider returning something indicitive of the result:
     # return {'status': 'deleted'}
     return 'OK'
@@ -228,7 +232,9 @@ def _get_layer_models(request, crit=None):
     if crit:
         qs = qs.filter(crit)
 
-    if request.GET.get('pending') is None:
+    if request.GET.get('pending') == 'true':
+        qs = qs.filter(dismissed=False)
+    else:
         qs = qs.filter(status_completed__isnull=False)
 
     filtered_layers = LayerFilter(request.GET, queryset=qs)

--- a/src/rf/js/src/core/models.js
+++ b/src/rf/js/src/core/models.js
@@ -243,12 +243,8 @@ var PublicLayers = BaseLayers.extend({
 });
 
 var PendingLayers = BaseLayers.extend({
-    initialize: function() {
-        this.created_at = new Date().getTime();
-    },
-
     url: function() {
-        return '/imports.json?page_size=0&pending=' + this.created_at;
+        return '/imports.json?page_size=0&pending=true';
     },
 
     existsUploading: function() {

--- a/src/rf/js/src/home/components/processing-block.js
+++ b/src/rf/js/src/home/components/processing-block.js
@@ -17,7 +17,7 @@ var LayerStatusComponent = React.createBackboneClass({
             chunkClass = this.pendingClass,
             mosaicClass = this.pendingClass,
             completeClass = this.pendingClass,
-            actionLink = (<a href="#" className="text-danger">Cancel</a>),
+            actionLink = (<a className="text-danger">Cancel</a>),
             uploadErrorsExist = false,
             layerError = false,
             layerErrorComponent = (

--- a/src/rf/sass/components/_processing-block.scss
+++ b/src/rf/sass/components/_processing-block.scss
@@ -96,8 +96,8 @@
 	}
 
 	.list-group-tool {
-
 		a {
+            cursor: pointer;
 			position: absolute;
 			top: 15px;
 			right: 10px;


### PR DESCRIPTION
Fixes a bug where dismissed layers were reappearing after polling for pending layers. The design of the pending filter was also simplified and is no longer based on a timestamp coming from the frontend.

To test, click Dismiss on a layer that is complete.  It should disappear and not come back in the processing block, although it should be in the imports list. Clicking on a failed layer should remove it from the processing block and it shouldn't show up in the imports list. These changes should persist after refreshing the browser.

Connects #282 