### PR TITLE
Feature/lol/image metadata

### DIFF
--- a/src/rf/apps/core/migrations/0035_add_image_layer_bounding_box.py
+++ b/src/rf/apps/core/migrations/0035_add_image_layer_bounding_box.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('core', '0034_simplify_transfer_status'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='layer',
+            name='max_x',
+            field=models.FloatField(default=None, null=True, blank=True),
+        ),
+        migrations.AddField(
+            model_name='layer',
+            name='max_y',
+            field=models.FloatField(default=None, null=True, blank=True),
+        ),
+        migrations.AddField(
+            model_name='layer',
+            name='min_x',
+            field=models.FloatField(default=None, null=True, blank=True),
+        ),
+        migrations.AddField(
+            model_name='layer',
+            name='min_y',
+            field=models.FloatField(default=None, null=True, blank=True),
+        ),
+        migrations.AddField(
+            model_name='layerimage',
+            name='max_x',
+            field=models.FloatField(default=None, null=True, blank=True),
+        ),
+        migrations.AddField(
+            model_name='layerimage',
+            name='max_y',
+            field=models.FloatField(default=None, null=True, blank=True),
+        ),
+        migrations.AddField(
+            model_name='layerimage',
+            name='min_x',
+            field=models.FloatField(default=None, null=True, blank=True),
+        ),
+        migrations.AddField(
+            model_name='layerimage',
+            name='min_y',
+            field=models.FloatField(default=None, null=True, blank=True),
+        ),
+    ]

--- a/src/rf/apps/core/models.py
+++ b/src/rf/apps/core/models.py
@@ -78,6 +78,11 @@ class Layer(Model):
     capture_start = DateField(blank=True, null=True)
     capture_end = DateField(blank=True, null=True)
 
+    min_x = FloatField(default=None, blank=True, null=True)
+    max_x = FloatField(default=None, blank=True, null=True)
+    min_y = FloatField(default=None, blank=True, null=True)
+    max_y = FloatField(default=None, blank=True, null=True)
+
     area = FloatField(default=0, blank=True, null=True)
     area_unit = CharField(
         blank=True,
@@ -180,6 +185,10 @@ class Layer(Model):
             'capture_end': capture_end,
             'area': self.area,
             'area_unit': self.area_unit,
+            'min_x': self.min_x,
+            'max_x': self.max_x,
+            'min_y': self.min_y,
+            'max_y': self.max_y,
             'projection': self.projection,
             'srid': self.srid,
             'tile_srid': self.tile_srid,
@@ -367,6 +376,13 @@ class Layer(Model):
         value = datetime.now()
         self.status_failed = value
 
+    def set_bounds(self, bounds):
+        self.min_x = bounds[0]
+        self.max_x = bounds[1]
+        self.min_y = bounds[2]
+        self.max_y = bounds[3]
+        self.save(update_fields=['min_x', 'max_x', 'min_y', 'max_y'])
+
     def __unicode__(self):
         return '{0} -> {1}'.format(self.user.username, self.name)
 
@@ -406,6 +422,12 @@ class LayerImage(Model):
         blank=True,
         help_text='Serialized JSON of image metadata',
     )
+
+    min_x = FloatField(default=None, blank=True, null=True)
+    max_x = FloatField(default=None, blank=True, null=True)
+    min_y = FloatField(default=None, blank=True, null=True)
+    max_y = FloatField(default=None, blank=True, null=True)
+
     file_name = CharField(
         blank=False,
         default='',
@@ -489,6 +511,10 @@ class LayerImage(Model):
             'thumb_small': generate_thumb_url(self.thumb_small_key),
             'thumb_large': generate_thumb_url(self.thumb_large_key),
             'meta_json': self.meta_json,
+            'min_x': self.min_x,
+            'max_x': self.max_x,
+            'min_y': self.min_y,
+            'max_y': self.max_y,
             'file_name': self.file_name,
             's3_uuid': str(self.s3_uuid),
             'file_extension': self.file_extension,
@@ -534,6 +560,13 @@ class LayerImage(Model):
         elif status == enums.STATUS_THUMBNAIL:
             self.status_thumbnail_end = value
             self.status_thumbnail_error = error_message
+
+    def set_bounds(self, bounds):
+        self.min_x = bounds[0]
+        self.max_x = bounds[1]
+        self.min_y = bounds[2]
+        self.max_y = bounds[3]
+        self.save(update_fields=['min_x', 'max_x', 'min_y', 'max_y'])
 
 
 class LayerMeta(Model):

--- a/src/rf/apps/workers/image_metadata.py
+++ b/src/rf/apps/workers/image_metadata.py
@@ -25,5 +25,5 @@ def get_image_exif_data(file_descriptor):
     tags = exifread.process_file(file_descriptor, details=False)
     data = []
     for tag in tags.keys():
-        data.append({'key': tag, 'value': str(tags[tag])})
+        data.append({'label': tag, 'value': str(tags[tag])})
     return data

--- a/src/rf/apps/workers/image_metadata.py
+++ b/src/rf/apps/workers/image_metadata.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import division
+
+import exifread
+
+from apps.core.models import Layer
+
+
+def calculate_and_save_layer_boundingbox(layer_id):
+    layer = Layer.objects.get(id=layer_id)
+    images = layer.layer_images.all()
+    bounds = [
+        min([i.min_x for i in images]),
+        max([i.max_x for i in images]),
+        min([i.min_y for i in images]),
+        max([i.max_y for i in images])
+    ]
+    layer.set_bounds(bounds)
+
+
+def get_image_exif_data(file_descriptor):
+    # Setting details to false disables reading baked in thumbnail data.
+    tags = exifread.process_file(file_descriptor, details=False)
+    data = []
+    for tag in tags.keys():
+        data.append({'key': tag, 'value': str(tags[tag])})
+    return data

--- a/src/rf/apps/workers/image_validator.py
+++ b/src/rf/apps/workers/image_validator.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 from __future__ import division
 
 import boto3
-from osgeo import gdal
+from osgeo import gdal, osr
 
 
 MINIMUM_BAND_COUNT = 3
@@ -52,4 +52,24 @@ class ImageValidator(object):
         min_y = bound_info[3] + (w * bound_info[4]) + (h * bound_info[5])
         max_x = bound_info[0] + (w * bound_info[1]) + (h * bound_info[2])
         max_y = bound_info[3]
-        return [min_x, max_x, min_y, max_y]
+
+        # Convert coords to WGS84
+        old_cs = osr.SpatialReference()
+        old_cs.ImportFromWkt(data.GetProjectionRef())
+        wgs84_wkt = """
+        GEOGCS["WGS 84",
+            DATUM["WGS_1984",
+                SPHEROID["WGS 84",6378137,298.257223563,
+                    AUTHORITY["EPSG","7030"]],
+                AUTHORITY["EPSG","6326"]],
+            PRIMEM["Greenwich",0,
+                AUTHORITY["EPSG","8901"]],
+            UNIT["degree",0.01745329251994328,
+                AUTHORITY["EPSG","9122"]],
+            AUTHORITY["EPSG","4326"]]"""
+        new_cs = osr.SpatialReference()
+        new_cs.ImportFromWkt(wgs84_wkt)
+        transform = osr.CoordinateTransformation(old_cs, new_cs)
+        mins = transform.TransformPoint(min_x, min_y)
+        maxes = transform.TransformPoint(max_x, max_y)
+        return [mins[0], maxes[0], mins[1], maxes[1]]

--- a/src/rf/apps/workers/image_validator.py
+++ b/src/rf/apps/workers/image_validator.py
@@ -41,3 +41,15 @@ class ImageValidator(object):
     def image_format_is_supported(self):
         data = self.open_image()
         return data.GetDriver().GetDescription().upper() == 'GTIFF'
+
+    def get_image_bounds(self):
+        data = self.open_image()
+        w = data.RasterXSize
+        h = data.RasterYSize
+
+        bound_info = data.GetGeoTransform()
+        min_x = bound_info[0]
+        min_y = bound_info[3] + (w * bound_info[4]) + (h * bound_info[5])
+        max_x = bound_info[0] + (w * bound_info[1]) + (h * bound_info[2])
+        max_y = bound_info[3]
+        return [min_x, max_x, min_y, max_y]

--- a/src/rf/apps/workers/thumbnail.py
+++ b/src/rf/apps/workers/thumbnail.py
@@ -94,6 +94,7 @@ def s3_make_thumbs(image, user_id, thumb_dims, thumb_ext):
         exif = get_image_exif_data(image_file)
     except IOError:
         log.exception('Could not open image to get metadata.')
+        exif = None
 
     log.info('Getting metadata as JSON.')
     image.meta_json = json.dumps(exif)

--- a/src/rf/apps/workers/thumbnail.py
+++ b/src/rf/apps/workers/thumbnail.py
@@ -90,16 +90,16 @@ def s3_make_thumbs(image, user_id, thumb_dims, thumb_ext):
                             image_filepath)
 
     try:
+        log.info('Getting metadata as JSON.')
         image_file = open(image_filepath)
         exif = get_image_exif_data(image_file)
+        image_file.close()
     except IOError:
         log.exception('Could not open image to get metadata.')
         exif = None
 
-    log.info('Getting metadata as JSON.')
     image.meta_json = json.dumps(exif)
     image.save()
-    image_file.close()
 
     try:
         image = Image.open(image_filepath)

--- a/src/rf/js/src/home/components/library.js
+++ b/src/rf/js/src/home/components/library.js
@@ -494,7 +494,8 @@ var ImageMetadata = React.createBackboneClass({
     render: function() {
         var layer = this.getActiveLayer(),
             image = layer && layer.getActiveImage(),
-            metadata = null;
+            metadata = null,
+            noMetadataMessage = null;
 
         if (!image) {
             return null;
@@ -502,6 +503,9 @@ var ImageMetadata = React.createBackboneClass({
 
         metadata = JSON.parse(image.meta_json);
         metadata = _.sortBy(metadata, 'label');
+        if (_.isEmpty(metadata)) {
+            noMetadataMessage = (<p>No image metadata found.</p>);
+        }
 
         return (
             <div className={'image-metadata animated active ' + this.state.slide}>
@@ -518,6 +522,7 @@ var ImageMetadata = React.createBackboneClass({
                     <img className="img-preview" src={image.thumb_large || 'https://placehold.it/300x300'} />
                     <hr />
                     <div className="scrollable">
+                        {noMetadataMessage}
                         {_.map(metadata, function(data, i) {
                             return (
                                 <dl key={i}>

--- a/src/rf/js/src/home/components/library.js
+++ b/src/rf/js/src/home/components/library.js
@@ -381,7 +381,7 @@ var ImageMetadataLink = React.createBackboneClass({
                 </div>
                 <div className="list-group-content">
                     <h5>{image.file_name}</h5>
-                    <a href="#" className="view-metadata hidden" data-id={image.id}
+                    <a href="#" className="view-metadata" data-id={image.id}
                         onClick={this.props.onClick}>View Metadata</a>
                 </div>
             </div>
@@ -493,11 +493,15 @@ var ImageMetadata = React.createBackboneClass({
 
     render: function() {
         var layer = this.getActiveLayer(),
-            image = layer && layer.getActiveImage();
+            image = layer && layer.getActiveImage(),
+            metadata = null;
 
         if (!image) {
             return null;
         }
+
+        metadata = JSON.parse(image.meta_json);
+        metadata = _.sortBy(metadata, 'label');
 
         return (
             <div className={'image-metadata animated active ' + this.state.slide}>
@@ -513,44 +517,16 @@ var ImageMetadata = React.createBackboneClass({
                 <div className="layer-detail-content">
                     <img className="img-preview" src={image.thumb_large || 'https://placehold.it/300x300'} />
                     <hr />
-                    <dl>
-                        <dt>Acquistion: </dt>
-                        <dd>11-12-2015</dd>
-                        <dt>Local Time of Day: </dt>
-                        <dd>15:42</dd>
-                        <dt>Latitude: </dt>
-                        <dd>39.226º</dd>
-                        <dt>Longitude: </dt>
-                        <dd>-74.892º</dd>
-                        <dt>Image Quality: </dt>
-                        <dd>Standard</dd>
-                        <dt>SNR: </dt>
-                        <dd>75.30</dd>
-                        <dt>Sun Alittude: </dt>
-                        <dd>N/A</dd>
-                        <dt>Sun Longitude: </dt>
-                        <dd>N/A</dd>
-                        <dt>Satellite ID: </dt>
-                        <dd>N/A</dd>
-                    </dl>
-                    <dl>
-                        <dt>Camera Bit Depth: </dt>
-                        <dd>10</dd>
-                        <dt>Camera Color Mode:</dt>
-                        <dd>RGB</dd>
-                        <dt>Camera Exposure Time: </dt>
-                        <dd>1170μs</dd>
-                        <dt>Camera Gain: </dt>
-                        <dd>350</dd>
-                        <dt>Camera TDI Pulses: </dt>
-                        <dd>15</dd>
-                        <dt>Cloud Cover: </dt>
-                        <dd>0.26%</dd>
-                        <dt>File Size: </dt>
-                        <dd>58MB</dd>
-                        <dt>GSD: </dt>
-                        <dd>4.25 m</dd>
-                    </dl>
+                    <div className="scrollable">
+                        {_.map(metadata, function(data, i) {
+                            return (
+                                <dl key={i}>
+                                    <dt>{data.label}: </dt>
+                                    <dd>{data.value}</dd>
+                                </dl>
+                            );
+                        })}
+                    </div>
                 </div>
             </div>
         );

--- a/src/rf/requirements/workers.txt
+++ b/src/rf/requirements/workers.txt
@@ -1,2 +1,3 @@
 GDAL==1.10.0
 numpy==1.10.1
+exifread==2.1.2

--- a/src/rf/sass/components/_layer-detail.scss
+++ b/src/rf/sass/components/_layer-detail.scss
@@ -18,7 +18,7 @@
 		border-bottom-color: $white;
 
 		&:hover {
-			background-color: $white; 
+			background-color: $white;
 		}
 	}
 
@@ -29,6 +29,7 @@
 }
 
 .layer-detail-content {
+    max-height: 720px;
 	padding: 20px 25px;
 	overflow: auto;
 

--- a/src/rf/sass/components/_layer-detail.scss
+++ b/src/rf/sass/components/_layer-detail.scss
@@ -1,45 +1,45 @@
 .layer-detail {
-	display: none;
-	width: 100%;
-	position: absolute;
-	top: 70px;
-	bottom: 0;
-	background: $white;
-	overflow: auto;
-	box-shadow: 0 0 4px rgba(black, .2);
+    display: none;
+    width: 100%;
+    position: absolute;
+    top: 70px;
+    bottom: 0;
+    background: $white;
+    overflow: auto;
+    box-shadow: 0 0 4px rgba(black, .2);
 
-	&.active {
-		display: block;
-	}
+    &.active {
+        display: block;
+    }
 
-	.sidebar-utility-toolbar li a {
-		padding-top: 24px;
-		padding-bottom: 24px;
-		border-bottom-color: $white;
+    .sidebar-utility-toolbar li a {
+        padding-top: 24px;
+        padding-bottom: 24px;
+        border-bottom-color: $white;
 
-		&:hover {
-			background-color: $white;
-		}
-	}
+        &:hover {
+            background-color: $white;
+        }
+    }
 
-	.close {
-		padding: 20px;
-		outline: none;
-	}
+    .close {
+        padding: 20px;
+        outline: none;
+    }
 }
 
 .layer-detail-content {
     max-height: 720px;
-	padding: 20px 25px;
-	overflow: auto;
+    padding: 20px 25px;
+    overflow: auto;
 
-	.img-preview {
-		display: block;
-		margin: 25px auto 30px;
-		border-radius: 5px;
-	}
+    .img-preview {
+        display: block;
+        margin: 25px auto 30px;
+        border-radius: 5px;
+    }
 
-	hr {
+    hr {
     margin-left: -25px;
     margin-right: -25px;
   }


### PR DESCRIPTION
Connects #330 

This re-enables the image metadata panel and populates it with the exif data pulled from the tiff.
Retrieving the metadata is done at two places: first, during image validation and second during thumbnailing. During validation we have access to gdal's opened copy of the image. At this point we retrieve the geodata from the tif. During thumbnailing, since we have the entire image already on disc, we read it and grab the exif data at that time. During layer thumbnail generation we calculate the layer's bounding box since we have all the images already verified and thus they should all have bounding boxes.

### To test:
 * Upload layers
 * Once complete, view the layer details and click on the images tab.
 * Click the "image metadata" link on each image in the list to see the metadata.
 * Check the database to see that the bounding boxes have been added to the layer and layer images.