### PR TITLE
Feature/lol/fix retry on complete

### DIFF
--- a/src/rf/apps/core/migrations/0033_layer_status_heartbeat.py
+++ b/src/rf/apps/core/migrations/0033_layer_status_heartbeat.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('core', '0032_add_dismissed'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='layer',
+            name='status_heartbeat',
+            field=models.DateTimeField(null=True, blank=True),
+        ),
+    ]

--- a/src/rf/apps/core/models.py
+++ b/src/rf/apps/core/models.py
@@ -311,6 +311,10 @@ class Layer(Model):
     def get_tile_bucket_path(self):
         return 's3://{}/{}'.format(settings.AWS_TILES_BUCKET, self.id)
 
+    def process_failed_heartbeat(self):
+        self.status_heartbeat = datetime.now()
+        self.save()
+
     def update_status_start(self, status):
         value = datetime.now()
         if status == enums.STATUS_UPLOAD:

--- a/src/rf/apps/core/models.py
+++ b/src/rf/apps/core/models.py
@@ -62,6 +62,7 @@ class Layer(Model):
     status_mosaic_end = DateTimeField(null=True, blank=True)
     status_failed = DateTimeField(null=True, blank=True)
     status_completed = DateTimeField(null=True, blank=True)
+    status_heartbeat = DateTimeField(null=True, blank=True)
 
     status_upload_error = CharField(max_length=255, blank=True, null=True)
     status_validate_error = CharField(max_length=255, blank=True, null=True)
@@ -207,6 +208,7 @@ class Layer(Model):
             'status_mosaic_end': self.status_mosaic_end is not None,
             'status_failed': self.status_failed is not None,
             'status_completed': self.status_completed is not None,
+            'status_heartbeat': self.status_completed is not None,
 
             'status_upload_error': self.status_upload_error,
             'status_validate_error': self.status_validate_error,


### PR DESCRIPTION
Connects #306 

Solves issues in which jobs were being marked as failed after they were marked as complete.

This partially stemmed from the fact that our heartbeat could in some cases check to see if the EMR cluster was terminated after the cluster returned a success message to the queues but before that message was processed.

### To test
 * Create a job
 * Wait for job to complete.
 * Ensure that the "retry" option is not available.
 * Use admin interface to ensure the failed status is not set and there are no error messages.