### PR TITLE
Fix IOError during thumbnail phase

### DIFF
--- a/src/rf/apps/workers/process.py
+++ b/src/rf/apps/workers/process.py
@@ -546,6 +546,6 @@ def extract_uuid_from_aws_key(key):
     AWS keys are a user id appended to a uuid with a file extension.
     EX: 10-1aa064aa-1086-4ff1-a90b-09d3420e0343.tif
     """
-    dot = key.find('.') if key.find('.') >= 0 else len(key)
+    dot = key.rfind('.') if key.rfind('.') >= 0 else len(key)
     first_dash = key.find('-')
-    return key[first_dash:dot]
+    return key[first_dash + 1:dot]

--- a/src/rf/apps/workers/process.py
+++ b/src/rf/apps/workers/process.py
@@ -5,7 +5,6 @@ from __future__ import division
 
 import math
 import time
-import uuid
 import logging
 
 from django.conf import settings
@@ -140,15 +139,11 @@ class QueueProcessor(object):
             return False
 
         s3_uuid = extract_uuid_from_aws_key(key)
-        try:
-            uuid.UUID(s3_uuid)
-        except ValueError:
-            return False
 
-        # Ignore thumbnails.
         try:
             image = LayerImage.objects.get(s3_uuid=s3_uuid)
-        except LayerImage.DoesNotExist:
+        except:
+            log.info('Ignoring thumbnail %s', s3_uuid)
             return True
 
         log.info('Image %d arrived', image.id)


### PR DESCRIPTION
This fixes a bug where certain TIFFs were not able to be thumbnailed by
Pillow. I solved this by using `gdal_translate` to produce a PNG which
is then used to generate each thumbnail.

I also discovered a utility function called `fit` in the PIL library
which I have decided to add since it is more succinct and also gives us
the ability to center align thumbnail images.

Connects #333
Connects #340