### PR TITLE
Not forward 5432 and add a psql helper script

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -23,8 +23,6 @@ Vagrant.configure(2) do |config|
 
   # application server
   config.vm.network :forwarded_port, guest: 9000, host: Integer(ENV.fetch("RF_PORT_9000", 9000))
-  # database
-  config.vm.network :forwarded_port, guest: 5432, host: Integer(ENV.fetch("RF_PORT_5432", 5432))
   # swagger editor
   config.vm.network :forwarded_port, guest: 8888, host: Integer(ENV.fetch("RF_PORT_9090", 9090))
   # nginx

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,8 +5,8 @@ services:
     volumes:
       - ./data/:/tmp/data/
     env_file: .env
-    ports:
-      - "5432:5432"
+    expose:
+      - "5432"
 
   nginx:
     image: rf-nginx

--- a/scripts/psql
+++ b/scripts/psql
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -eu
+
+DIR="$(dirname "$0")"
+
+# this does nothing if the service is already up
+docker-compose up -d postgres
+
+docker-compose -f "${DIR}/../docker-compose.yml" exec postgres bash -c "psql -U rasterfoundry -d rasterfoundry"


### PR DESCRIPTION
## Overview

We don't want to forward port 5432 from the VM because it causes problems if the host happens to have a postgres client running locally. However, we still want to have a way to connect to the database without having to type a long `docker-compose` command. This PR wraps the long `docker-compose` command into a script in `scripts/psql` and kills the port forwarding to host.

### Demo

![rfdemo](https://cloud.githubusercontent.com/assets/5702984/19577098/be044112-96e3-11e6-9cce-f2972ec517d1.gif)

## Testing Instructions

 * Pull down the branch
 * `vagrant up && vagrant ssh`
 * `./scripts/psql`

Closes #547

