### PR TITLE
Create config service / provider

### DIFF
--- a/app-frontend/config/webpack/environments/development.js
+++ b/app-frontend/config/webpack/environments/development.js
@@ -6,6 +6,7 @@
 
 let webpack = require('webpack');
 let port = process.env.RF_PORT_9091 || 9091;
+let serverport = process.env.RF_SERVER_PORT || 9100;
 
 module.exports = function (_path) {
     return {
@@ -21,11 +22,16 @@ module.exports = function (_path) {
             'history-api-fallback': true,
             port: port,
             proxy: {
-                '*': 'http://localhost:9100'
+                '*': 'http://localhost:' + serverport
             }
         },
         plugins: [
-            new webpack.HotModuleReplacementPlugin()
+            new webpack.HotModuleReplacementPlugin(),
+            new webpack.DefinePlugin({
+                'process.env': {
+                    NODE_ENV: JSON.stringify(process.env.NODE_ENV)
+                }
+            })
         ]
     };
 };

--- a/app-frontend/config/webpack/environments/production.js
+++ b/app-frontend/config/webpack/environments/production.js
@@ -27,6 +27,11 @@ module.exports = function (_path) {
                 minimize: true,
                 warnings: false,
                 sourceMap: true
+            }),
+            new webpack.DefinePlugin({
+                'process.env': {
+                    NODE_ENV: JSON.stringify('production')
+                }
             })
         ]
     };

--- a/app-frontend/config/webpack/environments/test.js
+++ b/app-frontend/config/webpack/environments/test.js
@@ -1,8 +1,10 @@
 'use strict';
-/* globals module */
+/* globals module process */
 /* eslint no-process-env: 0
  no-console: 0
  */
+
+let webpack = require('webpack');
 
 module.exports = function (_path) {
     return {
@@ -28,6 +30,15 @@ module.exports = function (_path) {
                     loader: 'null'
                 }
             ]
-        }
+        },
+        plugins: [
+            // None of these are used in tests yet, but keep them for parity with
+            // development and production configs
+            new webpack.DefinePlugin({
+                'process.env': {
+                    NODE_ENV: JSON.stringify(process.env.NODE_ENV)
+                }
+            })
+        ]
     };
 };

--- a/app-frontend/config/webpack/global.js
+++ b/app-frontend/config/webpack/global.js
@@ -114,6 +114,11 @@ module.exports = function (_path) {
                     'url-loader?name=assets/video/[name]_[hash].[ext]&limit=10000'
                 ]
             }, {
+                test: require.resolve('angular-deferred-bootstrap'),
+                loaders: [
+                    'expose?deferredBootstrapper'
+                ]
+            }, {
                 test: require.resolve('angular'),
                 loaders: [
                     'expose?angular'
@@ -162,11 +167,6 @@ module.exports = function (_path) {
                 $: 'jquery',
                 jQuery: 'jquery',
                 L: 'leaflet'
-            }),
-            new webpack.DefinePlugin({
-                'process.env.NODE_ENV': JSON.stringify(NODE_ENV),
-                'process.env.API_URL': 'http://localhost:9000/',
-                'process.env.CLIENT_ID': JSON.stringify('ZaCxyikiDLFLKBOfPB5R30tnc8r06nxU')
             }),
             new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/),
             new webpack.optimize.DedupePlugin(),

--- a/app-frontend/package.json
+++ b/app-frontend/package.json
@@ -26,6 +26,7 @@
     "angular-animate": "^1.5.8",
     "angular-aria": "^1.5.8",
     "angular-cookies": "^1.5.8",
+    "angular-deferred-bootstrap": "^0.1.9",
     "angular-jwt": "0.0.9",
     "angular-messages": "^1.5.8",
     "angular-resource": "^1.5.8",
@@ -38,7 +39,7 @@
     "auth0-lock": "^9.2.2",
     "bootstrap-sass": "^3.3.6",
     "jquery": "^2.1.4",
-    "leaflet": "^1.0.0-rc.2",
+    "leaflet": "^1.0.0",
     "lodash": "~4.5.0",
     "ng-infinite-scroll": "^1.3.0"
   },

--- a/app-frontend/src/app/components/navBar/navBar.controller.js
+++ b/app-frontend/src/app/components/navBar/navBar.controller.js
@@ -2,13 +2,20 @@ import assetLogo from '../../../assets/images/logo-raster-foundry.png';
 
 // rfNavBar controller class
 export default class NavBarController {
-    constructor($log, $state, store, auth, $scope) {
+    constructor( // eslint-disable-line max-params
+        $log, $state, store, auth, $scope, APP_CONFIG
+    ) {
         'ngInject';
 
         this.$log = $log;
         this.$state = $state;
         this.store = store;
         this.auth = auth;
+
+        if (APP_CONFIG.error) {
+            this.loadError = true;
+        }
+
         this.optionsOpen = false;
         this.isLoggedIn = auth.isAuthenticated;
         this.profile = {};
@@ -19,7 +26,7 @@ export default class NavBarController {
 
         $scope.$watch(function () {
             return auth.isAuthenticated;
-        }, function (isAuthenticated) {
+        }, (isAuthenticated) => {
             if (isAuthenticated) {
                 store.set('profile', this.auth.profile);
                 this.profile = this.auth.profile;
@@ -27,7 +34,7 @@ export default class NavBarController {
                 store.set('accessToken', this.auth.accessToken);
                 this.isLoggedIn = true;
             }
-        }.bind(this));
+        });
     }
 
     signin() {
@@ -40,7 +47,7 @@ export default class NavBarController {
             primaryColor: '#5e509b',
             icon: assetLogo,
             closable: true
-        }, function () {});
+        }, () => {});
     }
 
     logout() {

--- a/app-frontend/src/app/components/navBar/navBar.html
+++ b/app-frontend/src/app/components/navBar/navBar.html
@@ -1,4 +1,4 @@
-<div class="navbar primary-navbar">
+<div class="navbar primary-navbar" ng-show="!$ctrl.loadError">
 	<!-- Nav Left -->
 	<div class="navbar-left">
 	  <a href="#" class="brand">

--- a/app-frontend/src/app/core/core.module.js
+++ b/app-frontend/src/app/core/core.module.js
@@ -1,5 +1,6 @@
 const shared = angular.module('core.shared', []);
 
 require('./services/scene.service')(shared);
+require('./services/config.provider')(shared);
 
 export default shared;

--- a/app-frontend/src/app/core/services/config.provider.js
+++ b/app-frontend/src/app/core/services/config.provider.js
@@ -1,0 +1,26 @@
+export default (app) => {
+    class Config {
+        constructor(env, $resource) {
+            this.env = env;
+            this.Config = $resource('/config/');
+        }
+    }
+
+    class ConfigProvider {
+        constructor() {
+            this.env = null;
+        }
+
+        init(env) {
+            this.env = env;
+        }
+
+        $get($resource) {
+            'ngInject';
+            return new Config(this.env, $resource);
+        }
+    }
+
+    app.service('config', Config);
+    app.provider('config', ConfigProvider);
+};

--- a/app-frontend/src/app/core/services/scene.service.js
+++ b/app-frontend/src/app/core/services/scene.service.js
@@ -1,10 +1,10 @@
-export default function (app) {
+export default (app) => {
     class SceneService {
         constructor($resource) {
             'ngInject';
 
             this.Scene = $resource(
-                'http://localhost:9000/api/scenes/:id/', {
+                '/api/scenes/:id/', {
                     id: '@properties.id'
                 }, {
                     query: {
@@ -25,4 +25,4 @@ export default function (app) {
     }
 
     app.service('sceneService', SceneService);
-}
+};

--- a/app-frontend/src/app/index.bootstrap.js
+++ b/app-frontend/src/app/index.bootstrap.js
@@ -8,8 +8,22 @@ import './index.module';
 
 import '../assets/styles/sass/app.scss';
 
+import deferredBootstrapper from 'angular-deferred-bootstrap';
+
 angular.element(document).ready(function () {
-    angular.bootstrap(document, ['rasterFoundry'], {
-        strictDi: true
+    deferredBootstrapper.bootstrap({
+        element: document,
+        module: 'rasterFoundry',
+        bootstrapConfig: {
+            strictDi: true
+        },
+        resolve: {
+            APP_CONFIG: ['$http', ($http) => {
+                return $http.get('/config').then(
+                    (result) => result,
+                    (error) => ({error: error})
+                );
+            }]
+        }
     });
 });

--- a/app-frontend/src/app/index.config.js
+++ b/app-frontend/src/app/index.config.js
@@ -1,7 +1,10 @@
+/* globals process */
+
 'use strict';
 
-function config(
-    $logProvider, $compileProvider, authProvider, jwtInterceptorProvider, $httpProvider
+function config( // eslint-disable-line max-params
+    $logProvider, $compileProvider, authProvider, jwtInterceptorProvider,
+    $httpProvider, configProvider, APP_CONFIG
 ) {
     'ngInject';
 
@@ -9,26 +12,31 @@ function config(
     $logProvider.debugEnabled(true);
     $compileProvider.debugInfoEnabled(false);
 
-    authProvider.init({
-        domain: 'raster-foundry.auth0.com',
-        clientID: process.env.CLIENT_ID,
-        loginState: 'login',
-        sso: false
-    }, require('auth0-lock'));
+    if (!APP_CONFIG.error) {
+        authProvider.init({
+            domain: 'raster-foundry.auth0.com',
+            clientID: APP_CONFIG.clientId,
+            loginState: 'login',
+            sso: false
+        }, require('auth0-lock'));
 
-    authProvider.on('logout', function (store, $state) {
-        'ngInject';
-        store.remove('profile');
-        store.remove('token');
-        store.remove('accessToken');
-        $state.go('browse');
-    });
+        authProvider.on('logout', function (store, $state) {
+            'ngInject';
+            store.remove('profile');
+            store.remove('token');
+            store.remove('accessToken');
+            $state.go('browse');
+        });
 
-    jwtInterceptorProvider.tokenGetter = function (auth) {
-        'ngInject';
-        return auth.idToken;
-    };
+        jwtInterceptorProvider.tokenGetter = function (auth) {
+            'ngInject';
+            return auth.idToken;
+        };
+    }
+
     $httpProvider.interceptors.push('jwtInterceptor');
+
+    configProvider.init(process.env);
 }
 
 export default config;

--- a/app-frontend/src/app/index.module.js
+++ b/app-frontend/src/app/index.module.js
@@ -36,7 +36,8 @@ const App = angular.module(
         require('./pages/library/buckets/buckets.module.js').name,
         require('./pages/settings/settings.module.js').name,
         require('./pages/settings/profile/profile.module.js').name,
-        require('./pages/settings/account/account.module.js').name
+        require('./pages/settings/account/account.module.js').name,
+        require('./pages/error/error.module.js').name
 
     ]
 );

--- a/app-frontend/src/app/index.routes.js
+++ b/app-frontend/src/app/index.routes.js
@@ -7,6 +7,7 @@ import bucketsTpl from './pages/library/buckets/buckets.html';
 import settingsTpl from './pages/settings/settings.html';
 import profileTpl from './pages/settings/profile/profile.html';
 import accountTpl from './pages/settings/account/account.html';
+import errorTpl from './pages/error/error.html';
 
 
 function routeConfig($urlRouterProvider, $stateProvider) {
@@ -72,6 +73,12 @@ function routeConfig($urlRouterProvider, $stateProvider) {
             url: '/account',
             templateUrl: accountTpl,
             controller: 'AccountController',
+            controllerAs: '$ctrl'
+        })
+        .state('error', {
+            url: '/error',
+            templateUrl: errorTpl,
+            controller: 'ErrorController',
             controllerAs: '$ctrl'
         });
     $urlRouterProvider.otherwise('/browse/');

--- a/app-frontend/src/app/index.run.js
+++ b/app-frontend/src/app/index.run.js
@@ -1,5 +1,13 @@
-function runBlock($rootScope, auth, store, jwtHelper) {
+function runBlock( // eslint-disable-line max-params
+    $rootScope, auth, store, jwtHelper, $state, $location, APP_CONFIG
+) {
     'ngInject';
+    $rootScope.$on('$stateChangeStart', function (e, toState) {
+        if (APP_CONFIG.error && toState.name !== 'error') {
+            e.preventDefault();
+            $state.go('error');
+        }
+    });
     $rootScope.$on('$locationChangeStart', function () {
         let token = store.get('token');
         if (token) {

--- a/app-frontend/src/app/pages/browse/browse.controller.js
+++ b/app-frontend/src/app/pages/browse/browse.controller.js
@@ -1,7 +1,9 @@
 import assetLogo from '../../../assets/images/logo-raster-foundry.png';
 
 class BrowseController {
-    constructor($log, auth, $scope, sceneService, $state) {
+    constructor( // eslint-disable-line max-params
+        $log, auth, $scope, sceneService, $state
+    ) {
         'ngInject';
         this.$log = $log;
         this.auth = auth;

--- a/app-frontend/src/app/pages/error/error.controller.js
+++ b/app-frontend/src/app/pages/error/error.controller.js
@@ -1,0 +1,23 @@
+class ErrorController {
+    constructor( // eslint-disable-line max-params
+        $window, $state, APP_CONFIG, $interval, config
+    ) {
+        'ngInject';
+
+        this.config = config;
+        this.$state = $state;
+        this.$window = $window;
+
+        if (!APP_CONFIG.error) {
+            $state.go('browse');
+        }
+        $interval(this.getConfig.bind(this), 5000);
+    }
+
+    getConfig() {
+        this.config.Config.get().$promise.then(() => {
+            this.$window.location.reload();
+        });
+    }
+}
+export default ErrorController;

--- a/app-frontend/src/app/pages/error/error.html
+++ b/app-frontend/src/app/pages/error/error.html
@@ -1,0 +1,13 @@
+<div class="container column-stretch dashboard">
+  <div class="column">
+  </div>
+  <div class="column-6">
+    <h2>Oops! We seem to be having some server issues right now...</h2>
+    <h4>If you keep me open, I'll load once we've got things working again</h4>
+    <div class="list-placeholder">
+      <i class="icon-load"></i>
+    </div>
+  </div>
+  <div class="column">
+  </div>
+<div>

--- a/app-frontend/src/app/pages/error/error.module.js
+++ b/app-frontend/src/app/pages/error/error.module.js
@@ -1,0 +1,9 @@
+import angular from 'angular';
+
+import ErrorController from './error.controller.js';
+
+const ErrorModule = angular.module('pages.error', []);
+
+ErrorModule.controller('ErrorController', ErrorController);
+
+export default ErrorModule;

--- a/app-server/app/src/main/resources/application.conf
+++ b/app-server/app/src/main/resources/application.conf
@@ -47,7 +47,7 @@ slick {
 
 auth0 {
   clientId = ""
-  clientId = ${?AUTHO_CLIENT_ID}
+  clientId = ${?AUTH0_CLIENT_ID}
   domain = ""
   domain = ${?AUTH0_DOMAIN}
   # Development Secret Only

--- a/app-server/app/src/main/scala/Router.scala
+++ b/app-server/app/src/main/scala/Router.scala
@@ -12,6 +12,7 @@ import com.azavea.rf.scene.SceneRoutes
 import com.azavea.rf.thumbnail.ThumbnailRoutes
 import com.azavea.rf.user.UserRoutes
 import com.azavea.rf.image.ImageRoutes
+import com.azavea.rf.config.ConfigRoutes
 import com.azavea.rf.utils.Database
 
 
@@ -27,7 +28,8 @@ trait Router extends HealthCheckRoutes
     with SceneRoutes
     with BucketRoutes
     with ImageRoutes
-    with ThumbnailRoutes {
+    with ThumbnailRoutes
+    with ConfigRoutes {
 
   implicit def database: Database
   implicit val ec: ExecutionContext
@@ -41,6 +43,7 @@ trait Router extends HealthCheckRoutes
     sceneRoutes ~
     bucketRoutes ~
     imageRoutes ~
-    thumbnailRoutes
+    thumbnailRoutes ~
+    configRoutes
   }
 }

--- a/app-server/app/src/main/scala/config/Config.scala
+++ b/app-server/app/src/main/scala/config/Config.scala
@@ -1,0 +1,14 @@
+package com.azavea.rf.config
+
+import scala.concurrent.{Future, ExecutionContext}
+import com.azavea.rf.utils.{Database, Config}
+import com.azavea.rf.AkkaSystem
+
+case class AngularConfig(clientId: String)
+
+object AngularConfigService extends AkkaSystem.LoggerExecutor with Config {
+  def getConfig()(implicit database: Database, ec: ExecutionContext):
+      AngularConfig = {
+    return AngularConfig(auth0ClientId)
+  }
+}

--- a/app-server/app/src/main/scala/config/Routes.scala
+++ b/app-server/app/src/main/scala/config/Routes.scala
@@ -1,0 +1,20 @@
+package com.azavea.rf.config
+
+import akka.http.scaladsl.server.Route
+import scala.concurrent.ExecutionContext
+
+import com.azavea.rf.auth.Authentication
+import com.azavea.rf.utils.Database
+
+trait ConfigRoutes extends Authentication {
+  implicit def database: Database
+  implicit val ec: ExecutionContext
+
+  def configRoutes: Route = {
+    pathPrefix("config") {
+      get {
+        complete(AngularConfigService.getConfig())
+      }
+    }
+  }
+}

--- a/app-server/app/src/main/scala/config/package.scala
+++ b/app-server/app/src/main/scala/config/package.scala
@@ -1,0 +1,5 @@
+package com.azavea.rf
+
+package object config extends RfJsonProtocols {
+  implicit val configFormat = jsonFormat1(AngularConfig)
+}

--- a/app-server/app/src/main/scala/utils/Config.scala
+++ b/app-server/app/src/main/scala/utils/Config.scala
@@ -19,4 +19,5 @@ trait Config {
   val dbPassword = databaseConfig.getString("password")
 
   val auth0Secret = java.util.Base64.getUrlDecoder.decode(auth0Config.getString("secret"))
+  val auth0ClientId = auth0Config.getString("clientId")
 }

--- a/nginx/etc/nginx/conf.d/default.conf
+++ b/nginx/etc/nginx/conf.d/default.conf
@@ -46,6 +46,15 @@ server {
         proxy_pass http://app-server-upstream;
     }
 
+    # Angular config
+    location = /config {
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Forwarded-For $remote_addr;
+        proxy_redirect off;
+
+        proxy_pass http://app-server-upstream;
+    }
+
     # Static Assets
     location / {
         root /srv/dist/angular;


### PR DESCRIPTION
## Overview

Remove hard coded urls from the frontend application so we can have different URLS depending on the environment

I've created a config service and provider, which we can use to encapsulate all similar configuration

Upgrade leaflet from 1.0.0-rc2 to 1.0.0

## Testing Instructions
* Verify that no bare urls exist in the frontend part of the application
* Start the frontend with `npm start`, navigate to [the root url](http://localhost:9091/) , [library/scenes](http://localhost:9091/#/library/scenes/list?page=1) , and [library/scenes/detail](http://localhost:9091/#/library/scenes/detail/1d8706eb-0895-4169-ac6d-90ed8304ee0f) to verify that the urls still work
* Verify that the maps on the above pages still function as expected
  * Controls should be on the [browse page](http://localhost:9091/), but not on the [library/scenes](http://localhost:9091/#/library/scenes/list?page=1) , and [library/scenes/detail](http://localhost:9091/#/library/scenes/detail/1d8706eb-0895-4169-ac6d-90ed8304ee0f) page
  * The [library/scenes/detail](http://localhost:9091/#/library/scenes/detail/1d8706eb-0895-4169-ac6d-90ed8304ee0f) map should not allow any type of interaction (click, drag, double click, shift-click + drag, touch etc)