### PR TITLE
Add development setup for front-end

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,4 +97,7 @@ app-server/.ensime_cache/*
 /deployment/ansible/raster-foundry.retry
 /.ivy2/*
 .sbt/
+
 /.env
+.node_modules
+

--- a/README.md
+++ b/README.md
@@ -37,12 +37,30 @@ Development workflow varies by developer, but a typical development experience m
  - make changes to scala code
  - try compiling (`~compile`) or running the service to inspect it (`~run`)
 
+#### Frontend Development
+
+To do frontend development you will want to install [`nvm`](https://github.com/creationix/nvm#install-script) and use a recent version of node (e.g. 4+). After following the directions above for starting the VM, start the API server and other backend services by running `./scripts/server`.
+
+Then _outside_ the VM, while the server is still running, run `npm start` while inside the `app-frontend/` directory. This will start a `webpack-dev-server` on port 9090 that will auto-reload after javascript and styling changes.
+
+There are three options to rebuild the static assets served by nginx:
+ - run `npm run build` outside the VM
+ - run `./scripts/console app-frontend "npm run build"`
+ - run `./scripts/setup` (will also rebuild application server)
+ 
+To run tests you can do one of the following (in order of speed):
+ - run `npm run test` outside the VM (or `npm run test-watch`)
+ - run `./scripts/console app-frontend "npm run test"` inside the VM
+ - run `./scripts/test` inside the VM (will also run additional project tests)
+
 ## Ports
 
 The Vagrant configuration maps the following host ports to services running in the virtual machines. Ports can be overridden for individual developers using environment variables
 
 | Service                   | Port                            | Environment Variable |
 |---------------------------|---------------------------------|----------------------|
+| Application Frontend      | [`9090`](http://localhost:9090) | `RF_PORT_9090`       |
+| Nginx                     | [`9100`](http://localhost:9100) | `RF_PORT_9100`       |
 | Application Server (akka) | [`9000`](http://localhost:9000) | `RF_PORT_9000`       |
 | Database                  | `5432`                          | `RF_PORT_5432`       |
 | Swagger Editor            | [`8080`](http://localhost:8080) | `RF_PORT_8080`       |

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -27,6 +27,8 @@ Vagrant.configure(2) do |config|
   config.vm.network :forwarded_port, guest: 5432, host: Integer(ENV.fetch("RF_PORT_5432", 5432))
   # swagger editor
   config.vm.network :forwarded_port, guest: 8080, host: Integer(ENV.fetch("RF_PORT_8080", 8080))
+  # nginx
+  config.vm.network :forwarded_port, guest: 9100, host: Integer(ENV.fetch("RF_PORT_9100", 9100))
 
   config.vm.provider :virtualbox do |vb|
     vb.memory = 4096

--- a/app-frontend/.eslintrc
+++ b/app-frontend/.eslintrc
@@ -118,7 +118,7 @@
     "no-octal": 2, // disallow use of octal literals
     "no-octal-escape": 2, // disallow use of octal escape sequences in string literals, such as var foo = "Copyright \251";
     "no-param-reassign": 2, // disallow reassignment of function parameters (off by default)
-    "no-process-env": 2, // disallow use of process.env (off by default)
+    "no-process-env": 0, // disallow use of process.env (off by default)
     "no-proto": 2, // disallow usage of __proto__ property
     "no-redeclare": 2, // disallow declaring the same variable more then once
     "no-return-assign": 2, // disallow use of assignment in return statement

--- a/app-frontend/config/webpack/environments/development.js
+++ b/app-frontend/config/webpack/environments/development.js
@@ -1,10 +1,11 @@
 'use strict';
-/* globals module */
-/* eslint no-process-env: 0
- no-console: 0
+/* globals module process */
+/* no-console: 0
  */
 
+
 let webpack = require('webpack');
+let port = process.env.RF_PORT_9090 || 9090;
 
 module.exports = function (_path) {
     return {
@@ -15,7 +16,13 @@ module.exports = function (_path) {
             contentBase: './dist',
             info: true,
             hot: true,
-            inline: true
+            inline: true,
+            progress: true,
+            'history-api-fallback': true,
+            port: port,
+            proxy: {
+                '*': 'http://localhost:9100'
+            }
         },
         plugins: [
             new webpack.HotModuleReplacementPlugin()

--- a/app-frontend/package.json
+++ b/app-frontend/package.json
@@ -13,8 +13,8 @@
   },
   "scripts": {
     "build": "npm run clean && cross-env NODE_ENV=production webpack -p --colors",
-    "clean": "rimraf dist",
-    "dev": "cross-env NODE_ENV=development webpack-dev-server --progress --history-apy-fallback --inline",
+    "clean": "rimraf dist/*",
+    "dev": "cross-env NODE_ENV=development webpack-dev-server",
     "serve-static": "npm run build && serve --path dist --port 9001",
     "sort-packages": "sort-package-json",
     "start": "npm run dev",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,21 @@ services:
     ports:
       - "5432:5432"
 
+  app-frontend:
+    image: node:4.4.7-wheezy
+    working_dir: /opt/raster-foundry/app-frontend/
+    volumes:
+      - ./app-frontend/.babelrc:/opt/raster-foundry/app-frontend/.babelrc
+      - ./app-frontend/config/:/opt/raster-foundry/app-frontend/config/
+      - ./nginx/srv/dist/:/opt/raster-foundry/app-frontend/dist/
+      - ./app-frontend/.eslintrc:/opt/raster-foundry/app-frontend/.eslintrc
+      - ./app-frontend/karma.conf.js:/opt/raster-foundry/app-frontend/karma.conf.js
+      - ./.node_modules:/opt/raster-foundry/app-frontend/node_modules
+      - ./app-frontend/package.json:/opt/raster-foundry/app-frontend/package.json
+      - ./app-frontend/src:/opt/raster-foundry/app-frontend/src
+      - ./app-frontend/webpack.config.js:/opt/raster-foundry/app-frontend/webpack.config.js
+    command: npm run build-watch
+
   app-server:
     image: quay.io/azavea/scala:2.11.8
     links:
@@ -25,3 +40,14 @@ services:
     image: swaggerapi/swagger-editor:latest
     ports:
       - "8080:8080"
+
+  nginx:
+    image: nginx
+    ports:
+      - "9100:443"
+    links:
+      - app-server
+    volumes:
+      - ./nginx/srv/dist/:/srv/dist/
+      - ./nginx/etc/nginx/nginx.conf:/etc/nginx/nginx.conf
+      - ./nginx/etc/nginx/conf.d/default.conf:/etc/nginx/conf.d/default.conf      

--- a/nginx/etc/nginx/conf.d/default.conf
+++ b/nginx/etc/nginx/conf.d/default.conf
@@ -1,0 +1,56 @@
+
+server {
+    listen 80;
+    server_name staging.rasterfoundry.com rasterfoundry.com;
+    return 301 https://$host$request_uri;
+}
+
+map $http_x_forwarded_proto $policy {
+    default "";
+    https   "default-src https: data: blob: 'unsafe-inline' 'unsafe-eval'";
+}
+
+upstream app-server-upstream {
+    server app-server:9000;
+}
+
+server {
+    listen 443 default_server;
+    server_name staging.rasterfoundry.com rasterfoundry.com localhost;
+
+    # A set of recommended security headers:
+    #
+    #   https://scotthelme.co.uk/hardening-your-http-response-headers/
+    #
+    add_header Strict-Transport-Security "max-age=15552000; preload" always;
+    add_header Content-Security-Policy $policy always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header X-XSS-Protection "1; mode=block" always;
+
+    # Akka-Http API
+    location /api {
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Forwarded-For $remote_addr;
+        proxy_redirect off;
+
+        proxy_pass http://app-server-upstream;
+    }
+
+    # Health check
+    location = /healthcheck/ {
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Forwarded-For $remote_addr;
+        proxy_redirect off;
+
+        proxy_pass http://app-server-upstream;
+    }
+
+    # Static Assets
+    location / {
+        root /srv/dist;
+        index index.json index.html;
+        try_files $uri $uri/ /index.html =404;
+    }
+
+}

--- a/nginx/etc/nginx/nginx.conf
+++ b/nginx/etc/nginx/nginx.conf
@@ -1,0 +1,39 @@
+user nginx;
+worker_processes 1;
+pid /var/run/nginx.pid;
+
+events {
+    worker_connections 1024;
+    # multi_accept on;
+}
+
+http {
+    include /etc/nginx/mime.types;
+    default_type application/octet-stream;
+
+    log_format timed_combined '$remote_addr - $remote_user [$time_local] '
+                              '"$request" $status $body_bytes_sent $gzip_ratio '
+                              '"$http_referer" "$http_user_agent" '
+                              '$request_time $upstream_response_time';
+
+    access_log /var/log/nginx/access.log timed_combined;
+
+    sendfile on;
+
+    keepalive_timeout 65;
+
+    server_tokens off;
+
+    gzip on;
+    gzip_types application/javascript text/css application/json;
+    gzip_disable "msie6";
+
+    set_real_ip_from 10.0.0.0/24;
+    set_real_ip_from 10.0.2.0/24;
+    set_real_ip_from 10.0.4.0/24;
+    set_real_ip_from 10.0.6.0/24;
+
+    real_ip_header X-Forwarded-For;
+
+    include /etc/nginx/conf.d/*.conf;
+}

--- a/scripts/server
+++ b/scripts/server
@@ -19,7 +19,7 @@ then
     then
         usage
     else
-         docker-compose -f "${DIR}/../docker-compose.yml" up
+         docker-compose -f "${DIR}/../docker-compose.yml" up app-server nginx swagger-editor postgres
     fi
     exit
 fi

--- a/scripts/setup
+++ b/scripts/setup
@@ -20,7 +20,12 @@ then
     then
         usage
     else
+        # app-server
         docker-compose -f "${DIR}/../docker-compose.yml" run --rm app-server sbt update
+
+        # app-frontend
+        docker-compose -f "${DIR}/../docker-compose.yml" run --rm app-frontend npm install
+        docker-compose -f "${DIR}/../docker-compose.yml" run --rm app-frontend npm run build
     fi
     exit
 fi

--- a/scripts/test
+++ b/scripts/test
@@ -22,7 +22,7 @@ then
             find ./scripts -not -name "*.py*" -type f -exec shellcheck {} +
         fi
 
-        # Run linter/inspector to identify issues
+        # Run linter/inspector to identify issues with app-server
         docker-compose \
             -f "${DIR}/../docker-compose.yml" run \
             --rm \
@@ -35,6 +35,13 @@ then
             --rm \
             --entrypoint "/bin/bash -c" \
             app-server "./sbt test"
+
+        # Run js tests for app-frontend
+        docker-compose \
+            -f "${DIR}/../docker-compose.yml" run \
+            --rm \
+            --entrypoint "/bin/bash -c" \
+            app-frontend "npm run test"
 
     fi
     exit


### PR DESCRIPTION
This commit adds additional setup for frontend development in the
following ways:
 - adds an nginx container that serves static assets and proxies to
 application server/api/healthcheck
 - installs frontend dependencies and caches them in a ./node_modules
 directory so that tests and static assets can be build
 - adds a docker-compose configuration to run frontend commands and run
 builds and tests inside the container
 - adds development instructions for frontend development
 - adds running of frontend tests to `./scripts/test`

## Testing
- Provision vagrant VM (either `vagrant provision` or `vagrant up --provision`)
- SSH into vm and start server (`./scripts/server`)
- Outside the VM start `webpack-dev-server` from the `app-frontend` directory (`npm start`)
- Browse to [http://localhost:9090](http://localhost:9090) and verify application loads
- Browse to [http://localhost:9090/healthcheck/](http://localhost:9090/healthcheck/) and verify that healthcheck request is proxied correctly
- Browse to [http://localhost:9100](http://localhost:9100) and verify that bundled assets are served correctly
- Browse to [http://localhost:9100/healthcheck/](http://localhost:9100/healthcheck/) and verify that healthcheck requests are routed properly
- From within the VM stop the server (`ctrl-c`) and run tests, verifying that tests run for the frontend `./scripts/test`