### PR TITLE
Add logging to existing endpoints

### DIFF
--- a/app-server/app/src/main/resources/application.conf
+++ b/app-server/app/src/main/resources/application.conf
@@ -1,5 +1,7 @@
 akka {
   loglevel = DEBUG
+  loggers = ["akka.event.slf4j.Slf4jLogger"]
+  logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"
 }
 
 # Akka http extensions settings

--- a/app-server/app/src/main/resources/logback.xml
+++ b/app-server/app/src/main/resources/logback.xml
@@ -1,0 +1,12 @@
+<configuration>
+    <appender name="stdout" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level=${APP_SERVER_LOG_LEVEL:-info}>
+        <appender-ref ref="stdout"/>
+    </root>
+
+</configuration>

--- a/app-server/app/src/main/scala/Main.scala
+++ b/app-server/app/src/main/scala/Main.scala
@@ -1,15 +1,26 @@
 package com.azavea.rf
 
 import akka.actor.ActorSystem
+import akka.event.Logging
 import akka.http.scaladsl.Http
 import akka.stream.ActorMaterializer
 
 import com.azavea.rf.utils.{Config, Database}
 
-object Main extends App with Config with Router {
-
+object AkkaSystem {
   implicit val system = ActorSystem("rf-system")
   implicit val materializer = ActorMaterializer()
+
+  trait LoggerExecutor {
+    protected implicit val executor = system.dispatcher
+    protected implicit val log = Logging(system, "app")
+  }
+}
+
+object Main extends App with Config with Router with AkkaSystem.LoggerExecutor {
+
+  import AkkaSystem._
+
   implicit val ec = system.dispatcher
   implicit val database = new Database(jdbcUrl, dbUser, dbPassword)
 

--- a/app-server/app/src/main/scala/healthcheck/Healthcheck.scala
+++ b/app-server/app/src/main/scala/healthcheck/Healthcheck.scala
@@ -4,6 +4,7 @@ import scala.concurrent.ExecutionContext
 
 import com.azavea.rf.datamodel.latest.schema.tables.Users
 import com.azavea.rf.utils.Database
+import com.azavea.rf.AkkaSystem
 
 
 /**
@@ -42,7 +43,7 @@ case class HealthCheck(status: HealthCheckStatus.Status, services: Seq[ServiceCh
 case class DatabaseException(description:String) extends Exception
 
 
-object HealthCheckService {
+object HealthCheckService extends AkkaSystem.LoggerExecutor {
 
   /**
     * Perform healthcheck by verifying at least the following:
@@ -51,19 +52,26 @@ object HealthCheckService {
     */
   def healthCheck()(implicit database:Database, ec:ExecutionContext) = {
 
+    log.debug("Healthcheck requested")
+
     import database.driver.api._
 
     // Ensure that there is at least one user. This should always be true,
     // because a default user is created in a data migration.
+    val countAction = Users.length.result
     database.db.run {
-      Users.length.result
+      countAction
     } map {
       case count:Int if count > 0 =>
+        log.debug(
+          s"Healthcheck returned successfully -- SQL: ${countAction.statements.headOption}"
+        )
         HealthCheck(
           HealthCheckStatus.OK,
           Seq(ServiceCheck("database", HealthCheckStatus.OK))
         )
       case _ =>
+        log.error(s"Healthcheck failing -- SQL: ${countAction.statements.headOption}")
         HealthCheck(
           HealthCheckStatus.Failing,
           Seq(ServiceCheck("database", HealthCheckStatus.Failing))

--- a/app-server/app/src/main/scala/organization/Organization.scala
+++ b/app-server/app/src/main/scala/organization/Organization.scala
@@ -22,6 +22,7 @@ import com.azavea.rf.utils.{
   UserErrorException
 }
 import com.azavea.rf.user.UserRoles
+import com.azavea.rf.AkkaSystem
 
 
 case class UserWithRole(id: String, role: String, createdAt: Timestamp, modifiedAt: Timestamp)
@@ -44,7 +45,8 @@ case class OrganizationsRowCreate(name: String) {
 }
 
 
-object OrganizationService {
+object OrganizationService extends AkkaSystem.LoggerExecutor {
+
   def applyOrgSort(
     query: Query[Organizations, Organizations#TableElementType, Seq],
     sortMap: Map[String, Order]
@@ -55,23 +57,55 @@ object OrganizationService {
     sortMap.headOption match {
       case Some(("id", order)) =>
         order match {
-          case Order.Asc => applyOrgSort(query.sortBy(_.id.asc), sortMap.tail)
-          case Order.Desc => applyOrgSort(query.sortBy(_.id.desc), sortMap.tail)
+          case Order.Asc => {
+            val sortQuery = query.sortBy(_.id.asc)
+            log.debug(s"Org sort query to run: $sortQuery")
+            applyOrgSort(sortQuery, sortMap.tail)
+          }
+          case Order.Desc => {
+            val sortQuery = query.sortBy(_.id.desc)
+            log.debug(s"Org sort query to run: $sortQuery")
+            applyOrgSort(sortQuery, sortMap.tail)
+          }
         }
       case Some(("name", order)) =>
         order match {
-          case Order.Asc => applyOrgSort(query.sortBy(_.name.asc), sortMap.tail)
-          case Order.Desc => applyOrgSort(query.sortBy(_.name.desc), sortMap.tail)
+          case Order.Asc => {
+            val sortQuery = query.sortBy(_.name.asc)
+            log.debug(s"Org sort query to run: $sortQuery")
+            applyOrgSort(sortQuery, sortMap.tail)
+          }
+          case Order.Desc => {
+            val sortQuery = query.sortBy(_.name.desc)
+            log.debug(s"Org sort query to run: $sortQuery")
+            applyOrgSort(sortQuery, sortMap.tail)
+          }
         }
       case Some(("modified", order)) =>
         order match {
-          case Order.Asc => applyOrgSort(query.sortBy(_.modifiedAt.asc), sortMap.tail)
-          case Order.Desc => applyOrgSort(query.sortBy(_.modifiedAt.desc), sortMap.tail)
+          case Order.Asc => {
+            val sortQuery = query.sortBy(_.modifiedAt.asc)
+            log.debug(s"Org sort query to run: $sortQuery")
+            applyOrgSort(sortQuery, sortMap.tail)
+          }
+          case Order.Desc => {
+            val sortQuery = query.sortBy(_.modifiedAt.desc)
+            log.debug(s"Org sort query to run: $sortQuery")
+            applyOrgSort(sortQuery, sortMap.tail)
+          }
         }
       case Some(("created", order)) =>
         order match {
-          case Order.Asc => applyOrgSort(query.sortBy(_.createdAt.asc), sortMap.tail)
-          case Order.Desc => applyOrgSort(query.sortBy(_.createdAt.desc), sortMap.tail)
+          case Order.Asc => {
+            val sortQuery = query.sortBy(_.createdAt.asc)
+            log.debug(s"Org sort query to run: $sortQuery")
+            applyOrgSort(sortQuery, sortMap.tail)
+          }
+          case Order.Desc => {
+            val sortQuery = query.sortBy(_.createdAt.desc)
+            log.debug(s"Org sort query to run: $sortQuery")
+            applyOrgSort(sortQuery, sortMap.tail)
+          }
         }
       case Some((_, order)) => applyOrgSort(query, sortMap.tail)
       case _ => query
@@ -88,25 +122,60 @@ object OrganizationService {
     sortMap.headOption match {
       case Some(("id", order)) =>
         order match {
-          case Order.Asc => applyUserRoleSort(query.sortBy(_.userId.asc), sortMap.tail)
-          case Order.Desc => applyUserRoleSort(query.sortBy(_.userId.desc), sortMap.tail)
+          case Order.Asc => {
+            val sortQuery = query.sortBy(_.userId.asc)
+            log.debug(s"User role sort query: ${sortQuery.result.statements.headOption}")
+            applyUserRoleSort(sortQuery, sortMap.tail)
+          }
+          case Order.Desc => {
+            val sortQuery = query.sortBy(_.userId.desc)
+            log.debug(s"User role sort query: ${sortQuery.result.statements.headOption}")
+            applyUserRoleSort(query.sortBy(_.userId.desc), sortMap.tail)
+          }
         }
       case Some(("role", order)) =>
         order match {
-          case Order.Asc => applyUserRoleSort(query.sortBy(_.role.asc), sortMap.tail)
-          case Order.Desc => applyUserRoleSort(query.sortBy(_.role.desc), sortMap.tail)
+          case Order.Asc => {
+            val sortQuery = query.sortBy(_.role.asc)
+            log.debug(s"User role sort query: ${sortQuery.result.statements.headOption}")
+            applyUserRoleSort(sortQuery, sortMap.tail)
+          }
+          case Order.Desc => {
+            val sortQuery = query.sortBy(_.role.asc)
+            log.debug(s"User role sort query: ${sortQuery.result.statements.headOption}")
+            applyUserRoleSort(query.sortBy(_.role.desc), sortMap.tail)
+          }
         }
       case Some(("modified", order)) =>
         order match {
-          case Order.Asc => applyUserRoleSort(query.sortBy(_.modifiedAt.asc), sortMap.tail)
-          case Order.Desc => applyUserRoleSort(query.sortBy(_.modifiedAt.desc), sortMap.tail)
+          case Order.Asc => {
+            val sortQuery = query.sortBy(_.modifiedAt.asc)
+            log.debug(s"User role sort query: ${sortQuery.result.statements.headOption}")
+            applyUserRoleSort(sortQuery, sortMap.tail)
+          }
+          case Order.Desc => {
+            val sortQuery = query.sortBy(_.modifiedAt.desc)
+            log.debug(s"User role sort query: ${sortQuery.result.statements.headOption}")
+            applyUserRoleSort(sortQuery, sortMap.tail)
+          }
         }
       case Some(("created", order)) =>
         order match {
-          case Order.Asc => applyUserRoleSort(query.sortBy(_.createdAt.asc), sortMap.tail)
-          case Order.Desc => applyUserRoleSort(query.sortBy(_.createdAt.desc), sortMap.tail)
+          case Order.Asc => {
+            val sortQuery =  query.sortBy(_.createdAt.asc)
+            log.debug(s"User role sort query: ${sortQuery.result.statements.headOption}")
+            applyUserRoleSort(sortQuery, sortMap.tail)
+          }
+          case Order.Desc => {
+            val sortQuery = query.sortBy(_.createdAt.desc)
+            log.debug(s"User role sort query: ${sortQuery.result.statements.headOption}")
+            applyUserRoleSort(sortQuery, sortMap.tail)
+          }
         }
-      case Some((_, order)) => applyUserRoleSort(query, sortMap.tail)
+      case Some((_, order)) => {
+        log.debug(s"User role sort query: ${query.result.statements.headOption}")
+        applyUserRoleSort(query, sortMap.tail)
+      }
       case _ => query
     }
   }
@@ -140,8 +209,10 @@ object OrganizationService {
       Future[Option[OrganizationsRow]] = {
     import database.driver.api._
 
+    val action = Organizations.filter(_.id === id).result
+    log.debug(s"Query for org $id: ${action.statements.headOption}")
     database.db.run {
-      Organizations.filter(_.id === id).result.headOption
+      action.headOption
     }
   }
 
@@ -152,8 +223,10 @@ object OrganizationService {
 
     val rowInsert = org.toOrganizationsRow()
 
+    val action = Organizations.forceInsert(rowInsert)
+    log.debug(s"Inserting org with: ${action.statements.headOption}")
     database.db.run {
-      Organizations.forceInsert(rowInsert).asTry
+      action.asTry
     } map {
       case Success(res) => {
         res match {
@@ -187,8 +260,10 @@ object OrganizationService {
     } yield (
       updateorg.name, updateorg.modifiedAt
     )
+    val action = updateQuery.update((org.name, now))
+    log.debug(s"Updating org with: ${action.statements.headOption}")
     database.db.run {
-      updateQuery.update((org.name, now)).asTry
+      action.asTry
     } map {
       case Success(res) => {
         res match {
@@ -238,8 +313,10 @@ object OrganizationService {
         .filter(_.organizationId === orgId)
       user <- Users.filter(_.id === relationship.userId)
     } yield (user.id, relationship.role, relationship.createdAt, relationship.modifiedAt)
+    val action = getOrgUserQuery.result
+    log.debug(s"Getting org user with: ${action.statements.headOption}")
     database.db.run {
-      getOrgUserQuery.result.headOption
+      action.headOption
     } map {
       case Some(tuple) => Option(UserWithRole.tupled(tuple))
       case _ => None
@@ -257,8 +334,10 @@ object OrganizationService {
       userWithRole.id, orgId, userWithRole.role, userWithRole.createdAt, userWithRole.modifiedAt
     )
 
+    val action = UsersToOrganizations.forceInsert(insertRow)
+    log.debug(s"Inserting User to Org with: ${action.statements.headOption}")
     database.db.run {
-      UsersToOrganizations.forceInsert(insertRow).asTry
+      action.asTry
     } map {
       case Success(user) => Success(userWithRole)
       case Failure(_) => throw new UserErrorException("User is already in the organization")
@@ -269,10 +348,13 @@ object OrganizationService {
     userId: String, orgId: java.util.UUID
   )(implicit database: Database, ex: ExecutionContext): Future[Option[UserWithRole]] = {
     import database.driver.api._
+
+    val action = UsersToOrganizations.filter(
+      rel => rel.userId === userId && rel.organizationId === orgId
+    ).result
+    log.debug(s"Getting user org role with: ${action.statements.headOption}")
     database.db.run {
-      UsersToOrganizations.filter(
-        rel => rel.userId === userId && rel.organizationId === orgId
-      ).result.headOption
+      action.headOption
     } map {
       case Some(rel) => Some(UserWithRole(rel.userId, rel.role, rel.createdAt, rel.modifiedAt))
       case _ => None
@@ -283,10 +365,13 @@ object OrganizationService {
     userId: String, orgId: java.util.UUID
   )(implicit database: Database): Future[Int] = {
     import database.driver.api._
+
+    val action = UsersToOrganizations.filter(
+      rel => rel.userId === userId && rel.organizationId === orgId
+    ).delete
+    log.debug(s"Deleting User to Org with: ${action.statements.headOption}")
     database.db.run {
-      UsersToOrganizations.filter(
-        rel => rel.userId === userId && rel.organizationId === orgId
-      ).delete
+      action
     }
   }
 
@@ -307,10 +392,13 @@ object OrganizationService {
           relationship.modifiedAt, relationship.role
         )
 
+        val action = rowUpdate.update(
+          (now, userWithRole.role)
+        )
+        log.debug(s"Updating user with role with: ${action.statements.headOption}")
+
         database.db.run {
-          rowUpdate.update(
-            (now, userWithRole.role)
-          ).asTry
+          action.asTry
         }
       }
       case invalidRole: String => throw new UserErrorException(

--- a/app-server/build.sbt
+++ b/app-server/build.sbt
@@ -46,7 +46,8 @@ lazy val appSettings = commonSettings ++ Seq(
 )
 
 lazy val loggingDependencies = List(
-  Dependencies.slf4j
+  "com.typesafe.akka" % "akka-slf4j_2.11" % "2.4.10",
+  "ch.qos.logback" %  "logback-classic" % "1.1.7"
 )
 
 lazy val slickDependencies = List(


### PR DESCRIPTION
This commit:

1. changes logging dependencies from basic `slf4j` to akka's special
`akka-slf4j` plus `logback`
2. logs the sql that Akka plans to execute at the `users` and
`healthcheck` endpoints at the debug level. It logs into a file in the
`app-server/app` directory.

It borrows logging setup heavily from the [GeoWave/GeoMesa comparative
analysis](https://github.com/azavea/gwgm-ca-performance-tests-server)
tests server but with a little more logging config in
`src/main/resources` and redirection to a log file, which I don't think
is present in the GWGM repo.

Fixes #394