### PR TITLE
Restart Jenkins every 3 hours to stop branch indexing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,6 +89,10 @@ src_managed/
 project/boot/
 project/plugins/project/
 
+# Molecule
+.molecule/
+*__pycache__*
+
 # Scala-IDE specific
 .scala_dependencies
 .worksheet

--- a/deployment/ansible/roles/raster-foundry.jenkins/defaults/main.yml
+++ b/deployment/ansible/roles/raster-foundry.jenkins/defaults/main.yml
@@ -2,3 +2,4 @@
 # defaults for jenkins
 jenkins_server_name: jenkins.staging.rasterfoundry.com
 jenkins_http_port: "8080"
+jenkins_jar_path: /var/lib/jenkins/jenkins-cli.jar

--- a/deployment/ansible/roles/raster-foundry.jenkins/defaults/main.yml
+++ b/deployment/ansible/roles/raster-foundry.jenkins/defaults/main.yml
@@ -2,4 +2,4 @@
 # defaults for jenkins
 jenkins_server_name: jenkins.staging.rasterfoundry.com
 jenkins_http_port: "8080"
-jenkins_jar_path: /var/lib/jenkins/jenkins-cli.jar
+jenkins_cli_jar_path: /var/cache/jenkins/war/WEB-INF/jenkins-cli.jar

--- a/deployment/ansible/roles/raster-foundry.jenkins/files/config.xml
+++ b/deployment/ansible/roles/raster-foundry.jenkins/files/config.xml
@@ -1,0 +1,38 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<hudson>
+  <disabledAdministrativeMonitors/>
+  <version>1.0</version>
+  <numExecutors>2</numExecutors>
+  <mode>NORMAL</mode>
+  <useSecurity>false</useSecurity>
+  <securityRealm class="hudson.security.HudsonPrivateSecurityRealm">
+    <disableSignup>true</disableSignup>
+    <enableCaptcha>false</enableCaptcha>
+  </securityRealm>
+  <disableRememberMe>false</disableRememberMe>
+  <projectNamingStrategy class="jenkins.model.ProjectNamingStrategy$DefaultProjectNamingStrategy"/>
+  <workspaceDir>${JENKINS_HOME}/workspace/${ITEM_FULLNAME}</workspaceDir>
+  <buildsDir>${ITEM_ROOTDIR}/builds</buildsDir>
+  <jdks/>
+  <viewsTabBar class="hudson.views.DefaultViewsTabBar"/>
+  <myViewsTabBar class="hudson.views.DefaultMyViewsTabBar"/>
+  <clouds/>
+  <scmCheckoutRetryCount>0</scmCheckoutRetryCount>
+  <views>
+    <hudson.model.AllView>
+      <owner class="hudson" reference="../../.."/>
+      <name>All</name>
+      <filterExecutors>false</filterExecutors>
+      <filterQueue>false</filterQueue>
+      <properties class="hudson.model.View$PropertyList"/>
+    </hudson.model.AllView>
+  </views>
+  <primaryView>All</primaryView>
+  <slaveAgentPort>-1</slaveAgentPort>
+  <label></label>
+  <crumbIssuer class="hudson.security.csrf.DefaultCrumbIssuer">
+    <excludeClientIPFromCrumb>false</excludeClientIPFromCrumb>
+  </crumbIssuer>
+  <nodeProperties/>
+  <globalNodeProperties/>
+</hudson>

--- a/deployment/ansible/roles/raster-foundry.jenkins/meta/main.yml
+++ b/deployment/ansible/roles/raster-foundry.jenkins/meta/main.yml
@@ -2,4 +2,8 @@
 # meta file for raster-foundry.jenkins
 dependencies:
   - { role: azavea.nginx, nginx_delete_default_site: True }
-  - { role: azavea.jenkins }
+  - { role: azavea.jenkins,
+      jenkins_java_opts:
+        ['-Djava.awt.headless=true',
+        '-Djava.net.preferIPv4Stack=true',
+        '-Djenkins.install.runSetupWizard=false' ] }

--- a/deployment/ansible/roles/raster-foundry.jenkins/molecule-playbook.yml
+++ b/deployment/ansible/roles/raster-foundry.jenkins/molecule-playbook.yml
@@ -1,0 +1,34 @@
+---
+- hosts: all
+  gather_facts: False
+  become: True
+  pre_tasks:
+
+    # Check Ubuntu release version to determine if we need to install python 2,
+    # an Ansible dependency that isn't included by default in Ubuntu 16.04 and
+    # up.
+
+    - name: Check Ubuntu release
+      raw: cat /etc/lsb-release | grep DISTRIB_RELEASE | cut -d "=" -f2
+      register: ubuntu_release
+      changed_when: False
+
+    - debug: msg="Running Ubuntu version {{ ubuntu_release.stdout|float }}"
+
+    # Update apt cache and install python 2 for Ubuntu versions greater than
+    # 16.04
+
+    - name: Update APT cache
+      raw: apt-get update
+      changed_when: False
+
+    - name: Install python
+      raw: apt-get install -yq python
+      when: "{{ ubuntu_release.stdout| version_compare('16.04', '>=') }}"
+
+    # Gather facts once ansible dependencies are installed
+    - name: Gather facts
+      setup:
+
+  roles:
+     - { role: "../raster-foundry.jenkins" }

--- a/deployment/ansible/roles/raster-foundry.jenkins/molecule-requirements.yml
+++ b/deployment/ansible/roles/raster-foundry.jenkins/molecule-requirements.yml
@@ -1,0 +1,1 @@
+- src: azavea.java

--- a/deployment/ansible/roles/raster-foundry.jenkins/molecule.cfg
+++ b/deployment/ansible/roles/raster-foundry.jenkins/molecule.cfg
@@ -1,0 +1,2 @@
+[defaults]
+roles_path = ../:.molecule/

--- a/deployment/ansible/roles/raster-foundry.jenkins/molecule.yml
+++ b/deployment/ansible/roles/raster-foundry.jenkins/molecule.yml
@@ -34,3 +34,5 @@ molecule:
 
 verifier:
   name: testinfra
+  options:
+    sudo: True

--- a/deployment/ansible/roles/raster-foundry.jenkins/molecule.yml
+++ b/deployment/ansible/roles/raster-foundry.jenkins/molecule.yml
@@ -1,0 +1,36 @@
+---
+ansible:
+  config_file: molecule.cfg
+  requirements_file: molecule-requirements.yml
+  playbook: molecule-playbook.yml
+  verbose:
+  sudo: True
+
+vagrant:
+  platforms:
+    - name: trusty64
+      box: ubuntu/trusty64
+
+    - name: xenial64
+      box: ubuntu/xenial64
+
+  providers:
+    - name: virtualbox
+      type: virtualbox
+      options:
+        memory: 1024
+
+  instances:
+    - name: raster-foundry-jenkins
+
+molecule:
+  test:
+    sequence:
+      - syntax
+      - create
+      - converge
+      - idempotence
+      - verify
+
+verifier:
+  name: testinfra

--- a/deployment/ansible/roles/raster-foundry.jenkins/tasks/main.yml
+++ b/deployment/ansible/roles/raster-foundry.jenkins/tasks/main.yml
@@ -1,4 +1,11 @@
 ---
+- name: Disable authentication for login
+  copy:
+    src=files/config.xml
+    dest=/var/lib/jenkins/config.xml
+  notify:
+    - Restart Jenkins
+
 - name: Add Jenkins Nginx config
   template: src=jenkins.conf.j2
             dest=/etc/nginx/sites-available/jenkins.conf

--- a/deployment/ansible/roles/raster-foundry.jenkins/tasks/main.yml
+++ b/deployment/ansible/roles/raster-foundry.jenkins/tasks/main.yml
@@ -12,11 +12,6 @@
   notify:
     - Restart Nginx
 
-- name: Download Jenkins CLI jar
-  get_url:
-    url=http://localhost:{{ jenkins_http_port}}/jnlpJars/jenkins-cli.jar
-    dest={{ jenkins_jar_path }}
-
 - name: Setup hourly docker-gc cron task
   cron:
     name: "docker-gc"
@@ -29,6 +24,7 @@
       -v /etc:/etc
       spotify/docker-gc
     state: "present"
+  changed_when: False
 
 - name: Restart Jenkins every 3 hours
   cron:
@@ -37,6 +33,7 @@
     hour: "*/3"
     minute: "0"
     job: >
-      /usr/bin/java -jar {{ jenkins_jar_path }}
+      /usr/bin/java -jar {{ jenkins_cli_jar_path }}
       -s http://localhost:{{ jenkins_http_port }}
       restart
+  changed_when: False

--- a/deployment/ansible/roles/raster-foundry.jenkins/tasks/main.yml
+++ b/deployment/ansible/roles/raster-foundry.jenkins/tasks/main.yml
@@ -12,6 +12,11 @@
   notify:
     - Restart Nginx
 
+- name: Download Jenkins CLI jar
+  get_url:
+    url=http://localhost:{{ jenkins_http_port}}/jnlpJars/jenkins-cli.jar
+    dest={{ jenkins_jar_path }}
+
 - name: Setup hourly docker-gc cron task
   cron:
     name: "docker-gc"
@@ -24,3 +29,14 @@
       -v /etc:/etc
       spotify/docker-gc
     state: "present"
+
+- name: Restart Jenkins every 3 hours
+  cron:
+    name: "jenkins-restart"
+    user: "{{ jenkins_name }}"
+    hour: "*/3"
+    minute: "0"
+    job: >
+      /usr/bin/java -jar {{ jenkins_jar_path }}
+      -s http://localhost:{{ jenkins_http_port }}
+      restart

--- a/deployment/ansible/roles/raster-foundry.jenkins/tests/test_jenkins.py
+++ b/deployment/ansible/roles/raster-foundry.jenkins/tests/test_jenkins.py
@@ -1,0 +1,111 @@
+import pytest
+
+
+@pytest.fixture()
+def AnsibleDefaults(Ansible):
+    """ Load default variables into dictionary.
+
+    Args:
+        Ansible - Requires the ansible connection backend.
+    """
+    return Ansible("include_vars", "./defaults/main.yml")["ansible_facts"]
+
+
+@pytest.fixture()
+def AnsibleFacts(Ansible):
+    """ Load ansible facts into a dictionary.
+
+    Args:
+        Ansible - Requires ansible connection backend.
+    """
+    return Ansible("setup")["ansible_facts"]
+
+
+def test_jenkins_cli_jar_exists(File, AnsibleDefaults):
+    """ Ensure the Jenkins CLI JAR exists.
+
+    Args:
+        File - module to determine CLI file existence
+        AnsibleDefaults - module to pull the Jenkins CLI JAR path.
+
+    Raises:
+        AssertionError if package is not installed or the wrong version.
+    """
+
+    jenkins_cli_jar_path = AnsibleDefaults["jenkins_cli_jar_path"]
+    jenkins_cli_jar = File(jenkins_cli_jar_path)
+    assert jenkins_cli_jar.exists
+
+
+def test_crontab_entry(Ansible, AnsibleDefaults, Command, Sudo):
+    """ Check the crontab for the Jenkins user to ensure that the entries
+        for Jenkins restart and Docker garbage collection are present and
+        correct.
+
+        Args:
+            Ansible - Obtain name of Jenkins user from azavea.jenkins defaults
+            AnsibleDefaults - Get location of Jenkins CLI JAR and Jenkins HTTP
+                              port.
+            Command - Run crontab
+            Sudo - Switch to Jenkins user
+
+        Raises:
+            AssertionError if Docker and Jenkins entries are not in the crontab
+
+    """
+
+    facts = Ansible("include_vars",
+                    "../azavea.jenkins/defaults/main.yml")["ansible_facts"]
+
+    jenkins_name = facts["jenkins_name"]
+    jenkins_crontab_entry = "0 */3 * * * /usr/bin/java -jar {} " \
+                            "-s http://localhost:{} restart".format(
+                                AnsibleDefaults["jenkins_cli_jar_path"],
+                                AnsibleDefaults["jenkins_http_port"])
+
+    docker_crontab_entry = "@hourly /usr/bin/docker run --rm -v " \
+                           "/var/run/docker.sock:/var/run/docker.sock -v " \
+                           "/etc:/etc spotify/docker-gc"
+
+    with Sudo(user=jenkins_name):
+        crontab = Command.check_output("crontab -l")
+        assert jenkins_crontab_entry in crontab
+        assert docker_crontab_entry in crontab
+
+
+def test_jenkins_cli_restart(Ansible, AnsibleDefaults, Command, Sudo):
+    """ Ensure we can use the Jenkins CLI to restart the service without
+    an inital login. In order for this to be the case, the Jenkins CLI
+    JAR must be in the proper location and athorizations have to be turned off.
+
+    Args:
+        Ansible - get_url module to interact with Jenkins
+        AnsibleDefaults - module to pull CLI Jar Location and Jenkins port
+        Command - module to run the restart command
+        Sudo - privilege escalation to reestart Jenkins
+
+    Raises:
+        Assertion error if command doesn't return 0, or if Jenkins doesn't
+        return a status page saying it's restarting.
+    """
+    jenkins_cli_jar_path = AnsibleDefaults["jenkins_cli_jar_path"]
+    jenkins_http_port = AnsibleDefaults["jenkins_http_port"]
+    jenkins_url = "http://localhost:{}".format(jenkins_http_port)
+
+    restart_command = "/usr/bin/java -jar {} " \
+                      "-s {} restart".format(jenkins_cli_jar_path, jenkins_url)
+    with Sudo():
+        restart_jenkins = Command(restart_command).rc
+
+    Command("sleep 15")
+
+    jenkins_restart_message = Ansible("get_url",
+                                      "url={} "
+                                      "dest=/tmp/jenkins.html".format(jenkins_url), # NOQA
+                                      check=False)["msg"]
+
+    # Check to see that the restart command exited successfully
+    assert restart_jenkins == 0
+
+    # Check to ensure Jenkins has successfully restarted.
+    assert "OK" in jenkins_restart_message


### PR DESCRIPTION
## Overview

Jenkins branch indexing hangs as described in https://issues.jenkins-ci.org/browse/JENKINS-36724 and #492 .

### Demo

<img width="1268" alt="screen shot 2016-10-11 at 11 00 05 am" src="https://cloud.githubusercontent.com/assets/2507188/19275500/f1b5b5a2-8fa1-11e6-9f4f-d17d758cc17f.png">


### Notes

There doesn't seem to be a fix to this issue besides restarting Jenkins. This PR installs the Jenkins CLI and sets a cronjob to restart Jenkins every few hours.


## Testing Instructions

 * Login to `jenkins.staging.rasterfoundry.com`
 * Ensure `/var/lib/jenkins/jenkins-cli.jar` exists
 * Ensure `/var/spool/crontabs/jenkins` exists and contains an entry to run the restart command every 3 hours as described in the [cli documentation](http://jenkins.staging.rasterfoundry.com/cli/command/restart).

Solves #492 

