### PR TITLE
Add images on Landsat 8 scene creation

### DIFF
--- a/app-tasks/dags/landsat8/import_landsat8_scenes.py
+++ b/app-tasks/dags/landsat8/import_landsat8_scenes.py
@@ -1,0 +1,64 @@
+"""Task for scheduled finding new Landsat 8 scenes to ingest"""
+
+from datetime import datetime
+import logging
+
+from airflow.operators.python_operator import PythonOperator
+from airflow.models import DAG
+
+from rf.uploads.landsat8 import find_landsat8_scenes, create_landsat8_scenes
+
+rf_logger = logging.getLogger('rf')
+ch = logging.StreamHandler()
+ch.setLevel(logging.INFO)
+formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+ch.setFormatter(formatter)
+rf_logger.addHandler(ch)
+
+logger = logging.getLogger(__name__)
+
+start_date = datetime(2016, 9, 25)
+
+args = {
+    'owner': 'raster-foundry',
+    'start_date': start_date
+}
+
+dag = DAG(
+    dag_id='find_landsat8_scenes',
+    default_args=args,
+    schedule_interval=None
+)
+
+
+def import_landsat8_scenes(*args, **kwargs):
+    """Find new Landsat 8 scenes and kick off imports
+
+    Uses the execution date from the Airflow context to determine what day
+    to check for imports.
+    """
+    execution_date = kwargs['execution_date']
+    logging.info('Finding Landsat 8 scenes for date: %s', execution_date)
+
+    csv_rows = find_landsat8_scenes(execution_date.year, execution_date.month,
+                                    execution_date.day)
+    if not csv_rows:
+        raise ValueError('No rows found to import for %s' % execution_date)
+    logger.info('Importing %d csv rows...', len(csv_rows))
+    for row in csv_rows:
+        scene_id = row['sceneID']
+        logger.info('Importing scenes from row %s...', scene_id)
+        scenes = create_landsat8_scenes(row)
+        for scene in scenes:
+            scene.create()
+        logger.info('Finished importing scenes for row %s', scene_id)
+
+
+landsat8_finder = PythonOperator(
+    task_id='import_new_landsat8_scenes'.format(
+        year=start_date.year, month=start_date.month, day=start_date.day
+    ),
+    provide_context=True,
+    python_callable=import_landsat8_scenes,
+    dag=dag
+)

--- a/app-tasks/dags/sentinel2/find_sentinel2_scenes.py
+++ b/app-tasks/dags/sentinel2/find_sentinel2_scenes.py
@@ -38,23 +38,23 @@ dag = DAG(
 DagArgs = namedtuple('DagArgs', 'dag_id, conf, run_id')
 
 
-def chunkify(lst,n):
+def chunkify(lst, n):
     """Helper function to split a list into roughly n chunks
 
     Args:
         lst (List): list of things to split
         n (Int): number of chunks to split into
     """
-    return [ lst[i::n] for i in xrange(n) ]
+    return [lst[i::n] for i in xrange(n)]
 
 
 def find_new_sentinel2_scenes(*args, **kwargs):
-    """Fine new Sentinel 2 scenes and kick off imports
+    """Find new Sentinel 2 scenes and kick off imports
 
     Uses the execution date to determine what day to check for imports
     """
 
-    logging.info("Finding Scenes...")
+    logging.info("Finding Sentinel-2 scenes...")
     execution_date = kwargs['execution_date']
     tilepaths = find_sentinel2_scenes(
         execution_date.year, execution_date.month, execution_date.day
@@ -72,11 +72,11 @@ def find_new_sentinel2_scenes(*args, **kwargs):
             year=execution_date.year, month=execution_date.month, day=execution_date.day,
             idx=idx, slug=slug_path
         )
-        logger.info('Kicking of new scene import: %s', run_id)
+        logger.info('Kicking off new scene import: %s', run_id)
         conf = json.dumps({'tilepaths': path_group})
         dag_args = DagArgs(dag_id=dag_id, conf=conf, run_id=run_id)
         trigger_dag(dag_args)
-    return "Finished kicking off new dags"
+    return "Finished kicking off new Sentinel-2 dags"
 
 
 PythonOperator(

--- a/app-tasks/dags/sentinel2/import_sentinel2_scenes.py
+++ b/app-tasks/dags/sentinel2/import_sentinel2_scenes.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 
 
 seven_days_ago = datetime.combine(
-        datetime.today() - timedelta(7), datetime.min.time())
+    datetime.today() - timedelta(7), datetime.min.time())
 
 
 args = {
@@ -34,7 +34,7 @@ dag = DAG(
 
 
 def import_sentinel2(*args, **kwargs):
-    """Creates new sentinel 2 scenes with associated images, thumbnails, and footprint"""
+    """Creates new Sentinel-2 scenes with associated images, thumbnails, and footprint"""
     logger.info('KWARGS: %s', kwargs)
     conf = kwargs['dag_run'].conf
     tilepaths = conf.get('tilepaths')

--- a/app-tasks/rf/src/rf/uploads/landsat8/create_images.py
+++ b/app-tasks/rf/src/rf/uploads/landsat8/create_images.py
@@ -1,0 +1,46 @@
+"""Creates images based on tileinfo and resolution requested"""
+
+import logging
+
+from rf.utils.io import Visibility, s3
+from rf.models import Image
+
+from .io import get_landsat_url, get_landsat_path
+from .settings import organization, resolution_band_lookup, bucket
+
+logger = logging.getLogger(__name__)
+
+
+def create_images(scene_id, resolution):
+    """Creates images based on scene_id
+
+    Args:
+        scene_id (str) id of the scene (e.g. LC81351172016273LGN00)
+
+    Returns:
+        List[Image]
+    """
+
+    s3_dir_path = get_landsat_url(scene_id)
+
+    bands = resolution_band_lookup[resolution]
+
+    tif_paths = ['{scene}_B{band}.TIF'.format(scene=scene_id, band=band) for band in bands]
+
+    def size_from_path(tif_path, scene_id=scene_id):
+        """Get the size of a tif in s3"""
+        s3_obj = s3.Object(bucket.name, get_landsat_path(scene_id) + tif_path)
+        return s3_obj.content_length
+
+    return [
+        Image(
+            organization,
+            size_from_path(tif_path),
+            Visibility.PUBLIC,
+            tif_path,
+            ''.join([s3_dir_path, tif_path]),
+            [band],
+            {},
+            scene_id
+        ) for tif_path, band in zip(tif_paths, bands)
+    ]

--- a/app-tasks/rf/src/rf/uploads/landsat8/create_scenes.py
+++ b/app-tasks/rf/src/rf/uploads/landsat8/create_scenes.py
@@ -10,7 +10,7 @@ from rf.utils.io import JobStatus, Visibility, s3_obj_exists
 
 from .create_thumbnails import create_thumbnails
 from .create_footprint import create_footprint
-from .settings import organization
+from .settings import organization, aws_landsat_base
 from .io import get_landsat_path
 
 
@@ -45,8 +45,12 @@ def create_landsat8_scenes(csv_row):
 
     scene_id = csv_row.pop('sceneID')
     landsat_path = get_landsat_path(scene_id)
-    if not s3_obj_exists(landsat_path):
-        return []
+    if not s3_obj_exists(aws_landsat_base + landsat_path + 'index.html'):
+        logger.error(
+            'AWS and USGS are not always in sync. Try again in several hours.\n'
+            'If you believe this message is in error, check %s manually.',
+            aws_landsat_base + landsat_path
+        )
     timestamp = csv_row.pop('acquisitionDate') + 'T00:00:00.000Z'
     cloud_cover = float(csv_row.pop('cloudCoverFull'))
     sun_elevation = float(csv_row.pop('sunElevation'))

--- a/app-tasks/rf/src/rf/uploads/landsat8/create_scenes.py
+++ b/app-tasks/rf/src/rf/uploads/landsat8/create_scenes.py
@@ -8,6 +8,7 @@ from rf.models import Scene
 from rf.utils.io import JobStatus, Visibility, s3_obj_exists
 
 
+from .create_images import create_images
 from .create_thumbnails import create_thumbnails
 from .create_footprint import create_footprint
 from .settings import organization, aws_landsat_base
@@ -82,7 +83,7 @@ def create_landsat8_scenes(csv_row):
         sunElevation=sun_elevation,
         footprint=create_footprint(csv_row),
         thumbnails=create_thumbnails(scene_id),
-        images=[]
+        images=create_images(scene_id, '15m')
     )
 
     scene30m = Scene(
@@ -103,7 +104,7 @@ def create_landsat8_scenes(csv_row):
         sunElevation=sun_elevation,
         footprint=create_footprint(csv_row),
         thumbnails=create_thumbnails(scene_id),
-        images=[]
+        images=create_images(scene_id, '30m')
     )
 
     return [scene15m, scene30m]

--- a/app-tasks/rf/src/rf/uploads/landsat8/settings.py
+++ b/app-tasks/rf/src/rf/uploads/landsat8/settings.py
@@ -5,3 +5,5 @@ organization = 'dfac6307-b5ef-43f7-beda-b9f208bb7726'
 usgs_landsat_url = (
     'http://landsat.usgs.gov/metadata_service/bulk_metadata_files/LANDSAT_8.csv'
 )
+
+aws_landsat_base = 'http://landsat-pds.s3.amazonaws.com/'

--- a/app-tasks/rf/src/rf/uploads/landsat8/settings.py
+++ b/app-tasks/rf/src/rf/uploads/landsat8/settings.py
@@ -1,9 +1,34 @@
 """Settings shared by functions for indexing Landsat 8 data"""
 
+from rf.utils.io import s3
+
 organization = 'dfac6307-b5ef-43f7-beda-b9f208bb7726'
+
+# Band 8 is panchromatic and at 15m resolution. All other bands
+# are at the 30m resolution. Bands are:
+# 1:  Coastal aerosol
+# 2:  Blue
+# 3:  Green
+# 4:  Red
+# 5:  Near infrared (NIR)
+# 6:  SWIR 1
+# 7:  SWIR 2
+# 8:  Panchromatic
+# 9:  Cirrus
+# 10: Themral infrared (TIRS 1) (resampled to 30m from 100m in product)
+# 11: Themral infrared (TIRS 2) (resampled to 30m from 100m in product)
+#
+# Source: http://landsat.usgs.gov/band_designations_landsat_satellites.php
+resolution_band_lookup = {
+    '15m': [8],
+    '30m': [1, 2, 3, 4, 5, 6, 7, 9, 10, 11]
+}
 
 usgs_landsat_url = (
     'http://landsat.usgs.gov/metadata_service/bulk_metadata_files/LANDSAT_8.csv'
 )
 
 aws_landsat_base = 'http://landsat-pds.s3.amazonaws.com/'
+
+bucket_name = 'landsat-pds'
+bucket = s3.Bucket(bucket_name)

--- a/app-tasks/rf/src/rf/uploads/sentinel2/create_images.py
+++ b/app-tasks/rf/src/rf/uploads/sentinel2/create_images.py
@@ -2,10 +2,10 @@
 
 import logging
 
-from rf.utils.io import Visibility
+from rf.utils.io import Visibility, s3
 from rf.models import Image
 
-from .settings import s3, organization, base_http_path, bucket
+from .settings import organization, base_http_path, bucket
 
 logger = logging.getLogger(__name__)
 

--- a/app-tasks/rf/src/rf/uploads/sentinel2/settings.py
+++ b/app-tasks/rf/src/rf/uploads/sentinel2/settings.py
@@ -1,6 +1,6 @@
 """Settings shared by functions for indexing Sentinel 2 data"""
 
-import boto3
+from rf.utils.io import s3
 
 # Public Organization UUID in Raster Foundry
 organization = 'dfac6307-b5ef-43f7-beda-b9f208bb7726'
@@ -9,6 +9,5 @@ organization = 'dfac6307-b5ef-43f7-beda-b9f208bb7726'
 base_http_path = 'http://sentinel-s2-l1c.s3-website.eu-central-1.amazonaws.com/{key_path}'
 
 # S3/AWS settings and objects
-s3 = boto3.resource('s3', region_name='eu-central-1')
 bucket_name = 'sentinel-s2-l1c'
 bucket = s3.Bucket(bucket_name)

--- a/app-tasks/rf/src/rf/utils/io.py
+++ b/app-tasks/rf/src/rf/utils/io.py
@@ -5,6 +5,9 @@ import boto3
 import requests
 
 
+s3 = boto3.resource('s3', region_name='eu-central-1')
+
+
 def delete_file(fname):
     """Helper function to delete a file without raising an error if it exists"""
 


### PR DESCRIPTION
## Overview

This PR adds a (currently unscheduled) DAG to import Landsat 8 scenes and their associated images, thumbnails, and footprints. We need it so that we can import Landsat 8 scenes

### Demo

...none yet

### Notes

Includes #521 as well, since the ingest with images depends on the DAG being present.

## Testing Instructions

 * `vagrant ssh`, `./scripts/server`
 * Navigate to the airflow ui at `localhost:8080`
 * Create a DAG run as follows:
   * Click "None" under the `find_landsat8_scenes` schedule field to create a scheduled run
   * Click "Create" 
   * Create some runs for some time in the past, like so:
![image](https://cloud.githubusercontent.com/assets/5702984/19252806/e8c55912-8f14-11e6-9c81-b34136d72a8a.png)
   * Click "Save"
 * Navigate bag to the DAGs home (`localhost:8080`) and click on the light green "Running" circle:
![image](https://cloud.githubusercontent.com/assets/5702984/19252847/1b633b14-8f15-11e6-8eaa-78b038872382.png)
 * Scroll all the way to the right and click on the log
![image](https://cloud.githubusercontent.com/assets/5702984/19252862/2bfd1490-8f15-11e6-90e7-00734193f6a2.png)
 * Observe! Your DAG is running and if you wait patiently you will see some uploading scenes in the log, and if you don't wait a sec and keep refreshing. You should also be able to see some scenes, images, thumbnails, and footprints for Landsat 8 at those endpoints in the API

Closes #470 
