### PR TITLE
Add filter pane component and hook up to browse view

### DIFF
--- a/app-frontend/package.json
+++ b/app-frontend/package.json
@@ -35,6 +35,7 @@
     "angular-touch": "^1.5.8",
     "angular-ui-bootstrap": "^2.1.4",
     "angular-ui-router": "^0.3.1",
+    "angularjs-slider": "^5.7.0",
     "auth0-angular": "^4.2.3",
     "auth0-lock": "^9.2.2",
     "bootstrap-sass": "^3.3.6",

--- a/app-frontend/src/app/components/filterPane/filterPane.component.js
+++ b/app-frontend/src/app/components/filterPane/filterPane.component.js
@@ -1,0 +1,11 @@
+import filterTpl from './filterPane.html';
+
+const rfFilterPane = {
+    templateUrl: filterTpl,
+    controller: 'FilterPaneController',
+    bindings: {
+        filters: '='
+    }
+};
+
+export default rfFilterPane;

--- a/app-frontend/src/app/components/filterPane/filterPane.controller.js
+++ b/app-frontend/src/app/components/filterPane/filterPane.controller.js
@@ -1,0 +1,336 @@
+import _ from 'lodash';
+export default class FilterPaneController {
+    constructor() {
+        'ngInject';
+
+        this.toggleDrag = {toggle: false, enabled: false};
+        this.initFilters();
+    }
+
+    onYearFiltersChange(id, minModel, maxModel) {
+        if (minModel === this.yearRange.min) {
+            delete this.filters.minAcquisitionDatetime;
+        } else {
+            this.filters.minAcquisitionDatetime =
+                (new Date(minModel, 0, 1))
+                .toISOString();
+        }
+
+        if (maxModel === this.yearRange.max) {
+            delete this.filters.maxAcquisitionDatetime;
+        } else {
+            this.filters.maxAcquisitionDatetime =
+                (new Date(maxModel, 11, 31))
+                .toISOString();
+        }
+    }
+
+    onCloudCoverFiltersChange(id, minModel, maxModel) {
+        if (minModel === this.cloudCoverRange.min) {
+            delete this.filters.minCloudCover;
+        } else {
+            this.filters.minCloudCover = minModel;
+        }
+
+        if (maxModel === this.cloudCoverRange.max) {
+            delete this.filters.maxCloudCover;
+        } else {
+            this.filters.maxCloudCover = maxModel;
+        }
+    }
+
+    onSunElevationFiltersChange(id, minModel, maxModel) {
+        if (minModel === this.sunElevationRange.min) {
+            delete this.filters.minSunElevation;
+        } else {
+            this.filters.minSunElevation = minModel;
+        }
+
+        if (maxModel === this.sunElevationRange.max) {
+            delete this.filters.maxSunElevation;
+        } else {
+            this.filters.maxSunElevation = maxModel;
+        }
+    }
+
+    onSunAzimuthFiltersChange(id, minModel, maxModel) {
+        if (minModel === this.sunAzimuthRange.min) {
+            delete this.filters.minSunAzimuth;
+        } else {
+            this.filters.minSunAzimuth = minModel;
+        }
+
+        if (maxModel === this.sunAzimuthRange.max) {
+            delete this.filters.maxSunAzimuth;
+        } else {
+            this.filters.maxSunAzimuth = maxModel;
+        }
+    }
+
+    initFilters() {
+        this.yearRange = {min: 2010, max: 2016};
+        let minAcquisitionDatetime =
+            (new Date(this.filters.minAcquisitionDatetime || NaN)).getFullYear() ||
+            this.yearRange.min;
+        let maxAcquisitionDatetime =
+            (new Date(this.filters.maxAcquisitionDatetime || NaN)).getFullYear() ||
+            this.yearRange.max;
+        this.yearFilters = {
+            minModel: minAcquisitionDatetime,
+            maxModel: maxAcquisitionDatetime,
+            options: {
+                floor: this.yearRange.min,
+                ceil: this.yearRange.max,
+                minRange: 1,
+                showTicks: 1,
+                showTicksValues: true,
+                pushRange: true,
+                draggableRange: true,
+                onEnd: this.onYearFiltersChange.bind(this)
+            }
+        };
+
+        this.initMonthFilters();
+
+        this.cloudCoverRange = {min: 0, max: 100};
+        let minCloudCover = parseInt(this.filters.minCloudCover, 10) ||
+            this.cloudCoverRange.min;
+        let maxCloudCover = parseInt(this.filters.maxCloudCover, 10) ||
+            this.cloudCoverRange.max;
+        this.cloudCoverFilters = {
+            minModel: minCloudCover,
+            maxModel: maxCloudCover,
+            options: {
+                floor: this.cloudCoverRange.min,
+                ceil: this.cloudCoverRange.max,
+                minRange: 10,
+                showTicks: 10,
+                showTicksValues: true,
+                step: 10,
+                pushRange: true,
+                draggableRange: true,
+                onEnd: this.onCloudCoverFiltersChange.bind(this)
+            }
+        };
+
+        this.sunElevationRange = {min: 0, max: 180};
+        let minSunElevation = parseInt(this.filters.minSunElevation, 10) ||
+            this.sunElevationRange.min;
+        let maxSunElevation = parseInt(this.filters.maxSunElevation, 10) ||
+            this.sunElevationRange.max;
+        this.sunElevationFilters = {
+            minModel: minSunElevation,
+            maxModel: maxSunElevation,
+            options: {
+                floor: this.sunElevationRange.min,
+                ceil: this.sunElevationRange.max,
+                minRange: 10,
+                showTicks: 30,
+                showTicksValues: true,
+                step: 10,
+                pushRange: true,
+                draggableRange: true,
+                onEnd: this.onSunElevationFiltersChange.bind(this)
+            }
+        };
+
+        this.sunAzimuthRange = {min: 0, max: 360};
+        let minSunAzimuth = parseInt(this.filters.minSunAzimuth, 10) ||
+            this.sunAzimuthRange.min;
+        let maxSunAzimuth = parseInt(this.filters.maxSunAzimuth, 10) ||
+            this.sunAzimuthRange.max;
+        this.sunAzimuthFilters = {
+            minModel: minSunAzimuth,
+            maxModel: maxSunAzimuth,
+            options: {
+                floor: this.sunAzimuthRange.min,
+                ceil: this.sunAzimuthRange.max,
+                minRange: 10,
+                showTicks: 60,
+                showTicksValues: true,
+                step: 10,
+                pushRange: true,
+                draggableRange: true,
+                onEnd: this.onSunAzimuthFiltersChange.bind(this)
+            }
+        };
+
+        this.initSourceFilters();
+    }
+
+    initMonthFilters() {
+        this.monthFilters = {
+            1: {label: 'Jan', enabled: false},
+            2: {label: 'Feb', enabled: false},
+            3: {label: 'Mar', enabled: false},
+            4: {label: 'Apr', enabled: false},
+            5: {label: 'May', enabled: false},
+            6: {label: 'Jun', enabled: false},
+            7: {label: 'Jul', enabled: false},
+            8: {label: 'Aug', enabled: false},
+            9: {label: 'Sep', enabled: false},
+            10: {label: 'Oct', enabled: false},
+            11: {label: 'Nov', enabled: false},
+            12: {label: 'Dec', enabled: false}
+        };
+
+        if (this.filters.month) {
+            if (!isNaN(this.filters.month)) {
+                this.monthFilters[parseInt(this.filters.month, 10)].enabled = true;
+            } else if (
+                Object.prototype.toString.call(this.filters.month)
+                    === '[object Array]'
+            ) {
+                this.monthFilters = _.mapValues(
+                    this.monthFilters,
+                    (val, key) => {
+                        val.enabled = this.filters.month.indexOf(key) !== -1;
+                        return val;
+                    }
+                );
+            } else {
+                this.filters.month = null;
+            }
+        }
+    }
+
+    initSourceFilters() {
+        this.sourceFilters = {
+            self: {label: 'My Imports', enabled: false},
+            users: {label: 'Raster Foundry Users', enabled: false},
+            'Sentinel-2': {label: 'Sentinel-2', enabled: false},
+            'Landsat-8': {label: 'Landsat-8', enabled: false}
+        };
+        if (this.filters.datasource) {
+            if (
+                Object.prototype.toString.call(this.filters.datasource)
+                    === '[object Array]'
+            ) {
+                this.sourceFilters = _.mapValues(
+                    this.sourceFilters,
+                    (val, key) => {
+                        val.enabled = this.filters.datasource.indexOf(key) !== -1;
+                        return val;
+                    }
+                );
+            } else {
+                this.sourceFilters[this.filters.datasource].enabled = true;
+            }
+        }
+    }
+
+    resetAllFilters() {
+        this.yearFilters.minModel = this.yearRange.min;
+        this.yearFilters.maxModel = this.yearRange.max;
+        delete this.filters.minAcquisitionDatetime;
+        delete this.filters.maxAcquisitionDatetime;
+
+        this.monthFilters = _.mapValues(this.monthFilters, (val) => {
+            val.enabled = false;
+            return val;
+        });
+        delete this.filters.month;
+
+        this.cloudCoverFilters.minModel = this.cloudCoverRange.min;
+        this.cloudCoverFilters.maxModel = this.cloudCoverRange.max;
+        delete this.filters.minCloudCover;
+        delete this.filters.maxCloudCover;
+
+
+        this.sunElevationFilters.minModel = this.sunElevationRange.min;
+        this.sunElevationFilters.maxModel = this.sunElevationRange.max;
+        delete this.filters.minSunElevation;
+        delete this.filters.maxSunElevation;
+
+        this.sunAzimuthFilters.minModel = this.sunAzimuthRange.min;
+        this.sunAzimuthFilters.maxModel = this.sunAzimuthRange.max;
+        delete this.filters.minSunAzimuth;
+        delete this.filters.maxSunAzimuth;
+
+        this.sourceFilters = _.mapValues(this.sourceFilters, (val) => {
+            val.enabled = false;
+            return val;
+        });
+        delete this.filters.datasource;
+    }
+
+    onMonthFilterChange(newVal) {
+        if (!newVal || !this.filters) {
+            return;
+        }
+
+        let enabledMonths = Object.keys(newVal).filter((key) => {
+            return newVal[key].enabled;
+        }).map((key) => {
+            let month = {};
+            month[key] = newVal[key];
+            return month;
+        });
+
+        if (enabledMonths.length === 0) {
+            delete this.filters.month;
+        } else {
+            this.filters.month = [];
+            enabledMonths.forEach((monthAttr) => {
+                this.filters.month.push(Object.keys(monthAttr)[0]);
+            });
+        }
+    }
+
+    setMonthFilter(month, enabled) {
+        this.monthFilters[month].enabled = enabled;
+        this.onMonthFilterChange(this.monthFilters);
+    }
+
+    onMonthFilterMousedown(filter, filterAttrs) {
+        this.toggleDrag.toggle = true;
+        this.toggleDrag.enabled = !filterAttrs.enabled;
+        this.setMonthFilter(filter, this.toggleDrag.enabled);
+    }
+
+    onMonthFilterMouseover(filter) {
+        if (this.toggleDrag.toggle) {
+            this.setMonthFilter(filter, this.toggleDrag.enabled);
+        }
+    }
+
+    onSourceFilterChange(newVal) {
+        if (!newVal || !this.filters) {
+            return;
+        }
+
+        let enabledSources = Object.keys(newVal).filter((key) => {
+            return newVal[key].enabled;
+        }).map((key) => {
+            let source = {};
+            source[key] = newVal[key];
+            return source;
+        });
+
+        if (enabledSources.length === 0) {
+            delete this.filters.datasource;
+        } else {
+            this.filters.datasource = [];
+            enabledSources.forEach((sourceAttrs) => {
+                this.filters.datasource.push(Object.keys(sourceAttrs)[0]);
+            });
+        }
+    }
+
+    setSourceFilter(source, enabled) {
+        this.sourceFilters[source].enabled = enabled;
+        this.onSourceFilterChange(this.sourceFilters);
+    }
+
+    onSourceFilterMousedown(filter, filterAttrs) {
+        this.toggleDrag.toggle = true;
+        this.toggleDrag.enabled = !filterAttrs.enabled;
+        this.setSourceFilter(filter, this.toggleDrag.enabled);
+    }
+
+    onSourceFilterMouseover(filter) {
+        if (this.toggleDrag.toggle) {
+            this.setSourceFilter(filter, this.toggleDrag.enabled);
+        }
+    }
+}

--- a/app-frontend/src/app/components/filterPane/filterPane.html
+++ b/app-frontend/src/app/components/filterPane/filterPane.html
@@ -1,0 +1,75 @@
+<div class="sidebar-static" >
+  <h5>Filters</h5>
+  <div class="sidebar-actions">
+    <a href ng-click="$ctrl.resetAllFilters()">Clear all filters</a>
+  </div>
+</div>
+<div class="sidebar-scrollable" >
+  <div class="content">
+    <div class="filter">
+      <label>Year</label>
+      <div class="filter-item slider-filter">
+        <div id="year_slider"></div>
+      </div>
+      <rzslider rz-slider-model="$ctrl.yearFilters.minModel"
+                rz-slider-high="$ctrl.yearFilters.maxModel"
+                rz-slider-options="$ctrl.yearFilters.options"
+      ></rzslider>
+    </div>
+    <div class="filter"
+         ng-mouseup="$ctrl.toggleDrag.toggle = false"
+         ng-mouseleave="$ctrl.toggleDrag.toggle = false">
+      <label>Month</label>
+      <div class="filter-item month-filter">
+        <button type="button"
+                class="btn btn-toggle btn-small"
+                autocomplete="off"
+                ng-class="{'active': monthAttrs.enabled,
+                           'disabled': !$ctrl.filters.month}"
+                ng-mousedown="$ctrl.onMonthFilterMousedown(month, monthAttrs)"
+                ng-mouseover="$ctrl.onMonthFilterMouseover(month)"
+                ng-repeat="(month, monthAttrs) in $ctrl.monthFilters track by month">
+          {{monthAttrs.label}}
+        </button>
+      </div>
+    </div>
+    <div class="filter">
+      <label>Cloud cover</label>
+      <rzslider rz-slider-model="$ctrl.cloudCoverFilters.minModel"
+                rz-slider-high="$ctrl.cloudCoverFilters.maxModel"
+                rz-slider-options="$ctrl.cloudCoverFilters.options"></rzslider>
+    </div>
+    <div class="filter">
+      <label>Sun elevation</label>
+      <rzslider rz-slider-model="$ctrl.sunElevationFilters.minModel"
+                rz-slider-high="$ctrl.sunElevationFilters.maxModel"
+                rz-slider-options="$ctrl.sunElevationFilters.options"></rzslider>
+    </div>
+    <div class="filter">
+      <label>Sun azimuth</label>
+      <div class="filter-item slider-filter">
+        <div id="sun_slider"></div>
+      </div>
+      <rzslider rz-slider-model="$ctrl.sunAzimuthFilters.minModel"
+                rz-slider-high="$ctrl.sunAzimuthFilters.maxModel"
+                rz-slider-options="$ctrl.sunAzimuthFilters.options"></rzslider>
+    </div>
+    <div class="filter"
+         ng-mouseleave="$ctrl.toggleDrag.toggle = false"
+         ng-mouseup="$ctrl.toggleDrag.toggle = false">
+      <label>Imagery sources</label>
+      <div class="filter-item tag-filter">
+        <button type="button"
+                class="btn btn-toggle btn-small"
+                autocomplete="off"
+                ng-mousedown="$ctrl.onSourceFilterMousedown(filter, filterAttrs)"
+                ng-mouseover="$ctrl.onSourceFilterMouseover(filter)"
+                ng-class="{'active': filterAttrs.enabled,
+                          'disabled': !$ctrl.filters.datasource}"
+                ng-repeat="(filter, filterAttrs) in $ctrl.sourceFilters track by filter">
+          {{filterAttrs.label}}
+        </button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app-frontend/src/app/components/filterPane/filterPane.module.js
+++ b/app-frontend/src/app/components/filterPane/filterPane.module.js
@@ -1,0 +1,13 @@
+import angular from 'angular';
+import slider from 'angularjs-slider';
+require('../../../assets/font/fontello/css/fontello.css');
+
+import FilterPanComponent from './filterPane.component.js';
+import FilterPaneController from './filterPane.controller.js';
+
+const FilterPaneModule = angular.module('components.filterPane', [slider]);
+
+FilterPaneModule.component('rfFilterPane', FilterPanComponent);
+FilterPaneModule.controller('FilterPaneController', FilterPaneController);
+
+export default FilterPaneModule;

--- a/app-frontend/src/app/components/leafletMap/leafletMap.controller.js
+++ b/app-frontend/src/app/components/leafletMap/leafletMap.controller.js
@@ -10,7 +10,7 @@ export default class LeafletMapController {
         this.initMap();
         this.initLayers();
 
-        $scope.$watch(() => this.footprint, (newVal) => {
+        $scope.$watch('$ctrl.footprint', (newVal) => {
             if (newVal) {
                 let geojsonFeature = {
                     type: 'Feature',

--- a/app-frontend/src/app/components/navBar/navBar.controller.js
+++ b/app-frontend/src/app/components/navBar/navBar.controller.js
@@ -24,9 +24,7 @@ export default class NavBarController {
 
         $log.debug('Navbar controller initialized');
 
-        $scope.$watch(function () {
-            return auth.isAuthenticated;
-        }, (isAuthenticated) => {
+        $scope.$watch('$ctrl.auth.isAuthenticated', (isAuthenticated) => {
             if (isAuthenticated) {
                 store.set('profile', this.auth.profile);
                 this.profile = this.auth.profile;

--- a/app-frontend/src/app/index.components.js
+++ b/app-frontend/src/app/index.components.js
@@ -1,6 +1,7 @@
 export default angular.module('index.components', [
     require('./components/leafletMap/leafletMap.module.js').name,
     require('./components/navBar/navBar.module.js').name,
+    require('./components/filterPane/filterPane.module.js').name,
     require('./components/sceneItem/sceneItem.module.js').name,
     require('./components/sceneDetail/sceneDetail.module.js').name,
     require('./components/bucketItem/bucketItem.module.js').name,

--- a/app-frontend/src/app/index.routes.js
+++ b/app-frontend/src/app/index.routes.js
@@ -13,8 +13,8 @@ import profileTpl from './pages/settings/profile/profile.html';
 import accountTpl from './pages/settings/account/account.html';
 import errorTpl from './pages/error/error.html';
 
-function librarySceneStates(provider) {
-    provider
+function librarySceneStates($stateProvider) {
+    $stateProvider
         .state('library.scenes', {
             url: '/scenes',
             templateUrl: scenesTpl,
@@ -37,8 +37,8 @@ function librarySceneStates(provider) {
         });
 }
 
-function libraryBucketStates(provider) {
-    provider
+function libraryBucketStates($stateProvider) {
+    $stateProvider
         .state('library', {
             url: '/library',
             templateUrl: libraryTpl,
@@ -83,8 +83,8 @@ function libraryBucketStates(provider) {
         });
 }
 
-function settingsStates(provider) {
-    provider
+function settingsStates($stateProvider) {
+    $stateProvider
         .state('settings', {
             url: '/settings',
             templateUrl: settingsTpl,
@@ -113,17 +113,35 @@ function settingsStates(provider) {
         });
 }
 
-function routeConfig($urlRouterProvider, $stateProvider) {
-    'ngInject';
+function browseStates($stateProvider) {
+    let queryParams = [
+        'maxCloudCover',
+        'minCloudCover',
+        'minAcquisitionDatetime',
+        'maxAcquisitionDatetime',
+        'datasource',
+        'month',
+        'maxSunAzimuth',
+        'minSunAzimuth',
+        'maxSunElevation',
+        'minSunElevation',
+        'bbox',
+        'point'
+    ].join('&');
 
     $stateProvider
         .state('browse', {
-            url: '/browse/:id',
+            url: '/browse/:id?' + queryParams,
             templateUrl: browseTpl,
             controller: 'BrowseController',
             controllerAs: '$ctrl'
         });
+}
 
+function routeConfig($urlRouterProvider, $stateProvider) {
+    'ngInject';
+
+    browseStates($stateProvider);
     librarySceneStates($stateProvider);
     libraryBucketStates($stateProvider);
     settingsStates($stateProvider);

--- a/app-frontend/src/app/pages/browse/browse.html
+++ b/app-frontend/src/app/pages/browse/browse.html
@@ -6,9 +6,6 @@
 
       <h5 class="sidebar-title">{{$ctrl.lastSceneResult.count | number}} Results Found</h5>
       <div class="sidebar-actions">
-        <button class="btn btn-default btn-square" ng-click="$ctrl.populateInitialSceneList()">
-          <i class="icon-arrows-cw"></i>
-        </button>
         <button class="btn btn-default btn-square" ng-click="$ctrl.toggleFilterPane()">
           <i class="icon-filter"></i>
         </button>
@@ -37,7 +34,8 @@
           <i class="icon-load"></i>
         </span>
       </div>
-      <div class="list-group" ng-show="!$ctrl.loading && $ctrl.lastSceneResult && !$ctrl.lastSceneResult.hasNext">
+      <div class="list-group"
+           ng-show="!$ctrl.loading && $ctrl.lastSceneResult && !$ctrl.lastSceneResult.hasNext">
         <span class="list-placeholder">
           No more scenes to load
         </span>
@@ -47,7 +45,8 @@
           {{$ctrl.errorMsg}}
         </span>
       </div>
-      <div class="list-group load-message" ng-show="!$ctrl.loading && $ctrl.lastSceneResult && $ctrl.lastSceneResult.hasNext">
+      <div class="list-group load-message"
+           ng-show="!$ctrl.loading && $ctrl.lastSceneResult && $ctrl.lastSceneResult.hasNext">
         <a href ng-click="$ctrl.getMoreScenes()">Load More...</a>
       </div>
     </div>
@@ -113,83 +112,7 @@
 
   <div class="sidebar sidebar-extended map-filters"
        ng-show="$ctrl.showFilterPane && !$ctrl.activeScene">
-    <div class="sidebar-static">
-      <h5>Filter imagery</h5>
-      <div class="sidebar-actions">
-        <a href="#">Clear all filters</a>
-      </div>
-    </div>
-    <div class="sidebar-scrollable">
-      <div class="content">
-        <div class="filter">
-          <label>Year</label>
-          <div class="filter-item slider-filter">
-            <div id="year_slider"></div>
-          </div>
-        </div>
-        <div class="filter">
-          <label>Month</label>
-          <div class="filter-item month-filter">
-            <button type="button" class="btn btn-toggle btn-small active" data-toggle="button" aria-pressed="false" autocomplete="off">Jan</button>
-            <button type="button" class="btn btn-toggle btn-small" data-toggle="button" aria-pressed="false" autocomplete="off">Feb</button>
-            <button type="button" class="btn btn-toggle btn-small" data-toggle="button" aria-pressed="false" autocomplete="off">Mar</button>
-            <button type="button" class="btn btn-toggle btn-small" data-toggle="button" aria-pressed="false" autocomplete="off">Apr</button>
-            <button type="button" class="btn btn-toggle btn-small" data-toggle="button" aria-pressed="false" autocomplete="off">May</button>
-            <button type="button" class="btn btn-toggle btn-small" data-toggle="button" aria-pressed="false" autocomplete="off">Jun</button>
-            <button type="button" class="btn btn-toggle btn-small" data-toggle="button" aria-pressed="false" autocomplete="off">Jul</button>
-            <button type="button" class="btn btn-toggle btn-small" data-toggle="button" aria-pressed="false" autocomplete="off">Aug</button>
-            <button type="button" class="btn btn-toggle btn-small" data-toggle="button" aria-pressed="false" autocomplete="off">Sep</button>
-            <button type="button" class="btn btn-toggle btn-small" data-toggle="button" aria-pressed="false" autocomplete="off">Oct</button>
-            <button type="button" class="btn btn-toggle btn-small" data-toggle="button" aria-pressed="false" autocomplete="off">Nov</button>
-            <button type="button" class="btn btn-toggle btn-small" data-toggle="button" aria-pressed="false" autocomplete="off">Dec</button>
-          </div>
-        </div>
-        <div class="filter">
-          <label>Cloud cover</label>
-          <div class="filter-item slider-filter">
-            <div id="cloud_slider"></div>
-          </div>
-        </div>
-        <div class="filter">
-          <label>Sun elevation</label>
-          <div class="filter-item slider-filter">
-            <div id="sun_slider"></div>
-          </div>
-        </div>
-        <div class="filter">
-          <label>Imagery sources</label>
-          <div class="filter-item tag-filter">
-            <button type="button" class="btn btn-toggle btn-small active" data-toggle="button" aria-pressed="false" autocomplete="off">My Imports</button>
-            <button type="button" class="btn btn-toggle btn-small" data-toggle="button" aria-pressed="false" autocomplete="off">Raster Foundry Users</button>
-            <button type="button" class="btn btn-toggle btn-small active" data-toggle="button" aria-pressed="false" autocomplete="off">NASA</button>
-            <button type="button" class="btn btn-toggle btn-small" data-toggle="button" aria-pressed="false" autocomplete="off">Planet Labs</button>
-            <button type="button" class="btn btn-toggle btn-small" data-toggle="button" aria-pressed="false" autocomplete="off">satimagingcorp</button>
-            <button type="button" class="btn btn-toggle btn-small" data-toggle="button" aria-pressed="false" autocomplete="off">USGS</button>
-          </div>
-        </div>
-        <div class="filter">
-          <label>Broadband</label>
-          <div class="filter-item tag-filter">
-            <button type="button" class="btn btn-toggle btn-small active" data-toggle="button" aria-pressed="false" autocomplete="off">Visible</button>
-            <button type="button" class="btn btn-toggle btn-small" data-toggle="button" aria-pressed="false" autocomplete="off">SWIR</button>
-            <button type="button" class="btn btn-toggle btn-small" data-toggle="button" aria-pressed="false" autocomplete="off">LWIR</button>
-          </div>
-        </div>
-        <div class="filter">
-          <label>Wavelength</label>
-          <div class="filter-item tag-filter">
-            <!-- Based on http://www.markelowitz.com/Hyperspectral.html -->
-            <button type="button" class="btn btn-toggle btn-small active" data-toggle="button" aria-pressed="false" autocomplete="off">.45-.52nm</button>
-            <button type="button" class="btn btn-toggle btn-small" data-toggle="button" aria-pressed="false" autocomplete="off">.52-.60nm</button>
-            <button type="button" class="btn btn-toggle btn-small" data-toggle="button" aria-pressed="false" autocomplete="off">.63-.69nm</button>
-            <button type="button" class="btn btn-toggle btn-small" data-toggle="button" aria-pressed="false" autocomplete="off">.79-.90nm</button>
-            <button type="button" class="btn btn-toggle btn-small" data-toggle="button" aria-pressed="false" autocomplete="off">1.55-1.75nm</button>
-            <button type="button" class="btn btn-toggle btn-small" data-toggle="button" aria-pressed="false" autocomplete="off">2.08-2.35nm</button>
-            <button type="button" class="btn btn-toggle btn-small" data-toggle="button" aria-pressed="false" autocomplete="off">10.4-12.4nm</button>
-          </div>
-        </div>
-      </div>
-    </div>
+    <rf-filter-pane filters="$ctrl.filters"></rf-filter-pane>
   </div>
 
   <div class="main">

--- a/app-frontend/src/assets/styles/sass/app.scss
+++ b/app-frontend/src/assets/styles/sass/app.scss
@@ -62,7 +62,8 @@
   "components/map",
   "components/login",
   "components/item-detail",
-  "components/pagination";
+  "components/pagination",
+  "components/slider";
 
 /**
  * Pages

--- a/app-frontend/src/assets/styles/sass/components/_slider.scss
+++ b/app-frontend/src/assets/styles/sass/components/_slider.scss
@@ -1,0 +1,31 @@
+$slider-base: #353c58;
+$slider-selected: #728ffc;
+
+.rzslider .rz-pointer {
+  width: 24px;
+  height: 24px;
+  left: -12px;
+  top: -10px;
+  border-radius: 2px;
+  background: $slider-selected;
+  cursor: default;
+  &:after {
+    display: none;
+  }
+}
+
+.rzslider .rz-bar {
+  height: 12px;
+  top: 12px;
+  background: $slider-base;
+  &.rz-selection {
+    background: $slider-selected;
+  }
+}
+
+.rzslider .rz-ticks .rz-tick{
+  background: none;
+  &.rz-selected {
+    background: none;
+  }
+}

--- a/app-frontend/src/assets/styles/sass/layout/_sidebar.scss
+++ b/app-frontend/src/assets/styles/sass/layout/_sidebar.scss
@@ -100,3 +100,7 @@
   }
 }
 
+rf-filter-pane {
+  display: flex;
+  flex-flow: column;
+}


### PR DESCRIPTION
## Overview

Hook up the browse filter to the sidebar queries and url
Add angularjs-sliders to handle sliders in a way that's easy to style

### Demo

Basic interaction
![anim](https://cloud.githubusercontent.com/assets/4392704/19529990/fe6eba28-95ff-11e6-9624-fb9480e7a880.gif)  

Drag select on months / sources and clearing filters
![anim](https://cloud.githubusercontent.com/assets/4392704/19530181/c421604a-9600-11e6-86d2-5cc473c2f949.gif)


### Notes

Map based filters will be implemented when on a different card
Currently no way to fetch the correct filter value ranges for the year filter and source filter from the API - this will have to be part of a filter enhancement later on which will probably add the histogram visuals from the original prototype

## Testing Instructions

* Open the app to the /browse page
* Click on the filter button
* Modify each filter value and verify:
  * the state is tracked in the url using query parameters
  * The scene list updates with every filter change
  * Only one query runs at a time
  * If a filter changes while a scene query is in progress, it will wait until the query finished before sending a second query with the latest filter parameters
* Verify that filter values are tracked across reloads
* Verify that filter values are tracked in the history
   * There will only ever be one history value for /browse - the filter will overwrite it so that hitting the back button goes to the last state rather than the last filter value

Discovered https://github.com/azavea/raster-foundry/issues/552 https://github.com/azavea/raster-foundry/issues/554