### PR TITLE
Make PGUtilsSpec unmixable

### DIFF
--- a/app-server/app/src/test/scala/thumbnail/ThumbnailSpec.scala
+++ b/app-server/app/src/test/scala/thumbnail/ThumbnailSpec.scala
@@ -1,20 +1,35 @@
 package com.azavea.rf.thumbnail
 
+import org.scalatest.{Matchers, WordSpec}
+import akka.http.scaladsl.testkit.{ScalatestRouteTest, RouteTestTimeout}
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.model.{HttpEntity, ContentTypes}
 import akka.actor.ActorSystem
-import com.azavea.rf._
-import com.azavea.rf.datamodel.latest.schema.tables._
-import com.azavea.rf.thumbnail._
-import com.azavea.rf.utils._
-import java.sql._
+import concurrent.duration._
+import spray.json._
 import java.util.UUID
 
-import org.scalatest._
-
-import scala.concurrent.Future
+import com.azavea.rf.utils.Config
+import com.azavea.rf.{DBSpec, Router}
+import com.azavea.rf.datamodel.latest.schema.tables._
+import com.azavea.rf.datamodel.enums._
+import com.azavea.rf.utils.PaginatedResponse
+import com.azavea.rf.AuthUtils
 import scala.util.{Success, Failure, Try}
 import slick.lifted.TableQuery
 
-class ThumbnailSpec extends PGUtilsSpec with Thumbnail {
+import java.sql.Timestamp
+
+class ThumbnailSpec extends WordSpec
+    with Matchers
+    with ScalatestRouteTest
+    with Config
+    with DBSpec
+    with Thumbnail {
+
+  implicit val ec = system.dispatcher
+
+  implicit val database = db
 
   val thumbnails = TableQuery[Thumbnails]
   val uuid = new UUID(123456789, 123456789)

--- a/app-server/app/src/test/scala/utils/PGUtilsSpec.scala
+++ b/app-server/app/src/test/scala/utils/PGUtilsSpec.scala
@@ -11,7 +11,7 @@ import com.azavea.rf._
   * This set of tests ensures the basic functionality of the utilities
   * within PGUtils and which are depended upon for all database-reliant tests
   */
-class PGUtilsSpec extends WordSpec
+final class PGUtilsSpec extends WordSpec
     with Matchers
     with ScalatestRouteTest
     with Config


### PR DESCRIPTION
Mixing in `PGUtilsSpec` caused database setup and teardown to happen
twice, which probabilistically killed the Jenkins build. Now PGUtilsSpec
is final so that's impossible. Changes to `ThumbnailsSpec` are also
included since that was the offender.