### PR TITLE
Add initial Auth0 settings to application

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,4 @@ app-server/.ensime_cache/*
 /deployment/ansible/raster-foundry.retry
 /.ivy2/*
 .sbt/
+/.env

--- a/README.md
+++ b/README.md
@@ -8,6 +8,13 @@ A virtual machine is used to encapsulate docker dependencies. `docker-compose` i
 - Vagrant 1.8.0+
 - VirtualBox 5.0.14+
 - Ansible 1.8.0+ (on host)
+- AWS CLI 1.10+
+
+On your host machine you need to set up a `raster-foundry` profile for the Raster Foundry AWS account using the following command:
+```
+aws configure --profile raster-foundry
+```
+You will be prompted for an access key and secret key.
 
 ### Development
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -44,7 +44,7 @@ Vagrant.configure(2) do |config|
 
       cd /opt/raster-foundry/deployment/ansible && \
       ANSIBLE_FORCE_COLOR=1 PYTHONUNBUFFERED=1 ANSIBLE_CALLBACK_WHITELIST=profile_tasks \
-      ansible-playbook -u vagrant -i 'localhost,' --extra-vars "aws_profile=rasterfoundry" \
+      ansible-playbook -u vagrant -i 'localhost,' --extra-vars "aws_profile=raster-foundry" \
           raster-foundry.yml
       cd /opt/raster-foundry
       su vagrant ./scripts/bootstrap

--- a/app-server/src/main/resources/application.conf
+++ b/app-server/src/main/resources/application.conf
@@ -15,3 +15,13 @@ database = {
   password = "rasterfoundry"
   password = ${?POSTGRES_PASSWORD}
 }
+
+auth0 = {
+  clientId = ""
+  clientId = ${?AUTHO_CLIENT_ID}
+  domain = ""
+  domain = ${?AUTH0_DOMAIN}
+  # Development Secret Only
+  secret = ""
+  secret = ${?AUTH0_CLIENT_SECRET}
+}

--- a/app-server/src/test/resources/application.conf
+++ b/app-server/src/test/resources/application.conf
@@ -15,3 +15,13 @@ database = {
   password = "rasterfoundry"
   password = ${?POSTGRES_PASSWORD}
 }
+
+auth0 = {
+  clientId = ""
+  clientId = ${?AUTHO_CLIENT_ID}
+  domain = ""
+  domain = ${?AUTH0_DOMAIN}
+  # Development Secret Only
+  secret = ""
+  secret = ${?AUTH0_CLIENT_SECRET}
+}

--- a/deployment/ansible/raster-foundry.yml
+++ b/deployment/ansible/raster-foundry.yml
@@ -9,7 +9,12 @@
 
   roles:
     - role: "raster-foundry.docker"
+    - role: "raster-foundry.aws-cli"
 
   tasks:
     - name: Change directory on login
       lineinfile: dest=/home/vagrant/.bashrc regexp=^raster-foundry_PROFILE line="cd /opt/raster-foundry/"
+
+    - name: Set Environment variable for AWS profile
+      lineinfile: dest=/etc/environment regexp=^AWS_PROFILE line="AWS_PROFILE={{aws_profile}}"
+      when: aws_profile is defined

--- a/deployment/ansible/roles/raster-foundry.aws-cli/meta/main.yml
+++ b/deployment/ansible/roles/raster-foundry.aws-cli/meta/main.yml
@@ -1,0 +1,5 @@
+---
+# meta file for raster-foundry.aws-cli
+
+dependencies:
+  - { role: azavea.pip }

--- a/deployment/ansible/roles/raster-foundry.aws-cli/tasks/main.yml
+++ b/deployment/ansible/roles/raster-foundry.aws-cli/tasks/main.yml
@@ -1,0 +1,8 @@
+---
+# tasks for raster-foundry.aws-cli
+
+- name: Install AWS Command Line Interface
+  pip: name=awscli version=1.10.16
+
+- name: Install boto3
+  pip: name=boto3 version=1.3.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,10 +3,7 @@ services:
   # Database
   postgres:
     image: quay.io/azavea/postgis:9.4.4
-    environment:
-      POSTGRES_USER: rasterfoundry
-      POSTGRES_PASSWORD: rasterfoundry
-      POSTGRES_DB: rasterfoundry
+    env_file: .env
     ports:
       - "5432:5432"
 
@@ -14,9 +11,7 @@ services:
     image: quay.io/azavea/scala:2.11.8
     links:
       - postgres:database.raster-foundry.internal
-    environment:
-      POSTGRES_USER: rasterfoundry
-      POSTGRES_PASSWORD: rasterfoundry
+    env_file: .env
     ports:
       - "9000:9000"
     volumes:

--- a/scripts/bootstrap
+++ b/scripts/bootstrap
@@ -15,9 +15,15 @@ Example: ./scripts/bootstrap
 
 
 function main() {
-    echo "Building/Pulling containers..."
 
-    # Pull images for postgres
+    echo "Pulling down development environment..."
+    pushd "${DIR}/.."
+    # Download environment configuration from S3
+    aws s3 cp "s3://config-development-raster-foundry/.env" ".env"
+    popd
+
+    echo "Building/Pulling containers..."
+    # Pull images for postgres and scala
     docker-compose \
         -f "${DIR}/../docker-compose.yml" \
         pull


### PR DESCRIPTION
This commit adds support for using Auth0 settings in the application:
 - client id: used to authenticate against a certain application in
   Auth0
 - domain: domain to use for sending requests to Auth0 for
   authenticatino
 - secret: secret used to verify signature of JWT

In this case the client secret is only the secret for the development
environment. Because this accesses an external service it still needs to
be kept secret. To accomplish this environment settings/files are placed
in an S3 bucket that is pulled down during provisioning. This requires
that developers have access to the AWS account.

## Testing

1. Go through the additional steps in the README to add an AWS profile
2. Provision the application
3. Verify you can start the application `./scripts/server` and visit the [healthcheck](http://localhost:9000/healthcheck)