### PR TITLE
Add an initial style guide and update PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,6 +2,10 @@
 
 Brief description of what this PR does, and why it is needed.
 
+### Checklist
+
+- [ ] Styleguide updated, if necessary
+
 ### Demo
 
 Optional. Screenshots, `curl` examples, etc.

--- a/docs/style/scala.md
+++ b/docs/style/scala.md
@@ -1,0 +1,206 @@
+Raster Foundry Style Guide
+============
+
+Comments
+--------
+
+Single line comments should be wrapped in `/**...*/` if they're for Scaladoc (i.e.
+they're above methods, classes, traits, objects, or packages). Otherwise, `//`
+is fine.
+
+```scala
+/** good */
+object foo {
+  ???
+}
+
+// bad
+object foo {
+  ???
+}
+
+/** fine */
+object foo {
+  val bar = ??? // magic number from somewhere
+}
+```
+
+Multi-line comments should start with a `/**`, have following lines asterisks trail
+the _second_ asterisk from the first line, and end with a `*/`:
+
+```scala
+/** This is a good multi-line comment
+  *
+  * good stuff
+  */
+```
+
+```scala
+/** This is a bad multi-line comment
+ *
+ *  bad stuff
+ */
+```
+
+This is _different_ from Scaladoc's style, but it's how we've done things, and it's
+more consistent with autoindentation in IntelliJ's IDEA and the spacemacs scala
+layer.
+
+Class Declarations
+---------
+
+When a class extends many traits, the subsequent `with foo` blocks should be
+indented four lines, with the last one followed by the opening curly brace.
+
+```scala
+class GoodClass extends Foo
+    with Bar
+    with Baz
+    with Qux {
+    ...
+}
+```
+
+"Many traits" means the class declaration would be over 100 characters, though if
+it's getting close and readability would be improved you should go ahead and separate
+the lines anyway.
+
+Long-hanging indents before `with` statements can be replaced with
+`sed "s/\\s\{n\}\(with.*\)/    \1/" filename > filename.styled`,
+optionally `sed -i` if you're feeling lucky.
+
+Endpoints and Routes
+---------
+
+#### Methods
+
+Folowing route definition, methods should be the outermost block of code, e.g.:
+
+```scala
+get {
+  stuff {
+    ...more stuff...
+  }
+} ~
+post {
+  authenticate {
+    ...stuff...
+  }
+} ~ ...
+```
+
+Not:
+
+```scala
+authenticate {
+  post {
+    ...more stuff...
+  }
+} ~
+stuff {
+  get {
+    ...more stuff...
+  }
+} ~ ...
+```
+
+Methods as the outermost block puts allowed methods in a consistent place and also
+prevents the problem discussed in [issue #562](https://github.com/azavea/raster-foundry/issues/562/).
+
+Methods should return results of explicitly defined functions, e.g.:
+
+```scala
+def userToInt(u: User): Int = ??? 
+
+post {
+  entity(as[User]) {
+    complete {
+      userToInt
+    }
+  }
+}
+```
+
+This style allows explicitly testing the logic of the return value by testing the `userToInt`
+function without having to surround that test in boilerplate for the endpoint.
+
+#### Routes
+
+Endpoints for returning several objecst are `list` endpoints, and should be named `list{object}` as
+opposed to `get{object}s`, since `get{objects}s` is hard to distinguish visually from `get{object}`.
+([Issue #475](https://github.com/azavea/raster-foundry/issues/475))
+
+Static components of a package's routes should not be defined in the package itself, but in a
+`Router` trait that has access to that information. Prefer:
+
+```scala
+// In the router trait
+val routes = cors() {
+  pathPrefix("healthcheck") {
+    healthCheckRoutes
+  } ~
+  pathPrefix("api") {
+    pathPrefix("foo") {
+      fooRoutes
+    } ~
+    pathPrefix("bar") {
+      barRoutes
+    }
+  } ~
+  ???
+}
+```
+
+to:
+
+```scala
+val routes = cors() {
+  healthCheckRoutes ~
+  fooRoutes ~
+  barRoutes ~
+  ???
+}
+```
+
+Slick
+---------
+
+#### Queries with several actions
+
+Slick gives us several options for combining DBIO actions. Use for-comprehensions anywhere
+the two actions depend on each other (e.g., the value `a` below is necessary for `b`).
+
+```scala
+for {
+  a <- db.someAction()
+  b <- db.someActionUsing(a.id)
+} yield (a, b)
+```
+
+In addition to making `a` available for the second action, for-comprehensions fail fast. If
+`a` were to fail, the operation to attain `b` wouldn't even be attempted. We'd get back an
+empty (failed) future.
+
+For general, possibly unrelated sequences of actions, also use for-comprehensions and ensure
+to mark them transactional
+
+```scala
+for {
+  a <- db.someAction()
+  b <- db.someAction()
+  c <- db.someAction()
+} yield (a, b, c) .transactionally
+```
+
+We _could_ use `DBIO.seq` and mark the sequence transactional, but using for-comprehensions
+will:
+
+- ensure style consistency for all sequences of actions, related or not
+- ensure atomic success or failure with the presence of `.transactionally`
+- yield futures that we can then use instead of yielding `Unit`
+
+General Rules
+---------
+
+- Don't have hanging indents over 50 characters.
+- Try to keep things on one line unless readability would be improved otherwise.


### PR DESCRIPTION
## Overview

This PR adds an initial style guide for scala code in Raster Foundry. The focus in this first pass
is on existing issues that address style (#475, #562); things we've probably done wrong
(superindented blocks of with statements, as in our [table definitions](https://github.com/azavea/raster-foundry/blob/d50d9fa05d6d8b67137c64781b8bf7fe15798ca7/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Organizations.scala#L20-L21); and a
planned departure from the Scaladoc style in how we do multi-line comments.

This PR is needed to provide a place for documenting our style and to begin documenting.

### Checklist

- [x] Styleguide updated, if necessary

Closes #472, closes #475
