### PR TITLE
Bump terraform version to 0.7.4

### DIFF
--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -9,4 +9,4 @@ shellcheck_version: "0.3.*"
 docker_users:
   - "{{ ansible_user }}"
 
-terraform_version: "0.7.2"
+terraform_version: "0.7.4"


### PR DESCRIPTION
The terraform state file for raster-foundry was created with terraform `0.7.3`, which is ahead of the version on Jenkins (`0.7.2`). This creates an error when trying to `terraform apply` infrastructure changes during CI. This PR bumps the terraform version to `0.7.4`.

# Testing
View the Jenkins output for this PR build