### PR TITLE
Add m3.medium to EC2 instance types

### DIFF
--- a/deployment/cfn/utils/constants.py
+++ b/deployment/cfn/utils/constants.py
@@ -2,7 +2,8 @@ EC2_INSTANCE_TYPES = [
     't2.micro',
     't2.small',
     't2.medium',
-    't2.large'
+    't2.large',
+    'm3.medium'
 ]
 
 RDS_INSTANCE_TYPES = [


### PR DESCRIPTION
This is the lowest `m3` family instance type with ephemeral storage.