### PR TITLE
Install Pillow 3.1.0.dev0

### DIFF
--- a/src/rf/requirements/base.txt
+++ b/src/rf/requirements/base.txt
@@ -4,4 +4,5 @@ django-registration-redux==1.2
 django-filter==0.10.0
 boto==2.38.0
 boto3==1.1.4
-pillow==3.0.0
+# See also: https://github.com/azavea/raster-foundry/issues/278
+git+https://github.com/python-pillow/Pillow.git@ba626ef504


### PR DESCRIPTION
Pillow > 3.0.0 has improved its support for dealing with TIFFs, but their latest official release is 3.0.0. This uses a Git SHA of their current `master` (as of today) to install version 3.1.0.dev0.

Attempts to resolve #278.

---

**Testing**

Attempt to process [this](https://s3.amazonaws.com/sample-tiffs/LC81410412014277LGN00_bands_432.TIF) TIFF that was failing with `Pillow==3.0.0`