### PR TITLE
Add support for publishing container images to ECR

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,11 +1,31 @@
 node {
-	stage 'checkout'
+  try {
+    stage 'checkout'
 
-	checkout scm
+    checkout scm
 
-	stage 'cibuild'
-	sh "scripts/cibuild"
-	
-	stage 'cipublish'
-	sh "sleep 3;"
+    stage 'cibuild'
+
+    wrap([$class: 'AnsiColorBuildWrapper']) {
+      sh 'scripts/cibuild'
+    }
+
+    stage 'cipublish'
+
+    if (env.BRANCH_NAME == 'develop') {
+      withCredentials([[$class: 'StringBinding', credentialsId: 'AWS_ECR_ENDPOINT', variable: 'AWS_ECR_ENDPOINT']]) {
+        wrap([$class: 'AnsiColorBuildWrapper']) {
+          env.AWS_DEFAULT_REGION = 'us-east-1'
+
+          sh './scripts/cipublish'
+        }
+      }
+
+      slackSend color: 'good', message: "raster-foundry/${env.BRANCH_NAME} #${env.BUILD_NUMBER}: Success! (<${env.BUILD_URL}|Open>)"
+    }
+  } catch (err) {
+    slackSend color: 'bad', message: "raster-foundry/${env.BRANCH_NAME} #${env.BUILD_NUMBER}: Failure! (<${env.BUILD_URL}|Open>)"
+
+    throw err
+  }
 }

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ There are three options to rebuild the static assets served by nginx:
  - run `npm run build` outside the VM
  - run `./scripts/console app-frontend "npm run build"`
  - run `./scripts/setup` (will also rebuild application server)
- 
+
 To run tests you can do one of the following (in order of speed):
  - run `npm run test` outside the VM (or `npm run test-watch`)
  - run `./scripts/console app-frontend "npm run test"` inside the VM
@@ -95,6 +95,8 @@ Helper and development scripts are located in the `./scripts` directory at the r
 | `server`    | Starts a development server                                  |
 | `console`   | Gives access to a running container via `docker-compose run` |
 | `test`      | Runs tests and linters for project                           |
+| `cibuild`   | Invoked by CI server and makes use of `test`.                |
+| `cipublish` | Publish container images to container image repositories.    |
 
 ## Testing
 

--- a/scripts/cipublish
+++ b/scripts/cipublish
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+set -e
+
+if [[ -n "${RF_DEBUG}" ]]; then
+    set -x
+fi
+
+function usage() {
+    echo -n \
+"Usage: $(basename "$0")
+
+Publish container images to Elastic Container Registry (ECR).
+"
+}
+
+if [[ -n "${GIT_COMMIT}" ]]; then
+    GIT_COMMIT="${GIT_COMMIT:0:7}"
+else
+    GIT_COMMIT="$(git rev-parse --short HEAD)"
+fi
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+    if [ "${1:-}" = "--help" ]; then
+        usage
+    else
+        if [[ -n "${AWS_ECR_ENDPOINT}" ]]; then
+            # Evaluate the return value of the get-login subcommand, which
+            # is a docker login command with temporarily ECR credentials.
+            eval "$(aws ecr get-login)"
+
+            docker tag "raster-foundry-nginx:${GIT_COMMIT}" \
+                   "${AWS_ECR_ENDPOINT}/raster-foundry-nginx:${GIT_COMMIT}"
+            docker tag "raster-foundry-app-server:${GIT_COMMIT}" \
+                   "${AWS_ECR_ENDPOINT}/raster-foundry-app-server:${GIT_COMMIT}"
+            docker tag "raster-foundry-airflow:${GIT_COMMIT}" \
+                   "${AWS_ECR_ENDPOINT}/raster-foundry-airflow:${GIT_COMMIT}"
+
+            docker push "${AWS_ECR_ENDPOINT}/raster-foundry-nginx:${GIT_COMMIT}"
+            docker push "${AWS_ECR_ENDPOINT}/raster-foundry-app-server:${GIT_COMMIT}"
+            docker push "${AWS_ECR_ENDPOINT}/raster-foundry-airflow:${GIT_COMMIT}"
+        else
+            echo "ERROR: No AWS_ECR_ENDPOINT variable defined."
+            exit 1
+        fi
+    fi
+fi


### PR DESCRIPTION
Adds a `cipublish` script responsible for authenticating with, and pushing container images to Amazon Container Registry (ECR).

Depends on https://github.com/azavea/raster-foundry/pull/431

---

**Testing**

Inspect the output of a successful job run [here](http://jenkins.staging.rasterfoundry.com/job/raster-foundry/job/raster-foundry/job/feature%252Fhmc%252Fcipublish/16/). Successful run is a bit artificial. Because the build is currently broken, I had to build container images manually on the server so that the images could be pushed to ECR.