### PR TITLE
Remove `restart-jenkins` cronjob, add Jenkins user to sudoers

### DIFF
--- a/deployment/ansible/roles.yml
+++ b/deployment/ansible/roles.yml
@@ -5,7 +5,7 @@
   version: 0.1.1
 
 - src: azavea.jenkins
-  version: 1.0.1
+  version: 1.1.1
 
 - src: azavea.nginx
   version: 0.3.0

--- a/deployment/ansible/roles/raster-foundry.jenkins/molecule-playbook.yml
+++ b/deployment/ansible/roles/raster-foundry.jenkins/molecule-playbook.yml
@@ -30,5 +30,10 @@
     - name: Gather facts
       setup:
 
-  roles:
-     - { role: "../raster-foundry.jenkins" }
+    - name: Include raster-foundry group_vars
+      include_vars: "{{ item }}"
+      with_items:
+        - "../../group_vars/all"
+        - "../../group_vars/jenkins"
+
+- include: ../../raster-foundry-jenkins.yml

--- a/deployment/ansible/roles/raster-foundry.jenkins/molecule.yml
+++ b/deployment/ansible/roles/raster-foundry.jenkins/molecule.yml
@@ -11,9 +11,6 @@ vagrant:
     - name: trusty64
       box: ubuntu/trusty64
 
-    - name: xenial64
-      box: ubuntu/xenial64
-
   providers:
     - name: virtualbox
       type: virtualbox
@@ -21,7 +18,7 @@ vagrant:
         memory: 1024
 
   instances:
-    - name: raster-foundry-jenkins
+    - name: jenkins
 
 molecule:
   test:

--- a/deployment/ansible/roles/raster-foundry.jenkins/tasks/main.yml
+++ b/deployment/ansible/roles/raster-foundry.jenkins/tasks/main.yml
@@ -1,10 +1,30 @@
 ---
-- name: Disable authentication for login
-  copy:
-    src=files/config.xml
+- name: Disable security for login, set number of executors
+  lineinfile:
     dest=/var/lib/jenkins/config.xml
+    state={{ item.state }}
+    regexp={{ item.regexp }}
+    line={{ item.line }}
+    backrefs={{ item.backrefs }}
   notify:
     - Restart Jenkins
+  with_items:
+    - { regexp: '(.*<useSecurity>).*(</useSecurity>.*)',
+        line: '\1false\2',
+        state: present,
+        backrefs: yes }
+    - { regexp: '(.*<numExecutors>)\d+(</numExecutors>.*)',
+        line: '\1 1\2',
+        state: present,
+        backrefs: yes }
+
+- name: Remove Authorization and Security XML from config.
+  replace: dest=/var/lib/jenkins/config.xml regexp={{ item }}
+  notify:
+    - Restart Jenkins
+  with_items:
+    - '\s*<authorizationStrategy.*>(?:\n.*)*</authorizationStrategy>'
+    - '\s*<securityRealm.*>(?:\n.*)*</securityRealm>'
 
 - name: Add Jenkins Nginx config
   template: src=jenkins.conf.j2
@@ -19,6 +39,17 @@
   notify:
     - Restart Nginx
 
+- name: Add jenkins user to docker, sudo and adm groups
+  user: name="{{ jenkins_name }}"
+        groups="{{ item }}"
+        append=yes
+  with_items:
+    - "docker"
+    - "adm"
+    - "sudo"
+  notify:
+    - Restart Jenkins
+
 - name: Setup hourly docker-gc cron task
   cron:
     name: "docker-gc"
@@ -31,16 +62,4 @@
       -v /etc:/etc
       spotify/docker-gc
     state: "present"
-  changed_when: False
-
-- name: Restart Jenkins every 3 hours
-  cron:
-    name: "jenkins-restart"
-    user: "{{ jenkins_name }}"
-    hour: "*/3"
-    minute: "0"
-    job: >
-      /usr/bin/java -jar {{ jenkins_cli_jar_path }}
-      -s http://localhost:{{ jenkins_http_port }}
-      restart
   changed_when: False

--- a/deployment/ansible/roles/raster-foundry.jenkins/tests/test_jenkins.py
+++ b/deployment/ansible/roles/raster-foundry.jenkins/tests/test_jenkins.py
@@ -1,4 +1,6 @@
 import pytest
+from os.path import dirname, realpath, join
+import re
 
 
 @pytest.fixture()
@@ -9,6 +11,18 @@ def AnsibleDefaults(Ansible):
         Ansible - Requires the ansible connection backend.
     """
     return Ansible("include_vars", "./defaults/main.yml")["ansible_facts"]
+
+
+@pytest.fixture()
+def JenkinsRoleDefaults(Ansible):
+    """ Load default variables into dictionary.
+
+    Args:
+        Ansible - Requires the ansible connection backend.
+    """
+    roles_dir = dirname(dirname(dirname(realpath(__file__))))
+    jenkins_defaults_file = join(roles_dir, "azavea.jenkins/defaults/main.yml")
+    return Ansible("include_vars", jenkins_defaults_file)["ansible_facts"]
 
 
 @pytest.fixture()
@@ -31,81 +45,35 @@ def test_jenkins_cli_jar_exists(File, AnsibleDefaults):
     Raises:
         AssertionError if package is not installed or the wrong version.
     """
-
     jenkins_cli_jar_path = AnsibleDefaults["jenkins_cli_jar_path"]
     jenkins_cli_jar = File(jenkins_cli_jar_path)
     assert jenkins_cli_jar.exists
 
 
-def test_crontab_entry(Ansible, AnsibleDefaults, Command, Sudo):
-    """ Check the crontab for the Jenkins user to ensure that the entries
-        for Jenkins restart and Docker garbage collection are present and
-        correct.
-
-        Args:
-            Ansible - Obtain name of Jenkins user from azavea.jenkins defaults
-            AnsibleDefaults - Get location of Jenkins CLI JAR and Jenkins HTTP
-                              port.
-            Command - Run crontab
-            Sudo - Switch to Jenkins user
-
-        Raises:
-            AssertionError if Docker and Jenkins entries are not in the crontab
-
-    """
-
-    facts = Ansible("include_vars",
-                    "../azavea.jenkins/defaults/main.yml")["ansible_facts"]
-
-    jenkins_name = facts["jenkins_name"]
-    jenkins_crontab_entry = "0 */3 * * * /usr/bin/java -jar {} " \
-                            "-s http://localhost:{} restart".format(
-                                AnsibleDefaults["jenkins_cli_jar_path"],
-                                AnsibleDefaults["jenkins_http_port"])
-
+def test_docker_cronjob(Command, Sudo, JenkinsRoleDefaults):
     docker_crontab_entry = "@hourly /usr/bin/docker run --rm -v " \
                            "/var/run/docker.sock:/var/run/docker.sock -v " \
                            "/etc:/etc spotify/docker-gc"
 
-    with Sudo(user=jenkins_name):
+    with Sudo(user=JenkinsRoleDefaults["jenkins_name"]):
         crontab = Command.check_output("crontab -l")
-        assert jenkins_crontab_entry in crontab
         assert docker_crontab_entry in crontab
 
 
-def test_jenkins_cli_restart(Ansible, AnsibleDefaults, Command, Sudo):
-    """ Ensure we can use the Jenkins CLI to restart the service without
-    an inital login. In order for this to be the case, the Jenkins CLI
-    JAR must be in the proper location and athorizations have to be turned off.
+def test_jenkins_config(File):
+    """ Make sure jenkins file is correct """
+    jenkins_conf = File("/var/lib/jenkins/config.xml").content_string
+    assert re.findall("<useSecurity>false</useSecurity>", jenkins_conf)
+    assert re.findall("<numExecutors> 1</numExecutors>", jenkins_conf)
+    assert not (re.findall("<authorizationStrategy", jenkins_conf))
+    assert not (re.findall("<securityRealm>", jenkins_conf))
 
+
+def test_jenkins_groups(User, JenkinsRoleDefaults):
+    """ Ensure Jenkins is in the right groups
     Args:
-        Ansible - get_url module to interact with Jenkins
-        AnsibleDefaults - module to pull CLI Jar Location and Jenkins port
-        Command - module to run the restart command
-        Sudo - privilege escalation to reestart Jenkins
-
-    Raises:
-        Assertion error if command doesn't return 0, or if Jenkins doesn't
-        return a status page saying it's restarting.
+        User: module to determine Jenkins group membership.
     """
-    jenkins_cli_jar_path = AnsibleDefaults["jenkins_cli_jar_path"]
-    jenkins_http_port = AnsibleDefaults["jenkins_http_port"]
-    jenkins_url = "http://localhost:{}".format(jenkins_http_port)
-
-    restart_command = "/usr/bin/java -jar {} " \
-                      "-s {} restart".format(jenkins_cli_jar_path, jenkins_url)
-    with Sudo():
-        restart_jenkins = Command(restart_command).rc
-
-    Command("sleep 15")
-
-    jenkins_restart_message = Ansible("get_url",
-                                      "url={} "
-                                      "dest=/tmp/jenkins.html".format(jenkins_url), # NOQA
-                                      check=False)["msg"]
-
-    # Check to see that the restart command exited successfully
-    assert restart_jenkins == 0
-
-    # Check to ensure Jenkins has successfully restarted.
-    assert "OK" in jenkins_restart_message
+    jenkins_name = JenkinsRoleDefaults["jenkins_name"]
+    jenkins_groups = User(jenkins_name).groups
+    assert set(["adm", "sudo", "jenkins"]).issubset(jenkins_groups)

--- a/scripts/cipublish
+++ b/scripts/cipublish
@@ -32,14 +32,14 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
             docker tag "raster-foundry-nginx:${GIT_COMMIT}" \
                    "${AWS_ECR_ENDPOINT}/raster-foundry-nginx:${GIT_COMMIT}"
             docker tag "raster-foundry-app-backend:${GIT_COMMIT}" \
-                   "${AWS_ECR_ENDPOINT}/raster-foundry-app-backend:${GIT_COMMIT}"
+                   "${AWS_ECR_ENDPOINT}/raster-foundry-app-server:${GIT_COMMIT}"
             docker tag "raster-foundry-airflow:${GIT_COMMIT}" \
                    "${AWS_ECR_ENDPOINT}/raster-foundry-airflow:${GIT_COMMIT}"
             docker tag "raster-foundry-app-migrations:${GIT_COMMIT}" \
                    "${AWS_ECR_ENDPOINT}/raster-foundry-migrations:${GIT_COMMIT}"
 
             docker push "${AWS_ECR_ENDPOINT}/raster-foundry-nginx:${GIT_COMMIT}"
-            docker push "${AWS_ECR_ENDPOINT}/raster-foundry-app-backend:${GIT_COMMIT}"
+            docker push "${AWS_ECR_ENDPOINT}/raster-foundry-app-server:${GIT_COMMIT}"
             docker push "${AWS_ECR_ENDPOINT}/raster-foundry-airflow:${GIT_COMMIT}"
             docker push "${AWS_ECR_ENDPOINT}/raster-foundry-migrations:${GIT_COMMIT}"
         else


### PR DESCRIPTION
## Overview

Remove the restart-jenkins crontask, and add `jenkins` user to `sudoers` to alleviate branch-indexing issues.


## Testing Instructions

 * change `hosts: jenkins` to `hosts:all` in `raster-foundry-jenkins.yml`
 * run `molecule test`, ensure all tests pass.
 * ssh into jenkins.staging.rasterfoundry.com and ensure `jenkins` is in the `sudo`, `docker`, `adm` groups.