### PR TITLE
Temporarily disable SMTP email backend on staging/production

### DIFF
--- a/src/rf/rf/settings/production.py
+++ b/src/rf/rf/settings/production.py
@@ -21,3 +21,5 @@ ALLOWED_HOSTS = [
 # the Host header.
 ALLOWED_HOSTS.append(instance_metadata['local-ipv4'])
 # END HOST CONFIGURATION
+
+EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'


### PR DESCRIPTION
This fixes a bug where user registration throws an Internal Server
Error on staging. The fix is to temporarily disable the SMTP email
backend until we have configured it properly on AWS.

Test by successfully creating a user on staging and logging in as that
user.

Connects #287