### PR TITLE
Exclude signatures of signed jars during assembly

### DIFF
--- a/app-server/build.sbt
+++ b/app-server/build.sbt
@@ -32,10 +32,8 @@ lazy val appSettings = commonSettings ++ Seq(
   assemblyMergeStrategy in assembly := {
     case "reference.conf" => MergeStrategy.concat
     case "application.conf" => MergeStrategy.concat
+    case n if n.endsWith(".SF") || n.endsWith(".RSA") || n.endsWith(".DSA") => MergeStrategy.discard
     case "META-INF/MANIFEST.MF" => MergeStrategy.discard
-    case "META-INF\\MANIFEST.MF" => MergeStrategy.discard
-    case "META-INF/ECLIPSEF.RSA" => MergeStrategy.discard
-    case "META-INF/ECLIPSEF.SF" => MergeStrategy.discard
     case _ => MergeStrategy.first
   },
   resolvers += "Open Source Geospatial Foundation Repo" at "http://download.osgeo.org/webdav/geotools/",


### PR DESCRIPTION
## Overview

The jar built with SBT assembly includes signatures from dependencies that prevent the jar from being used with `java -jar`

## Testing Instructions

 * Build an assembly jar manually

    ```
    ./scripts/console app-server "./sbt app/assembly"
    ```
  
 * Build a test image for the jar and run it
  
  ```
  cd app-server/app
  docker build -t rf-server .
  docker run rf-server
  ```

 * Exceptions will be thrown because the database is not available, but the security exception that causes the JVM to exit immediately will no longer be a problem. (In practice the database problem isn't an issue, this is just to confirm that the security problem is solved).

Connects #510