### PR TITLE
Only validate images once

### DIFF
--- a/src/rf/apps/core/models.py
+++ b/src/rf/apps/core/models.py
@@ -480,6 +480,9 @@ class LayerImage(Model):
 
         self.save()
 
+    def has_been_validated(self):
+        return self.status_validate_end is not None
+
     def has_copied_image(self):
         return self.source_s3_bucket_key is not None
 

--- a/src/rf/apps/workers/process.py
+++ b/src/rf/apps/workers/process.py
@@ -183,6 +183,10 @@ class QueueProcessor(object):
         s3_uuid = image.s3_uuid
         key = image.get_s3_key()
 
+        if image.has_been_validated():
+            log.info('Image %d is already validated', image.id)
+            return True
+
         # Validate image.
         status_updates.mark_image_status_start(s3_uuid, enums.STATUS_VALIDATE)
         validator = ImageValidator(settings.AWS_BUCKET_NAME, key)


### PR DESCRIPTION
This fixes a bug where the validation job could be handled more than
once which could result in a duplicate EMR cluster spinning up for the
same layer.

Connects #318