### PR TITLE
Add authentication directive to authenticate users

### DIFF
--- a/app-server/app/src/main/scala/Main.scala
+++ b/app-server/app/src/main/scala/Main.scala
@@ -6,14 +6,13 @@ import akka.stream.ActorMaterializer
 
 import com.azavea.rf.utils.{Config, Database}
 
-object Main extends App with Config {
+object Main extends App with Config with Router {
 
   implicit val system = ActorSystem("rf-system")
   implicit val materializer = ActorMaterializer()
-  implicit val executionContext = system.dispatcher
+  implicit val ec = system.dispatcher
   implicit val database = new Database(jdbcUrl, dbUser, dbPassword)
-  val router = new Router()
 
-  Http().bindAndHandle(router.routes, httpHost, httpPort)
+  Http().bindAndHandle(routes, httpHost, httpPort)
 
 }

--- a/app-server/app/src/main/scala/Router.scala
+++ b/app-server/app/src/main/scala/Router.scala
@@ -14,9 +14,12 @@ import akka.http.scaladsl.server.Directives._
   * Actual routes should be written in the relevant feature as much as is feasible
   * 
   */
-class Router()(implicit db:Database, ec:ExecutionContext) extends HealthCheckRoutes with UserRoutes {
+trait Router extends HealthCheckRoutes with UserRoutes {
 
-  val routes = healthCheckRoutes() ~
-    userRoutes()
+  implicit val database: Database
+  implicit val ec: ExecutionContext
 
+  val routes =
+    healthCheckRoutes ~
+    userRoutes
 }

--- a/app-server/app/src/main/scala/auth/Authentication.scala
+++ b/app-server/app/src/main/scala/auth/Authentication.scala
@@ -26,12 +26,15 @@ trait Authentication extends Directives with Config {
   lazy val anonymousUser:Future[Option[UsersRow]] = UserService.getUserByEmail("info+raster.foundry@azavea.com")
 
   // HTTP Challenge to use for Authentication failures
-  lazy val challenge = HttpChallenge("Token", "https://rasterfoundry.com")
+  lazy val challenge = HttpChallenge("Bearer", "https://rasterfoundry.com")
 
   /**
     * Handle validating Json Web Token - optionally returns token
+    *
+    * @param bearerToken bearer token of the form Bearer <token>
     */
-  def validateJWT(token:String): Directive1[UsersRow] = {
+  def validateJWT(bearerToken:String): Directive1[UsersRow] = {
+    val token = bearerToken.split(" ").last
     val jwt = JsonWebToken.read(token, auth0Secret) match {
       case Right(token) => Some(token)
       case _ => None

--- a/app-server/app/src/main/scala/auth/Authentication.scala
+++ b/app-server/app/src/main/scala/auth/Authentication.scala
@@ -1,0 +1,79 @@
+package com.azavea.rf.auth
+
+import scala.concurrent.{Future, ExecutionContext}
+
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.model.headers._
+import akka.http.scaladsl.server._
+import akka.http.scaladsl.server.AuthenticationFailedRejection.CredentialsRejected
+import akka.http.scaladsl.server.directives.AuthenticationResult
+
+import de.choffmeister.auth.common.JsonWebToken
+
+import com.azavea.rf.datamodel.latest.schema.tables._
+import com.azavea.rf.utils.{Config, Database}
+import com.azavea.rf.user.UserService
+
+
+trait Authentication extends Directives with Config {
+
+  implicit val database: Database
+  implicit val ec: ExecutionContext
+
+  import database.driver.api._
+
+  // Default user returned when no credentials are provided
+  lazy val anonymousUser:Future[Option[UsersRow]] = UserService.getUserByEmail("info+raster.foundry@azavea.com")
+
+  // HTTP Challenge to use for Authentication failures
+  lazy val challenge = HttpChallenge("Token", "https://rasterfoundry.com")
+
+  /**
+    * Handle validating Json Web Token - optionally returns token
+    */
+  def validateJWT(token:String): Directive1[UsersRow] = {
+    val jwt = JsonWebToken.read(token, auth0Secret) match {
+      case Right(token) => Some(token)
+      case _ => None
+    }
+    jwt match {
+      case Some(valid) => {
+        val email = valid.claimAsString("email").right.get
+        onSuccess(UserService.getUserByEmail(email)).flatMap {
+          case Some(user) => provide(user)
+          case None => reject(AuthenticationFailedRejection(CredentialsRejected, challenge))
+        }
+      }
+      case _ => reject(AuthenticationFailedRejection(CredentialsRejected, challenge))
+    }
+  }
+
+  /**
+    * Authenticates requests and provides a User to requests
+    * 
+    * - Rejects invalid credentials
+    * - Allows anonymous users if credentials are provided
+    * - If credentials are valid, but user does not exist, rejects
+    */
+  def authenticateAndAllowAnonymous: Directive1[UsersRow] = {
+    optionalHeaderValueByName("Authorization").flatMap {
+      case Some(token) => validateJWT(token)
+      // No credentials = anonymous user, if can't get that then an error occurred
+      case _ => onSuccess(anonymousUser).flatMap {
+        case Some(user) => provide(user)
+        case None => complete(StatusCodes.InternalServerError)
+      }
+    }
+  }
+
+  /**
+    * Authenticates requests and requires a valid user
+    *
+    */
+  def authenticate: Directive1[UsersRow] = {
+    optionalHeaderValueByName("Authorization").flatMap {
+      case Some(token) => validateJWT(token)
+      case _ => reject(AuthenticationFailedRejection(CredentialsRejected, challenge))
+    }
+  }
+}

--- a/app-server/app/src/main/scala/user/Routes.scala
+++ b/app-server/app/src/main/scala/user/Routes.scala
@@ -7,48 +7,53 @@ import akka.http.scaladsl.server.PathMatchers.JavaUUID
 import akka.http.scaladsl.model.StatusCodes
 
 import com.azavea.rf.datamodel.latest.schema.tables.UsersRow
-
 import com.azavea.rf.utils.Database
-
+import com.azavea.rf.auth.Authentication
 
 /**
   * Routes for users
   */
-trait UserRoutes {
-  def userRoutes()(implicit db:Database, ec:ExecutionContext) = (
-    pathPrefix("api" / "users") {
-      pathEndOrSingleSlash {
-        get {
-          onSuccess(UserService.getUsers) {
-            resp => complete(resp)
-          }
-        } ~
-        post {
-          entity(as[UsersRow]) {
-            user =>
-            onSuccess(UserService.createUser(db, ec, user)) {
-              resp => complete((StatusCodes.Created, user))
+trait UserRoutes extends Authentication {
+
+  implicit val database: Database
+  implicit val ec: ExecutionContext
+
+  def userRoutes = (
+    authenticate { user =>
+      pathPrefix("api" / "users") {
+        pathEndOrSingleSlash {
+          get {
+            onSuccess(UserService.getUsers) {
+              resp => complete(resp)
+            }
+          } ~
+          post {
+            entity(as[UsersRow]) {
+              user =>
+              onSuccess(UserService.createUser(user)) {
+                resp => complete(StatusCodes.Created, user)
+              }
             }
           }
-        }
-      } ~
+        } ~
         pathPrefix(JavaUUID) { id =>
           pathEndOrSingleSlash {
             get {
-              onSuccess(UserService.getUserById(db, ec, id)) {
+              onSuccess(UserService.getUserById(id)) {
                 resp => complete(resp)
               }
             } ~
-              put {
-                entity(as[UsersRow]) {
-                  user =>
-                  onSuccess(UserService.updateUser(db, ec, user)) {
-                    resp => complete((StatusCodes.NoContent))
-                  }
+            put {
+              entity(as[UsersRow]) {
+                user =>
+                onSuccess(UserService.updateUser(user)) {
+                  resp => complete(StatusCodes.NoContent)
                 }
               }
+            }
           }
         }
+      }
     }
   )
 }

--- a/app-server/app/src/main/scala/user/User.scala
+++ b/app-server/app/src/main/scala/user/User.scala
@@ -1,6 +1,6 @@
 package com.azavea.rf.user
 
-import scala.concurrent.ExecutionContext
+import scala.concurrent.{Future, ExecutionContext}
 
 import com.azavea.rf.datamodel.latest.schema.tables.Users
 import com.azavea.rf.datamodel.latest.schema.tables.UsersRow
@@ -15,7 +15,7 @@ object UserService {
     }
   }
 
-  def getUserById(implicit database:Database, ec:ExecutionContext, id: java.util.UUID) = {
+  def getUserById(id: java.util.UUID)(implicit database:Database, ec:ExecutionContext) = {
     import database.driver.api._
 
     database.db.run {
@@ -23,15 +23,29 @@ object UserService {
     }
   }
 
-  def createUser(implicit database:Database, ec:ExecutionContext, user:UsersRow ) = {
+  def createUser(user:UsersRow)(implicit database:Database, ec:ExecutionContext) = {
     import database.driver.api._
+
     database.db.run {
       Users.forceInsert(user)
     }
   }
 
-  def updateUser(implicit database:Database, ec:ExecutionContext, user:UsersRow ) = {
+  def getUserByEmail(email:String)(implicit database:Database, ec:ExecutionContext):Future[Option[UsersRow]] = {
     import database.driver.api._
+
+    database.db.run {
+      Users.filter(_.email === email)
+        .sortBy(_.createdAt)
+        .take(1)
+        .result
+        .headOption
+    }
+  }
+
+  def updateUser(user:UsersRow)(implicit database:Database, ec:ExecutionContext) = {
+    import database.driver.api._
+
     database.db.run {
       Users.filter(_.id === user.id).update(user)
     }

--- a/app-server/app/src/main/scala/utils/Config.scala
+++ b/app-server/app/src/main/scala/utils/Config.scala
@@ -7,6 +7,7 @@ trait Config {
   private val config = ConfigFactory.load()
   private val httpConfig = config.getConfig("http")
   private val databaseConfig = config.getConfig("slick.db")
+  private val auth0Config = config.getConfig("auth0")
 
   val httpHost = httpConfig.getString("interface")
   val httpPort = httpConfig.getInt("port")
@@ -14,4 +15,6 @@ trait Config {
   val jdbcUrl = databaseConfig.getString("url")
   val dbUser = databaseConfig.getString("user")
   val dbPassword = databaseConfig.getString("password")
+
+  val auth0Secret = java.util.Base64.getUrlDecoder.decode(auth0Config.getString("secret"))
 }

--- a/app-server/build.sbt
+++ b/app-server/build.sbt
@@ -65,7 +65,9 @@ lazy val appDependencies = dbDependencies ++ loggingDependencies ++ Seq(
   Dependencies.akkajson,
   Dependencies.akkastream,
   Dependencies.akkatestkit,
-  Dependencies.scalatest
+  Dependencies.scalatest,
+  Dependencies.authCommon,
+  Dependencies.authAkka
 )
 
 lazy val migrationManagerDependencies = dbDependencies ++ forkliftDependencies

--- a/app-server/project/Dependencies.scala
+++ b/app-server/project/Dependencies.scala
@@ -14,4 +14,6 @@ object Dependencies {
   val scalatest     = "org.scalatest"      %% "scalatest" % Version.scalaTest % "test"
   val slf4j         = "org.slf4j"           % "slf4j-simple" % Version.slf4j
   val slick         = "com.typesafe.slick" %% "slick" % Version.slick
+  val authCommon    = "de.choffmeister"    %% "auth-common" % Version.akkaAuth
+  val authAkka      = "de.choffmeister"    %% "auth-akka-http" % Version.akkaAuth
 }

--- a/app-server/project/Version.scala
+++ b/app-server/project/Version.scala
@@ -12,4 +12,5 @@ object Version {
   val slf4j         = "1.6.4"
   val slick         = "3.1.1"
   val sprayjson     = "2.4.4"
+  val akkaAuth      = "0.2.0"
 }

--- a/app-server/project/plugins.sbt
+++ b/app-server/project/plugins.sbt
@@ -3,6 +3,8 @@ resolvers ++= Seq(
   Opts.resolver.sonatypeReleases
 )
 
+resolvers += Resolver.bintrayRepo("choffmeister", "maven")
+
 resolvers += Classpaths.typesafeResolver
 
 addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0")


### PR DESCRIPTION
This commit adds a directive to handle authentication. Authentication is
handled in the following way.

If a JSON web token provided in the Authorization header then one of
three things can happen:
 1. Token Valid and User in Database: request proceeds
 2. Token Valid and User _not_ in Database: rejected
 3. Token Invalid: rejected

If no Authentication is provided then an anonymous user is attached to
the request.

Also slightly cleans up the routes by converting them to traits.

We still need to do some work on `Authorization`, creating users if they are not in the database yet, and also determining what endpoints should allow anonymous users and not.

### Testing

1. Start up a development environment, running `vagrant up --provision` after switching to this branch
2. Start up the webpack server and log in
3. After logging in, grab your JWT
![screenshot from 2016-08-25 12 31 55](https://cloud.githubusercontent.com/assets/898060/17977551/2f8a8b0c-6ac0-11e6-8ef2-f6281d0c2554.png)
4. Start up the application server (`./scripts/server`)
5. Make the following requests and observe their output

| Request  | Response  |
|---|---|
| `curl localhost:9000/api/users`   | The supplied authentication is invalid   |
| `curl localhost:9000/healthcheck`   | Returns healthy status |
| `curl -H "Authorization: Not" localhost:9000/api/users/`  | The supplied authentication is invalid  |
| `curl -H "Authorization: <TOKEN>" localhost:9000/api/users/` | The supplied authentication is invalid |

At this point you can create your user with your email address with some SQL:

```
psql -h localhost -U rasterfoundry
# password rasterfoundry
```

```sql
CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
INSERT into users VALUES (
        uuid_generate_v4(),
        '2016-08-25T17:43:21+00:00',
        '2016-08-25T17:43:21+00:00',
        true,
        true,
        '<YOUR EMAIL>',
        '<YOUR FIRSTNAME>',
        '<YOUR LASTNAME>',
        '<UUID of ROOT ORG>'
);
```

Finally, make the request to the users endpoint with your token again: `curl -H "Authorization: <TOKEN>" localhost:9000/api/users/`. This time it should succeed.