### PR TITLE
Support Refresh Tokens

### DIFF
--- a/app-backend/app/src/main/resources/application.conf
+++ b/app-backend/app/src/main/resources/application.conf
@@ -53,4 +53,7 @@ auth0 {
   # Development Secret Only
   secret = ""
   secret = ${?AUTH0_CLIENT_SECRET}
+  # Auth0 Bearer with proper permissions for Management API
+  bearer = ""
+  bearer = ${?AUTH0_MANAGEMENT_BEARER}
 }

--- a/app-backend/app/src/main/scala/Router.scala
+++ b/app-backend/app/src/main/scala/Router.scala
@@ -15,6 +15,7 @@ import com.azavea.rf.user.UserRoutes
 import com.azavea.rf.image.ImageRoutes
 import com.azavea.rf.config.ConfigRoutes
 import com.azavea.rf.database.Database
+import com.azavea.rf.token.TokenRoutes
 
 
 /**
@@ -29,6 +30,7 @@ trait Router extends HealthCheckRoutes
     with SceneRoutes
     with BucketRoutes
     with ImageRoutes
+    with TokenRoutes
     with ThumbnailRoutes
     with ConfigRoutes {
 
@@ -43,6 +45,7 @@ trait Router extends HealthCheckRoutes
     sceneRoutes ~
     bucketRoutes ~
     imageRoutes ~
+    tokenRoutes ~
     thumbnailRoutes ~
     configRoutes
   }

--- a/app-backend/app/src/main/scala/token/Auth0ErrorHandler.scala
+++ b/app-backend/app/src/main/scala/token/Auth0ErrorHandler.scala
@@ -1,0 +1,15 @@
+package com.azavea.rf.token
+
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.server.{Directives, ExceptionHandler}
+import com.azavea.rf.utils.RfStackTrace
+import com.typesafe.scalalogging.LazyLogging
+
+trait Auth0ErrorHandler extends Directives with LazyLogging {
+
+  val auth0ExceptionHandler = ExceptionHandler {
+    case e: Auth0Exception =>
+      logger.error(RfStackTrace(e))
+      complete(StatusCodes.ServerError(500)("Authentication Service Error", e.getClientMessage))
+  }
+}

--- a/app-backend/app/src/main/scala/token/Auth0Exception.scala
+++ b/app-backend/app/src/main/scala/token/Auth0Exception.scala
@@ -1,0 +1,22 @@
+package com.azavea.rf.token
+
+import akka.http.scaladsl.model.StatusCode
+
+class Auth0Exception(code: StatusCode, message: String, cause: Throwable)
+  extends RuntimeException(Auth0Exception.defaultMessage(message, cause), cause) {
+
+  def this(code: StatusCode, message: String) = {
+    this(code, message, null)
+  }
+
+  def getClientMessage: String = s"Authentication service returned error $code"
+}
+
+object Auth0Exception {
+
+  def defaultMessage(message: String, cause: Throwable): String = {
+    if (message != null) message
+    else if (cause != null) cause.toString
+    else "Unknown error communicating with authentication service"
+  }
+}

--- a/app-backend/app/src/main/scala/token/Routes.scala
+++ b/app-backend/app/src/main/scala/token/Routes.scala
@@ -13,7 +13,8 @@ trait TokenRoutes extends Authentication {
 
   def tokenRoutes: Route = pathPrefix("api" / "tokens") {
     listRefreshTokens ~
-    getAuthorizedToken
+    getAuthorizedToken ~
+    revokeRefreshToken
   }
 
   def listRefreshTokens: Route = pathEndOrSingleSlash {
@@ -31,6 +32,16 @@ trait TokenRoutes extends Authentication {
       entity(as[RefreshToken]) { refreshToken =>
         onSuccess(TokenService.getAuthorizedToken(refreshToken)) { token =>
           complete(token)
+        }
+      }
+    }
+  }
+
+  def revokeRefreshToken: Route = pathPrefix(Segment) { deviceId =>
+    delete {
+      authenticate { user =>
+        onSuccess(TokenService.revokeRefreshToken(user, deviceId)) { response =>
+          complete(response)
         }
       }
     }

--- a/app-backend/app/src/main/scala/token/Routes.scala
+++ b/app-backend/app/src/main/scala/token/Routes.scala
@@ -12,7 +12,8 @@ trait TokenRoutes extends Authentication {
   import TokenJsonProtocol._
 
   def tokenRoutes: Route = pathPrefix("api" / "tokens") {
-    listRefreshTokens
+    listRefreshTokens ~
+    getAuthorizedToken
   }
 
   def listRefreshTokens: Route = pathEndOrSingleSlash {
@@ -20,6 +21,16 @@ trait TokenRoutes extends Authentication {
       authenticate { user =>
         onSuccess(TokenService.listRefreshTokens(user)) { tokens =>
           complete(tokens)
+        }
+      }
+    }
+  }
+
+  def getAuthorizedToken: Route = pathEndOrSingleSlash {
+    post {
+      entity(as[RefreshToken]) { refreshToken =>
+        onSuccess(TokenService.getAuthorizedToken(refreshToken)) { token =>
+          complete(token)
         }
       }
     }

--- a/app-backend/app/src/main/scala/token/Routes.scala
+++ b/app-backend/app/src/main/scala/token/Routes.scala
@@ -1,18 +1,22 @@
 package com.azavea.rf.token
 
 import akka.http.scaladsl.server.Route
+
 import com.azavea.rf.auth.Authentication
 
 
 /**
   * Routes for tokens
   */
-trait TokenRoutes extends Authentication {
+trait TokenRoutes extends Authentication
+  with Auth0ErrorHandler {
 
   def tokenRoutes: Route = pathPrefix("api" / "tokens") {
-    listRefreshTokens ~
-    getAuthorizedToken ~
-    revokeRefreshToken
+    handleExceptions(auth0ExceptionHandler) {
+      listRefreshTokens ~
+      getAuthorizedToken ~
+      revokeRefreshToken
+    }
   }
 
   def listRefreshTokens: Route = pathEndOrSingleSlash {

--- a/app-backend/app/src/main/scala/token/Routes.scala
+++ b/app-backend/app/src/main/scala/token/Routes.scala
@@ -1,0 +1,27 @@
+package com.azavea.rf.token
+
+import akka.http.scaladsl.server.Route
+import com.azavea.rf.auth.Authentication
+
+
+/**
+  * Routes for tokens
+  */
+trait TokenRoutes extends Authentication {
+
+  import TokenJsonProtocol._
+
+  def tokenRoutes: Route = pathPrefix("api" / "tokens") {
+    listRefreshTokens
+  }
+
+  def listRefreshTokens: Route = pathEndOrSingleSlash {
+    get {
+      authenticate { user =>
+        onSuccess(TokenService.listRefreshTokens(user)) { tokens =>
+          complete(tokens)
+        }
+      }
+    }
+  }
+}

--- a/app-backend/app/src/main/scala/token/Routes.scala
+++ b/app-backend/app/src/main/scala/token/Routes.scala
@@ -9,8 +9,6 @@ import com.azavea.rf.auth.Authentication
   */
 trait TokenRoutes extends Authentication {
 
-  import TokenJsonProtocol._
-
   def tokenRoutes: Route = pathPrefix("api" / "tokens") {
     listRefreshTokens ~
     getAuthorizedToken ~

--- a/app-backend/app/src/main/scala/token/Token.scala
+++ b/app-backend/app/src/main/scala/token/Token.scala
@@ -43,8 +43,8 @@ object TokenService extends Config {
       .flatMap {
         case HttpResponse(StatusCodes.OK, _, entity, _) =>
           Unmarshal(entity).to[List[DeviceCredential]]
-        case HttpResponse(errCode, _, _, _) =>
-          throw new Exception(s"Error communicating with Auth0: $errCode")
+        case HttpResponse(errCode, _, error, _) =>
+          throw new Auth0Exception(errCode, error.toString)
       }
   }
 
@@ -68,8 +68,8 @@ object TokenService extends Config {
       .flatMap {
         case HttpResponse(StatusCodes.OK, _, entity, _) =>
           Unmarshal(entity).to[AuthorizedToken]
-        case HttpResponse(errCode, _, _, _) =>
-          throw new Exception(s"Error communicating with Auth0: $errCode")
+        case HttpResponse(errCode, _, error, _) =>
+          throw new Auth0Exception(errCode, error.toString)
       }
   }
 
@@ -87,8 +87,8 @@ object TokenService extends Config {
             .map {
               case HttpResponse(StatusCodes.NoContent, _, _, _) =>
                 StatusCodes.NoContent
-              case HttpResponse(errCode, _, _, _) =>
-                throw new Exception(s"Error revoking refresh token: $errCode")
+              case HttpResponse(errCode, _, error, _) =>
+                throw new Auth0Exception(errCode, error.toString)
             }
         case _ => Future(StatusCodes.NotFound)
       }

--- a/app-backend/app/src/main/scala/token/Token.scala
+++ b/app-backend/app/src/main/scala/token/Token.scala
@@ -1,14 +1,11 @@
 package com.azavea.rf.token
 
 import akka.http.scaladsl.Http
-import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
 import akka.http.scaladsl.model.HttpMethods._
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.Uri.{Path, Query}
 import akka.http.scaladsl.model.headers.{Authorization, GenericHttpCredentials}
 import akka.http.scaladsl.unmarshalling.Unmarshal
-
-import spray.json.DefaultJsonProtocol
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
@@ -21,17 +18,8 @@ case class RefreshToken(refresh_token: String)
 case class DeviceCredential(id: String, device_name: String)
 case class AuthorizedToken(id_token: String, expires_in: Int, token_type: String)
 
-object TokenJsonProtocol extends SprayJsonSupport
-  with DefaultJsonProtocol {
-
-  implicit val refreshTokenJson = jsonFormat1(RefreshToken)
-  implicit val deviceCredentialJson = jsonFormat2(DeviceCredential)
-  implicit val authorizedTokenJson = jsonFormat3(AuthorizedToken)
-}
-
 object TokenService extends Config {
 
-  import TokenJsonProtocol._
   import com.azavea.rf.AkkaSystem._
 
   val uri = Uri(s"https://$auth0Domain/api/v2/device-credentials")

--- a/app-backend/app/src/main/scala/token/Token.scala
+++ b/app-backend/app/src/main/scala/token/Token.scala
@@ -1,0 +1,58 @@
+package com.azavea.rf.token
+
+import akka.http.scaladsl.Http
+import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
+import akka.http.scaladsl.model.HttpMethods._
+import akka.http.scaladsl.model._
+import akka.http.scaladsl.model.Uri.Query
+import akka.http.scaladsl.model.headers.{Authorization, GenericHttpCredentials}
+import akka.http.scaladsl.unmarshalling.Unmarshal
+
+import spray.json.DefaultJsonProtocol
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+
+import com.azavea.rf.datamodel.User
+import com.azavea.rf.utils.Config
+
+
+case class DeviceCredential(id: String, device_name: String)
+
+object TokenJsonProtocol extends SprayJsonSupport
+  with DefaultJsonProtocol {
+
+  implicit val deviceCredentialJson = jsonFormat2(DeviceCredential)
+}
+
+object TokenService extends Config {
+
+  import TokenJsonProtocol._
+  import com.azavea.rf.AkkaSystem._
+
+  val uri = Uri(s"https://$auth0Domain/api/v2/device-credentials")
+  val auth0BearerHeader = List(
+    Authorization(GenericHttpCredentials("Bearer", auth0Bearer))
+  )
+
+  def listRefreshTokens(user: User): Future[List[DeviceCredential]] = {
+
+    val params = Query(
+      "type" -> "refresh_token",
+      "user_id" -> user.id
+    )
+
+    Http()
+      .singleRequest(HttpRequest(
+        method = GET,
+        uri = uri.withQuery(params),
+        headers = auth0BearerHeader
+      ))
+      .flatMap {
+        case HttpResponse(StatusCodes.OK, _, entity, _) =>
+          Unmarshal(entity).to[List[DeviceCredential]]
+        case HttpResponse(errCode, _, _, _) =>
+          throw new Exception(s"Error communicating with Auth0: $errCode")
+      }
+  }
+}

--- a/app-backend/app/src/main/scala/token/Token.scala
+++ b/app-backend/app/src/main/scala/token/Token.scala
@@ -4,7 +4,7 @@ import akka.http.scaladsl.Http
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
 import akka.http.scaladsl.model.HttpMethods._
 import akka.http.scaladsl.model._
-import akka.http.scaladsl.model.Uri.Query
+import akka.http.scaladsl.model.Uri.{Path, Query}
 import akka.http.scaladsl.model.headers.{Authorization, GenericHttpCredentials}
 import akka.http.scaladsl.unmarshalling.Unmarshal
 
@@ -17,12 +17,16 @@ import com.azavea.rf.datamodel.User
 import com.azavea.rf.utils.Config
 
 
+case class RefreshToken(refresh_token: String)
 case class DeviceCredential(id: String, device_name: String)
+case class AuthorizedToken(id_token: String, expires_in: Int, token_type: String)
 
 object TokenJsonProtocol extends SprayJsonSupport
   with DefaultJsonProtocol {
 
+  implicit val refreshTokenJson = jsonFormat1(RefreshToken)
   implicit val deviceCredentialJson = jsonFormat2(DeviceCredential)
+  implicit val authorizedTokenJson = jsonFormat3(AuthorizedToken)
 }
 
 object TokenService extends Config {
@@ -51,6 +55,31 @@ object TokenService extends Config {
       .flatMap {
         case HttpResponse(StatusCodes.OK, _, entity, _) =>
           Unmarshal(entity).to[List[DeviceCredential]]
+        case HttpResponse(errCode, _, _, _) =>
+          throw new Exception(s"Error communicating with Auth0: $errCode")
+      }
+  }
+
+  def getAuthorizedToken(rt: RefreshToken): Future[AuthorizedToken] = {
+
+    val params = FormData(
+      "api_type" -> "app",
+      "grant_type" -> "urn:ietf:params:oauth:grant-type:jwt-bearer",
+      "scope" -> "openid",
+      "refresh_token" -> rt.refresh_token,
+      "client_id" -> auth0ClientId,
+      "target" -> auth0ClientId
+    ).toEntity
+
+    Http()
+      .singleRequest(HttpRequest(
+        method = POST,
+        uri = uri.withPath(Path("/delegation")),
+        entity = params
+      ))
+      .flatMap {
+        case HttpResponse(StatusCodes.OK, _, entity, _) =>
+          Unmarshal(entity).to[AuthorizedToken]
         case HttpResponse(errCode, _, _, _) =>
           throw new Exception(s"Error communicating with Auth0: $errCode")
       }

--- a/app-backend/app/src/main/scala/token/package.scala
+++ b/app-backend/app/src/main/scala/token/package.scala
@@ -1,0 +1,7 @@
+package com.azavea.rf
+
+package object token extends RfJsonProtocols {
+  implicit val refreshTokenJson = jsonFormat1(RefreshToken)
+  implicit val deviceCredentialJson = jsonFormat2(DeviceCredential)
+  implicit val authorizedTokenJson = jsonFormat3(AuthorizedToken)
+}

--- a/app-backend/app/src/main/scala/utils/Config.scala
+++ b/app-backend/app/src/main/scala/utils/Config.scala
@@ -18,6 +18,8 @@ trait Config {
   val dbUser = databaseConfig.getString("user")
   val dbPassword = databaseConfig.getString("password")
 
+  val auth0Domain = auth0Config.getString("domain")
+  val auth0Bearer = auth0Config.getString("bearer")
   val auth0Secret = java.util.Base64.getUrlDecoder.decode(auth0Config.getString("secret"))
   val auth0ClientId = auth0Config.getString("clientId")
 }

--- a/app-backend/app/src/main/scala/utils/RfStackTrace.scala
+++ b/app-backend/app/src/main/scala/utils/RfStackTrace.scala
@@ -1,0 +1,12 @@
+package com.azavea.rf.utils
+
+import java.io.{PrintWriter, StringWriter}
+
+object RfStackTrace {
+  // From http://alvinalexander.com/scala/how-convert-stack-trace-exception-string-print-logger-logging-log4j-slf4j
+  def apply(t: Throwable): String = {
+    val sw = new StringWriter
+    t.printStackTrace(new PrintWriter(sw))
+    sw.toString
+  }
+}


### PR DESCRIPTION
## Overview

Refresh tokens are useful for CLIs, mobile devices, and other long-lived clients of the API. The idea is to generate a token tied to the client that allows the user to not have to specify their username and password every time.

The workflow for the user will be as follows:

 1. Generate a Refresh Token from Auth0
 2. Use the Refresh Token to get a JWT by POSTing the Refresh Token to `/api/tokens`

        {
          "refresh_token": "eyJ..."
        }

 3. Use the JWT in all their subsequent requests

Each Refresh Token has two pieces of metadata: an `id` and a `device_name`. The `id` is for uniquely identify the token, for the purpose of deletion. The `device_name` is a friendly name the user chooses when creating a Refresh Token, to help them remember which device it was for. Once generated, the actual Refresh Token is never saved anywhere except for on the device by the user. We only have access to it's metadata, not the token itself. Thus, if a user loses their Refresh Token, they must get a new one.

Users can get a list of active tokens by simply GETing `/api/tokens` with their JWT. To revoke a particular token, they can DELETE `/api/tokens/{id}`.

All the tokens and their authorization logic is handled by Auth0. We simply proxy the requests to them, since listing and deleting Refresh is done via the Management API which requires Client Secret authentication.

### Demo

#### Acquiring a Refresh Token

Ensure that _nothing_ is running on `http://localhost:9091`. Construct and visit the following URL:

```
https://raster-foundry.auth0.com/authorize?response_type=token&client_id={{ AUTH0_CLIENT_ID }}&connection=Username-Password-Authentication&redirect_uri=http://localhost:9091&device={{ YOUR_DEVICE_NAME }}&scope=openid%20offline_access
```

You should be redirected to `http://localhost:9091/#access_token=Vhj...&refresh_token=VSW...&id_token=eyJ...&token_type=Bearer` with the `refresh_token` in the query hash:

![image](https://cloud.githubusercontent.com/assets/1430060/19391230/ad67787c-91f9-11e6-94c1-b600c08532ca.png)


#### Getting a JWT with a Refresh Token

Acquiring a JWT requires only a valid Refresh Token, and no JWT need be specified in the `Authorization: Bearer eyJ...` header. The JWT received in `id_token` should be used in all future requests.

```http
> http :9000/api/tokens refresh_token=AgmvVAbrl38KJH15Fpx2yCkEBCt8LCDcDD5mbwWn6Ud1N
HTTP/1.1 200 OK
Content-Length: 414
Content-Type: application/json
Date: Fri, 14 Oct 2016 14:17:22 GMT
Server: akka-http/2.4.10

{
    "expires_in": 36000,
    "id_token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwczovL3Jhc3Rlci1mb3VuZHJ5LmF1dGgwLmNvbS8iLCJzdWIiOiJhdXRoMHw1N2Y3YjMwMGI3ZWZkZTY5NmI0MjI0NTMiLCJhdWQiOiJaYUN4eWlraURMRkxLQk9mUEI1UjMwdG5jOHIwNm54VSIsImV4cCI6MTQ3NjQ5MDY0MiwiaWF0IjoxNDc2NDU0NjQyLCJhenAiOiJaYUN4eWlraURMRkxLQk9mUEI1UjMwdG5jOHIwNm54VSJ9._UFhSJI7B7s4friZ8XjIqdMBu0lWp20n7x7shjILAZg",
    "token_type": "Bearer"
}

```

or, if you inexplicably prefer `curl`:

```
> curl -X POST -H "Content-Type: application/json" -d '{"refresh_token": "AgmvVAbrl38KJH15Fpx2yCkEBCt8LCDcDD5mbwWn6Ud1N"}' http://localhost:9000/api/tokens
{
  "id_token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwczovL3Jhc3Rlci1mb3VuZHJ5LmF1dGgwLmNvbS8iLCJzdWIiOiJhdXRoMHw1N2Y3YjMwMGI3ZWZkZTY5NmI0MjI0NTMiLCJhdWQiOiJaYUN4eWlraURMRkxLQk9mUEI1UjMwdG5jOHIwNm54VSIsImV4cCI6MTQ3NjQ5MDk2MiwiaWF0IjoxNDc2NDU0OTYyLCJhenAiOiJaYUN4eWlraURMRkxLQk9mUEI1UjMwdG5jOHIwNm54VSJ9.nq7eDdCmAfxe_GhckoGO-bEEevwr0cjEJNYLDjNlyQQ",
  "expires_in": 36000,
  "token_type": "Bearer"
}
```

#### Listing Active Refresh Tokens

Here the user must be logged in, and use a valid JWT in the `Authorization: Bearer eyJ...` header.

```http
> http :9000/api/tokens "Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwczovL3Jhc3Rlci1mb3VuZHJ5LmF1dGgwLmNvbS8iLCJzdWIiOiJhdXRoMHw1N2Y3YjMwMGI3ZWZkZTY5NmI0MjI0NTMiLCJhdWQiOiJaYUN4eWlraURMRkxLQk9mUEI1UjMwdG5jOHIwNm54VSIsImV4cCI6MTQ3NjQ5MDk2MiwiaWF0IjoxNDc2NDU0OTYyLCJhenAiOiJaYUN4eWlraURMRkxLQk9mUEI1UjMwdG5jOHIwNm54VSJ9.nq7eDdCmAfxe_GhckoGO-bEEevwr0cjEJNYLDjNlyQQ"
HTTP/1.1 200 OK
Content-Length: 80
Content-Type: application/json
Date: Fri, 14 Oct 2016 14:24:39 GMT
Server: akka-http/2.4.10

[
    {
        "device_name": "ttuhinanshu-macbook-pro",
        "id": "dcr_iGZTCZOUpfAMvof4"
    }
]
```

```
> curl -H "Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwczovL3Jhc3Rlci1mb3VuZHJ5LmF1dGgwLmNvbS8iLCJzdWIiOiJhdXRoMHw1N2Y3YjMwMGI3ZWZkZTY5NmI0MjI0NTMiLCJhdWQiOiJaYUN4eWlraURMRkxLQk9mUEI1UjMwdG5jOHIwNm54VSIsImV4cCI6MTQ3NjQ5MDk2MiwiaWF0IjoxNDc2NDU0OTYyLCJhenAiOiJaYUN4eWlraURMRkxLQk9mUEI1UjMwdG5jOHIwNm54VSJ9.nq7eDdCmAfxe_GhckoGO-bEEevwr0cjEJNYLDjNlyQQ" http://localhost:9000/api/tokens
[{
  "id": "dcr_iGZTCZOUpfAMvof4",
  "device_name": "ttuhinanshu-macbook-pro"
}]
```

#### Revoking Refresh Token

```http
> http DELETE :9000/api/tokens/dcr_iGZTCZOUpfAMvof4 "Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwczovL3Jhc3Rlci1mb3VuZHJ5LmF1dGgwLmNvbS8iLCJzdWIiOiJhdXRoMHw1N2Y3YjMwMGI3ZWZkZTY5NmI0MjI0NTMiLCJhdWQiOiJaYUN4eWlraURMRkxLQk9mUEI1UjMwdG5jOHIwNm54VSIsImV4cCI6MTQ3NjQ5MDk2MiwiaWF0IjoxNDc2NDU0OTYyLCJhenAiOiJaYUN4eWlraURMRkxLQk9mUEI1UjMwdG5jOHIwNm54VSJ9.nq7eDdCmAfxe_GhckoGO-bEEevwr0cjEJNYLDjNlyQQ"
HTTP/1.1 204 No Content
Content-Type: text/plain; charset=UTF-8
Date: Fri, 14 Oct 2016 14:27:35 GMT
Server: akka-http/2.4.10

```

```
> curl -X DELETE -H  "Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwczovL3Jhc3Rlci1mb3VuZHJ5LmF1dGgwLmNvbS8iLCJzdWIiOiJhdXRoMHw1N2Y3YjMwMGI3ZWZkZTY5NmI0MjI0NTMiLCJhdWQiOiJaYUN4eWlraURMRkxLQk9mUEI1UjMwdG5jOHIwNm54VSIsImV4cCI6MTQ3NjQ5MDk2MiwiaWF0IjoxNDc2NDU0OTYyLCJhenAiOiJaYUN4eWlraURMRkxLQk9mUEI1UjMwdG5jOHIwNm54VSJ9.nq7eDdCmAfxe_GhckoGO-bEEevwr0cjEJNYLDjNlyQQ" http://localhost:9000/api/tokens/dcr_iGZTCZOUpfAMvof4

```

### Notes

The central question here is whether we pipe through the Auth0 responses directly, at a lower processing cost but potentially exposing more information than we mean to, or we intercept and reformat things, which comes at a cost of not just some performance but also code complexity, for the sake of clean interfaces?

With interception, a response looks like this:

```http
HTTP/1.1 200 OK
Content-Length: 414
Content-Type: application/json
Date: Fri, 14 Oct 2016 16:02:07 GMT
Server: akka-http/2.4.10

{
    "expires_in": 36000,
    "id_token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwczovL3Jhc3Rlci1mb3VuZHJ5LmF1dGgwLmNvbS8iLCJzdWIiOiJhdXRoMHw1N2Y3YjMwMGI3ZWZkZTY5NmI0MjI0NTMiLCJhdWQiOiJaYUN4eWlraURMRkxLQk9mUEI1UjMwdG5jOHIwNm54VSIsImV4cCI6MTQ3NjQ5NjkyNywiaWF0IjoxNDc2NDYwOTI3LCJhenAiOiJaYUN4eWlraURMRkxLQk9mUEI1UjMwdG5jOHIwNm54VSJ9.RYxFdjZKJ-ZLWn0l094Spzw73lMGOHTRrJWt4WgXxkg",
    "token_type": "Bearer"
}
```

without it, it looks like this:

```http
HTTP/1.1 200 OK
Cache-Control: no-cache
Connection: keep-alive
Content-Length: 401
Content-Type: application/json; charset=utf-8
Date: Fri, 14 Oct 2016 16:03:03 GMT
Keep-Alive: timeout=100
Set-Cookie: auth0=wZl-JBTGEnzAW08NEiNRuQ.9OjacqFY7_bjWY3yy7PwFop0wMSYCvpFwW0BWsyhaHCzUKLiTxXvNWzG96y5DR3x.1476460983022.604800000.IrHg-qWfjqbSqgXQGoonE2TKV8GpOKF38m6qD977T0c; path=/; expires=Mon, 17 Oct 2016 16:03:03 GMT; secure; httponly
Strict-Transport-Security: max-age=15724800
X-RateLimit-Limit: 10
X-RateLimit-Remaining: 8
X-RateLimit-Reset: 1476461048
X-Robots-Tag: noindex, nofollow, nosnippet, noarchive

{
    "expires_in": 36000,
    "id_token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwczovL3Jhc3Rlci1mb3VuZHJ5LmF1dGgwLmNvbS8iLCJzdWIiOiJhdXRoMHw1N2Y3YjMwMGI3ZWZkZTY5NmI0MjI0NTMiLCJhdWQiOiJaYUN4eWlraURMRkxLQk9mUEI1UjMwdG5jOHIwNm54VSIsImV4cCI6MTQ3NjQ5Njk4MywiaWF0IjoxNDc2NDYwOTgzLCJhenAiOiJaYUN4eWlraURMRkxLQk9mUEI1UjMwdG5jOHIwNm54VSJ9.DR4p3D8caegYSQ8EUl2PEinldjjn4S_ZMpmORu-Txmg",
    "token_type": "Bearer"
}
```

## Testing Instructions

 * Check out this branch
 * Get new credentials from S3:

        $ aws s3 --profile=raster-foundry cp s3://config-development-raster-foundry/.env .env

 * Spin up the server and the front-end, and ensure that you can login with your personal Auth0 account
 * Shut down the front-end
 * Go to https://raster-foundry.auth0.com/authorize?response_type=token&client_id=AUTH0_CLIENT_ID&connection=Username-Password-Authentication&redirect_uri=http://localhost:9091&device=YOUR_DEVICE_NAME&scope=openid%20offline_access after replacing `AUTH0_CLIENT_ID` and `YOUR_DEVICE_NAME` in the URL appropriately.
 * You should be redirected to `http://localhost:9091/#/` with `access_token`, `refresh_token`, `id_token`, and `token_type` in the hash. Copy the `refresh_token` to a file.
 * Ensure the back-end is up
 * Test getting JWT with your `refresh_token`

        $ http :9000/api/tokens refresh_token=YOUR_REFRESH_TOKEN

 * Test listing all your Refresh Tokens with the JWT from the previous call

        $ http :9000/api/tokens "Authorization: Bearer eyJ..."

 * Test deleting the Refresh Token returned by the previous call

        $ http :9000/api/tokens/dcr_... "Authorization: Bearer eyJ..."

Connects #523 