### PR TITLE
Update Route Ordering

### DIFF
--- a/app-backend/app/src/main/scala/Router.scala
+++ b/app-backend/app/src/main/scala/Router.scala
@@ -42,13 +42,15 @@ trait Router extends HealthCheckRoutes
     pathPrefix("healthcheck") {
       healthCheckRoutes
     } ~
-    userRoutes ~
     organizationRoutes ~
     sceneRoutes ~
     bucketRoutes ~
     imageRoutes ~
     tokenRoutes ~
     thumbnailRoutes ~
+    pathPrefix("api") {
+      pathPrefix("users") { userRoutes }
+    } ~
     pathPrefix("config") {
       configRoutes
     }

--- a/app-backend/app/src/main/scala/Router.scala
+++ b/app-backend/app/src/main/scala/Router.scala
@@ -43,12 +43,12 @@ trait Router extends HealthCheckRoutes
       healthCheckRoutes
     } ~
     organizationRoutes ~
-    sceneRoutes ~
     bucketRoutes ~
     imageRoutes ~
     tokenRoutes ~
     thumbnailRoutes ~
     pathPrefix("api") {
+      pathPrefix("scenes") { sceneRoutes } ~
       pathPrefix("users") { userRoutes }
     } ~
     pathPrefix("config") {

--- a/app-backend/app/src/main/scala/Router.scala
+++ b/app-backend/app/src/main/scala/Router.scala
@@ -42,12 +42,12 @@ trait Router extends HealthCheckRoutes
     pathPrefix("healthcheck") {
       healthCheckRoutes
     } ~
-    organizationRoutes ~
     tokenRoutes ~
     thumbnailRoutes ~
     pathPrefix("api") {
       pathPrefix("buckets") { bucketRoutes } ~
       pathPrefix("images") { imageRoutes } ~
+      pathPrefix("organizations") { organizationRoutes } ~
       pathPrefix("scenes") { sceneRoutes } ~
       pathPrefix("users") { userRoutes }
     } ~

--- a/app-backend/app/src/main/scala/Router.scala
+++ b/app-backend/app/src/main/scala/Router.scala
@@ -39,7 +39,9 @@ trait Router extends HealthCheckRoutes
   val corsSettings = CorsSettings.defaultSettings
 
   val routes = cors() {
-    healthCheckRoutes ~
+    pathPrefix("healthcheck") {
+      healthCheckRoutes
+    } ~
     userRoutes ~
     organizationRoutes ~
     sceneRoutes ~

--- a/app-backend/app/src/main/scala/Router.scala
+++ b/app-backend/app/src/main/scala/Router.scala
@@ -49,6 +49,8 @@ trait Router extends HealthCheckRoutes
     imageRoutes ~
     tokenRoutes ~
     thumbnailRoutes ~
-    configRoutes
+    pathPrefix("config") {
+      configRoutes
+    }
   }
 }

--- a/app-backend/app/src/main/scala/Router.scala
+++ b/app-backend/app/src/main/scala/Router.scala
@@ -42,13 +42,13 @@ trait Router extends HealthCheckRoutes
     pathPrefix("healthcheck") {
       healthCheckRoutes
     } ~
-    tokenRoutes ~
     pathPrefix("api") {
       pathPrefix("buckets") { bucketRoutes } ~
       pathPrefix("images") { imageRoutes } ~
       pathPrefix("organizations") { organizationRoutes } ~
       pathPrefix("scenes") { sceneRoutes } ~
       pathPrefix("thumbnails") { thumbnailRoutes } ~
+      pathPrefix("tokens") { tokenRoutes } ~
       pathPrefix("users") { userRoutes }
     } ~
     pathPrefix("config") {

--- a/app-backend/app/src/main/scala/Router.scala
+++ b/app-backend/app/src/main/scala/Router.scala
@@ -43,11 +43,11 @@ trait Router extends HealthCheckRoutes
       healthCheckRoutes
     } ~
     organizationRoutes ~
-    imageRoutes ~
     tokenRoutes ~
     thumbnailRoutes ~
     pathPrefix("api") {
       pathPrefix("buckets") { bucketRoutes } ~
+      pathPrefix("images") { imageRoutes } ~
       pathPrefix("scenes") { sceneRoutes } ~
       pathPrefix("users") { userRoutes }
     } ~

--- a/app-backend/app/src/main/scala/Router.scala
+++ b/app-backend/app/src/main/scala/Router.scala
@@ -43,11 +43,11 @@ trait Router extends HealthCheckRoutes
       healthCheckRoutes
     } ~
     organizationRoutes ~
-    bucketRoutes ~
     imageRoutes ~
     tokenRoutes ~
     thumbnailRoutes ~
     pathPrefix("api") {
+      pathPrefix("buckets") { bucketRoutes } ~
       pathPrefix("scenes") { sceneRoutes } ~
       pathPrefix("users") { userRoutes }
     } ~

--- a/app-backend/app/src/main/scala/Router.scala
+++ b/app-backend/app/src/main/scala/Router.scala
@@ -43,12 +43,12 @@ trait Router extends HealthCheckRoutes
       healthCheckRoutes
     } ~
     tokenRoutes ~
-    thumbnailRoutes ~
     pathPrefix("api") {
       pathPrefix("buckets") { bucketRoutes } ~
       pathPrefix("images") { imageRoutes } ~
       pathPrefix("organizations") { organizationRoutes } ~
       pathPrefix("scenes") { sceneRoutes } ~
+      pathPrefix("thumbnails") { thumbnailRoutes } ~
       pathPrefix("users") { userRoutes }
     } ~
     pathPrefix("config") {

--- a/app-backend/app/src/main/scala/auth/Authentication.scala
+++ b/app-backend/app/src/main/scala/auth/Authentication.scala
@@ -1,7 +1,6 @@
 package com.azavea.rf.auth
 
-import scala.concurrent.{Future, ExecutionContext}
-import scala.util.{Success, Failure}
+import scala.concurrent.Future
 
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.model.headers._
@@ -9,9 +8,10 @@ import akka.http.scaladsl.server._
 import akka.http.scaladsl.server.AuthenticationFailedRejection.CredentialsRejected
 
 import de.choffmeister.auth.common.JsonWebToken
-import com.azavea.rf.datamodel.User
+
 import com.azavea.rf.database.tables._
 import com.azavea.rf.database.Database
+import com.azavea.rf.datamodel._
 import com.azavea.rf.utils.Config
 
 

--- a/app-backend/app/src/main/scala/bucket/Routes.scala
+++ b/app-backend/app/src/main/scala/bucket/Routes.scala
@@ -17,12 +17,14 @@ import com.azavea.rf.database.tables._
 import com.azavea.rf.database.Database
 import com.azavea.rf.utils.queryparams.QueryParametersCommon
 import com.azavea.rf.scene.SceneQueryParameterDirective
+import com.azavea.rf.utils.UserErrorHandler
 
 
 trait BucketRoutes extends Authentication
     with QueryParametersCommon
     with SceneQueryParameterDirective
-    with PaginationDirectives {
+    with PaginationDirectives
+    with UserErrorHandler {
 
   implicit def database: Database
 
@@ -33,124 +35,135 @@ trait BucketRoutes extends Authentication
 
   val BULK_OPERATION_MAX_LIMIT = 100
 
-  def bucketRoutes: Route = {
-    pathPrefix("api" / "buckets") {
+  val bucketRoutes: Route = handleExceptions(userExceptionHandler) {
+    pathEndOrSingleSlash {
+      get { listBuckets } ~
+      post { createBucket }
+    } ~
+    pathPrefix(JavaUUID) { bucketId =>
       pathEndOrSingleSlash {
-        authenticateAndAllowAnonymous { user =>
-          withPagination { page =>
-            get {
-              bucketQueryParameters { bucketQueryParameters =>
-                onSuccess(Buckets.getBuckets(page, bucketQueryParameters)) { scenes =>
-                  complete(scenes)
-                }
-              }
-            }
-          }
-        } ~
-        authenticate { user =>
-          post {
-            entity(as[Bucket.Create]) { newBucket =>
-              onComplete(Buckets.insertBucket(newBucket.toBucket(user.id))) {
-                case Success(bucket) => complete(bucket)
-                case Failure(_) => complete(StatusCodes.InternalServerError)
-              }
-            }
-          }
-        }
+        get { getBucket(bucketId) } ~
+        put { updateBucket(bucketId) } ~
+        delete { deleteBucket(bucketId) }
       } ~
-      pathPrefix(JavaUUID) { bucketId =>
+      pathPrefix("scenes") {
         pathEndOrSingleSlash {
-          authenticateAndAllowAnonymous { user =>
-            get {
-              onSuccess(Buckets.getBucket(bucketId)) {
-                case Some(bucket) => complete(bucket)
-                case _ => complete(StatusCodes.NotFound)
-              }
-            }
-          } ~
-          authenticate { user =>
-            put {
-              entity(as[Bucket]) { updatedBucket =>
-                onSuccess(Buckets.updateBucket(updatedBucket, bucketId, user)) {
-                  case 1 => complete(StatusCodes.NoContent)
-                }
-              }
-            } ~
-            delete {
-              onSuccess(Buckets.deleteBucket(bucketId)) {
-                case 1 => complete(StatusCodes.NoContent)
-                case 0 => complete(StatusCodes.NotFound)
-                case _ => complete(StatusCodes.InternalServerError)
-              }
-            }
-          }
+          get { listBucketScenes(bucketId) } ~
+          post { addBucketScenes(bucketId) } ~
+          put { updateBucketScenes(bucketId) } ~
+          delete { deleteBucketScenes(bucketId) }
         } ~
-        pathPrefix("scenes") {
+        pathPrefix(JavaUUID) { sceneId =>
           pathEndOrSingleSlash {
-            authenticateAndAllowAnonymous { user =>
-              withPagination { page =>
-                get {
-                  sceneQueryParameters { sceneParams =>
-                    onSuccess(Buckets.getBucketScenes(bucketId, page, sceneParams)) { scenes =>
-                      complete(scenes)
-                    }
-                  }
-                }
-              }
-            } ~
-            post {
-              (authenticate & entity(as[Seq[UUID]])) { (user, sceneIds) =>
-                if (sceneIds.length > BULK_OPERATION_MAX_LIMIT) {
-                  complete(StatusCodes.RequestEntityTooLarge)
-                }
-
-                complete {
-                  Buckets.addScenesToBucket(sceneIds, bucketId)
-                }
-              }
-            } ~
-            put {
-              (authenticate & entity(as[Seq[UUID]])) { (user, sceneIds) =>
-                if (sceneIds.length > BULK_OPERATION_MAX_LIMIT) {
-                  complete(StatusCodes.RequestEntityTooLarge)
-                }
-
-                complete {
-                  Buckets.replaceScenesInBucket(sceneIds, bucketId)
-                }
-              }
-            } ~
-            delete {
-              (authenticate & entity(as[Seq[UUID]])) { (user, sceneIds) =>
-                if (sceneIds.length > BULK_OPERATION_MAX_LIMIT) {
-                  complete(StatusCodes.RequestEntityTooLarge)
-                }
-
-                onSuccess(Buckets.deleteScenesFromBucket(sceneIds, bucketId)) {
-                  _ => complete(StatusCodes.NoContent)
-                }
-              }
-            }
-          } ~
-          authenticate { user =>
-            pathPrefix(JavaUUID) { sceneId =>
-              pathEndOrSingleSlash {
-                post {
-                  onSuccess(Buckets.addSceneToBucket(sceneId, bucketId)) { resp =>
-                    complete(StatusCodes.Created)
-                  }
-                } ~
-                delete {
-                  onSuccess(Buckets.deleteSceneFromBucket(sceneId, bucketId)) {
-                    case 1 => complete(StatusCodes.NoContent)
-                    case 0 => complete(StatusCodes.NotFound)
-                    case _ => complete(StatusCodes.InternalServerError)
-                  }
-                }
-              }
-            }
+            post { addBucketScene(bucketId, sceneId) } ~
+            delete { deleteBucketScene(bucketId, sceneId) }
           }
         }
+      }
+    }
+  }
+
+  def listBuckets: Route = authenticateAndAllowAnonymous { user =>
+    (withPagination & bucketQueryParameters) { (page, bucketQueryParameters) =>
+      complete {
+        Buckets.listBuckets(page, bucketQueryParameters)
+      }
+    }
+  }
+
+  def createBucket: Route = authenticate { user =>
+    entity(as[Bucket.Create]) { newBucket =>
+      onSuccess(Buckets.insertBucket(newBucket.toBucket(user.id))) { bucket =>
+        complete(StatusCodes.Created, bucket)
+      }
+    }
+  }
+
+  def getBucket(bucketId: UUID): Route = authenticateAndAllowAnonymous { user =>
+    rejectEmptyResponse {
+      complete {
+        Buckets.getBucket(bucketId)
+      }
+    }
+  }
+
+  def updateBucket(bucketId: UUID): Route = authenticate { user =>
+    entity(as[Bucket]) { updatedBucket =>
+      onSuccess(Buckets.updateBucket(updatedBucket, bucketId, user)) {
+        case 1 => complete(StatusCodes.NoContent)
+        case count => throw new IllegalStateException(
+          s"Error updating bucket: update result expected to be 1, was $count"
+        )
+      }
+    }
+  }
+
+  def deleteBucket(bucketId: UUID): Route = authenticate { user =>
+    onSuccess(Buckets.deleteBucket(bucketId)) {
+      case 1 => complete(StatusCodes.NoContent)
+      case 0 => complete(StatusCodes.NotFound)
+      case count => throw new IllegalStateException(
+        s"Error deleting bucket: delete result expected to be 1, was $count"
+      )
+    }
+  }
+
+  def listBucketScenes(bucketId: UUID): Route = authenticateAndAllowAnonymous { user =>
+    (withPagination & sceneQueryParameters) { (page, sceneParams) =>
+      complete {
+        Buckets.listBucketScenes(bucketId, page, sceneParams)
+      }
+    }
+  }
+
+  def addBucketScene(bucketId: UUID, sceneId: UUID): Route = authenticate { user =>
+    onSuccess(Buckets.addSceneToBucket(sceneId, bucketId)) { _ =>
+      complete(StatusCodes.Created)
+    }
+  }
+
+  def addBucketScenes(bucketId: UUID): Route = authenticate { user =>
+    entity(as[Seq[UUID]]) { sceneIds =>
+      if (sceneIds.length > BULK_OPERATION_MAX_LIMIT) {
+        complete(StatusCodes.RequestEntityTooLarge)
+      }
+
+      complete {
+        Buckets.addScenesToBucket(sceneIds, bucketId)
+      }
+    }
+  }
+
+  def updateBucketScenes(bucketId: UUID): Route = authenticate { user =>
+    entity(as[Seq[UUID]]) { sceneIds =>
+      if (sceneIds.length > BULK_OPERATION_MAX_LIMIT) {
+        complete(StatusCodes.RequestEntityTooLarge)
+      }
+
+      complete {
+        Buckets.replaceScenesInBucket(sceneIds, bucketId)
+      }
+    }
+  }
+
+  def deleteBucketScene(bucketId: UUID, sceneId: UUID): Route = authenticate { user =>
+    onSuccess(Buckets.deleteSceneFromBucket(sceneId, bucketId)) {
+      case 1 => complete(StatusCodes.NoContent)
+      case 0 => complete(StatusCodes.NotFound)
+      case count => throw new IllegalStateException(
+        s"Error deleting scene from bucket: delete result expected to be 1, was $count"
+      )
+    }
+  }
+
+  def deleteBucketScenes(bucketId: UUID): Route = authenticate { user =>
+    entity(as[Seq[UUID]]) { sceneIds =>
+      if (sceneIds.length > BULK_OPERATION_MAX_LIMIT) {
+        complete(StatusCodes.RequestEntityTooLarge)
+      }
+
+      onSuccess(Buckets.deleteScenesFromBucket(sceneIds, bucketId)) {
+        _ => complete(StatusCodes.NoContent)
       }
     }
   }

--- a/app-backend/app/src/main/scala/bucket/Routes.scala
+++ b/app-backend/app/src/main/scala/bucket/Routes.scala
@@ -1,8 +1,6 @@
 package com.azavea.rf.bucket
 
 import java.util.UUID
-import scala.concurrent.ExecutionContext
-import scala.util.{Success, Failure}
 
 import akka.http.scaladsl.server.Route
 import akka.http.scaladsl.unmarshalling._
@@ -10,13 +8,12 @@ import akka.http.scaladsl.model.StatusCodes
 
 import com.lonelyplanet.akka.http.extensions.PaginationDirectives
 
-import com.azavea.rf.scene._
 import com.azavea.rf.auth.Authentication
-import com.azavea.rf.datamodel._
-import com.azavea.rf.database.tables._
+import com.azavea.rf.database.tables.Buckets
 import com.azavea.rf.database.Database
+import com.azavea.rf.datamodel._
+import com.azavea.rf.scene._
 import com.azavea.rf.utils.queryparams.QueryParametersCommon
-import com.azavea.rf.scene.SceneQueryParameterDirective
 import com.azavea.rf.utils.UserErrorHandler
 
 
@@ -167,8 +164,4 @@ trait BucketRoutes extends Authentication
       }
     }
   }
-}
-
-object BucketRoutes {
-
 }

--- a/app-backend/app/src/main/scala/config/Routes.scala
+++ b/app-backend/app/src/main/scala/config/Routes.scala
@@ -1,10 +1,9 @@
 package com.azavea.rf.config
 
 import akka.http.scaladsl.server.Route
-import scala.concurrent.ExecutionContext
 
 import com.azavea.rf.auth.Authentication
-import com.azavea.rf.database.Database
+
 
 trait ConfigRoutes extends Authentication {
   def configRoutes: Route = {

--- a/app-backend/app/src/main/scala/config/Routes.scala
+++ b/app-backend/app/src/main/scala/config/Routes.scala
@@ -8,9 +8,11 @@ import com.azavea.rf.database.Database
 
 trait ConfigRoutes extends Authentication {
   def configRoutes: Route = {
-    pathPrefix("config") {
+    pathEndOrSingleSlash {
       get {
-        complete(AngularConfigService.getConfig())
+        complete {
+          AngularConfigService.getConfig()
+        }
       }
     }
   }

--- a/app-backend/app/src/main/scala/healthcheck/Routes.scala
+++ b/app-backend/app/src/main/scala/healthcheck/Routes.scala
@@ -1,15 +1,13 @@
 package com.azavea.rf.healthcheck
 
-import scala.concurrent.ExecutionContext
-
-import akka.http.scaladsl.model._
+import akka.http.scaladsl.model.StatusCodes._
 import akka.http.scaladsl.server._
-import StatusCodes._
 
 import org.postgresql.util.PSQLException
 
-import com.azavea.rf.database.Database
 import com.azavea.rf.auth.Authentication
+import com.azavea.rf.database.Database
+
 
 /**
   * Routes for healthchecks -- additional routes for individual healthchecks

--- a/app-backend/app/src/main/scala/healthcheck/Routes.scala
+++ b/app-backend/app/src/main/scala/healthcheck/Routes.scala
@@ -29,17 +29,13 @@ trait HealthCheckRoutes extends Authentication {
       }
   }
 
-  val healthCheckRoutes = (
-    handleExceptions(healthCheckExceptionHandler) {
-      authenticateAndAllowAnonymous { user =>
-        pathPrefix("healthcheck") {
-          pathEndOrSingleSlash {
-            onSuccess(HealthCheckService.healthCheck) { resp =>
-              complete(resp)
-            }
-          }
+  val healthCheckRoutes = handleExceptions(healthCheckExceptionHandler) {
+    pathEndOrSingleSlash {
+      get {
+        complete {
+          HealthCheckService.healthCheck
         }
       }
     }
-  )
+  }
 }

--- a/app-backend/app/src/main/scala/image/Routes.scala
+++ b/app-backend/app/src/main/scala/image/Routes.scala
@@ -2,19 +2,15 @@ package com.azavea.rf.image
 
 import java.util.UUID
 
-import com.azavea.rf.datamodel.Image
-
-import scala.concurrent.ExecutionContext
-import scala.util.{Success, Failure}
-
 import akka.http.scaladsl.server.Route
 import akka.http.scaladsl.model.StatusCodes
 
 import com.lonelyplanet.akka.http.extensions.PaginationDirectives
 
 import com.azavea.rf.auth.Authentication
-import com.azavea.rf.database.tables._
+import com.azavea.rf.database.tables.Images
 import com.azavea.rf.database.Database
+import com.azavea.rf.datamodel._
 import com.azavea.rf.utils.{UserErrorHandler, RouterHelper}
 
 

--- a/app-backend/app/src/main/scala/image/Routes.scala
+++ b/app-backend/app/src/main/scala/image/Routes.scala
@@ -1,5 +1,7 @@
 package com.azavea.rf.image
 
+import java.util.UUID
+
 import com.azavea.rf.datamodel.Image
 
 import scala.concurrent.ExecutionContext
@@ -24,70 +26,60 @@ trait ImageRoutes extends Authentication
 
   implicit def database: Database
 
-  def imageRoutes: Route = handleExceptions(userExceptionHandler) {
-    pathPrefix("api" / "images") {
-      listImages ~
-      createImages ~
-      getImage ~
-      updateImage ~
-      deleteImage
+  val imageRoutes: Route = handleExceptions(userExceptionHandler) {
+    pathEndOrSingleSlash {
+      get { listImages } ~
+      post { createImage }
+    } ~
+    pathPrefix(JavaUUID) { imageId =>
+      get { getImage(imageId) } ~
+      put { updateImage(imageId) } ~
+      delete { deleteImage(imageId) }
     }
   }
 
 
-  def listImages: Route = anonWithPage { (user, page) =>
+  def listImages: Route = authenticateAndAllowAnonymous { user =>
+    (withPagination & imageQueryParameters) { (page, imageParams) =>
+      complete {
+        Images.listImages(page, imageParams)
+      }
+    }
+  }
+
+  def createImage: Route = authenticate { user =>
+    entity(as[Image.Create]) { newImage =>
+      onSuccess(Images.insertImage(newImage.toImage(user.id))) { image =>
+        complete(StatusCodes.Created, image)
+      }
+    }
+  }
+
+  def getImage(imageId: UUID): Route = authenticateAndAllowAnonymous { user =>
     get {
-      imageQueryParameters { imageParams =>
-        onSuccess(Images.listImages(page, imageParams)) { images =>
-          complete(images)
+      rejectEmptyResponse {
+        complete {
+          Images.getImage(imageId)
         }
       }
     }
   }
 
-  def createImages: Route = authenticate { user =>
-    post {
-      entity(as[Image.Create]) { newImage =>
-        onComplete(Images.insertImage(newImage.toImage(user.id))) {
-          case Success(image) => complete(image)
-          case Failure(_) => complete(StatusCodes.InternalServerError)
-        }
+  def updateImage(imageId: UUID): Route = authenticate { user =>
+    entity(as[Image]) { updatedImage =>
+      onSuccess(Images.updateImage(updatedImage, imageId, user)) { count =>
+        complete(StatusCodes.NoContent)
       }
     }
   }
 
-  def getImage: Route = pathPrefix(JavaUUID) {imageId =>
-    anonWithSlash { user =>
-      get {
-        onSuccess(Images.getImage(imageId)) {
-          case Some(image) => complete(image)
-          case _ => complete(StatusCodes.NotFound)
-        }
-      }
-    }
-  }
-
-  def updateImage: Route = pathPrefix(JavaUUID) {imageId =>
-    authenticate { user =>
-      put {
-        entity(as[Image]) { updatedImage =>
-          onSuccess(Images.updateImage(updatedImage, imageId, user)) { count =>
-            complete(StatusCodes.NoContent)
-          }
-        }
-      }
-    }
-  }
-
-  def deleteImage: Route = pathPrefix(JavaUUID) {imageId =>
-    authenticate { user =>
-      delete {
-        onSuccess(Images.deleteImage(imageId)) {
-          case 1 => complete(StatusCodes.NoContent)
-          case 0 => complete(StatusCodes.NotFound)
-          case _ => complete(StatusCodes.InternalServerError)
-        }
-      }
+  def deleteImage(imageId: UUID): Route = authenticate { user =>
+    onSuccess(Images.deleteImage(imageId)) {
+      case 1 => complete(StatusCodes.NoContent)
+      case 0 => complete(StatusCodes.NotFound)
+      case count => throw new IllegalStateException(
+        s"Error deleting image: delete result expected to be 1, was $count"
+      )
     }
   }
 }

--- a/app-backend/app/src/main/scala/organization/Routes.scala
+++ b/app-backend/app/src/main/scala/organization/Routes.scala
@@ -1,7 +1,5 @@
 package com.azavea.rf.organization
 
-import scala.concurrent.ExecutionContext
-import scala.util.{Success, Failure}
 import java.util.UUID
 
 import akka.http.scaladsl.server.Route
@@ -11,10 +9,10 @@ import com.lonelyplanet.akka.http.extensions.PaginationDirectives
 
 import com.azavea.rf.auth.Authentication
 import com.azavea.rf.database.Database
-import com.azavea.rf.database.tables._
+import com.azavea.rf.database.tables.Organizations
 import com.azavea.rf.datamodel._
 import com.azavea.rf.utils.UserErrorHandler
-import com.azavea.rf.datamodel.Organization
+
 
 /**
   * Routes for Organizations

--- a/app-backend/app/src/main/scala/scene/Routes.scala
+++ b/app-backend/app/src/main/scala/scene/Routes.scala
@@ -1,21 +1,20 @@
 package com.azavea.rf.scene
 
-import java.sql.Timestamp
+import java.util.UUID
 
-import scala.concurrent.ExecutionContext
 import scala.util.{Success, Failure}
 
 import akka.http.scaladsl.server.Route
 import akka.http.scaladsl.model.StatusCodes
 
 import com.lonelyplanet.akka.http.extensions.PaginationDirectives
+
 import com.azavea.rf.auth.Authentication
-import com.azavea.rf.datamodel._
-import com.azavea.rf.database.tables._
+import com.azavea.rf.database.tables.Scenes
 import com.azavea.rf.database.Database
-import com.azavea.rf.utils.{UnmarshallWithExtraJson, UserErrorHandler}
-import spray.json._
-import java.util.UUID
+import com.azavea.rf.datamodel._
+import com.azavea.rf.utils.UserErrorHandler
+
 
 trait SceneRoutes extends Authentication
     with SceneQueryParameterDirective

--- a/app-backend/app/src/main/scala/thumbnail/Routes.scala
+++ b/app-backend/app/src/main/scala/thumbnail/Routes.scala
@@ -1,9 +1,7 @@
 package com.azavea.rf.thumbnail
 
 import java.util.UUID
-import com.azavea.rf.datamodel.Thumbnail
 
-import scala.concurrent.ExecutionContext
 import scala.util.{Success, Failure}
 
 import akka.http.scaladsl.server.Route
@@ -12,9 +10,9 @@ import akka.http.scaladsl.model.StatusCodes
 import com.lonelyplanet.akka.http.extensions.PaginationDirectives
 
 import com.azavea.rf.auth.Authentication
-import com.azavea.rf.datamodel._
-import com.azavea.rf.database.tables._
+import com.azavea.rf.database.tables.Thumbnails
 import com.azavea.rf.database.Database
+import com.azavea.rf.datamodel._
 import com.azavea.rf.utils.{UserErrorHandler, RouterHelper}
 
 

--- a/app-backend/app/src/main/scala/thumbnail/Routes.scala
+++ b/app-backend/app/src/main/scala/thumbnail/Routes.scala
@@ -26,69 +26,65 @@ trait ThumbnailRoutes extends Authentication
 
   implicit def database: Database
 
-  def thumbnailRoutes: Route = handleExceptions(userExceptionHandler) {
-    pathPrefix("api" / "thumbnails") {
-      getThumbnail ~
-      listThumbnails ~
-      createThumbnail ~
-      updateThumbnail ~
-      deleteThumbnail
-    }
-  }
-
-  def listThumbnails: Route = anonWithPage { (user, page) =>
-    get {
-      thumbnailSpecificQueryParameters { thumbnailSpecificQueryParameters =>
-        onSuccess(Thumbnails.getThumbnails(page, thumbnailSpecificQueryParameters)) { thumbs =>
-          complete(thumbs)
-        }
+  val thumbnailRoutes: Route = handleExceptions(userExceptionHandler) {
+    pathEndOrSingleSlash {
+      get { listThumbnails } ~
+      post { createThumbnail }
+    } ~
+    pathPrefix(JavaUUID) { thumbnailId =>
+      pathEndOrSingleSlash {
+        get { getThumbnail(thumbnailId) } ~
+        put { updateThumbnail(thumbnailId) } ~
+        delete { deleteThumbnail(thumbnailId) }
       }
     }
   }
 
-  def getThumbnail: Route = pathPrefix(JavaUUID) { thumbnailId =>
-    anonWithPage { (user, page) =>
-      get {
-        onSuccess(Thumbnails.getThumbnail(thumbnailId)) {
-          case Some(thumbnail) => complete(thumbnail)
-          case _ => complete(StatusCodes.NotFound)
-        }
+  def listThumbnails: Route = authenticateAndAllowAnonymous { user =>
+    (withPagination & thumbnailSpecificQueryParameters) { (page, thumbnailParams) =>
+      complete {
+        Thumbnails.listThumbnails(page, thumbnailParams)
       }
     }
   }
 
   def createThumbnail: Route = authenticate { user =>
-    post {
-      entity(as[Thumbnail.Create]) { newThumbnail =>
-        onComplete(Thumbnails.insertThumbnail(newThumbnail.toThumbnail)) {
-          case Success(thumbnail) => complete(thumbnail)
-          case Failure(_) => complete(StatusCodes.InternalServerError)
+    entity(as[Thumbnail.Create]) { newThumbnail =>
+      onSuccess(Thumbnails.insertThumbnail(newThumbnail.toThumbnail)) { thumbnail =>
+        complete(StatusCodes.Created, thumbnail)
+      }
+    }
+  }
+
+  def getThumbnail(thumbnailId: UUID): Route = authenticateAndAllowAnonymous { user =>
+    withPagination { page =>
+      rejectEmptyResponse {
+        complete {
+          Thumbnails.getThumbnail(thumbnailId)
         }
       }
     }
   }
 
-  def deleteThumbnail: Route = pathPrefix(JavaUUID) {thumbnailId =>
-    authenticate { user =>
-      delete {
-        onComplete(Thumbnails.deleteThumbnail(thumbnailId)) {
-          case Success(1) => complete(StatusCodes.NoContent)
-          case Success(0) => complete(StatusCodes.NotFound)
-          case _ => complete(StatusCodes.InternalServerError)
-        }
+  def updateThumbnail(thumbnailId: UUID): Route = authenticate { user =>
+    entity(as[Thumbnail]) { updatedThumbnail =>
+      onSuccess(Thumbnails.updateThumbnail(updatedThumbnail, thumbnailId)) {
+        case 1 => complete(StatusCodes.NoContent)
+        case 0 => complete(StatusCodes.NotFound)
+        case count => throw new IllegalStateException(
+          s"Error updating thumbnail: update result expected to be 1, was $count"
+        )
       }
     }
   }
 
-  def updateThumbnail: Route =  pathPrefix(JavaUUID) {thumbnailId =>
-    authenticate { user =>
-      put {
-        entity(as[Thumbnail]) { updatedThumbnail =>
-          onSuccess(Thumbnails.updateThumbnail(updatedThumbnail, thumbnailId)) {
-            case 1 => complete(StatusCodes.NoContent)
-          }
-        }
-      }
+  def deleteThumbnail(thumbnailId: UUID): Route = authenticate { user =>
+    onSuccess(Thumbnails.deleteThumbnail(thumbnailId)) {
+      case 1 => complete(StatusCodes.NoContent)
+      case 0 => complete(StatusCodes.NotFound)
+      case count => throw new IllegalStateException(
+        s"Error deleting thumbnail: delete result expected to be 1, was $count"
+      )
     }
   }
 }

--- a/app-backend/app/src/main/scala/user/Routes.scala
+++ b/app-backend/app/src/main/scala/user/Routes.scala
@@ -1,7 +1,5 @@
 package com.azavea.rf.user
 
-import scala.concurrent.ExecutionContext
-import scala.util.{Success, Failure}
 import java.net.URLDecoder
 
 import akka.http.scaladsl.server.Route
@@ -12,8 +10,9 @@ import com.lonelyplanet.akka.http.extensions.PaginationDirectives
 import com.azavea.rf.auth.Authentication
 import com.azavea.rf.database.Database
 import com.azavea.rf.database.tables.Users
-import com.azavea.rf.utils.UserErrorHandler
 import com.azavea.rf.datamodel._
+import com.azavea.rf.utils.UserErrorHandler
+
 
 /**
   * Routes for users

--- a/app-backend/app/src/main/scala/user/Routes.scala
+++ b/app-backend/app/src/main/scala/user/Routes.scala
@@ -2,6 +2,7 @@ package com.azavea.rf.user
 
 import scala.concurrent.ExecutionContext
 import scala.util.{Success, Failure}
+import java.net.URLDecoder
 
 import akka.http.scaladsl.server.Route
 import akka.http.scaladsl.model.StatusCodes
@@ -21,46 +22,43 @@ trait UserRoutes extends Authentication with PaginationDirectives with UserError
 
   implicit def database: Database
 
-  def userRoutes:Route = {
-    handleExceptions(userExceptionHandler) {
-      authenticate { user =>
-        pathPrefix("api" / "users") {
-          pathEndOrSingleSlash {
-            withPagination { page =>
-              get {
-                onSuccess(Users.getPaginatedUsers(page)) { resp =>
-                  complete(resp)
-                }
-              }
-            } ~
-            post {
-              //TODO: This should only be accessible by users with the correct permission
-              //      (IE admin in the "Public" org)
-              entity(as[User.Create]) { newUser =>
-                onComplete(Users.createUser(newUser)) {
-                  case Success(user) => onSuccess(Users.getUserWithOrgsById(user.id)) {
-                    case Some(user) => complete(StatusCodes.Created, user)
-                    case None => complete(StatusCodes.InternalServerError)
-                  }
-                  case Failure(_) => complete(StatusCodes.InternalServerError)
-                }
-              }
-            }
-          } ~
-          pathPrefix(Segment) { authIdEncoded =>
-            val authId = java.net.URLDecoder.decode(authIdEncoded, "US_ASCII")
-            pathEndOrSingleSlash {
-              get {
-                onSuccess(
-                  Users.getUserWithOrgsById(authId)
-                ) {
-                  case Some(user) => complete(user)
-                  case _ => complete((StatusCodes.NotFound))
-                }
-              }
-            }
-          }
+  val userRoutes: Route = handleExceptions(userExceptionHandler) {
+    pathEndOrSingleSlash {
+      get { listUsers } ~
+      post { createUser }
+    } ~
+    pathPrefix(Segment) { authIdEncoded =>
+      pathEndOrSingleSlash {
+        get { getUserByEncodedAuthId(authIdEncoded) }
+      }
+    }
+  }
+
+  def listUsers: Route = authenticate { user =>
+    withPagination { page =>
+      complete {
+        Users.getPaginatedUsers(page)
+      }
+    }
+  }
+
+  // TODO: Restrict to users with correct permissions, e.g. admin
+  def createUser: Route = authenticate { admin =>
+    entity(as[User.Create]) { newUser =>
+      onSuccess(Users.createUser(newUser)) { createdUser =>
+        onSuccess(Users.getUserWithOrgsById(createdUser.id)) {
+          case Some(user) => complete(StatusCodes.Created, user)
+          case None => throw new IllegalStateException("Unable to create user")
         }
+      }
+    }
+  }
+
+  def getUserByEncodedAuthId(authIdEncoded: String): Route = authenticate { user =>
+    rejectEmptyResponse {
+      complete {
+        val authId = URLDecoder.decode(authIdEncoded, "US_ASCII")
+        Users.getUserWithOrgsById(authId)
       }
     }
   }

--- a/app-backend/app/src/test/scala/auth/AuthSpec.scala
+++ b/app-backend/app/src/test/scala/auth/AuthSpec.scala
@@ -24,6 +24,9 @@ class AuthSpec extends WordSpec
   val newUserId = "NewUser"
   val authorization = AuthUtils.generateAuthHeader(newUserId)
 
+  // Alias to baseRoutes to be explicit
+  val baseRoutes = routes
+
   /** Route for testing the authenticate directive.
     *
     * If authenticate provides a user, a get request to "/" will return a 202 Accepted
@@ -45,7 +48,7 @@ class AuthSpec extends WordSpec
     "create a new user then authenticate using it if a user which matches the JWT token doesn't exist" in {
       Get("/").addHeader(authorization) ~> authenticateDirectiveTestRoute ~> check {
         Get(s"/api/users/$newUserId")
-          .addHeader(authorization) ~> userRoutes ~> check {
+          .addHeader(authorization) ~> baseRoutes ~> check {
           responseAs[User.WithOrgs]
         }
       }

--- a/app-backend/app/src/test/scala/bucket/BucketSceneSpec.scala
+++ b/app-backend/app/src/test/scala/bucket/BucketSceneSpec.scala
@@ -39,7 +39,7 @@ class BucketSceneSpec extends WordSpec
           ContentTypes.`application/json`,
           newBucket1.toJson.toString()
         )
-      ) ~> bucketRoutes ~> check {
+      ) ~> baseRoutes ~> check {
         responseAs[Bucket]
       }
 
@@ -55,10 +55,10 @@ class BucketSceneSpec extends WordSpec
     }
 
     "not have any scenes attached to initial bucket" in {
-      Get("/api/buckets/") ~> bucketRoutes ~> check {
+      Get("/api/buckets/") ~> baseRoutes ~> check {
         val buckets = responseAs[PaginatedResponse[Bucket]]
         val bucketId = buckets.results.head.id
-        Get(s"/api/buckets/${bucketId}/scenes/") ~> bucketRoutes ~> check {
+        Get(s"/api/buckets/${bucketId}/scenes/") ~> baseRoutes ~> check {
           responseAs[PaginatedResponse[Scene.WithRelated]].count shouldEqual 0
         }
       }
@@ -66,7 +66,7 @@ class BucketSceneSpec extends WordSpec
 
     "should be able to attach scene to bucket via post" in {
       // Get buckets to get ID
-      Get("/api/buckets/") ~> bucketRoutes ~> check {
+      Get("/api/buckets/") ~> baseRoutes ~> check {
         val buckets = responseAs[PaginatedResponse[Bucket]]
         val bucketId = buckets.results.head.id
 
@@ -77,7 +77,7 @@ class BucketSceneSpec extends WordSpec
 
           Post(s"/api/buckets/${bucketId}/scenes/${sceneId}/").withHeaders(
             List(authorization)
-          ) ~> bucketRoutes ~> check {
+          ) ~> baseRoutes ~> check {
             status shouldEqual StatusCodes.Created
           }
         }
@@ -85,27 +85,27 @@ class BucketSceneSpec extends WordSpec
     }
 
     "should have one scene attached to bucket" in {
-      Get("/api/buckets/") ~> bucketRoutes ~> check {
+      Get("/api/buckets/") ~> baseRoutes ~> check {
         val buckets = responseAs[PaginatedResponse[Bucket]]
         val bucketId = buckets.results.head.id
-        Get(s"/api/buckets/${bucketId}/scenes/") ~> bucketRoutes ~> check {
+        Get(s"/api/buckets/${bucketId}/scenes/") ~> baseRoutes ~> check {
           responseAs[PaginatedResponse[Scene.WithRelated]].count shouldEqual 1
         }
       }
     }
 
     "should be able to apply filters for scenes on bucket" in {
-      Get("/api/buckets/") ~> bucketRoutes ~> check {
+      Get("/api/buckets/") ~> baseRoutes ~> check {
         val buckets = responseAs[PaginatedResponse[Bucket]]
         val bucketId = buckets.results.head.id
-        Get(s"/api/buckets/${bucketId}/scenes/?datasource=DoesNotExist") ~> bucketRoutes ~> check {
+        Get(s"/api/buckets/${bucketId}/scenes/?datasource=DoesNotExist") ~> baseRoutes ~> check {
           responseAs[PaginatedResponse[Scene.WithRelated]].count shouldEqual 0
         }
       }
     }
 
     "should be able to remove scene from bucket via delete" in {
-      Get("/api/buckets/") ~> bucketRoutes ~> check {
+      Get("/api/buckets/") ~> baseRoutes ~> check {
         val buckets = responseAs[PaginatedResponse[Bucket]]
         val bucketId = buckets.results.head.id
 
@@ -116,7 +116,7 @@ class BucketSceneSpec extends WordSpec
 
           Delete(s"/api/buckets/${bucketId}/scenes/${sceneId}/").withHeaders(
             List(authorization)
-          ) ~> bucketRoutes ~> check {
+          ) ~> baseRoutes ~> check {
             status shouldEqual StatusCodes.NoContent
           }
         }
@@ -124,10 +124,10 @@ class BucketSceneSpec extends WordSpec
     }
 
     "should not have a scene attached to bucket after delete" in {
-      Get("/api/buckets/") ~> bucketRoutes ~> check {
+      Get("/api/buckets/") ~> baseRoutes ~> check {
         val buckets = responseAs[PaginatedResponse[Bucket]]
         val bucketId = buckets.results.head.id
-        Get(s"/api/buckets/${bucketId}/scenes/") ~> bucketRoutes ~> check {
+        Get(s"/api/buckets/${bucketId}/scenes/") ~> baseRoutes ~> check {
           responseAs[PaginatedResponse[Scene.WithRelated]].count shouldEqual 0
         }
       }

--- a/app-backend/app/src/test/scala/bucket/BucketSceneSpec.scala
+++ b/app-backend/app/src/test/scala/bucket/BucketSceneSpec.scala
@@ -27,6 +27,9 @@ class BucketSceneSpec extends WordSpec
   implicit def database = db
   implicit def default(implicit system: ActorSystem) = RouteTestTimeout(DurationInt(20).second)
 
+  // Alias to baseRoutes to be explicit
+  val baseRoutes = routes
+
 
   "/api/buckets/{bucket}/scenes/" should {
     "allow creating buckets and scenes" in {
@@ -46,7 +49,7 @@ class BucketSceneSpec extends WordSpec
           ContentTypes.`application/json`,
           newScene.toJson.toString()
         )
-      ) ~> sceneRoutes ~> check {
+      ) ~> baseRoutes ~> check {
         responseAs[Scene.WithRelated]
       }
     }
@@ -68,7 +71,7 @@ class BucketSceneSpec extends WordSpec
         val bucketId = buckets.results.head.id
 
         // Get scenes to get ID
-        Get("/api/scenes/") ~> sceneRoutes ~> check {
+        Get("/api/scenes/") ~> baseRoutes ~> check {
           val scenes = responseAs[PaginatedResponse[Scene.WithRelated]]
           val sceneId = scenes.results.head.id
 
@@ -107,7 +110,7 @@ class BucketSceneSpec extends WordSpec
         val bucketId = buckets.results.head.id
 
         // Get scenes to get ID
-        Get("/api/scenes/") ~> sceneRoutes ~> check {
+        Get("/api/scenes/") ~> baseRoutes ~> check {
           val scenes = responseAs[PaginatedResponse[Scene.WithRelated]]
           val sceneId = scenes.results.head.id
 

--- a/app-backend/app/src/test/scala/healthcheck/HealthCheckSpec.scala
+++ b/app-backend/app/src/test/scala/healthcheck/HealthCheckSpec.scala
@@ -20,12 +20,14 @@ class HealthCheckSpec extends WordSpec
   implicit def database = db
   implicit def default(implicit system: ActorSystem) = RouteTestTimeout(DurationInt(20).second)
 
+  // Alias to baseRoutes to be explicit
+  val baseRoutes = routes
+
   "The healthcheck service" should {
     "return an OK status" in {
       val dbCheck = ServiceCheck("database", HealthCheckStatus.OK)
       val healthCheck = HealthCheck(HealthCheckStatus.OK, Seq(dbCheck))
-      val routes = healthCheckRoutes
-      Get("/healthcheck") ~> routes ~> check {
+      Get("/healthcheck") ~> baseRoutes ~> check {
         responseAs[HealthCheck] shouldEqual healthCheck
       }
     }

--- a/app-backend/app/src/test/scala/image/ImageSpec.scala
+++ b/app-backend/app/src/test/scala/image/ImageSpec.scala
@@ -42,6 +42,9 @@ class ImageSpec extends WordSpec
     List.empty[Image.Identified], None, List.empty[Thumbnail.Identified]
   )
 
+  // Alias to baseRoutes to be explicit
+  val baseRoutes = routes
+
 
   "/api/images/{uuid}" should {
 
@@ -85,7 +88,7 @@ class ImageSpec extends WordSpec
           ContentTypes.`application/json`,
           newSceneDatasource1.toJson.toString()
         )
-      ) ~> sceneRoutes ~> check {
+      ) ~> baseRoutes ~> check {
         val sceneId = responseAs[Scene.WithRelated].id
 
         val newImageDatasource1 = Image.Create(
@@ -135,7 +138,7 @@ class ImageSpec extends WordSpec
     }
 
     "filter by scene correctly" in {
-      Get("/api/scenes/") ~> sceneRoutes ~> check {
+      Get("/api/scenes/") ~> baseRoutes ~> check {
         val scenes = responseAs[PaginatedResponse[Scene.WithRelated]]
         val sceneId = scenes.results.head.id
 

--- a/app-backend/app/src/test/scala/image/ImageSpec.scala
+++ b/app-backend/app/src/test/scala/image/ImageSpec.scala
@@ -6,6 +6,7 @@ import org.scalatest.{Matchers, WordSpec}
 import akka.http.scaladsl.testkit.{ScalatestRouteTest, RouteTestTimeout}
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.model.{HttpEntity, ContentTypes}
+import akka.http.scaladsl.server.Route
 import akka.actor.ActorSystem
 import concurrent.duration._
 import spray.json._
@@ -49,14 +50,14 @@ class ImageSpec extends WordSpec
   "/api/images/{uuid}" should {
 
     "return a 404 for non-existent image" in {
-      Get(s"${baseImagePath}${publicOrgId}") ~> imageRoutes ~> check {
+      Get(s"${baseImagePath}${publicOrgId}") ~> Route.seal(baseRoutes) ~> check {
         status shouldEqual StatusCodes.NotFound
       }
     }
 
     "return a image" ignore {
       val imageId = ""
-      Get(s"${baseImagePath}${imageId}/") ~> imageRoutes ~> check {
+      Get(s"${baseImagePath}${imageId}/") ~> baseRoutes ~> check {
         responseAs[Image]
       }
     }
@@ -67,7 +68,7 @@ class ImageSpec extends WordSpec
 
     "delete a image" ignore {
       val imageId = ""
-      Delete(s"${baseImagePath}${imageId}/") ~> imageRoutes ~> check {
+      Delete(s"${baseImagePath}${imageId}/") ~> baseRoutes ~> check {
         status shouldEqual StatusCodes.NoContent
       }
     }
@@ -75,7 +76,7 @@ class ImageSpec extends WordSpec
 
   "/api/images/" should {
     "not require authentication" in {
-      Get("/api/images/") ~> imageRoutes ~> check {
+      Get("/api/images/") ~> baseRoutes ~> check {
         responseAs[PaginatedResponse[Image]]
       }
     }
@@ -104,35 +105,35 @@ class ImageSpec extends WordSpec
             ContentTypes.`application/json`,
             newImageDatasource1.toJson.toString()
           )
-        ) ~> imageRoutes ~> check {
+        ) ~> baseRoutes ~> check {
           responseAs[Image]
         }
       }
     }
 
     "filter by one organization correctly" in {
-      Get(s"$baseImagePath?organization=${publicOrgId}") ~> imageRoutes ~> check {
+      Get(s"$baseImagePath?organization=${publicOrgId}") ~> baseRoutes ~> check {
         responseAs[PaginatedResponse[Image]].count shouldEqual 1
       }
     }
 
     "filter by two organizations correctly" in {
       val url = s"$baseImagePath?organization=${publicOrgId}&organization=dfac6307-b5ef-43f7-beda-b9f208bb7725"
-      Get(url) ~> imageRoutes ~> check {
+      Get(url) ~> baseRoutes ~> check {
         responseAs[PaginatedResponse[Image]].count shouldEqual 1
       }
     }
 
     "filter by one (non-existent) organizations correctly" in {
       val url = s"$baseImagePath?organization=dfac6307-b5ef-43f7-beda-b9f208bb7725"
-      Get(url) ~> imageRoutes ~> check {
+      Get(url) ~> baseRoutes ~> check {
         responseAs[PaginatedResponse[Image]].count shouldEqual 0
       }
     }
 
     "filter by min bytes correctly" in {
       val url = s"$baseImagePath?minRawDataBytes=10"
-      Get(url) ~> imageRoutes ~> check {
+      Get(url) ~> baseRoutes ~> check {
         responseAs[PaginatedResponse[Image]].count shouldEqual 1
       }
     }
@@ -143,7 +144,7 @@ class ImageSpec extends WordSpec
         val sceneId = scenes.results.head.id
 
         val url = s"$baseImagePath?scene=$sceneId"
-        Get(url) ~> imageRoutes ~> check {
+        Get(url) ~> baseRoutes ~> check {
           responseAs[PaginatedResponse[Image]].count shouldEqual 1
         }
       }

--- a/app-backend/app/src/test/scala/thumbnail/ThumbnailSpec.scala
+++ b/app-backend/app/src/test/scala/thumbnail/ThumbnailSpec.scala
@@ -41,6 +41,9 @@ class ThumbnailSpec extends WordSpec
     ThumbnailSize.Large
   )
 
+  // Alias to baseRoutes to be explicit
+  val baseRoutes = routes
+
   "Creating a row" should {
     "add a row to the table" ignore {
       val result = Thumbnails.insertThumbnail(baseThumbnailRow)
@@ -118,7 +121,7 @@ class ThumbnailSpec extends WordSpec
           ContentTypes.`application/json`,
           newScene.toJson.toString()
         )
-      ) ~> sceneRoutes ~> check {
+      ) ~> baseRoutes ~> check {
         responseAs[Scene.WithRelated]
       }
     }
@@ -131,7 +134,7 @@ class ThumbnailSpec extends WordSpec
 
 
     "create thumbnails only with authentication" in {
-      Get("/api/scenes/") ~> sceneRoutes ~> check {
+      Get("/api/scenes/") ~> baseRoutes ~> check {
         val scenes = responseAs[PaginatedResponse[Scene.WithRelated]]
         val sceneId = scenes.results.head.id
         val thumbnailToPost1 = newThumbnail(ThumbnailSize.Small, sceneId)
@@ -169,7 +172,7 @@ class ThumbnailSpec extends WordSpec
     }
 
     "filter by one scene correctly" in {
-      Get("/api/scenes/") ~> sceneRoutes ~> check {
+      Get("/api/scenes/") ~> baseRoutes ~> check {
         val scenes = responseAs[PaginatedResponse[Scene.WithRelated]]
         val sceneId = scenes.results.head.id
         Get(s"/api/thumbnails/?sceneId=$sceneId") ~> thumbnailRoutes ~> check {

--- a/app-backend/app/src/test/scala/thumbnail/ThumbnailSpec.scala
+++ b/app-backend/app/src/test/scala/thumbnail/ThumbnailSpec.scala
@@ -6,6 +6,7 @@ import java.util.UUID
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.model.{HttpEntity, ContentTypes}
 import akka.http.scaladsl.testkit.ScalatestRouteTest
+import akka.http.scaladsl.server.Route
 import org.scalatest.{Matchers, WordSpec}
 import spray.json._
 
@@ -89,14 +90,14 @@ class ThumbnailSpec extends WordSpec
 
   "/api/thumbnails/{uuid}" should {
     "return a 404 for non-existent thumbnail" ignore {
-      Get(s"${baseThumbnail}${publicOrgId}") ~> thumbnailRoutes ~> check {
+      Get(s"${baseThumbnail}${publicOrgId}") ~> Route.seal(baseRoutes) ~> check {
         status shouldEqual StatusCodes.NotFound
       }
     }
 
     "return a thumbnail" ignore {
       val thumbnailId = ""
-      Get(s"${baseThumbnail}${thumbnailId}/") ~> thumbnailRoutes ~> check {
+      Get(s"${baseThumbnail}${thumbnailId}/") ~> baseRoutes ~> check {
         responseAs[Thumbnail]
       }
     }
@@ -107,7 +108,7 @@ class ThumbnailSpec extends WordSpec
 
     "delete a thumbnail" ignore {
       val thumbnailId = ""
-      Delete(s"${baseThumbnail}${thumbnailId}/") ~> thumbnailRoutes ~> check {
+      Delete(s"${baseThumbnail}${thumbnailId}/") ~> baseRoutes ~> check {
         status shouldEqual StatusCodes.NoContent
       }
     }
@@ -127,7 +128,7 @@ class ThumbnailSpec extends WordSpec
     }
 
     "not require authentication for list" in {
-      Get("/api/thumbnails/") ~> thumbnailRoutes ~> check {
+      Get("/api/thumbnails/") ~> baseRoutes ~> check {
         responseAs[PaginatedResponse[Thumbnail]]
       }
     }
@@ -145,7 +146,7 @@ class ThumbnailSpec extends WordSpec
             ContentTypes.`application/json`,
             thumbnailToPost1.toJson.toString()
           )
-        ) ~> thumbnailRoutes ~> check {
+        ) ~> baseRoutes ~> check {
           reject
         }
 
@@ -155,7 +156,7 @@ class ThumbnailSpec extends WordSpec
             ContentTypes.`application/json`,
             thumbnailToPost1.toJson.toString()
           )
-        ) ~> thumbnailRoutes ~> check {
+        ) ~> baseRoutes ~> check {
           responseAs[Thumbnail]
         }
 
@@ -165,7 +166,7 @@ class ThumbnailSpec extends WordSpec
             ContentTypes.`application/json`,
             thumbnailToPost2.toJson.toString()
           )
-        ) ~> thumbnailRoutes ~> check {
+        ) ~> baseRoutes ~> check {
           responseAs[Thumbnail]
         }
       }
@@ -175,7 +176,7 @@ class ThumbnailSpec extends WordSpec
       Get("/api/scenes/") ~> baseRoutes ~> check {
         val scenes = responseAs[PaginatedResponse[Scene.WithRelated]]
         val sceneId = scenes.results.head.id
-        Get(s"/api/thumbnails/?sceneId=$sceneId") ~> thumbnailRoutes ~> check {
+        Get(s"/api/thumbnails/?sceneId=$sceneId") ~> baseRoutes ~> check {
           responseAs[PaginatedResponse[Thumbnail]].count shouldEqual 2
         }
       }
@@ -183,14 +184,14 @@ class ThumbnailSpec extends WordSpec
 
     "filter by one (non-existent) scene correctly" in {
       val url = s"/api/thumbnails/?sceneId=${UUID.randomUUID}"
-      Get(url) ~> thumbnailRoutes ~> check {
+      Get(url) ~> baseRoutes ~> check {
         responseAs[PaginatedResponse[Thumbnail]].count shouldEqual 0
       }
     }
 
     "sort by one field correctly" ignore {
       val url = s"/api/thumbnails/?sort=..."
-      Get(url) ~> thumbnailRoutes ~> check {
+      Get(url) ~> baseRoutes ~> check {
         /** Sorting behavior isn't described in the spec currently but might be someday */
         responseAs[PaginatedResponse[Thumbnail]]
       }

--- a/app-backend/app/src/test/scala/user/UserSpec.scala
+++ b/app-backend/app/src/test/scala/user/UserSpec.scala
@@ -22,16 +22,19 @@ class UserSpec extends WordSpec
 
   val authorization = AuthUtils.generateAuthHeader("Default")
 
+  // Alias to baseRoutes to be explicit
+  val baseRoutes = routes
+
   "/api/users" should {
     "return a paginated list of users" in {
       Get("/api/users")
-        .addHeader(authorization) ~> userRoutes ~> check {
+        .addHeader(authorization) ~> baseRoutes ~> check {
         responseAs[PaginatedResponse[User.WithOrgs]]
       }
     }
 
     "require authentication" in {
-      Get("/api/users") ~> userRoutes ~> check {
+      Get("/api/users") ~> baseRoutes ~> check {
         rejection
       }
     }
@@ -40,7 +43,7 @@ class UserSpec extends WordSpec
   "/api/users/{UUID}" should {
     "return a single user" in {
       Get("/api/users/Default")
-        .addHeader(authorization)~> userRoutes ~> check {
+        .addHeader(authorization)~> baseRoutes ~> check {
         responseAs[User.WithOrgs]
       }
     }

--- a/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Buckets.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Buckets.scala
@@ -79,7 +79,7 @@ object Buckets extends TableQuery(tag => new Buckets(tag)) with LazyLogging {
     *
     * @param bucketId UUID bucket to request scenes for
     */
-  def getBucketScenes(bucketId: UUID, pageRequest: PageRequest, combinedParams: CombinedSceneQueryParams)
+  def listBucketScenes(bucketId: UUID, pageRequest: PageRequest, combinedParams: CombinedSceneQueryParams)
     (implicit database: DB): Future[PaginatedResponse[Scene.WithRelated]] = {
 
     val bucketSceneQuery = for {
@@ -154,7 +154,7 @@ object Buckets extends TableQuery(tag => new Buckets(tag)) with LazyLogging {
     * @param pageRequest PageRequest pagination parameters
     * @param queryParams BucketQueryParams query parameters relevant for buckets
     */
-  def getBuckets(pageRequest: PageRequest, queryParams: BucketQueryParameters)
+  def listBuckets(pageRequest: PageRequest, queryParams: BucketQueryParameters)
     (implicit database: DB): Future[PaginatedResponse[Bucket]] = {
 
     val buckets = Buckets.filterByOrganization(queryParams.orgParams)

--- a/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Organizations.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Organizations.scala
@@ -36,7 +36,7 @@ object Organizations extends TableQuery(tag => new Organizations(tag)) with Lazy
       new NameFieldSort(identity[Organizations]),
       new TimestampSort(identity[Organizations]))
 
-  def getOrganizationList(page: PageRequest)(implicit database: DB): Future[PaginatedResponse[Organization]] = {
+  def listOrganizations(page: PageRequest)(implicit database: DB): Future[PaginatedResponse[Organization]] = {
 
     val organizationsQueryResult = database.db.run {
       Organizations
@@ -110,7 +110,7 @@ object Organizations extends TableQuery(tag => new Organizations(tag)) with Lazy
     }
   }
 
-  def getOrganizationUsers(
+  def listOrganizationUsers(
     page: PageRequest, id: java.util.UUID
   )(implicit database: DB): Future[PaginatedResponse[User.WithRole]] = {
     val getOrgUsersResult = database.db.run {

--- a/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Scenes.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Scenes.scala
@@ -131,7 +131,7 @@ object Scenes extends TableQuery(tag => new Scenes(tag)) with LazyLogging {
   }
 
   /** Get scenes given a page request and query parameters */
-  def getScenes(pageRequest: PageRequest, combinedParams: CombinedSceneQueryParams)
+  def listScenes(pageRequest: PageRequest, combinedParams: CombinedSceneQueryParams)
     (implicit database: DB): Future[PaginatedResponse[Scene.WithRelated]] = {
 
     val scenesQueryResult = database.db.run {

--- a/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Thumbnails.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Thumbnails.scala
@@ -76,7 +76,7 @@ object Thumbnails extends TableQuery(tag => new Thumbnails(tag)) with LazyLoggin
     }
   }
 
-  def getThumbnails(pageRequest: PageRequest, queryParams: ThumbnailQueryParameters)
+  def listThumbnails(pageRequest: PageRequest, queryParams: ThumbnailQueryParameters)
     (implicit database: DB): Future[PaginatedResponse[Thumbnail]] = {
 
     val thumbnails = Thumbnails.filterBySceneParams(queryParams)


### PR DESCRIPTION
~~**NOTE** This is a preview of the route style I'm going with. I'd love to get feedback so we can zero in on a format we like. I'm going to continue updating the other routes to this style until I get feedback.~~

## Overview

Update routes to ensure the right order of operations. The style is like:

```scala
routes: Route = {
  pathPrefix("api" / "route") {
    pathEndOrSingleSlash {
      get { listHandler } ~
      post { createHandler } 
    } ~
    pathPrefix(JavaUUID) { id =>
      pathEndOrSingleSlash {
        get { getHandler(id) } ~
        put { updateHandler(id) } ~
        delete { deleteHandler(id) }
      } ~
      pathPrefix("subroute") {
        pathEndOrSingleSlash {
          get { listSubHandler(id) } ~
          post { createSubHandler(id) }
        } ~
        pathPrefix(JavaUUID) { subid => 
          pathEndOrSingleSlash {
            get { getSubHandler(id, subid) } ~
            put { updateSubHandler(id, subid) } ~
            delete { deleteSubHandler(id, subid) }
          }
        }
      }
    }
  }
}
```

and then each handler is defined separately. This allows us to look at the API structure at a glance, and each handler can be as detailed as it needs. User authentication and entity extraction is done on the handler itself.

## Testing Instructions

Review the code, run the tests.

Connects #562 