### PR TITLE
Allow user to dismiss own layers

### DIFF
--- a/src/rf/apps/home/views.py
+++ b/src/rf/apps/home/views.py
@@ -71,14 +71,8 @@ def layer_dismiss(request):
     user_id = request.user.id
     layer_id = request.POST.get('layer_id')
     layer = get_object_or_404(Layer, id=layer_id, user_id=user_id)
-    if layer.status_failed:
-        _delete_layer(request, layer, request.user.username)
-    else:
-        layer.dismissed = True
-        layer.save()
-
-    # TODO: Consider returning something indicitive of the result:
-    # return {'status': 'deleted'}
+    layer.dismissed = True
+    layer.save()
     return 'OK'
 
 

--- a/src/rf/js/src/home/components/processing-block.js
+++ b/src/rf/js/src/home/components/processing-block.js
@@ -17,7 +17,7 @@ var LayerStatusComponent = React.createBackboneClass({
             chunkClass = this.pendingClass,
             mosaicClass = this.pendingClass,
             completeClass = this.pendingClass,
-            actionLinks = (<a className="text-danger">Cancel</a>),
+            actionLinks = (<a href="javascript:;" onClick={this.deleteLayer} className="text-danger">Cancel</a>),
             uploadErrorsExist = false,
 
             layerError = false,
@@ -171,6 +171,13 @@ var LayerStatusComponent = React.createBackboneClass({
                 </div>
             </div>
         );
+    },
+
+    deleteLayer: function(e) {
+        e.preventDefault();
+        if (window.confirm('Are you sure you would like to cancel processing this layer?')) {
+            this.getModel().destroy();
+        }
     },
 
     dismiss: function(e) {


### PR DESCRIPTION
Fixes a bug where the "pending" layer criteria in `_get_layer_models`
prevented users from dismissing their own layers.

I solved this by moving the "pending" criteria, which is only relevant
for a single endpoint, to the appropriate view function.

Connects #304