### PR TITLE
Fix EMR add_steps function

### DIFF
--- a/src/rf/apps/workers/emr.py
+++ b/src/rf/apps/workers/emr.py
@@ -147,6 +147,7 @@ def add_steps(layer, status_queue, cluster_id):
         Steps=get_steps(layer, status_queue),
     )
     log.debug(response)
+    return response
 
 
 def get_steps(layer, status_queue):


### PR DESCRIPTION
This fix allows us to swap create_cluster with add_steps so that we can
reuse EMR clusters during development.

Connects #265