### PR TITLE
Add initial airflow scaffolding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,4 +99,10 @@ app-server/.ensime_cache/*
 .sbt/
 
 /.env
+
 .node_modules
+
+app-tasks/usr/local/airflow/logs/
+/app-tasks/usr/local/airflow/airflow-webserver.pid
+/app-tasks/usr/local/airflow/unittests.cfg
+

--- a/README.md
+++ b/README.md
@@ -79,7 +79,9 @@ The Vagrant configuration maps the following host ports to services running in t
 | Nginx                     | [`9100`](http://localhost:9100) | `RF_PORT_9100`       |
 | Application Server (akka) | [`9000`](http://localhost:9000) | `RF_PORT_9000`       |
 | Database                  | `5432`                          | `RF_PORT_5432`       |
-| Swagger Editor            | [`8080`](http://localhost:8080) | `RF_PORT_8080`       |
+| Airflow UI                | [`8080`](http://localhost:8080) | `RF_PORT_8080`       |
+| Airflow Flower            | [`5555`](http://localhost:5555) | `RF_PORT_5555`       |
+| Swagger Editor            | [`9090`](http://localhost:9090) | `RF_PORT_9090`       |
 
 
 ## Scripts

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -26,9 +26,13 @@ Vagrant.configure(2) do |config|
   # database
   config.vm.network :forwarded_port, guest: 5432, host: Integer(ENV.fetch("RF_PORT_5432", 5432))
   # swagger editor
-  config.vm.network :forwarded_port, guest: 8080, host: Integer(ENV.fetch("RF_PORT_8080", 8080))
+  config.vm.network :forwarded_port, guest: 9090, host: Integer(ENV.fetch("RF_PORT_9090", 9090))
   # nginx
   config.vm.network :forwarded_port, guest: 9100, host: Integer(ENV.fetch("RF_PORT_9100", 9100))
+  # airflow webserver editor
+  config.vm.network :forwarded_port, guest: 8080, host: Integer(ENV.fetch("RF_PORT_8080", 8080))
+  # airflow flower editor
+  config.vm.network :forwarded_port, guest: 5555, host: Integer(ENV.fetch("RF_PORT_5555", 5555))
 
   config.vm.provider :virtualbox do |vb|
     vb.memory = 4096

--- a/app-tasks/Dockerfile
+++ b/app-tasks/Dockerfile
@@ -1,0 +1,21 @@
+FROM python:2.7
+
+ENV AIRFLOW_HOME /usr/local/airflow
+
+COPY requirements.txt /tmp/
+
+RUN set -ex \
+  && pip install --no-cache-dir -r /tmp/requirements.txt \
+  && rm /tmp/requirements.txt
+
+COPY usr/local/airflow/airflow.cfg ${AIRFLOW_HOME}/airflow.cfg
+
+EXPOSE 8080 5555 8793
+
+COPY rf/ /tmp/rf
+RUN set -ex \
+    && cd /tmp/rf \
+    && python setup.py install \
+    && rm -rf /tmp/rf
+
+WORKDIR ${AIRFLOW_HOME}

--- a/app-tasks/README.md
+++ b/app-tasks/README.md
@@ -1,0 +1,24 @@
+# Raster Foundry Task/Workflows
+
+Asynchronous tasks and workflows are managed through [Airflow](https://pythonhosted.org/airflow/index.html). 
+
+[DAGs](https://pythonhosted.org/airflow/concepts.html#dags) are stored in the `dags/` directory.
+Configuration is stored in `usr/`.
+`rf` is a pip-installable package that houses code which can be used an imported in `DAGs`; however, is maintained apart from the `DAGs` to keep it easy to test.
+
+# Requirements
+
+All requirements are handled via the Raster Foundry project's provisioning, including creating a `docker` container to use for development via `./scripts/setup`. 
+
+# Development
+
+To enhance `dags` likely requires editing two different sets of files:
+
+ 1. Editing/adding an existing `DAG`
+ 2. Adding functionality to the `rf` library that will be used in the `DAG`
+ 
+`DAG` code should be as thin as possible, deferring complicated logic and operations to the `rf` library where possible. This will help maintain at least some composability and ensure that tasks performed in `DAGs` can be easily tested. Code executed in the `DAG` should be broken up into functions for ease of testing as much as possible.
+
+# Testing
+
+Run `./scripts/test` or `./scripts/console airflow-worker python rf/setup.py test`

--- a/app-tasks/dags/import_tif_image.py
+++ b/app-tasks/dags/import_tif_image.py
@@ -1,0 +1,76 @@
+from airflow.operators.python_operator import PythonOperator
+from airflow.models import DAG
+from datetime import datetime, timedelta
+
+from rf.uploads.geotiff import (
+    create_thumbnail,
+    extract_metadata,
+    extract_footprint
+)
+
+
+import logging
+
+logger = logging.getLogger('rf')
+ch = logging.StreamHandler()
+ch.setLevel(logging.DEBUG)
+formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+ch.setFormatter(formatter)
+logger.addHandler(ch)
+
+seven_days_ago = datetime.combine(
+        datetime.today() - timedelta(7), datetime.min.time())
+
+
+args = {
+    'owner': 'airflow',
+    'start_date': seven_days_ago,
+}
+
+
+dag = DAG(
+    dag_id='import_tif_image',
+    default_args=args,
+    schedule_interval=None
+)
+
+
+def create_thumbnails(*args, **kwargs):
+    tif_path = kwargs['dag_run'].conf.get('tif_path', 'example.tif')
+    """This is a function that will run within the DAG execution"""
+    create_thumbnail(tif_path)
+    return kwargs
+
+
+def extract_tif_metadata(*args, **kwargs):
+    tif_path = kwargs['dag_run'].conf.get('tif_path', 'example.tif')
+    extract_metadata(tif_path)
+    return kwargs
+
+
+def extract_polygon(*args, **kwargs):
+    tif_path = kwargs['dag_run'].conf.get('tif_path', 'example.tif')
+    extract_footprint(tif_path)
+    return kwargs
+
+
+PythonOperator(
+    task_id='create_thumbnails',
+    provide_context=True,    
+    python_callable=create_thumbnails,
+    dag=dag
+)
+
+PythonOperator(
+    task_id='extract_tif_metadata',
+    provide_context=True,    
+    python_callable=extract_tif_metadata,
+    dag=dag
+)
+
+PythonOperator(
+    task_id='extract_polygons',
+    provide_context=True,    
+    python_callable=extract_polygon,
+    dag=dag
+)

--- a/app-tasks/requirements.txt
+++ b/app-tasks/requirements.txt
@@ -1,0 +1,5 @@
+boto3==1.3.1
+airflow[async,celery,crypto,hive,password,postgres,s3,slack]==1.7.1.3
+redis==2.10.5
+pytest==2.9.2
+pytest-runner==2.9

--- a/app-tasks/rf/.gitignore
+++ b/app-tasks/rf/.gitignore
@@ -1,0 +1,64 @@
+*.py[cod]
+
+# C extensions
+*.so
+
+# Packages
+*.egg
+*.egg-info
+dist
+build
+eggs
+.eggs
+parts
+bin
+var
+sdist
+wheelhouse
+develop-eggs
+.installed.cfg
+lib
+lib64
+venv*/
+pyvenv*/
+
+# Installer logs
+pip-log.txt
+
+# Unit test / coverage reports
+.coverage
+.tox
+.coverage.*
+nosetests.xml
+coverage.xml
+htmlcov
+
+# Translations
+*.mo
+
+# Mr Developer
+.mr.developer.cfg
+.project
+.pydevproject
+.idea
+*.iml
+*.komodoproject
+
+# Complexity
+output/*.html
+output/*/index.html
+
+# Sphinx
+docs/_build
+
+.DS_Store
+*~
+.*.sw[po]
+.build
+.ve
+.env
+.cache
+.pytest
+.bootstrap
+.appveyor.token
+*.bak

--- a/app-tasks/rf/MANIFEST.in
+++ b/app-tasks/rf/MANIFEST.in
@@ -1,0 +1,13 @@
+graft docs
+graft examples
+graft src
+graft ci
+graft tests
+
+include .bumpversion.cfg
+include .coveragerc
+include .cookiecutterrc
+include .editorconfig
+include .isort.cfg
+
+global-exclude *.py[cod] __pycache__ *.so *.dylib

--- a/app-tasks/rf/setup.cfg
+++ b/app-tasks/rf/setup.cfg
@@ -1,0 +1,18 @@
+[bdist_wheel]
+universal = 1
+
+[flake8]
+max-line-length = 140
+exclude = tests/*,*/migrations/*,*/south_migrations/*
+
+[aliases]
+test=pytest
+
+[isort]
+force_single_line=True
+line_length=120
+known_first_party=rf
+default_section=THIRDPARTY
+forced_separate=test_rf
+not_skip = __init__.py
+skip = migrations, south_migrations

--- a/app-tasks/rf/setup.py
+++ b/app-tasks/rf/setup.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python
+from __future__ import absolute_import
+from __future__ import print_function
+
+import io
+from glob import glob
+from os.path import basename
+from os.path import dirname
+from os.path import join
+from os.path import splitext
+
+from setuptools import find_packages
+from setuptools import setup
+
+
+def read(*names, **kwargs):
+    return io.open(
+        join(dirname(__file__), *names),
+        encoding=kwargs.get('encoding', 'utf8')
+    ).read()
+
+
+setup(
+    name='rf',
+    version='0.1.0',
+    license='Apache',
+    description='An application to import, process, and export raster imagery.',
+    author='Azavea',
+    author_email='systems+rf@azavea.com',
+    url='https://github.com/azavea/raster-foundry',
+    packages=find_packages('src'),
+    package_dir={'': 'src'},
+    py_modules=[splitext(basename(path))[0] for path in glob('src/*.py')],
+    include_package_data=True,
+    zip_safe=False,
+    classifiers=[
+        # complete classifier list: http://pypi.python.org/pypi?%3Aaction=list_classifiers
+        'Development Status :: 5 - Production/Stable',
+        'Intended Audience :: Developers',
+        'License :: OSI Approved :: BSD License',
+        'Operating System :: Unix',
+        'Operating System :: POSIX',
+        'Operating System :: Microsoft :: Windows',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: Implementation :: CPython',
+        'Programming Language :: Python :: Implementation :: PyPy',
+        # uncomment if you test on these interpreters:
+        # 'Programming Language :: Python :: Implementation :: IronPython',
+        # 'Programming Language :: Python :: Implementation :: Jython',
+        # 'Programming Language :: Python :: Implementation :: Stackless',
+        'Topic :: Utilities',
+    ],
+    keywords=[
+        # eg: 'keyword1', 'keyword2', 'keyword3',
+    ],
+    install_requires=[
+        # eg: 'aspectlib==1.1.1', 'six>=1.7',
+    ],
+    extras_require={
+        # eg:
+        #   'rst': ['docutils>=0.11'],
+        #   ':python_version=="2.6"': ['argparse'],
+    },
+)

--- a/app-tasks/rf/src/rf/__init__.py
+++ b/app-tasks/rf/src/rf/__init__.py
@@ -1,0 +1,6 @@
+__version__ = "0.1.0"
+
+import logging
+from logging import NullHandler
+
+logging.getLogger(__name__).addHandler(NullHandler())

--- a/app-tasks/rf/src/rf/uploads/geotiff/__init__.py
+++ b/app-tasks/rf/src/rf/uploads/geotiff/__init__.py
@@ -1,0 +1,3 @@
+from .create_thumbnail import create_thumbnail
+from .extract_metadata import extract_metadata
+from .extract_footprint import extract_footprint

--- a/app-tasks/rf/src/rf/uploads/geotiff/create_thumbnail.py
+++ b/app-tasks/rf/src/rf/uploads/geotiff/create_thumbnail.py
@@ -1,0 +1,7 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+def create_thumbnail(tif_path):
+    logger.info('Creating Thumbnail for %s', tif_path)
+    return tif_path

--- a/app-tasks/rf/src/rf/uploads/geotiff/extract_footprint.py
+++ b/app-tasks/rf/src/rf/uploads/geotiff/extract_footprint.py
@@ -1,0 +1,7 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+def extract_footprint(tif_path):
+    logger.info('Extracting footprint for %s', tif_path)
+    return tif_path

--- a/app-tasks/rf/src/rf/uploads/geotiff/extract_metadata.py
+++ b/app-tasks/rf/src/rf/uploads/geotiff/extract_metadata.py
@@ -1,0 +1,7 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+def extract_metadata(tif_path):
+    logger.info('Extracting metadata for %s', tif_path)
+    return tif_path

--- a/app-tasks/rf/src/rf/utils/io.py
+++ b/app-tasks/rf/src/rf/utils/io.py
@@ -1,0 +1,32 @@
+import os
+from urlparse import urlparse
+
+import boto3
+
+
+def delete_file(fname):
+    """Helper function to delete a file without raising an error if it exists"""
+
+    try:
+        os.remove(fname)
+    except OSError:
+        pass
+
+
+def create_s3_obj(url):
+    """Helper function to create an S3 object from a URL
+
+    This function's purpose is to create a boto s3 object from a URL
+
+    Args:
+        url (str): either an s3 or https URL for an object stored in S3
+    """
+    s3 = boto3.resource('s3')
+    parsed_url = urlparse(url)
+    if parsed_url.scheme == 's3':
+        return s3.Object(parsed_url.netloc, parsed_url.path)
+    elif parsed_url.scheme == 'https' and parsed_url.netloc == 's3.amazonaws.com':
+        parts = parsed_url.path[1:].split('/')
+        bucket = parts[0]
+        key = '/'.join(parts[1:])
+        return s3.Object(bucket, key)

--- a/app-tasks/rf/tests/test_rf.py
+++ b/app-tasks/rf/tests/test_rf.py
@@ -1,0 +1,11 @@
+
+import rf
+
+import unittest
+
+
+class RasterFoundryTestCase(unittest.TestCase):
+    """Test that we can import raster foundry"""
+
+    def test_rf(self):
+        assert rf  # use your library here

--- a/app-tasks/usr/local/airflow/airflow.cfg
+++ b/app-tasks/usr/local/airflow/airflow.cfg
@@ -28,7 +28,7 @@ executor = CeleryExecutor
 # The SqlAlchemy connection string to the metadata database.
 # SqlAlchemy supports many different database engine, more information
 # their website
-sql_alchemy_conn = postgresql+psycopg2://${POSTGRES_USER}:${POSTGRES_PASSWORD}@database.raster-foundry.internal/${POSTGRES_DB}
+sql_alchemy_conn = postgresql+psycopg2://${POSTGRES_USER}:${POSTGRES_PASSWORD}@database.raster-foundry.internal/${AIRFLOW_POSTGRES_DB}
 
 # The SqlAlchemy pool size is the maximum number of database connections
 # in the pool.

--- a/app-tasks/usr/local/airflow/airflow.cfg
+++ b/app-tasks/usr/local/airflow/airflow.cfg
@@ -1,0 +1,214 @@
+[core]
+# The home folder for airflow, default is ~/airflow
+airflow_home = /usr/local/airflow
+
+# The folder where your airflow pipelines live, most likely a
+# subfolder in a code repository
+dags_folder = /opt/raster-foundry/app-tasks/dags
+
+# The folder where airflow should store its log files. This location
+base_log_folder = /usr/local/airflow/logs
+
+# Airflow can store logs remotely in AWS S3 or Google Cloud Storage. Users
+# must supply a remote location URL (starting with either 's3://...' or
+# 'gs://...') and an Airflow connection id that provides access to the storage
+# location.
+remote_base_log_folder =
+remote_log_conn_id =
+
+# Use server-side encryption for logs stored in S3
+encrypt_s3_logs = False
+# deprecated option for remote log storage, use remote_base_log_folder instead!
+# s3_log_folder =
+
+# The executor class that airflow should use. Choices include
+# SequentialExecutor, LocalExecutor, CeleryExecutor
+executor = CeleryExecutor
+
+# The SqlAlchemy connection string to the metadata database.
+# SqlAlchemy supports many different database engine, more information
+# their website
+sql_alchemy_conn = postgresql+psycopg2://${POSTGRES_USER}:${POSTGRES_PASSWORD}@database.raster-foundry.internal/${POSTGRES_DB}
+
+# The SqlAlchemy pool size is the maximum number of database connections
+# in the pool.
+sql_alchemy_pool_size = 5
+
+# The SqlAlchemy pool recycle is the number of seconds a connection
+# can be idle in the pool before it is invalidated. This config does
+# not apply to sqlite.
+sql_alchemy_pool_recycle = 3600
+
+# The amount of parallelism as a setting to the executor. This defines
+# the max number of task instances that should run simultaneously
+# on this airflow installation
+parallelism = 32
+
+# The number of task instances allowed to run concurrently by the scheduler
+dag_concurrency = 16
+
+# Are DAGs paused by default at creation
+dags_are_paused_at_creation = False
+
+# The maximum number of active DAG runs per DAG
+max_active_runs_per_dag = 16
+
+# Whether to load the examples that ship with Airflow. It's good to
+# get started, but you probably want to set this to False in a production
+# environment
+load_examples = False
+
+# Where your Airflow plugins are stored
+plugins_folder = /usr/local/airflow/plugins
+
+# Secret key to save connection passwords in the db
+fernet_key = ${AIRFLOW_SECRET_KEY}
+
+# Whether to disable pickling dags
+donot_pickle = False
+
+# How long before timing out a python file import while filling the DagBag
+dagbag_import_timeout = 30
+
+[webserver]
+# The base url of your website as airflow cannot guess what domain or
+# cname you are using. This is use in automated emails that
+# airflow sends to point links to the right web server
+base_url = http://localhost:8080
+
+# The ip specified when starting the web server
+web_server_host = 0.0.0.0
+
+# The port on which to run the web server
+web_server_port = 8080
+
+# The time the gunicorn webserver waits before timing out on a worker
+web_server_worker_timeout = 120
+
+# Secret key used to run your flask app
+secret_key = temporary_key
+
+# Number of workers to run the Gunicorn web server
+workers = 4
+
+# The worker class gunicorn should use. Choices include
+# sync (default), eventlet, gevent
+worker_class = sync
+
+# Expose the configuration file in the web server
+expose_config = true
+
+# Set to true to turn on authentication : http://pythonhosted.org/airflow/installation.html#web-authentication
+authenticate = False
+
+# Filter the list of dags by owner name (requires authentication to be enabled)
+filter_by_owner = False
+
+[email]
+email_backend = airflow.utils.send_email_smtp
+
+[smtp]
+# If you want airflow to send emails on retries, failure, and you want to
+# the airflow.utils.send_email function, you have to configure an smtp
+# server here
+smtp_host = localhost
+smtp_starttls = True
+smtp_ssl = False
+smtp_user = airflow
+smtp_port = 25
+smtp_password = airflow
+smtp_mail_from = airflow@airflow.local
+
+[celery]
+# This section only applies if you are using the CeleryExecutor in
+# [core] section above
+
+# The app name that will be used by celery
+celery_app_name = airflow.executors.celery_executor
+
+# The concurrency that will be used when starting workers with the
+# "airflow worker" command. This defines the number of task instances that
+# a worker will take, so size up your workers based on the resources on
+# your worker box and the nature of your tasks
+celeryd_concurrency = 16
+
+# When you start an airflow worker, airflow starts a tiny web server
+# subprocess to serve the workers local log files to the airflow main
+# web server, who then builds pages and sends them to users. This defines
+# the port on which the logs are served. It needs to be unused, and open
+# visible from the main web server to connect into the workers.
+worker_log_server_port = 8793
+
+# The Celery broker URL. Celery supports RabbitMQ, Redis and experimentally
+# a sqlalchemy database. Refer to the Celery documentation for more
+# information.
+broker_url = redis://redis.raster-foundry.internal:6379/0
+
+# Another key Celery setting
+celery_result_backend = redis://redis.raster-foundry.internal:6379/0
+
+# Celery Flower is a sweet UI for Celery. Airflow has a shortcut to start
+# it `airflow flower`. This defines the port that Celery Flower runs on
+flower_port = 5555
+
+# Default queue that tasks get assigned to and that worker listen on.
+default_queue = default
+
+[scheduler]
+# Task instances listen for external kill signal (when you clear tasks
+# from the CLI or the UI), this defines the frequency at which they should
+# listen (in seconds).
+job_heartbeat_sec = 5
+
+# The scheduler constantly tries to trigger new tasks (look at the
+# scheduler section in the docs for more information). This defines
+# how often the scheduler should run (in seconds).
+scheduler_heartbeat_sec = 5
+
+# Statsd (https://github.com/etsy/statsd) integration settings
+# statsd_on =  False
+# statsd_host =  localhost
+# statsd_port =  8125
+# statsd_prefix = airflow
+
+# The scheduler can run multiple threads in parallel to schedule dags.
+# This defines how many threads will run. However airflow will never
+# use more threads than the amount of cpu cores available.
+max_threads = 4
+
+[mesos]
+# Mesos master address which MesosExecutor will connect to.
+master = localhost:5050
+
+# The framework name which Airflow scheduler will register itself as on mesos
+framework_name = Airflow
+
+# Number of cpu cores required for running one task instance using
+# 'airflow run <dag_id> <task_id> <execution_date> --local -p <pickle_id>'
+# command on a mesos slave
+task_cpu = 1
+
+# Memory in MB required for running one task instance using
+# 'airflow run <dag_id> <task_id> <execution_date> --local -p <pickle_id>'
+# command on a mesos slave
+task_memory = 256
+
+# Enable framework checkpointing for mesos
+# See http://mesos.apache.org/documentation/latest/slave-recovery/
+checkpoint = False
+
+# Failover timeout in milliseconds.
+# When checkpointing is enabled and this option is set, Mesos waits
+# until the configured timeout for
+# the MesosExecutor framework to re-register after a failover. Mesos
+# shuts down running tasks if the
+# MesosExecutor framework fails to re-register within this timeframe.
+# failover_timeout = 604800
+
+# Enable framework authentication for mesos
+# See http://mesos.apache.org/documentation/latest/configuration/
+authenticate = False
+
+# Mesos credentials, if authentication is enabled
+# default_principal = admin
+# default_secret = admin

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,17 @@ services:
     ports:
       - "5432:5432"
 
+  nginx:
+    image: nginx
+    ports:
+      - "9100:443"
+    links:
+      - app-server
+    volumes:
+      - ./nginx/srv/dist/:/srv/dist/
+      - ./nginx/etc/nginx/nginx.conf:/etc/nginx/nginx.conf
+      - ./nginx/etc/nginx/conf.d/default.conf:/etc/nginx/conf.d/default.conf
+
   app-frontend:
     image: node:4.4.7-wheezy
     working_dir: /opt/raster-foundry/app-frontend/
@@ -39,15 +50,85 @@ services:
   swagger-editor:
     image: swaggerapi/swagger-editor:latest
     ports:
-      - "8080:8080"
+      - "8888:8080"
 
-  nginx:
-    image: nginx
-    ports:
-      - "9100:443"
-    links:
-      - app-server
+  redis:
+    image: redis:3-alpine
+
+  airflow-webserver:
+    image: raster-foundry-airflow
     volumes:
-      - ./nginx/srv/dist/:/srv/dist/
-      - ./nginx/etc/nginx/nginx.conf:/etc/nginx/nginx.conf
-      - ./nginx/etc/nginx/conf.d/default.conf:/etc/nginx/conf.d/default.conf
+      - ./app-tasks/usr/local/airflow/:/usr/local/airflow/
+      - ./app-tasks/dags/:/opt/raster-foundry/app-tasks/dags/
+      - ./app-tasks/rf/:/opt/raster-foundry/app-tasks/rf/
+      - ./app-tasks/rf/src/rf/:/usr/local/bin/rf/
+    build:
+      context: ./app-tasks
+      dockerfile: Dockerfile
+    env_file: .env
+    links:
+      - postgres:database.raster-foundry.internal
+      - redis:redis.raster-foundry.internal
+    environment:
+      - AIRFLOW_HOME=/usr/local/airflow
+    ports:
+      - "8080:8080"
+    command: airflow webserver
+
+  airflow-flower:
+    image: raster-foundry-airflow
+    volumes:
+      - ./app-tasks/usr/local/airflow/:/usr/local/airflow/
+    build:
+      context: ./app-tasks
+      dockerfile: Dockerfile
+    links:
+      - postgres:database.raster-foundry.internal
+      - redis:redis.raster-foundry.internal
+    env_file: .env
+    environment:
+      - AIRFLOW_HOME=/usr/local/airflow
+    ports:
+      - "5555:5555"
+    command: airflow flower
+
+  airflow-scheduler:
+    image: raster-foundry-airflow
+    volumes:
+      - ./app-tasks/usr/local/airflow/:/usr/local/airflow/
+      - ./app-tasks/dags/:/opt/raster-foundry/app-tasks/dags/
+      - ./app-tasks/rf/:/opt/raster-foundry/app-tasks/rf/
+      - ./app-tasks/rf/src/rf/:/usr/local/bin/rf/
+      - $HOME/.aws:/root/.aws:ro
+    build:
+      context: ./app-tasks
+      dockerfile: Dockerfile
+    restart: always
+    links:
+      - postgres:database.raster-foundry.internal
+      - redis:redis.raster-foundry.internal
+    env_file: .env
+    environment:
+      - AIRFLOW_HOME=/usr/local/airflow
+      - PYTHONPATH=/opt/raster-foundry/app-tasks/rf/src/
+    command: airflow scheduler
+
+  airflow-worker:
+    image: raster-foundry-airflow
+    volumes:
+      - ./app-tasks/usr/local/airflow/:/usr/local/airflow/
+      - ./app-tasks/dags/:/opt/raster-foundry/app-tasks/dags/
+      - ./app-tasks/rf/:/opt/raster-foundry/app-tasks/rf/
+      - ./app-tasks/rf/src/rf/:/usr/local/bin/rf/
+      - $HOME/.aws:/root/.aws:ro
+    build:
+      context: ./app-tasks
+      dockerfile: Dockerfile
+    links:
+      - postgres:database.raster-foundry.internal
+      - redis:redis.raster-foundry.internal
+    env_file: .env
+    environment:
+      - AIRFLOW_HOME=/usr/local/airflow
+      - C_FORCE_ROOT=True
+    command: airflow worker

--- a/docs/architecture/adr-0006-workflow-manager.md
+++ b/docs/architecture/adr-0006-workflow-manager.md
@@ -1,0 +1,46 @@
+# 0006 - Workflow/Task Manager
+
+## Context
+
+Some actions and features of Raster Foundry require a way to manage asynchronous tasks and workflows. 
+For instance, user uploads of imagery or models may start workflows in an ad hoc manner, while in
+contrast imports of imagery from NASA or partners may need to happen on a schedule. The nature of
+these tasks could vary from bash scripts and python functions to spark jobs and ECS tasks.
+
+The ideal tool will provide some means to monitor task progress, retry on some failures, and 
+notify personnel if necessary. There are a few options of tools we can use: celery, SWF, Luigi, and Airflow.
+Azavea has experience working with both celery and SWF; however, due to our past experience with these
+tools it seemed prudent to explore additional options as well.
+
+| Workflow Tool   | Pros | Cons |
+|-----------------|------|------|
+| Celery          | Familiar, written in python, flexible | Provides poor primitives for workflows, many open issues, difficult to monitor workflows |
+| SWF (botoflow)) | Familiar, now written in python, maintaining state is not our responsibility (HA by default), great primitives for workflows and tasks | Difficult to monitor, relatively immature tools and projects, not many others using it |
+| Luigi           | Mature, seems to be stable, written in python | Unfamiliar execution model, primarily designed for scheduled, recurring task |
+| Airflow         | Mature, stable, fits into our execution model, written in python, excellent UI | Requires celery (for what we want to do)), requires managing the scheduler and a cache |
+## Decision
+
+Raster Foundry will use Airflow as a task manager. There are a number of advantages over some of the
+alternatives. First, Airflow has a large, active, user base that have used it in production. The 
+project itself is in the Apache incubator, providing a strong signal that the project is of high quality
+Second, Airflow's UI for monitoring task and workflow progress is great. It provides 
+high-level relevant information that will enable us to diagnose issues quickly. Additionally, it
+provides a means to view log output of tasks directly in the admin interface. Third, Airflow 
+supports both scheduled and ad hoc tasks. Lastly, Airflow's architecture would re-use many 
+components that will already be a part of Raster Foundry's infrastructure - including a Postgres
+database and a redis cache.
+
+## Consequences and Alternatives
+
+As a result of choosing Airflow we will need to become more familiar with it as a tool. However,
+the documentation is good and always getting better. Additionally, we may need to extend its 
+functionality if it is lacking in some area; however, that is unlikely to be the case in the
+short-term.
+
+While ideal in many aspects, there are a few areas that Airflow does not necessarily provide the
+greatest of tools out of the box. For instance, it is possible to approach versioning of 
+tasks/workflows from a few  different ways, but there is not an obviously best way. Because tasks will be
+run inside the container of the worker itself, we will need to do one of the following:
+ - ensure that all dependencies for all  tasks are installed in that container
+ - write an Airflow operator that can run ECS task definitions
+ - use queues to manage which workers take which jobs

--- a/scripts/bootstrap
+++ b/scripts/bootstrap
@@ -23,10 +23,12 @@ function main() {
     popd
 
     echo "Building/Pulling containers..."
-    # Pull images for postgres and scala
     docker-compose \
         -f "${DIR}/../docker-compose.yml" \
-        pull
+        build
+    docker-compose \
+        -f "${DIR}/../docker-compose.yml" \
+        pull nginx postgres swagger-editor redis
 }
 
 

--- a/scripts/server
+++ b/scripts/server
@@ -19,7 +19,16 @@ then
     then
         usage
     else
-         docker-compose -f "${DIR}/../docker-compose.yml" up app-server nginx swagger-editor postgres
+        docker-compose -f "${DIR}/../docker-compose.yml" up \
+                       app-server \
+                       nginx \
+                       swagger-editor \
+                       postgres \
+                       airflow-worker \
+                       airflow-webserver \
+                       airflow-scheduler \
+                       airflow-flower \
+                       redis
     fi
     exit
 fi

--- a/scripts/setup
+++ b/scripts/setup
@@ -26,6 +26,7 @@ then
         # app-frontend
         docker-compose -f "${DIR}/../docker-compose.yml" run --rm app-frontend npm install
         docker-compose -f "${DIR}/../docker-compose.yml" run --rm app-frontend npm run build
+        docker-compose -f "${DIR}/../docker-compose.yml" run --rm airflow-webserver airflow initdb
     fi
     exit
 fi

--- a/scripts/setup
+++ b/scripts/setup
@@ -14,19 +14,61 @@ Basic project setup
 }
 
 
+function check_database() {
+    # Check if database is set up to continue
+
+    max=21 # 1 minute
+    counter=1
+    while true
+    do
+        echo "Checking if database is up yet (try ${counter})..."
+        set +e
+        docker-compose -f "${DIR}/../docker-compose.yml" exec postgres gosu postgres psql -d rasterfoundry -c 'select 1' >/dev/null 2>/dev/null
+        status_check=$?
+        if [ $status_check == 0 ]
+        then
+            echo "Connected to database successfully"
+            break
+        fi
+        set -e
+        if [[ ${counter} == "${max}" ]]
+        then
+            echo "Could not connect to database after some time"
+            exit 1
+        fi
+        sleep 3
+        (( counter++ ))
+    done
+}
+
+
+function create_airflow_database() {
+    docker-compose -f "${DIR}/../docker-compose.yml" up -d postgres
+    check_database
+    set +e
+    # Create database (have to ignore errors if database already exists)
+    docker-compose -f "${DIR}/../docker-compose.yml" exec postgres gosu postgres createdb airflow >/dev/null 2>/dev/null
+    set -e
+    docker-compose -f "${DIR}/../docker-compose.yml" run --rm airflow-webserver airflow initdb
+    docker-compose -f "${DIR}/../docker-compose.yml" stop postgres
+}
+
+
 if [ "${BASH_SOURCE[0]}" = "${0}" ]
 then
     if [ "${1:-}" = "--help" ]
     then
         usage
     else
+        # Create airflow database
+        create_airflow_database
+
         # app-server
         docker-compose -f "${DIR}/../docker-compose.yml" run --rm app-server sbt update
 
         # app-frontend
         docker-compose -f "${DIR}/../docker-compose.yml" run --rm app-frontend npm install
         docker-compose -f "${DIR}/../docker-compose.yml" run --rm app-frontend npm run build
-        docker-compose -f "${DIR}/../docker-compose.yml" run --rm airflow-webserver airflow initdb
     fi
     exit
 fi

--- a/scripts/setup
+++ b/scripts/setup
@@ -23,7 +23,7 @@ function check_database() {
     do
         echo "Checking if database is up yet (try ${counter})..."
         set +e
-        docker-compose -f "${DIR}/../docker-compose.yml" exec postgres gosu postgres psql -d rasterfoundry -c 'select 1' >/dev/null 2>/dev/null
+        docker-compose -f "${DIR}/../docker-compose.yml" exec -T postgres gosu postgres psql -d rasterfoundry -c 'select 1' >/dev/null 2>/dev/null
         status_check=$?
         if [ $status_check == 0 ]
         then
@@ -47,7 +47,7 @@ function create_airflow_database() {
     check_database
     set +e
     # Create database (have to ignore errors if database already exists)
-    docker-compose -f "${DIR}/../docker-compose.yml" exec postgres gosu postgres createdb airflow >/dev/null 2>/dev/null
+    docker-compose -f "${DIR}/../docker-compose.yml" exec -T postgres gosu postgres createdb airflow >/dev/null 2>/dev/null
     set -e
     docker-compose -f "${DIR}/../docker-compose.yml" run --rm airflow-webserver airflow initdb
     docker-compose -f "${DIR}/../docker-compose.yml" stop postgres

--- a/scripts/test
+++ b/scripts/test
@@ -43,6 +43,12 @@ then
             --entrypoint "/bin/bash -c" \
             app-frontend "npm run test"
 
+        # Run tests for app tasks library
+        docker-compose \
+            -f "${DIR}/../docker-compose.yml" run \
+            --rm --entrypoint "/bin/bash -c" airflow-worker \
+            "cd /opt/raster-foundry/app-tasks/rf && python setup.py test"
+
     fi
     exit
 fi


### PR DESCRIPTION
This commit adds a prototype for using airflow for task management. A
simple DAG is added to simulate an import of a single geotiff that would
cause 3 tasks to be kicked off:
 - metadata extraction
 - footprint extraction
 - thumbnail generation

Airflow itself has a web UI that this commit adds for opening up on
port 8080. Flower is used for monitoring celery workers, which the
airflow worker uses for parallelization of tasks. A redis instance is
added as a broker for the celery workers.

There may be a few minor things that need to be cleaned up if we wanted to go with this, but I think this is most of the way there.

## Testing
1. Restart your VM and provision: `vagrant reload --provision`
2. Start server `./scripts/server`
3. Log output shouldn't show any failures. After the web server starts you should be able to open [`localhost:8080'](http://localhost:8080) and see the admin interface.
    ![airflow-home](https://cloud.githubusercontent.com/assets/898060/17341786/3ceefebc-58c4-11e6-97b6-02e2c261f33c.png)
4. Kick off a `DAG` by running: `./scripts/console airflow-worker "airflow trigger_dag import_tif_image --conf='{\"tif_path\": \"s3://rf/ex.tif\"}'"`
5. Observe some log output that it ran: 

    ```
airflow-worker_1     | [2016-08-02 19:12:50,654] {__init__.py:36} INFO - Using executor CeleryExecutor
airflow-worker_1     | [2016-08-02 19:12:50,665] {__init__.py:36} INFO - Using executor CeleryExecutor
airflow-worker_1     | [2016-08-02 19:12:50,745] {__init__.py:36} INFO - Using executor CeleryExecutor
airflow-worker_1     | 2016-08-02 19:12:51,387 - rf.uploads.geotiff.extract_metadata - INFO - Extracting metadata for s3://rf/ex.tif
airflow-worker_1     | 2016-08-02 19:12:51,514 - rf.uploads.geotiff.extract_footprint - INFO - Extracting footprint for s3://rf/ex.tif
postgres_1           | 2016-08-02 19:12:51 UTC [29-1] rasterfoundry@rasterfoundry LOG:  could not receive data from client: Connection reset by peer
postgres_1           | 2016-08-02 19:12:51 UTC [31-1] rasterfoundry@rasterfoundry LOG:  could not receive data from client: Connection reset by peer
airflow-worker_1     | 2016-08-02 19:12:51,697 - rf.uploads.geotiff.create_thumbnail - INFO - Creating Thumbnail for s3://rf/ex.tif
```
6. Browse through the UI looking at log output for tasks (should be printed) and looking at graphs, etc. You can kick off more to see how it changes over time too.

     ![log-imoprt-fig](https://cloud.githubusercontent.com/assets/898060/17341791/4133153a-58c4-11e6-80f0-12e7b064ae57.png)

7. Check out the flower ui at [`localhost:5555`](http://localhost:5555) to check out stats about the celery workers running
    ![flower-home](https://cloud.githubusercontent.com/assets/898060/17341834/74b8e79a-58c4-11e6-88df-00c58303c0e5.png)

