### PR TITLE
Add embedded map w/ geojson to library/scenes/{id}

### DIFF
--- a/app-frontend/src/app/components/leafletMap/leafletMap.component.js
+++ b/app-frontend/src/app/components/leafletMap/leafletMap.component.js
@@ -3,7 +3,11 @@
 
 const leafletMap = {
     template: '<div></div>',
-    controller: 'LeafletMapController'
+    controller: 'LeafletMapController',
+    bindings: {
+        static: '<?',
+        footprint: '<?'
+    }
 };
 
 export default leafletMap;

--- a/app-frontend/src/app/components/sceneDetail/sceneDetail.component.js
+++ b/app-frontend/src/app/components/sceneDetail/sceneDetail.component.js
@@ -3,10 +3,8 @@ import sceneDetailTpl from './sceneDetail.html';
 
 const rfSceneItem = {
     templateUrl: sceneDetailTpl,
-    controller: 'RfSceneDetailController',
     bindings: {
-        scene: '<',
-        withMap: '<?'
+        scene: '<'
     },
     replace: true
 };

--- a/app-frontend/src/app/components/sceneDetail/sceneDetail.controller.js
+++ b/app-frontend/src/app/components/sceneDetail/sceneDetail.controller.js
@@ -1,5 +1,0 @@
-export default class SceneDetailController {
-    constructor() {
-        'ngInject';
-    }
-}

--- a/app-frontend/src/app/components/sceneDetail/sceneDetail.module.js
+++ b/app-frontend/src/app/components/sceneDetail/sceneDetail.module.js
@@ -1,11 +1,9 @@
 import angular from 'angular';
 import SceneDetailComponent from './sceneDetail.component.js';
-import SceneDetailController from './sceneDetail.controller.js';
 require('../../../assets/font/fontello/css/fontello.css');
 
 const SceneDetailModule = angular.module('components.sceneDetail', []);
 
 SceneDetailModule.component('rfSceneDetail', SceneDetailComponent);
-SceneDetailModule.controller('RfSceneDetailController', SceneDetailController);
 
 export default SceneDetailModule;

--- a/app-frontend/src/app/components/sceneItem/sceneItem.component.js
+++ b/app-frontend/src/app/components/sceneItem/sceneItem.component.js
@@ -6,7 +6,8 @@ const rfSceneItem = {
     controller: 'SceneItemController',
     bindings: {
         scene: '<',
-        selected: '=?'
+        selected: '&',
+        onSelect: '&'
     }
 };
 

--- a/app-frontend/src/app/components/sceneItem/sceneItem.controller.js
+++ b/app-frontend/src/app/components/sceneItem/sceneItem.controller.js
@@ -1,10 +1,16 @@
 export default class SceneItemController {
-    constructor() {
+    constructor($scope) {
         'ngInject';
+        $scope.$watch(
+            () => this.selected({scene: this.scene}),
+            (selected) => {
+                this.selectedStatus = selected;
+            }
+        );
     }
 
     toggleSelected(event) {
-        this.selected = !this.selected;
+        this.onSelect({scene: this.scene, selected: !this.selectedStatus});
         event.stopPropagation();
     }
 }

--- a/app-frontend/src/app/components/sceneItem/sceneItem.html
+++ b/app-frontend/src/app/components/sceneItem/sceneItem.html
@@ -15,10 +15,10 @@
   <div class="list-group-right">
     <button class="btn btn-square"
             ng-click="$ctrl.toggleSelected($event)"
-            ng-class="{'btn-secondary': $ctrl.selected}">
+            ng-class="{'btn-secondary': $ctrl.selectedStatus}">
       <i ng-class="{
-                   'icon-plus': !$ctrl.selected,
-                   'icon-check': $ctrl.selected
+                   'icon-plus': !$ctrl.selectedStatus,
+                   'icon-check': $ctrl.selectedStatus
                    }">
       </i>
     </button>

--- a/app-frontend/src/app/index.routes.js
+++ b/app-frontend/src/app/index.routes.js
@@ -38,13 +38,15 @@ function routeConfig($urlRouterProvider, $stateProvider) {
             templateUrl: sceneDetailTpl,
             params: {scene: null},
             controller: 'SceneDetailController',
-            controllerAs: '$ctrl'
+            controllerAs: '$ctrl',
+            parent: 'library.scenes'
         })
         .state('library.scenes.list', {
             url: '/list?:page',
             templateUrl: scenesListTpl,
             controller: 'ScenesListController',
-            controllerAs: '$ctrl'
+            controllerAs: '$ctrl',
+            parent: 'library.scenes'
         })
         .state('library.buckets', {
             url: '/buckets',

--- a/app-frontend/src/app/pages/browse/browse.html
+++ b/app-frontend/src/app/pages/browse/browse.html
@@ -23,9 +23,11 @@
           infinite-scroll-container="'#infscroll'"
           class="list-group">
         <rf-scene-item
-            ng-click="$ctrl.openDetailPane(item)"
-            scene="item.scene" selected="item.selected"
-            ng-repeat="item in $ctrl.sceneList track by item.scene.id">
+            ng-click="$ctrl.openDetailPane(scene)"
+            scene="scene"
+            selected="$ctrl.isSelected(scene)"
+            on-select="$ctrl.setSelected(scene, selected)";
+            ng-repeat="scene in $ctrl.sceneList track by scene.id">
         </rf-scene-item>
       </div>
       <div class="list-group" ng-show="$ctrl.loading">
@@ -49,7 +51,7 @@
     </div>
 
     <div class="sidebar-static">
-      <h5>Selected: {{$ctrl.numSelected}}</h5>
+      <h5>Selected: {{$ctrl.selectedScenes.length || 'None'}}</h5>
       <div class="sidebar-actions">
         <a href ng-click="$ctrl.selectAllScenes()">Select All</a>
         <button type="button"
@@ -66,8 +68,8 @@
   <div class="sidebar sidebar-extended" ng-if="$ctrl.activeScene">
     <div class="sidebar-static">
       <p>
-        <strong class="color-dark">{{$ctrl.activeScene.scene.name}}</strong><br>
-        {{$ctrl.activeScene.scene.datasource}}
+        <strong class="color-dark">{{$ctrl.activeScene.name}}</strong><br>
+        {{$ctrl.activeScene.datasource}}
       </p>
       <div class="sidebar-actions">
         <button class="btn btn-square" ng-click="$ctrl.closeDetailPane()">
@@ -75,23 +77,23 @@
         </button>
       </div>
     </div>
-    <img ng-if="$ctrl.activeScene.scene.thumbnails[0]"
-         ng-attr-src="{{$ctrl.activeScene.scene.thumbnails[0].url}}"
+    <img ng-if="$ctrl.activeScene.thumbnails[0]"
+         ng-attr-src="{{$ctrl.activeScene.thumbnails[0].url}}"
          class="rounded-img detail-img">
-    <img ng-if="!$ctrl.activeScene.scene.thumbnails.length"
+    <img ng-if="!$ctrl.activeScene.thumbnails.length"
          src="http://placehold.it/275x275"
          class="rounded-img detail-img">
     <rf-scene-detail class="sidebar-scrollable"
-                     scene="$ctrl.activeScene.scene"></rf-scene-detail>
+                     scene="$ctrl.activeScene"></rf-scene-detail>
     <div class="sidebar-static">
       <div class="sidebar-actions">
         <button class="btn btn-square btn-default"
                 ng-click="$ctrl.toggleSelectAndClosePane()">
-          <span ng-if="!$ctrl.activeScene.selected">
+          <span ng-if="!$ctrl.isSelected($ctrl.activeScene)">
             <i class="icon-plus"></i>
             Select Scene
           </span>
-          <span ng-if="$ctrl.activeScene.selected">
+          <span ng-if="$ctrl.isSelected($ctrl.activeScene)">
             <i class="icon-cross"></i>
             Deselect
           </span>

--- a/app-frontend/src/app/pages/library/scenes/detail/detail.html
+++ b/app-frontend/src/app/pages/library/scenes/detail/detail.html
@@ -1,16 +1,21 @@
 <div class="row content stack-sm">
-  <div class="column-8" ng-show="!$ctrl.loading">
+  <div class="column-8" ng-if="!$ctrl.loading">
     <div class="embedded-scrollable">
       <h1 class="h3 page-title">
-        <a ui-sref="library.scenes.list">{{$ctrl.scene.id}}</a>
+        <a ui-sref="library.scenes.list">Scenes</a>
         <br>
         {{$ctrl.scene.name}}
       </h1>
+      <rf-leaflet-map
+          class="map-container"
+          static="true",
+          footprint="$ctrl.scene.footprint"
+      ></rf-leaflet-map>
       <rf-scene-detail class="sidebar-scrollable"
                        scene="$ctrl.scene"></rf-scene-detail>
     </div>
   </div>
-  <div class="column" ng-show="$ctrl.loading">
+  <div class="column-8" ng-if="$ctrl.loading">
     <div class="list-group">
       <div class="list-placeholder">
           <i class="icon-load"></i>
@@ -20,8 +25,11 @@
   <div class="column-4">
     <div class="content">
       <nav>
-        <a href="#"><i class="icon-trash"></i> Remove from bucket</a>
-        <a href="#"><i class="icon-download"></i> Download</a>
+        <a href><i class="icon-bucket"></i> Add to bucket</a>
+        <a href><i class="icon-download"></i> Download</a>
+        <a href><i class="icon-unlocked"></i> Make public</a>
+
+        <a href><i class="icon-trash"></i> Delete</a>
       </nav>
     </div>
   </div>

--- a/app-frontend/src/app/pages/library/scenes/list/list.controller.js
+++ b/app-frontend/src/app/pages/library/scenes/list/list.controller.js
@@ -1,14 +1,15 @@
 class ScenesListController {
-    constructor($log, auth, sceneService, $state) {
+    constructor($log, auth, sceneService, $state, $scope) {
         'ngInject';
 
         this.$log = $log;
         this.auth = auth;
         this.sceneService = sceneService;
         this.$state = $state;
+        this.$scope = $scope;
+        this.$parent = $scope.$parent.$ctrl;
 
         this.sceneList = [];
-
         this.populateSceneList($state.params.page || 1);
     }
 
@@ -41,12 +42,7 @@ class ScenesListController {
                     notify: false
                 }
             );
-            this.sceneList = this.lastSceneResult.results.map(function (scene) {
-                return {
-                    scene: scene,
-                    selected: false
-                };
-            });
+            this.sceneList = this.lastSceneResult.results;
             this.loading = false;
         }.bind(this), function (error) {
             if (error.status === -1 || error.status === 500) {
@@ -55,8 +51,38 @@ class ScenesListController {
             this.loading = false;
         }.bind(this));
     }
+
     viewSceneDetail(scene) {
-        this.$state.go('library.scenes.detail', {scene: scene, id: scene.id});
+        this.$state.go(
+            'library.scenes.detail',
+            {
+                scene: scene,
+                id: scene.id
+            }
+        );
+    }
+
+    selectAll() {
+        this.sceneList.forEach((scene) => {
+            this.setSelected(scene, true);
+        });
+    }
+
+    selectNone() {
+        this.$parent.selectedScenes = [];
+    }
+
+    isSelected(scene) {
+        return this.$parent.selectedScenes.indexOf(scene.id) !== -1;
+    }
+
+    setSelected(scene, selected) {
+        if (!selected) {
+            let index = this.$parent.selectedScenes.indexOf(scene.id);
+            this.$parent.selectedScenes.splice(index, 1);
+        } else if (!this.isSelected(scene)) {
+            this.$parent.selectedScenes.push(scene.id);
+        }
     }
 }
 

--- a/app-frontend/src/app/pages/library/scenes/list/list.html
+++ b/app-frontend/src/app/pages/library/scenes/list/list.html
@@ -1,52 +1,72 @@
-<div class="row content stack-sm">
-  <div class="column">
-    <h1 class="h3">Scenes</h1>
-    <div class="embedded-scrollable">
-      <div class="list-group">
-        <rf-scene-item
-            ng-click="$ctrl.viewSceneDetail(item.scene)"
-            scene="item.scene" selected="item.selected"
-            ng-repeat="item in $ctrl.sceneList track by item.scene.id">
-        </rf-scene-item>
-      </div>
-      <div class="list-group" ng-show="$ctrl.loading">
-        <span class="list-placeholder">
-          <i class="icon-load"></i>
-        </span>
-      </div>
-      <div class="list-group text-center"
-           ng-show="!$ctrl.loading && $ctrl.lastSceneResult && $ctrl.lastSceneResult.count !== 0 && !$ctrl.errorMsg">
-        <ul uib-pagination
-            items-per-page="$ctrl.lastSceneResult.pageSize"
-            total-items="$ctrl.lastSceneResult.count"
-            ng-model="$ctrl.currentPage"
-            max-size="4"
-            rotate="true"
-            boundary-link-numbers="true"
-            force-ellipses="true"
-            ng-change="$ctrl.populateSceneList($ctrl.currentPage)">
-        </ul>
-      </div>
-      <div ng-if="!$ctrl.loading && $ctrl.lastSceneResult && $ctrl.lastSceneResult.count === 0"
-           class="list-group">
-        <span class="list-placeholder">You haven't uploaded any scenes. Click the Import Data button to get started!</span>
-      </div>
-      <div class="list-group" ng-show="$ctrl.errorMsg">
-        <span class="list-placeholder">
-          {{$ctrl.errorMsg}}
-          <a href ng-click="$ctrl.populateSceneList(0)">Try again</a>
-        </span>
+<div class="content">
+  <div class="row stack-sm library-header">
+    <h1 ng-show="!$ctrl.$parent.selectedScenes.length"
+        class="h3">Scenes</h1>
+    <div ng-show="$ctrl.$parent.selectedScenes.length">
+      <h1 class="h3 highlight">
+        <ng-pluralize count="$ctrl.$parent.selectedScenes.length"
+                      when="{'one': '1 scene selected.',
+                            'other': '{} scenes selected.'}">
+        </ng-pluralize>
+      </h1>
+      <div class="button-group">
+        <a href ng-click="$ctrl.selectAll()">Select All</a>
+        <a href ng-click="$ctrl.selectNone()">Deselect All</a>
+        <a href>Add to Bucket...</a>
+        <a href>Delete...</a>
       </div>
     </div>
   </div>
-  <div class="column-4">
-    <div class="content">
-      <h5>What can be imported?</h5>
-      <p class="font-size-small">Lorem ipsum dolor sit amet, consectetur adipisicing elit. Iusto assumenda magnam pariatur facere perferendis temporibus doloremque quam delectus, veniam vel iure optio quibusdam tempore non minima est voluptatum provident, quidem.</p>
-      <h5>Are my imports public?</h5>
-      <p class="font-size-small">Your imports a private by default but you may make them available to the public. If public, they will be discoverable.</p>
-      <h5>What can be done to imports:</h5>
-      <p class="font-size-small">You can simply use Raster Foundry as a storage point or mosaic your imports and run advanced models against them.</p>
+  <div class="row stack-sm">
+    <div class="column">
+      <div class="embedded-scrollable">
+        <div class="list-group">
+          <rf-scene-item
+              ng-click="$ctrl.viewSceneDetail(scene)"
+              scene="scene" selected="$ctrl.isSelected(scene)"
+              on-select="$ctrl.setSelected(scene, selected)"
+              ng-repeat="scene in $ctrl.sceneList track by scene.id">
+          </rf-scene-item>
+        </div>
+        <div class="list-group" ng-show="$ctrl.loading">
+          <span class="list-placeholder">
+            <i class="icon-load"></i>
+          </span>
+        </div>
+        <div class="list-group text-center"
+             ng-show="!$ctrl.loading && $ctrl.lastSceneResult && $ctrl.lastSceneResult.count !== 0 && !$ctrl.errorMsg">
+          <ul uib-pagination
+              items-per-page="$ctrl.lastSceneResult.pageSize"
+              total-items="$ctrl.lastSceneResult.count"
+              ng-model="$ctrl.currentPage"
+              max-size="4"
+              rotate="true"
+              boundary-link-numbers="true"
+              force-ellipses="true"
+              ng-change="$ctrl.populateSceneList($ctrl.currentPage)">
+          </ul>
+        </div>
+        <div ng-if="!$ctrl.loading && $ctrl.lastSceneResult && $ctrl.lastSceneResult.count === 0"
+             class="list-group">
+          <span class="list-placeholder">You haven't uploaded any scenes. Click the Import Data button to get started!</span>
+        </div>
+        <div class="list-group" ng-show="$ctrl.errorMsg">
+          <span class="list-placeholder">
+            {{$ctrl.errorMsg}}
+            <a href ng-click="$ctrl.populateSceneList(0)">Try again</a>
+          </span>
+        </div>
+      </div>
+    </div>
+    <div class="column-4">
+      <div class="content">
+        <h5>What can be imported?</h5>
+        <p class="font-size-small">Lorem ipsum dolor sit amet, consectetur adipisicing elit. Iusto assumenda magnam pariatur facere perferendis temporibus doloremque quam delectus, veniam vel iure optio quibusdam tempore non minima est voluptatum provident, quidem.</p>
+        <h5>Are my imports public?</h5>
+        <p class="font-size-small">Your imports a private by default but you may make them available to the public. If public, they will be discoverable.</p>
+        <h5>What can be done to imports:</h5>
+        <p class="font-size-small">You can simply use Raster Foundry as a storage point or mosaic your imports and run advanced models against them.</p>
+      </div>
     </div>
   </div>
 </div>

--- a/app-frontend/src/app/pages/library/scenes/scenes.controller.js
+++ b/app-frontend/src/app/pages/library/scenes/scenes.controller.js
@@ -1,6 +1,7 @@
 class ScenesController {
     constructor() {
         'ngInject';
+        this.selectedScenes = [];
     }
 }
 

--- a/app-frontend/src/assets/styles/sass/app.scss
+++ b/app-frontend/src/assets/styles/sass/app.scss
@@ -37,7 +37,8 @@
   "layout/header",
   "layout/sidebar",
   "layout/footer",
-  "layout/embedded";
+  "layout/embedded",
+  "layout/library";
 
 /**
  * Components

--- a/app-frontend/src/assets/styles/sass/layout/_embedded.scss
+++ b/app-frontend/src/assets/styles/sass/layout/_embedded.scss
@@ -1,4 +1,9 @@
 .embedded-scrollable {
   overflow: auto;
   flex: 1;
+  .map-container {
+    width: 100%;
+    height: 250px;
+    display: flex;
+  }
 }

--- a/app-frontend/src/assets/styles/sass/layout/_library.scss
+++ b/app-frontend/src/assets/styles/sass/layout/_library.scss
@@ -1,0 +1,21 @@
+.library-header {
+  padding-left: 2rem;
+  margin-bottom: 0;
+
+  .highlight {
+    color: $brand-secondary;
+    display: inline-flex;
+    flex: 2;
+  }
+
+  .button-group {
+    display: inline-flex;
+    flex: 1;
+    margin-left: auto;
+
+    a {
+      padding: 0 0.5em 0 0.5em;
+      font-weight: 700;
+    }
+  }
+}

--- a/app-server/app/src/main/scala/scene/package.scala
+++ b/app-server/app/src/main/scala/scene/package.scala
@@ -8,6 +8,7 @@ import spray.json._
 import geotrellis.vector.io._
 import geotrellis.vector.Geometry
 import geotrellis.slick.Projected
+import geotrellis.proj4._
 
 import com.azavea.rf.datamodel.enums._
 
@@ -19,7 +20,8 @@ package object scene extends RfJsonProtocols {
 
   implicit object FootprintFormat extends RootJsonFormat[Projected[Geometry]] {
     def write(multipolygon: Projected[Geometry]) = {
-      multipolygon.geom.toGeoJson.parseJson.asJsObject
+      val latlngProjected = multipolygon.reproject(WebMercator, LatLng)(4236)
+      latlngProjected.geom.toGeoJson.parseJson.asJsObject
     }
 
     def read(value: JsValue) =


### PR DESCRIPTION
Refactor scene selection - Use callbacks instead of 2 way bindings
Output scene footprint in lat-lng instead of web-Mercator for leaflet

### Demo
Selecting scene when page is loaded into a browse detail view  
![anim](https://cloud.githubusercontent.com/assets/4392704/19159690/65d64bf8-8bbb-11e6-8857-26501ca71d48.gif)

Library scene list + detail interaction  
![anim](https://cloud.githubusercontent.com/assets/4392704/19159823/c1589f62-8bbb-11e6-96d4-a6836212c8bd.gif)


### Testing
New stuff:  
* browse/{:id} now allows you to select a scene when the initial page load is into the detail view
* library/scenes allows selection, moving into detail view / between pages will preserve selections
* library/scenes/{:id} is a detail view for the scene with a static non-interactive map containing the footprint of the scene. This will be updated once the importer is upgraded to include thumbnail coordinates
