### PR TITLE
Add layers API spec

### DIFF
--- a/docs/swagger/spec.yml
+++ b/docs/swagger/spec.yml
@@ -1,7 +1,7 @@
 swagger: '2.0'
 info:
   title: Raster Foundry
-  description: An application to work find and manipulate large-scale geospatial and raster data
+  description: An application to find and manipulate large-scale geospatial and raster data
   version: "0.1.0"
 
 host: localhost:9000
@@ -20,6 +20,8 @@ consumes:
 tags:
   - name: Users
     description: Operations involving users and organizations
+  - name: Layers
+    description: Interact with layers
 
 paths:
   /users/:
@@ -184,6 +186,259 @@ paths:
           description: Unexpected error
           schema:
             $ref: '#/definitions/Error'
+  /layers/:
+    get:
+      summary: Get list of layers the user is authorized to view
+      tags:
+        - Layers
+      parameters:
+        - $ref: '#/parameters/orderingBase'
+        - $ref: '#/parameters/pageSize'
+        - $ref: '#/parameters/page'
+      responses:
+        200:
+          description: Paginated list of layers the user is authorized to view
+          schema:
+            $ref: '#/definitions/LayerPaginated'
+    post:
+      summary: Create a new layer
+      tags:
+        - Layers
+      parameters:
+        - name: layer
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/Layer'
+      responses:
+        202:
+          description: Layer details; at this point import processes may be in-progress
+          schema:
+            $ref: '#/definitions/Layer'
+  /layers/{uuid}/:
+    get:
+      summary: Retrieve layer details
+      tags:
+        - Layers
+      parameters:
+        - $ref: '#/parameters/uuid'
+      responses:
+        200:
+          description: Info about Layer
+          schema:
+            $ref: '#/definitions/Layer'
+        404:
+          description: UUID parameter does not refer to a layer or the user is not able to view the layer it refers to
+          schema:
+            $ref: '#/definitions/Error'
+    put:
+      summary: Update a layer
+      tags:
+        - Layers
+      parameters:
+        - name: layer
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/Layer'
+        - $ref: '#/parameters/uuid'
+      responses:
+        202:
+          description: Layer update successful (further processing needed)
+          schema:
+            $ref: '#/definitions/LayerImage'
+        204:
+          description: Update successful (no further processing needed)
+        404:
+          description: The UUID parameter does not refer to a layer or the user does not have access to the layer it refers to
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+    delete:
+      summary: Delete a layer
+      tags:
+        - Layers
+      parameters:
+        - $ref: '#/parameters/uuid'
+      responses:
+        204:
+          description: Deletion successful (no content)
+        404:
+          description: The UUID parameter does not refer to a layer or the user does not have access to the layer it refers to
+          schema:
+            $ref: '#/definitions/Error'
+  /layers/{uuid}/images/:
+    get:
+      summary: Get a list of LayerImages associated with this layer
+      tags:
+        - Layers
+      parameters:
+        - $ref: '#/parameters/orderingBase'
+        - $ref: '#/parameters/pageSize'
+        - $ref: '#/parameters/page'
+        - $ref: '#/parameters/uuid'
+      responses:
+        200:
+          description: Paginated list of images associated with this Layer
+          schema:
+            $ref: '#/definitions/LayerImagePaginated'
+    post:
+      summary: Create a new association between an image and this layer
+      tags:
+        - Layers
+      parameters:
+        - $ref: '#/parameters/uuid'
+        - name: image
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/LayerImage'
+      responses:
+        202:
+          description: Layer image details; thumbnails and boundary may be in-progress
+          schema:
+            $ref: '#/definitions/LayerImage'
+        200:
+          description: Layer image details; the image already existed
+          schema:
+            $ref: '#/definitions/LayerImage'
+  /layer-images/:
+    get:
+      summary: Paginated list of layer images
+      tags:
+        - Layers
+      parameters:
+        - $ref: '#/parameters/orderingBase'
+        - $ref: '#/parameters/pageSize'
+        - $ref: '#/parameters/page'
+      responses:
+        200:
+          description: Paginated list of images
+          schema:
+            $ref: '#/definitions/LayerImagePaginated'
+    post:
+      summary: Create a new image not associated with any Layer
+      tags:
+        - Layers
+      parameters:
+        - name: image
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/LayerImage'
+      responses:
+        202:
+          description: Layer image details; thumbnails and boundary in-progress
+          schema:
+            $ref: '#/definitions/LayerImage'
+  /layer-images/{uuid}:
+    get:
+      summary: Details of a LayerImage
+      tags:
+        - Layers
+      parameters:
+        - $ref: '#/parameters/uuid'
+      responses:
+        200:
+          description: Image details (All task-populated fields have final values)
+          schema:
+            $ref: '#/definitions/LayerImage'
+        202:
+          description: Image details (some task-populated fields are in progress)
+          schema:
+            $ref: '#/definitions/LayerImage'
+        404:
+          description: Image UUID was not found
+          schema:
+            $ref: '#/definitions/Error'
+    put:
+      summary: Update a LayerImage
+      tags:
+        - Layers
+      parameters:
+        - $ref: '#/parameters/uuid'
+        - name: image
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/LayerImage'
+      responses:
+        202:
+          description: Update successful, further processing required
+          schema:
+            $ref: '#/definitions/LayerImage'
+        200:
+          description: Update successful, no further processing required
+          schema:
+            $ref: '#/definitions/LayerImage'
+        404:
+          description: Image UUID was not found
+          schema:
+            $ref: '#/definitions/Error'
+  /thumbnails/:
+    get:
+      summary: Paginated list of thumbnails
+      tags:
+        - Layers
+      parameters:
+        - $ref: '#/parameters/orderingBase'
+        - $ref: '#/parameters/pageSize'
+        - $ref: '#/parameters/page'
+      responses:
+        200:
+          description: Paginated list of thumbnail images
+          schema:
+            $ref: '#/definitions/ThumbnailPaginated'
+  /thumbnails/{uuid}/:
+    get:
+      summary: Thumbnail details
+      tags:
+        - Layers
+      parameters:
+        - $ref: '#/parameters/uuid'
+      responses:
+        200:
+          description: Details on Thumbnail object
+          schema:
+            $ref: '#/definitions/Thumbnail'
+        404:
+          description: Thumbnail UUID was not found
+          schema:
+            $ref: '#/definitions/Error'
+
+  /boundaries/:
+    get:
+      summary: Paginated list of boundaries
+      tags:
+        - Layers
+      parameters:
+        - $ref: '#/parameters/orderingBase'
+        - $ref: '#/parameters/pageSize'
+        - $ref: '#/parameters/page'
+      responses:
+        200:
+          description: Paginated list of boundaries
+          schema:
+            $ref: '#/definitions/BoundaryPaginated'
+  /boundaries/{uuid}/:
+    get:
+      summary: Boundary details
+      tags:
+        - Layers
+      parameters:
+        - $ref: '#/parameters/uuid'
+      responses:
+        200:
+          description: Details of Boundary object
+          schema:
+            $ref: '#/definitions/Boundary'
+        404:
+          description: Boundary UUID was not found
+          schema:
+            $ref: '#/definitions/Error'
 
 parameters:
   orderingBase:
@@ -238,6 +493,18 @@ definitions:
         type: string
         description: timestamp of object modificiation
         format: date-time
+  UserTrackingMixin:
+    type: object
+    readOnly: true
+    properties:
+      createdBy:
+        type: string
+        format: uri
+        description: Link to User who created the Object
+      modifiedBy:
+        type: string
+        format: uri
+        description: Link to User who most recently modified the object
   User:
     allOf:
       - $ref: '#/definitions/BaseModel'
@@ -321,6 +588,112 @@ definitions:
         type: string
         description: URL safe version of name
         readOnly: true
+  Layer:
+    allOf:
+      - $ref: '#/definitions/BaseModel'
+      - $ref: '#/definitions/UserTrackingMixin'
+      - type: object
+        properties:
+          name:
+            type: string
+            description: The display name of the layer
+          slugLabel:
+            type: string
+            description: URL-safe version of name
+            readOnly: true
+          description:
+            type: string
+            description: Long-form description of the layer
+          tags:
+            type: array
+            items:
+              - type: string
+          images:
+            type: string
+            description: URI to layer's image information
+            format: uri
+          thumbnails:
+            type: object
+            description: The thumbnails associated with this layer
+            properties:  # Sizes inspired by Flickr
+              large:
+                $ref: '#/definitions/TaskPopulatedField'
+              small:
+                $ref: '#/definitions/TaskPopulatedField'
+              square:
+                $ref: '#/definitions/TaskPopulatedField'
+            readOnly: true
+          boundary:
+            allOf:
+              - $ref: '#/definitions/TaskPopulatedField'
+            readOnly: true
+  LayerImage:
+    allOf:
+      - $ref: '#/definitions/BaseModel'
+      - $ref: '#/definitions/UserTrackingMixin'
+      - type: object
+        properties:
+          fileName:
+              type: string
+              description: Name of the image file
+          sourceURI:
+            type: string
+            description: URI to raw source that will be used for this image
+          metadata:
+            type: object
+            description: Metadata about this image
+          thumbnails:
+            type: object
+            description: Thumbnails associated with this layer-image
+            properties:
+              large:
+                $ref: '#/definitions/TaskPopulatedField'
+              small:
+                $ref: '#/definitions/TaskPopulatedField'
+              square:
+                $ref: '#/definitions/TaskPopulatedField'
+            readOnly: true
+          boundary:
+            allOf:
+              - $ref: '#/definitions/TaskPopulatedField'
+            readOnly: true
+        required:
+          - fileName
+          - sourceURI
+          - thumbnails
+          - boundary
+  LayerPaginated:
+    allOf:
+      - $ref: '#/definitions/PaginatedResponse'
+    properties:
+      results:
+        type: array
+        items:
+          $ref: '#/definitions/Layer'
+  LayerImagePaginated:
+    allOf:
+      - $ref: '#/definitions/PaginatedResponse'
+      - type: object
+        properties:
+          results:
+            type: array
+            items:
+              $ref: '#/definitions/LayerImage'
+  TaskPopulatedField:
+    type: object
+    properties:
+      taskStatus:
+        type: string
+        description: The current status of the task
+        enum:
+          - PENDING
+          - PROCESSING
+          - COMPLETED
+          - FAILED
+      result:
+        type: string
+        format: uri
+        description: Link at which the results of this task can be found
   Error:
     type: object
     properties:
@@ -329,3 +702,46 @@ definitions:
         format: int32
       message:
         type: string
+  Thumbnail:
+    allOf:
+      - $ref: '#/definitions/BaseModel'
+      - type: object
+        properties:
+          widthPx:
+            type: integer
+            format: int32
+            description: The width of the thumbnail, in pixels
+          heightPx:
+            type: integer
+            format: int32
+            description: The height of the thumbnail, in pixels
+          url:
+            type: string
+            format: uri
+            description: A client-accessible URL pointing to the image file
+  ThumbnailPaginated:
+    allOf:
+    - $ref: '#/definitions/PaginatedResponse'
+    - type: object
+      properties:
+        results:
+          type: array
+          items:
+            $ref: '#/definitions/Thumbnail'
+  Boundary:
+    allOf:
+      - $ref: '#/definitions/BaseModel'
+      - type: object
+        properties:
+          geojson:
+            type: object
+            description: GeoJSON representing the boundary geometry
+  BoundaryPaginated:
+    allOf:
+      - $ref: '#/definitions/PaginatedResponse'
+      - type: object
+        properties:
+          results:
+            type: array
+            items:
+              $ref: '#/definitions/Boundary'


### PR DESCRIPTION
Adds a spec for interacting with layers and some of their associated tasks. I didn't flesh out the bigger GeoTrellis import task because I don't have a good idea of exactly what that would look like, but I added thumbnail and raster boundary tasks which provide a template that could be reused once we know more about what the bigger task will return.

The task interaction is inspired by promises, and I'm envisioning it would look something like this:

1) POST -> `/layers/`. Status 202
```
{
  "uuid": "<layer-uuid>",
  ...
  "thumbnail": {
    "dataType": "ThumbnailPromise",
    "promise": "https://raster-foundry.com/api/layers/<layer-uuid>/tasks/<task-uuid>"
  },
  ...
}
```
A GET -> `/layers/<layer-uuid>/` at this point would return the same thing.

2) GET -> `/layers/<layer-uuid>/tasks/<task-uuid>/`, Status 202
```
{
  "taskStatus": "processing",
  "layer": "<layer-uuid>",
  "taskType": "thumbnail",
  "result": null
}
```

3) GET -> `/layers/<layer-uuid>/tasks/<task-uuid>/`, Status 200
```
{
  "taskStatus": "complete",
  "layer": "<layer-uuid>",
  "taskType": "thumbnail",
  "result": {
    "widthPx": 50,
    "heightPx": 50,
    "url": "https://whatever/thumbnail.png"
  }
}
```

4) An error condition would look something like
GET -> `/layers/<layer-uuid>/tasks/<task-uuid>/`, Status 200
```
{
  "taskStatus": "error",
  "layer": "<layer-uuid>",
  "taskType": "thumbnail",
  "result": {
    "code": 12345,
    "message": "Oh noes!"
  }
}
```

5) After the task has completed successfully, a GET -> `/layers/<layer-uuid>/` would return Status 200:
```
{
  "uuid": <layer-uuid>,
  ...
  "thumbnail": {
    "dataType": "ThumbnailResult",
    "widthPx": 50,
    "heightPx": 50,
    "url": "https://whatever/thumbnail.png"
  },
  ...
}
```

In this scheme it's possible to conduct polling for success against either `/layers/<layer-uuid>/` or by polling tasks individually via `/layers/<layer-uuid>/tasks/<task-uuid>/`. My guess is that polling by task will probably be better (because there will be multiple asynchronous tasks associated with each Layer) but it's not totally clear yet; doing it per-task would give us a lot of granularity in being able to control how we poll for each type of asynchronous information, which could help us increase perceived UI speed, but it's not clear how that would affect overall number of requests over the lifespan of an import. For example, if thumbnails take 3 seconds to process, the GeoTrellis import takes 5 minutes, and we want to poll the thumbnails every 0.5 seconds then granular polling could use significantly fewer requests because we could poll the shorter task at a higher frequency without causing a big spike in requests over the long term. A third option that @notthatbreezy brought up would be to create a status-only endpoint for each layer that would provide the status of its associated tasks but not their outputs; that could be a useful middle ground depending on what the performance bottlenecks end up being.

There are a couple things I'm not thrilled with about this scheme--suggestions welcome:
- Swagger's inheritance is a bit awkward; it doesn't allow the use of JSON-Schema `anyOf` for inheritance, so in order to specify that a field can be a Promise OR Error OR Thumbnail, I had to use a base class with a "discriminator" field that will contain the class name (which is what the "dataType" field is). Then I had to define subclasses for each of Promise, Error, and Thumbnail. However, since the base class doesn't know about any of its children, the documentation simply specifies that an instance of the base class will be returned, which isn't very satisfying. The lack of generics also means that each time we add a field that requires asynchronous processing, it will require the creation of three associated Promise/Error/Result models, none of which will be actually detected by the Swagger documentation generator (although I assume they will be used correctly by auto-generated clients in strongly typed languages).
- The structure of the `LayerTask` endpoint and the corresponding fields on the `Layer` model are inconsistent, but because the `result` field of the `LayerTask` model is just a featureless `object` blob, substituting a `LayerTask` schema for the fields that requires asynchronous processing doesn't seem like it's necessarily a positive change.

Closes #379 