### PR TITLE
Bulk Scene Operations

### DIFF
--- a/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Buckets.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Buckets.scala
@@ -118,6 +118,25 @@ object Buckets extends TableQuery(tag => new Buckets(tag)) with LazyLogging {
     }
   }
 
+  /** Get specific scenes from a bucket. Returns any scenes from the list of
+    * specified ids that are associated to the given bucket.
+    *
+    * @param bucketId UUID primary key of the bucket to limit results to
+    * @param sceneIds Seq[UUID] primary key of scenes to retrieve
+    */
+  def getBucketScenes(bucketId: UUID, sceneIds: Seq[UUID])
+    (implicit database: DB): Future[Iterable[Scene.WithRelated]] = {
+
+    val scenes = for {
+      sceneToBucket <- ScenesToBuckets if sceneToBucket.bucketId === bucketId && sceneToBucket.sceneId.inSet(sceneIds)
+      scene <- Scenes if scene.id === sceneToBucket.sceneId
+    } yield scene
+
+    database.db.run {
+      scenes.joinWithRelated.result
+    } map Scene.WithRelated.fromRecords
+  }
+
   /** Get bucket given a bucketId
     *
     * @param bucketId UUID primary key of bucket to retrieve
@@ -223,6 +242,34 @@ object Buckets extends TableQuery(tag => new Buckets(tag)) with LazyLogging {
     }
   }
 
+  /** Adds a list of scenes to a bucket
+    *
+    * @param sceneIds Seq[UUID] list of primary keys of scens to add to bucket
+    * @param bucketId UUID primary key of back to add scenes to
+    */
+  def addScenesToBucket(sceneIds: Seq[UUID], bucketId: UUID)
+    (implicit database: DB): Future[Iterable[Scene.WithRelated]] = {
+
+    val sceneBucketJoinQuery = for {
+      s <- ScenesToBuckets if s.sceneId.inSet(sceneIds) && s.bucketId === bucketId
+    } yield s
+
+    database.db.run {
+      sceneBucketJoinQuery.result
+    } map { alreadyAdded =>
+      val newScenes = sceneIds.filterNot(alreadyAdded.toSet)
+      val newScenesToBuckets = newScenes.map { sceneId =>
+        SceneToBucket(sceneId, bucketId)
+      }
+
+      database.db.run {
+        ScenesToBuckets.forceInsertAll(newScenesToBuckets)
+      }
+    }
+
+    getBucketScenes(bucketId, sceneIds)
+  }
+
   /** Removes scene from bucket
     *
     * @param sceneId UUID primary key of scene to remove from bucket
@@ -238,5 +285,47 @@ object Buckets extends TableQuery(tag => new Buckets(tag)) with LazyLogging {
     database.db.run {
       sceneBucketJoinQuery.delete
     }
+  }
+
+  /** Removes scenes from bucket
+    *
+    * @param sceneIds Seq[UUID] primary key of scenes to remove from bucket
+    * @param bucketId UUID primary key of bucket these scenes will be removed from
+    */
+  def deleteScenesFromBucket(sceneIds: Seq[UUID], bucketId: UUID)
+    (implicit database: DB): Future[Int] = {
+
+    val sceneBucketJoinQuery = for {
+      s <- ScenesToBuckets if s.sceneId.inSet(sceneIds) && s.bucketId === bucketId
+    } yield s
+
+    database.db.run {
+      sceneBucketJoinQuery.delete
+    }
+  }
+
+  /** Removes all scenes from bucket, then adds all specified scenes to it
+    *
+    * @param sceneIds Seq[UUID] primary key of scenes to add to bucket
+    * @param bucketId UUID primary key of bucket to remove all scenes from and add specified scenes to
+    * @return Scenes that were added
+    */
+  def replaceScenesInBucket(sceneIds: Seq[UUID], bucketId: UUID)
+    (implicit database: DB): Future[Iterable[Scene.WithRelated]] = {
+
+    val scenesToBuckets = sceneIds.map { sceneId =>
+      SceneToBucket(sceneId, bucketId)
+    }
+
+    val actions = DBIO.seq(
+      ScenesToBuckets.filter(_.bucketId === bucketId).delete,
+      ScenesToBuckets.forceInsertAll(scenesToBuckets)
+    )
+
+    database.db.run {
+      actions.transactionally
+    }
+
+    getBucketScenes(bucketId, sceneIds)
   }
 }

--- a/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Buckets.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Buckets.scala
@@ -124,7 +124,7 @@ object Buckets extends TableQuery(tag => new Buckets(tag)) with LazyLogging {
     * @param bucketId UUID primary key of the bucket to limit results to
     * @param sceneIds Seq[UUID] primary key of scenes to retrieve
     */
-  def getBucketScenes(bucketId: UUID, sceneIds: Seq[UUID])
+  def listBucketScenes(bucketId: UUID, sceneIds: Seq[UUID])
     (implicit database: DB): Future[Iterable[Scene.WithRelated]] = {
 
     val scenes = for {
@@ -267,7 +267,7 @@ object Buckets extends TableQuery(tag => new Buckets(tag)) with LazyLogging {
       }
     }
 
-    getBucketScenes(bucketId, sceneIds)
+    listBucketScenes(bucketId, sceneIds)
   }
 
   /** Removes scene from bucket
@@ -326,6 +326,6 @@ object Buckets extends TableQuery(tag => new Buckets(tag)) with LazyLogging {
       actions.transactionally
     }
 
-    getBucketScenes(bucketId, sceneIds)
+    listBucketScenes(bucketId, sceneIds)
   }
 }


### PR DESCRIPTION
## Overview

Adds support for adding and removing scenes from buckets in bulk. See commit messages for details.

### Notes

The original issue asks for changes to the UI as well. I'm putting this up to get early feedback. We can then decide if we want to do the frontend changes as part of this or in a separate PR.

## Testing Instructions

~~Test upserting values by POSTing to `/api/buckets/:bucketId/scenes` a JSON like this:~~

~~Test deleting values by POSTing something like this:~~

Ensure you have an account, a JWT, and a bucket to your name.

Test adding scenes to your bucket:

```bash
$ echo '["1ac24024-963a-4a50-b234-3dc411e7917c","6ae1495d-3fee-4038-a493-059f8efb334d","3777e8b2-4dfe-484c-a696-fcc104be53d3","ca179a10-2058-490f-9130-862f423b02d6","4dbe9d6e-f479-4a41-8dba-83510e04386c","68b50942-650c-414f-ab0b-7dd69c5db608","50dc6a9e-52a5-4170-b997-aa8e9cc83695"]' | http :9000/api/buckets/YOUR_BUCKET_ID/scenes "Authorization: Bearer eyJ..."
```

```bash
$ curl -X POST -H "Authorization: Bearer eyJ..." -H "Content-Type: application/json" -d '["1ac24024-963a-4a50-b234-3dc411e7917c","6ae1495d-3fee-4038-a493-059f8efb334d","3777e8b2-4dfe-484c-a696-fcc104be53d3","ca179a10-2058-490f-9130-862f423b02d6","4dbe9d6e-f479-4a41-8dba-83510e04386c","68b50942-650c-414f-ab0b-7dd69c5db608","50dc6a9e-52a5-4170-b997-aa8e9cc83695"]' http:localhost:9000/api/buckets/YOUR_BUCKET_ID/scenes
```

```
rasterfoundry=# SELECT * FROM scenes_to_buckets;
               scene_id               |              bucket_id
--------------------------------------+--------------------------------------
 1ac24024-963a-4a50-b234-3dc411e7917c | 31c3201b-8663-4906-b887-6a95bcc10620
 6ae1495d-3fee-4038-a493-059f8efb334d | 31c3201b-8663-4906-b887-6a95bcc10620
 3777e8b2-4dfe-484c-a696-fcc104be53d3 | 31c3201b-8663-4906-b887-6a95bcc10620
 ca179a10-2058-490f-9130-862f423b02d6 | 31c3201b-8663-4906-b887-6a95bcc10620
 4dbe9d6e-f479-4a41-8dba-83510e04386c | 31c3201b-8663-4906-b887-6a95bcc10620
 68b50942-650c-414f-ab0b-7dd69c5db608 | 31c3201b-8663-4906-b887-6a95bcc10620
 50dc6a9e-52a5-4170-b997-aa8e9cc83695 | 31c3201b-8663-4906-b887-6a95bcc10620
(7 rows)
```

Test deleting a few of these values:

```bash
$ echo '["1ac24024-963a-4a50-b234-3dc411e7917c","6ae1495d-3fee-4038-a493-059f8efb334d"]' | http DELETE :9000/api/buckets/YOUR_BUCKET_ID/scenes "Authorization: Bearer eyJ..."
```

```bash
$ curl -X DELETE -H "Authorization: Bearer eyJ..." -H "Content-Type: application/json" -d '["1ac24024-963a-4a50-b234-3dc411e7917c","6ae1495d-3fee-4038-a493-059f8efb334d"]' http:localhost:9000/api/buckets/YOUR_BUCKET_ID/scenes
```

```
rasterfoundry=# SELECT * FROM scenes_to_buckets;
               scene_id               |              bucket_id
--------------------------------------+--------------------------------------
 3777e8b2-4dfe-484c-a696-fcc104be53d3 | 31c3201b-8663-4906-b887-6a95bcc10620
 ca179a10-2058-490f-9130-862f423b02d6 | 31c3201b-8663-4906-b887-6a95bcc10620
 4dbe9d6e-f479-4a41-8dba-83510e04386c | 31c3201b-8663-4906-b887-6a95bcc10620
 68b50942-650c-414f-ab0b-7dd69c5db608 | 31c3201b-8663-4906-b887-6a95bcc10620
 50dc6a9e-52a5-4170-b997-aa8e9cc83695 | 31c3201b-8663-4906-b887-6a95bcc10620
(5 rows)
```

Try replacing these values with other ones:

```bash
$ echo '["1ac24024-963a-4a50-b234-3dc411e7917c","6ae1495d-3fee-4038-a493-059f8efb334d","3777e8b2-4dfe-484c-a696-fcc104be53d3"]' | http PUT :9000/api/buckets/YOUR_BUCKET_ID/scenes "Authorization: Bearer eyJ..."
```

```bash
$ curl -X PUT -H "Authorization: Bearer eyJ..." -H "Content-Type: application/json" -d '["1ac24024-963a-4a50-b234-3dc411e7917c","6ae1495d-3fee-4038-a493-059f8efb334d","3777e8b2-4dfe-484c-a696-fcc104be53d3"]' http:localhost:9000/api/buckets/YOUR_BUCKET_ID/scenes
```

```
rasterfoundry=# SELECT * FROM scenes_to_buckets;
               scene_id               |              bucket_id
--------------------------------------+--------------------------------------
 1ac24024-963a-4a50-b234-3dc411e7917c | 31c3201b-8663-4906-b887-6a95bcc10620
 6ae1495d-3fee-4038-a493-059f8efb334d | 31c3201b-8663-4906-b887-6a95bcc10620
 3777e8b2-4dfe-484c-a696-fcc104be53d3 | 31c3201b-8663-4906-b887-6a95bcc10620
(3 rows)
```

Connects #530 
