### PR TITLE
Remove swagger UI from nginx config

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ The Vagrant configuration maps the following host ports to services running in t
 | Airflow UI                | [`8080`](http://localhost:8080) | `RF_PORT_8080`       |
 | Airflow Flower            | [`5555`](http://localhost:5555) | `RF_PORT_5555`       |
 | Swagger Editor            | [`9090`](http://localhost:9090) | `RF_PORT_9090`       |
+| Swagger UI                | [`9999`](http://localhost:9999) | `RF_PORT_9999`       |
 
 
 ## Scripts

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,9 +16,8 @@ services:
     links:
       - app-server
     volumes:
-      - ./nginx/srv/dist/angular/:/srv/dist/angular/
+      - ./nginx/srv/dist/:/srv/dist/
       - ./nginx/etc/nginx/nginx.conf:/etc/nginx/nginx.conf
-      - ./docs/swagger/:/srv/dist/docs/swagger/
       - ./nginx/etc/nginx/conf.d/default.conf:/etc/nginx/conf.d/default.conf
 
   app-frontend:
@@ -27,7 +26,7 @@ services:
     volumes:
       - ./app-frontend/.babelrc:/opt/raster-foundry/app-frontend/.babelrc
       - ./app-frontend/config/:/opt/raster-foundry/app-frontend/config/
-      - ./nginx/srv/dist/angular/:/opt/raster-foundry/app-frontend/dist/
+      - ./nginx/srv/dist/:/opt/raster-foundry/app-frontend/dist/
       - ./app-frontend/.eslintrc:/opt/raster-foundry/app-frontend/.eslintrc
       - ./app-frontend/karma.conf.js:/opt/raster-foundry/app-frontend/karma.conf.js
       - ./.node_modules:/opt/raster-foundry/app-frontend/node_modules

--- a/docs/swagger/index.js
+++ b/docs/swagger/index.js
@@ -1,5 +1,5 @@
 $(function () {
-    var url = window.location.protocol + '//' + window.location.host + '/docs/swagger/spec.yml';
+    var url = window.location.protocol + '//' + window.location.host + '/spec.yml';
 
     // Pre load translate...
     if(window.SwaggerTranslator) {

--- a/nginx/etc/nginx/conf.d/default.conf
+++ b/nginx/etc/nginx/conf.d/default.conf
@@ -46,12 +46,6 @@ server {
         proxy_pass http://app-server-upstream;
     }
 
-    location /docs/ {
-        root /srv/dist/;
-        index index.json index.html;
-        try_files $uri $uri/ =404;
-    }
-
     # Static Assets
     location / {
         root /srv/dist/angular;

--- a/scripts/bootstrap
+++ b/scripts/bootstrap
@@ -22,11 +22,6 @@ function main() {
     aws s3 cp "s3://config-development-raster-foundry/.env" ".env"
     popd
 
-    # Copy documentation
-    echo "Copying Documentation"
-    mkdir -p "${DIR}/../nginx/srv/dist/docs/"
-    cp -r "${DIR}/../docs/swagger/" "${DIR}/../nginx/srv/dist/docs/"
-
     echo "Building/Pulling containers..."
     docker-compose \
         -f "${DIR}/../docker-compose.yml" \

--- a/scripts/cibuild
+++ b/scripts/cibuild
@@ -55,9 +55,6 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
             run --no-deps --rm --entrypoint ./sbt app-server app/assembly
 
         # Build app, airflow
-        echo "Copying Documentation into nginx directory"
-        cp -r "${DIR}/../docs/swagger/" "${DIR}/../nginx/srv/dist/docs/"
-
         echo "Building app, airflow..."
         GIT_COMMIT="${GIT_COMMIT}" docker-compose \
             -f "${DIR}/../docker-compose.yml" \


### PR DESCRIPTION
This reverts an attempt to add swagger documentation to the nginx
container with the application code until we have time to devote to
fixing issues with permissions and other problems.

## Testing
- provision machine
- start server: `./scripts/server`
- ensure the swagger UI shows up at `localhost:9999`