### PR TITLE
Bump terraform install version and azavea.terraform role version

### DIFF
--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -9,4 +9,4 @@ shellcheck_version: "0.3.*"
 docker_users:
   - "{{ ansible_user }}"
 
-terraform_version: "0.7.4"
+terraform_version: "0.7.6"

--- a/deployment/ansible/roles.yml
+++ b/deployment/ansible/roles.yml
@@ -14,4 +14,4 @@
   version: 0.1.1
 
 - src: azavea.terraform
-  version: 0.2.0
+  version: 0.3.1


### PR DESCRIPTION
## Overview

Bump `terraform` version to `0.7.6`, `azavea.terraform` role version to `0.3.1`


## Testing Instructions

 * SSH into jenkins.staging.rasterfoundry.com.
 * Do `terraform -v`, ensure output is `Terraform v0.7.6`


