### PR TITLE
Add comments to Jenkinsfile; limit Slack messages to errors

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,13 +1,15 @@
 #!groovy
 
 node {
-  currentBuild.result = 'SUCCESS'
-
   try {
+    // Checkout the proper revision into the workspace.
     stage('checkout') {
       checkout scm
     }
 
+    // Execute `cibuild` wrapped within a plugin that translates
+    // ANSI color codes to something that renders inside the Jenkins
+    // console.
     stage('cibuild') {
       wrap([$class: 'AnsiColorBuildWrapper']) {
         sh 'scripts/cibuild'
@@ -18,7 +20,12 @@ node {
       env.AWS_DEFAULT_REGION = 'us-east-1'
       env.RF_SETTINGS_BUCKET = 'rasterfoundry-staging-config-us-east-1'
 
+      // Publish container images built and tested during `cibuild`
+      // to the private Amazon Container Registry tagged with the
+      // first seven characters of the revision SHA.
       stage('cipublish') {
+        // Decode the `AWS_ECR_ENDPOINT` credential stored within
+        // Jenkins. In includes the Amazon ECR registry endpoint.
         withCredentials([[$class: 'StringBinding',
                           credentialsId: 'AWS_ECR_ENDPOINT',
                           variable: 'AWS_ECR_ENDPOINT']]) {
@@ -28,6 +35,13 @@ node {
         }
       }
 
+      // Plan and apply the current state of the instracture as
+      // outlined by the `develop` branch of the `raster-foundry-deployment`
+      // repository.
+      //
+      // Also, use the container image revision referenced above to
+      // cycle in the newest version of the application into Amazon
+      // ECS.
       stage('infra') {
         checkout scm: [$class: 'GitSCM',
                        branches: [[name: 'develop']],
@@ -45,25 +59,17 @@ node {
       }
     }
   } catch (err) {
-    currentBuild.result = 'FAILURE'
-
-    throw err
-  } finally {
-    def buildEmoji = (currentBuild.result == 'SUCCESS') ? ':thumbsup:' : ':jenkins-angry:'
-    def buildColor = (currentBuild.result == 'SUCCESS') ? 'good' : 'danger'
-
-    def slackMessage = "${buildEmoji} *raster-foundry (${env.BRANCH_NAME}) #${env.BUILD_NUMBER}*"
+    // Some exception was raised in the `try` block above. Assemble
+    // an appropirate error message for Slack.
+    def slackMessage = ":jenkins-angry: *raster-foundry (${env.BRANCH_NAME}) #${env.BUILD_NUMBER}*"
     if (env.CHANGE_TITLE) {
       slackMessage += "\n${env.CHANGE_TITLE} - ${env.CHANGE_AUTHOR}"
     }
     slackMessage += "\n<${env.BUILD_URL}|View Build>"
+    slackSend color: 'danger', message: slackMessage
 
-    if (currentBuild.result == 'FAILURE' ||
-        (currentBuild.result == 'SUCCESS' &&
-         (env.BRANCH_NAME == 'develop'
-          || env.BRANCH_NAME.startsWith('release/')
-          || env.BRANCH_NAME.startsWith('PR-')))) {
-      slackSend color: buildColor, message: slackMessage
-    }
+    // Re-raise the exception so that the failure is propagated to
+    // Jenkins.
+    throw err
   }
 }


### PR DESCRIPTION
## Overview

Add comments for each stage of the `Jenkinsfile` build process and limit Slack messages to failures.

## Testing Instructions

* Review Jenkins file and see if the comments make sense
* Take a look at the [job output](http://jenkins.staging.rasterfoundry.com/job/raster-foundry/job/raster-foundry/job/feature%252Fhmc%252Fshhh-jenkins/) to ensure that it looks correct