### PR TITLE
Use Docker Compose to bring down services

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -71,5 +71,9 @@ node {
     // Re-raise the exception so that the failure is propagated to
     // Jenkins.
     throw err
+  } finally {
+    // Pass or fail, ensure that the services and networks
+    // created by Docker Compose are torn down.
+    sh 'docker-compose down -v'
   }
 }

--- a/scripts/cibuild
+++ b/scripts/cibuild
@@ -30,9 +30,6 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
         aws s3 cp "s3://rasterfoundry-testing-config-us-east-1/.env" ".env"
         popd
 
-        echo "Stopping all running containers before continuing CI suite..."
-        docker ps -aq | xargs -r docker stop
-
         docker-compose \
             -f "${DIR}/../docker-compose.yml" \
             run --rm app-server sbt update


### PR DESCRIPTION
## Overview

Docker Compose creates networks within the context of Docker in order to provide a communication mechanism between services. Because Docker Compose was responsible for creating the network initially, it should also be used to tear it down. 

See: https://github.com/docker/docker/issues/23971

## Testing Instructions

Inspect the output of the Jenkins job for this PR and ensure that the `docker-compose down` step completes successfully.