### PR TITLE
Return 400, not 500 for invalid tokens

### DIFF
--- a/app-backend/app/src/main/scala/token/Routes.scala
+++ b/app-backend/app/src/main/scala/token/Routes.scala
@@ -3,16 +3,18 @@ package com.azavea.rf.token
 import akka.http.scaladsl.server.Route
 
 import com.azavea.rf.auth.Authentication
+import com.azavea.rf.utils.UserErrorHandler
 
 
 /**
   * Routes for tokens
   */
 trait TokenRoutes extends Authentication
+  with UserErrorHandler
   with Auth0ErrorHandler {
 
   def tokenRoutes: Route = pathPrefix("api" / "tokens") {
-    handleExceptions(auth0ExceptionHandler) {
+    (handleExceptions(auth0ExceptionHandler) & handleExceptions(userExceptionHandler)) {
       listRefreshTokens ~
       getAuthorizedToken ~
       revokeRefreshToken

--- a/app-backend/app/src/main/scala/token/Token.scala
+++ b/app-backend/app/src/main/scala/token/Token.scala
@@ -68,6 +68,12 @@ object TokenService extends Config {
       .flatMap {
         case HttpResponse(StatusCodes.OK, _, entity, _) =>
           Unmarshal(entity).to[AuthorizedToken]
+        case HttpResponse(StatusCodes.Unauthorized, _, error, _) =>
+          if (error.toString.contains("invalid_refresh_token")) {
+            throw new IllegalArgumentException("Refresh token not recognized")
+          } else {
+            throw new Auth0Exception(StatusCodes.Unauthorized, error.toString)
+          }
         case HttpResponse(errCode, _, error, _) =>
           throw new Auth0Exception(errCode, error.toString)
       }

--- a/app-backend/app/src/main/scala/utils/UserErrorHandler.scala
+++ b/app-backend/app/src/main/scala/utils/UserErrorHandler.scala
@@ -8,16 +8,16 @@ import spray.json.{SerializationException, DeserializationException}
 trait UserErrorHandler extends Directives with LazyLogging {
   val userExceptionHandler = ExceptionHandler {
     case e: IllegalArgumentException =>
-      logger.error(e.getStackTrace.toString)
+      logger.error(RfStackTrace(e))
       complete(StatusCodes.ClientError(400)("Bad Argument", e.getMessage))
     case e: IllegalStateException =>
-      logger.error(e.getStackTrace.toString)
+      logger.error(RfStackTrace(e))
       complete(StatusCodes.ClientError(400)("Bad Request", e.getMessage))
     case e: DeserializationException =>
-      logger.error(e.getStackTrace.toString)
+      logger.error(RfStackTrace(e))
       complete(StatusCodes.ClientError(400)("Decoding Error", e.getMessage))
     case e: SerializationException =>
-      logger.error(e.getStackTrace.toString)
+      logger.error(RfStackTrace(e))
       complete(StatusCodes.ServerError(500)("Encoding Error", e.getMessage))
   }
 }


### PR DESCRIPTION
## Overview

Previously we would return a 500 for every Auth0 API error. But there is a use case when the user sends an invalid refresh token and Auth0 returns a 401 with an `invalid_refresh_token` error. Since this is a legitimate user error, we now inspect the Auth0 response and send back a 400 if this is the case.

We also add the UserErrorHandler trait and respective exception handler to the token route so it can translate an `IllegalArgumentException` to an error 400. Also update the logging code so now it prints the full stack trace for every error.

### Demo

```http
> http :9000/api/tokens refresh_token=TOTALLY_NOT_A_REFRESH_TOKEN
HTTP/1.1 400 Bad Argument
Content-Length: 28
Content-Type: text/plain; charset=UTF-8
Date: Wed, 19 Oct 2016 23:03:05 GMT
Server: akka-http/2.4.11

Refresh token not recognized

```

```
[info] 23:03:05.248 [rf-system-akka.actor.default-dispatcher-2] ERROR com.azavea.rf.Main$ - java.lang.IllegalArgumentException: Refresh token not recognized
[info] 	at com.azavea.rf.token.TokenService$$anonfun$getAuthorizedToken$1.apply(Token.scala:73)
[info] 	at com.azavea.rf.token.TokenService$$anonfun$getAuthorizedToken$1.apply(Token.scala:68)
[info] 	at scala.concurrent.Future$$anonfun$flatMap$1.apply(Future.scala:253)
[info] 	at scala.concurrent.Future$$anonfun$flatMap$1.apply(Future.scala:251)
[info] 	at scala.concurrent.impl.CallbackRunnable.run(Promise.scala:32)
[info] 	at scala.concurrent.impl.ExecutionContextImpl$AdaptedForkJoinTask.exec(ExecutionContextImpl.scala:121)
[info] 	at scala.concurrent.forkjoin.ForkJoinTask.doExec(ForkJoinTask.java:260)
[info] 	at scala.concurrent.forkjoin.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1339)
[info] 	at scala.concurrent.forkjoin.ForkJoinPool.runWorker(ForkJoinPool.java:1979)
[info] 	at scala.concurrent.forkjoin.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:107)

```

### Notes

Not sure if we need the full stack trace for a 400 response, maybe I should just raise a 400 and return a response immediately rather than go through the `IllegalArgumentException` rigamarole.

## Testing Instructions

Check out the branch, run the server. Use `http` or `curl` to try and validate a spurious refresh token:

```bash
$ http :9000/api/tokens refresh_token=HELLO_YES_THIS_IS_DOG
```

```bash
$ curl -vv -X POST -H "Content-Type: application/json" -d '{"refresh_token": "OPEN_SESAME"}' http://localhost:9000/api/tokens
```

Observe the return values and the error log. Ensure that legitimate refresh tokens still work.

Connects #553