### PR TITLE
Add support for VPC creation using terraform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,11 @@
+# Terraform
+.terraform
+*.tfplan
+*.tfvars
+*.tfstate
+*.tfstate.backup
+
+
 # Sass Cache
 .sass-cache
 

--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,7 @@ coverage.xml
 
 # Ansible
 deployment/ansible/roles/azavea.*
+*.retry
 
 # Vagrant
 .vagrant

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -1,1 +1,41 @@
-# Deployment
+# Amazon Web Services Deployment
+
+Amazon Web Services deployment is driven by [Terraform](https://terraform.io/) and the [AWS Command Line Interface (CLI)](http://aws.amazon.com/cli/).
+
+## Table of Contents
+
+* [AWS Credentials](#aws-credentials)
+* [Terraform](#terraform)
+
+## AWS Credentials
+
+Using the AWS CLI, create an AWS profile named `raster-foundry`:
+
+```bash
+$ vagrant ssh
+vagrant@vagrant-ubuntu-trusty-64:~$ aws --profile raster-foundry configure
+AWS Access Key ID [****************F2DQ]:
+AWS Secret Access Key [****************TLJ/]:
+Default region name [us-east-1]: us-east-1
+Default output format [None]:
+```
+
+You will be prompted to enter your AWS credentials, along with a default region. These credentials will be used to authenticate calls to the AWS API when using Terraform and the AWS CLI.
+
+## Terraform
+
+Next, use the Terraform wrapper script (`terraform.sh`) to lookup the remote state of the infrastructure and assemble a plan for work to be done:
+
+```bash
+vagrant@vagrant-ubuntu-trusty-64:~$ export RF_SETTINGS_BUCKET="raster-foundry.staging.config.us-east-1"
+vagrant@vagrant-ubuntu-trusty-64:~$ export AWS_PROFILE="raster-foundry"
+vagrant@vagrant-ubuntu-trusty-64:~$ ./scripts/terraform.sh plan
+```
+
+Once the plan has been assembled, and you agree with the changes, apply it:
+
+```bash
+vagrant@vagrant-ubuntu-trusty-64:~$ ./scripts/terraform.sh apply
+```
+
+This will attempt to apply the plan assembled in the previous step using Amazon's APIs. In order to change specific attributes of the infrastructure, inspect the contents of the environment's configuration file in Amazon S3.

--- a/deployment/ansible/raster-foundry.yml
+++ b/deployment/ansible/raster-foundry.yml
@@ -10,6 +10,7 @@
   roles:
     - role: "raster-foundry.docker"
     - role: "raster-foundry.aws-cli"
+    - role: "azavea.terraform"
 
   tasks:
     - name: Change directory on login

--- a/deployment/ansible/roles.yml
+++ b/deployment/ansible/roles.yml
@@ -3,3 +3,6 @@
 
 - src: azavea.pip
   version: 0.1.1
+
+- src: azavea.terraform
+  version: 0.1.0

--- a/deployment/terraform/firewall.tf
+++ b/deployment/terraform/firewall.tf
@@ -1,0 +1,35 @@
+resource "aws_security_group_rule" "bastion_ssh_ingress" {
+  type              = "ingress"
+  from_port         = 22
+  to_port           = 22
+  protocol          = "tcp"
+  cidr_blocks       = ["${var.external_access_cidr_block}"]
+  security_group_id = "${module.vpc.bastion_security_group_id}"
+}
+
+resource "aws_security_group_rule" "bastion_ssh_egress" {
+  type              = "egress"
+  from_port         = 22
+  to_port           = 22
+  protocol          = "tcp"
+  cidr_blocks       = ["${module.vpc.cidr_block}"]
+  security_group_id = "${module.vpc.bastion_security_group_id}"
+}
+
+resource "aws_security_group_rule" "bastion_http_egress" {
+  type              = "egress"
+  from_port         = 80
+  to_port           = 80
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = "${module.vpc.bastion_security_group_id}"
+}
+
+resource "aws_security_group_rule" "bastion_https_egress" {
+  type              = "egress"
+  from_port         = 443
+  to_port           = 443
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = "${module.vpc.bastion_security_group_id}"
+}

--- a/deployment/terraform/network.tf
+++ b/deployment/terraform/network.tf
@@ -1,0 +1,17 @@
+module "vpc" {
+  source = "github.com/azavea/terraform-aws-vpc?ref=2.0.1"
+
+  name                       = "StormdrainMarking-${var.environment}"
+  region                     = "${var.aws_region}"
+  key_name                   = "${var.aws_key_name}"
+  cidr_block                 = "${var.vpc_cidr_block}"
+  external_access_cidr_block = "${var.external_access_cidr_block}"
+  private_subnet_cidr_blocks = "${var.vpc_private_subnet_cidr_blocks}"
+  public_subnet_cidr_blocks  = "${var.vpc_public_subnet_cidr_blocks}"
+  availability_zones         = "${var.aws_availability_zones}"
+  bastion_ami                = "${var.bastion_ami}"
+  bastion_instance_type      = "${var.bastion_instance_type}"
+
+  project     = "${var.project}"
+  environment = "${var.environment}"
+}

--- a/deployment/terraform/provider.tf
+++ b/deployment/terraform/provider.tf
@@ -1,0 +1,3 @@
+provider "aws" {
+  region = "${var.aws_region}"
+}

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -1,0 +1,35 @@
+variable "project" {
+  default = "Raster Foundry"
+}
+
+variable "environment" {
+  default = "Staging"
+}
+
+variable "aws_region" {
+  default = "us-east-1"
+}
+
+variable "aws_availability_zones" {}
+
+variable "aws_key_name" {}
+
+variable "vpc_cidr_block" {
+  default = "10.0.0.0/16"
+}
+
+variable "external_access_cidr_block" {
+  default = "66.212.12.106/32"
+}
+
+variable "vpc_private_subnet_cidr_blocks" {
+  default = "10.0.1.0/24,10.0.3.0/24"
+}
+
+variable "vpc_public_subnet_cidr_blocks" {
+  default = "10.0.0.0/24,10.0.2.0/24"
+}
+
+variable "bastion_ami" {}
+
+variable "bastion_instance_type" {}

--- a/scripts/terraform.sh
+++ b/scripts/terraform.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+set -e
+
+if [[ -n "${RF_DEBUG}" ]]; then
+    set -x
+fi
+
+DIR="$(dirname "$0")"
+TERRAFORM_DIR="${DIR}/../deployment/terraform"
+
+function usage() {
+    echo -n \
+"Usage: $(basename "$0") COMMAND OPTION[S]
+Execute Terraform subcommands with remote state management.
+"
+}
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+    if [ "${1:-}" = "--help" ]; then
+        usage
+    else
+        if [[ -n "${RF_SETTINGS_BUCKET}" ]]; then
+            TF_FILE_BASE_NAME=$(echo "${RF_SETTINGS_BUCKET}" | tr . -)
+
+            pushd "${TERRAFORM_DIR}"
+
+            # Stop Terraform from trying to apply incorrect state across environments
+            if [ -f ".terraform/terraform.tfstate" ] && ! grep -q "${RF_SETTINGS_BUCKET}" ".terraform/terraform.tfstate"; then
+                echo "ERROR: Incorrect target environment detected in Terraform state! Please run"
+                echo "       the following command before proceeding:"
+                echo
+                echo "  rm -rf deployment/terraform/.terraform"
+                echo
+                exit 1
+            fi
+
+            aws s3 cp "s3://${RF_SETTINGS_BUCKET}/terraform/terraform.tfvars" "${TF_FILE_BASE_NAME}.tfvars"
+
+            terraform remote config \
+                      -backend="s3" \
+                      -backend-config="region=us-east-1" \
+                      -backend-config="bucket=${RF_SETTINGS_BUCKET}" \
+                      -backend-config="key=terraform/state" \
+                      -backend-config="encrypt=true"
+
+            case "${1}" in
+                fmt)
+                    terraform "$@"
+                    ;;
+                taint)
+                    terraform "$@"
+                    ;;
+                plan)
+                    terraform get -update
+                    terraform plan \
+                              -var-file="${TF_FILE_BASE_NAME}.tfvars" \
+                              -out="${TF_FILE_BASE_NAME}.tfplan"
+                    ;;
+                apply)         
+                    terraform apply "${TF_FILE_BASE_NAME}.tfplan"
+                    terraform remote push
+                    ;;
+                *)
+                    echo "ERROR: I don't have support for that Terraform subcommand!"
+                    exit 1
+                    ;;
+            esac
+
+            popd
+        else
+            echo "ERROR: No RF_SETTINGS_BUCKET variable defined."
+            exit 1
+        fi
+    fi
+fi
+


### PR DESCRIPTION
Use Terraform to create a project VPC with the terraform-aws-vpc module. Variables are stored in a Terraform settings file on Amazon S3 that is synced by the terraform.sh script via AWS CLI.

Depends on [#10]( https://github.com/azavea/terraform-aws-vpc/pull/10)
