### PR TITLE
Add support for infrastructure management via Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,8 @@
+#!groovy
+
 node {
+  currentBuild.result = 'SUCCESS'
+
   try {
     stage 'checkout'
 
@@ -10,22 +14,56 @@ node {
       sh 'scripts/cibuild'
     }
 
-    stage 'cipublish'
+    if (env.BRANCH_NAME == 'develop' || env.BRANCH_NAME.startsWith('release/')) {
+      env.AWS_DEFAULT_REGION = 'us-east-1'
+      env.RF_SETTINGS_BUCKET = 'rasterfoundry-staging-config-us-east-1'
 
-    if (env.BRANCH_NAME == 'develop') {
-      withCredentials([[$class: 'StringBinding', credentialsId: 'AWS_ECR_ENDPOINT', variable: 'AWS_ECR_ENDPOINT']]) {
+      stage 'cipublish'
+
+      withCredentials([[$class: 'StringBinding',
+                        credentialsId: 'AWS_ECR_ENDPOINT',
+                        variable: 'AWS_ECR_ENDPOINT']]) {
         wrap([$class: 'AnsiColorBuildWrapper']) {
-          env.AWS_DEFAULT_REGION = 'us-east-1'
-
           sh './scripts/cipublish'
         }
       }
 
-      slackSend color: 'good', message: "raster-foundry/${env.BRANCH_NAME} #${env.BUILD_NUMBER}: Success! (<${env.BUILD_URL}|Open>)"
+      stage 'infra'
+
+      checkout scm: [$class: 'GitSCM',
+                     branches: [[name: 'develop']],
+                     extensions: [[$class: 'RelativeTargetDirectory',
+                                   relativeTargetDir: 'raster-foundry-deployment']],
+                     userRemoteConfigs: [[credentialsId: '3bc1e878-814a-43d1-864e-2e378ebddb0f',
+                                          url: 'https://github.com/azavea/raster-foundry-deployment.git']]]
+
+      dir('raster-foundry-deployment') {
+        wrap([$class: 'AnsiColorBuildWrapper']) {
+          sh './scripts/infra plan'
+          sh './scripts/infra apply'
+        }
+      }
     }
   } catch (err) {
-    slackSend color: 'bad', message: "raster-foundry/${env.BRANCH_NAME} #${env.BUILD_NUMBER}: Failure! (<${env.BUILD_URL}|Open>)"
+    currentBuild.result = 'FAILURE'
 
     throw err
+  } finally {
+    def buildEmoji = (currentBuild.result == 'SUCCESS') ? ':thumbsup:' : ':jenkins-angry:'
+    def buildColor = (currentBuild.result == 'SUCCESS') ? 'good' : 'danger'
+
+    def slackMessage = "${buildEmoji} *raster-foundry (${env.BRANCH_NAME}) #${env.BUILD_NUMBER}*"
+    if (env.CHANGE_TITLE) {
+      slackMessage += "\n${env.CHANGE_TITLE} - ${env.CHANGE_AUTHOR}"
+    }
+    slackMessage += "\n<${env.BUILD_URL}|View Build>"
+
+    if (currentBuild.result == 'FAILURE' ||
+        (currentBuild.result == 'SUCCESS' &&
+         (env.BRANCH_NAME == 'develop'
+          || env.BRANCH_NAME.startsWith('release/')
+          || env.BRANCH_NAME.startsWith('PR-')))) {
+      slackSend color: buildColor, message: slackMessage
+    }
   }
 }

--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -8,3 +8,5 @@ shellcheck_version: "0.3.*"
 
 docker_users:
   - "{{ ansible_user }}"
+
+terraform_version: "0.7.2"

--- a/deployment/ansible/raster-foundry-jenkins.yml
+++ b/deployment/ansible/raster-foundry-jenkins.yml
@@ -9,6 +9,7 @@
 
   roles:
     - { role: azavea.ntp }
+    - { role: azavea.terraform }
     - { role: raster-foundry.aws-cli }
     - { role: raster-foundry.docker }
     - { role: raster-foundry.shellcheck }

--- a/deployment/ansible/roles.yml
+++ b/deployment/ansible/roles.yml
@@ -12,3 +12,6 @@
 
 - src: azavea.ntp
   version: 0.1.1
+
+- src: azavea.terraform
+  version: 0.2.0


### PR DESCRIPTION
First, add Terraform to the Ansible playbook for Jenkins. Then, add steps to execute `infra` from within the `raster-foundry` workspace on Jenkins.

Also, a bunch of logic was added to the `Jenkinsfile` to support more specific Slack messages (PR titles, build status, etc.). Overall, the message format was borrowed from Buildkite.

---

**Testing**

Attempt to execute the Terraform installation changes on Jenkins:

```bash
❯ ansible-galaxy install -r deployment/ansible/roles.yml -p deployment/ansible/roles
❯ ansible-playbook -i deployment/ansible/inventory/jenkins deployment/ansible/raster-foundry-jenkins.yml
```

Then, review the execution in [this](http://jenkins.staging.rasterfoundry.com/job/raster-foundry/job/raster-foundry/job/feature%252Fhmc%252Finfra/13/) Jenkins job to ensure that Terraform can be executed correctly.

I had to hardcode the branch name for the `cipublish` and `infra` blocks to `feature/hmc/infra`, and the branch of the `raster-foundry-deployment` repository to `feature/tnation/terraform-0.7`.