### PR TITLE
Fix pycparser installation

### DIFF
--- a/app-tasks/Dockerfile
+++ b/app-tasks/Dockerfile
@@ -14,6 +14,8 @@ RUN set -ex \
     libgdal-dev \
   ' \
   && apt-get update && apt-get install -y ${buildDeps} ${gdal} --no-install-recommends \
+  && pip install --no-cache-dir --no-binary \
+         pycparser \
   && pip install --no-cache-dir \
          numpy==$(grep "numpy" /tmp/requirements.txt | cut -d= -f3) \
   && pip install --no-cache-dir -r /tmp/requirements.txt \


### PR DESCRIPTION
## Overview

Don't use the wheels provided by `pycparser` because they are inconsistent with the source.

See:

- https://github.com/eliben/pycparser/issues/148
- https://github.com/pyca/cryptography/issues/3187

## Testing Instructions

Execute the following commands within the supplied virtual machine and ensure that `raster-foundry-airflow` completes successfully.

```bash
$ docker rmi -f raster-foundry-airflow
$ docker-compose build airflow-webserver
```