### PR TITLE
Use AWS session security token for S3 upload requests

### DIFF
--- a/src/rf/apps/core/context_processors.py
+++ b/src/rf/apps/core/context_processors.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 from __future__ import division
 
 import json
-import boto
+from boto import provider
 
 from django.conf import settings
 from django.core.urlresolvers import reverse
@@ -23,11 +23,11 @@ def page_context(request):
 
 
 def get_client_settings():
-    conn = boto.connect_s3()
-    aws_key = conn.aws_access_key_id
+    creds = provider.Provider('aws')
     client_settings = {
         'signerUrl': reverse('sign_request'),
-        'awsKey': aws_key,
+        'awsKey': creds.access_key,
+        'awsToken': creds.security_token,
         'awsBucket': settings.AWS_BUCKET_NAME,
     }
     return client_settings

--- a/src/rf/js/src/core/uploads.js
+++ b/src/rf/js/src/core/uploads.js
@@ -23,6 +23,8 @@ var uploadFiles = function(fileDescriptions) {
         logging: false
     });
 
+    var aws_token = settings.get('awsToken');
+
     var files = _.pluck(fileDescriptions, 'file'),
         invalidMimes = _.without(_.map(files, invalidTypes), null);
 
@@ -34,12 +36,20 @@ var uploadFiles = function(fileDescriptions) {
     _.each(fileDescriptions, function(fileDescription) {
         var userId = settings.getUser().get('id'),
             fileName = userId + '-' +
-                fileDescription.uuid + '.' + fileDescription.extension;
+                fileDescription.uuid + '.' + fileDescription.extension,
+            headers = {};
+
+        if (aws_token) {
+            headers['x-amz-security-token'] = aws_token;
+        }
 
         evap.add({
             name: fileName,
             file: fileDescription.file,
             contentType: fileDescription.file.type,
+            xAmzHeadersAtInitiate: headers,
+            xAmzHeadersAtUpload: headers,
+            xAmzHeadersAtComplete: headers,
             complete: function() {
                 console.log('File upload complete');
             },


### PR DESCRIPTION
Fixes a bug on staging where client-side uploads to S3 fail due to not
providing the long session token in the upload request headers.

Test by uploading a file on staging.

Connects #289