### PR TITLE
Remove owner role and replace with user

### DIFF
--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/User.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/User.scala
@@ -15,14 +15,14 @@ object User {
   implicit val defaultUserFormat = jsonFormat1(User.apply _)
 
   sealed abstract class Role(val repr: String) extends Product with Serializable
+  case object UserRole extends Role("USER")
   case object Viewer extends Role("VIEWER")
-  case object Owner extends Role("OWNER")
   case object Admin extends Role("ADMIN")
 
   object Role {
     def fromString(s: String) = s.toUpperCase match {
+      case "USER" => UserRole
       case "VIEWER" => Viewer
-      case "OWNER" => Owner
       case "ADMIN" => Admin
       case _ => throw new Exception(s"Unsupported user role string: $s")
     }


### PR DESCRIPTION
## Overview

This commit removes the owner role and replaces it back with the user
role, which was accidentally removed during a refactor. This also aligns
the datamodel with the enum constraints currently in the database.

## Testing Instructions

 * run `./scripts/load_development_data/`
 * start server: `./scripts/server`
 * start frontend: `npm start`
 * Log in, get JWT and make an authenticated request to the users endpoint with the JWT supplied. No 500s should be shown

