### PR TITLE
Feature/refresh token frontend

### DIFF
--- a/app-frontend/package.json
+++ b/app-frontend/package.json
@@ -37,7 +37,7 @@
     "angular-ui-bootstrap": "^2.1.4",
     "angular-ui-router": "^0.3.1",
     "angularjs-slider": "^5.7.0",
-    "auth0-lock": "^10.4.0",
+    "auth0-lock": "^10.4.1",
     "bootstrap-sass": "^3.3.6",
     "es6-map": "^0.1.4",
     "jquery": "^2.1.4",

--- a/app-frontend/src/app/components/confirmationModal/confirmationModal.html
+++ b/app-frontend/src/app/components/confirmationModal/confirmationModal.html
@@ -17,7 +17,7 @@
 	<div class="pull-left">
 	</div>
 	<button type="button" class="btn btn-default"
-          ng-click="$ctrl.selectedScenes.clear()">
+          ng-click="$ctrl.dismiss()">
     <i class="icon-cross"></i>
     {{$ctrl.resolve.cancelText}}
   </button>

--- a/app-frontend/src/app/components/refreshTokenModal/refreshTokenModal.component.js
+++ b/app-frontend/src/app/components/refreshTokenModal/refreshTokenModal.component.js
@@ -1,0 +1,15 @@
+// Component code
+import refreshTokenModalTpl from './refreshTokenModal.html';
+
+const RefreshTokenModalComponent = {
+    templateUrl: refreshTokenModalTpl,
+    bindings: {
+        close: '&',
+        dismiss: '&',
+        modalInstance: '<',
+        resolve: '<'
+    },
+    controller: 'RefreshTokenModalController'
+};
+
+export default RefreshTokenModalComponent;

--- a/app-frontend/src/app/components/refreshTokenModal/refreshTokenModal.controller.js
+++ b/app-frontend/src/app/components/refreshTokenModal/refreshTokenModal.controller.js
@@ -1,0 +1,10 @@
+export default class SelectedScenesModalController {
+    constructor() {
+        'ngInject';
+        this.refreshToken = this.resolve.refreshToken;
+        this.showToken = false;
+    }
+    toggleTokenVisibility() {
+        this.showToken = !this.showToken;
+    }
+}

--- a/app-frontend/src/app/components/refreshTokenModal/refreshTokenModal.html
+++ b/app-frontend/src/app/components/refreshTokenModal/refreshTokenModal.html
@@ -1,0 +1,18 @@
+<div class="modal-header">
+	<button type="button" class="close" aria-label="Close"
+          ng-click="$ctrl.dismiss()">
+    <span aria-hidden="true">&times;</span>
+  </button>
+  <h4 class="modal-title">Your new refresh token</h4>
+</div>
+<div class="modal-body">
+  <div class="list-group">
+    <button ng-click="$ctrl.toggleTokenVisibility()">Click to show token</button>
+    <div ng-if="$ctrl.showToken">
+      <input type="test" ng-model="$ctrl.refreshToken" readonly>
+    </div>
+  </div>
+</div>
+<div class="modal-footer">
+  This is the only time that this refresh token will be visible. Record it in a secure location.
+</div>

--- a/app-frontend/src/app/components/refreshTokenModal/refreshTokenModal.module.js
+++ b/app-frontend/src/app/components/refreshTokenModal/refreshTokenModal.module.js
@@ -1,0 +1,15 @@
+import angular from 'angular';
+import RefreshTokenModalComponent from './refreshTokenModal.component.js';
+import RefreshTokenModalController from './refreshTokenModal.controller.js';
+require('../../../assets/font/fontello/css/fontello.css');
+
+const RefreshTokenModalModule = angular.module('components.refreshTokenModal', []);
+
+RefreshTokenModalModule.controller(
+    'RefreshTokenModalController', RefreshTokenModalController
+);
+RefreshTokenModalModule.component(
+    'rfRefreshTokenModal', RefreshTokenModalComponent
+);
+
+export default RefreshTokenModalModule;

--- a/app-frontend/src/app/core/core.module.js
+++ b/app-frontend/src/app/core/core.module.js
@@ -5,5 +5,6 @@ require('./services/bucket.service')(shared);
 require('./services/user.service')(shared);
 require('./services/config.provider')(shared);
 require('./services/auth.service')(shared);
+require('./services/token.service')(shared);
 
 export default shared;

--- a/app-frontend/src/app/core/services/token.service.js
+++ b/app-frontend/src/app/core/services/token.service.js
@@ -1,0 +1,32 @@
+export default (app) => {
+    class TokenService {
+        constructor($resource) {
+            'ngInject';
+
+            this.Token = $resource(
+                '/api/tokens/:id', {
+                    id: '@id'
+                }, {
+                    query: {
+                        method: 'GET',
+                        cache: false,
+                        isArray: true
+                    },
+                    delete: {
+                        method: 'DELETE'
+                    }
+                }
+            );
+        }
+
+        query(params = {}) {
+            return this.Token.query(params).$promise;
+        }
+
+        delete(params) {
+            return this.Token.delete(params).$promise;
+        }
+    }
+
+    app.service('tokenService', TokenService);
+};

--- a/app-frontend/src/app/index.components.js
+++ b/app-frontend/src/app/index.components.js
@@ -7,5 +7,6 @@ export default angular.module('index.components', [
     require('./components/bucketItem/bucketItem.module.js').name,
     require('./components/selectedScenesModal/selectedScenesModal.module.js').name,
     require('./components/confirmationModal/confirmationModal.module.js').name,
-    require('./components/bucketAddModal/bucketAddModal.module.js').name
+    require('./components/bucketAddModal/bucketAddModal.module.js').name,
+    require('./components/refreshTokenModal/refreshTokenModal.module.js').name
 ]);

--- a/app-frontend/src/app/index.config.js
+++ b/app-frontend/src/app/index.config.js
@@ -23,8 +23,7 @@ function config( // eslint-disable-line max-params
                 closable: false,
                 auth: {
                     redirect: false,
-                    sso: true,
-                    scope: 'openid name email'
+                    sso: true
                 },
                 theme: {
                     logo: assetLogo,

--- a/app-frontend/src/app/index.module.js
+++ b/app-frontend/src/app/index.module.js
@@ -47,6 +47,7 @@ const App = angular.module(
         require('./pages/settings/settings.module.js').name,
         require('./pages/settings/profile/profile.module.js').name,
         require('./pages/settings/account/account.module.js').name,
+        require('./pages/settings/tokens/tokens.module.js').name,
         require('./pages/error/error.module.js').name
 
     ]

--- a/app-frontend/src/app/index.routes.js
+++ b/app-frontend/src/app/index.routes.js
@@ -11,6 +11,7 @@ import bucketScenesTpl from './pages/library/buckets/detail/bucketScenes/bucketS
 import settingsTpl from './pages/settings/settings.html';
 import profileTpl from './pages/settings/profile/profile.html';
 import accountTpl from './pages/settings/account/account.html';
+import tokensTpl from './pages/settings/tokens/tokens.html';
 import errorTpl from './pages/error/error.html';
 
 function librarySceneStates($stateProvider) {
@@ -105,10 +106,10 @@ function settingsStates($stateProvider) {
             controller: 'AccountController',
             controllerAs: '$ctrl'
         })
-        .state('error', {
-            url: '/error',
-            templateUrl: errorTpl,
-            controller: 'ErrorController',
+        .state('settings.tokens', {
+            url: '/tokens',
+            templateUrl: tokensTpl,
+            controller: 'TokensController',
             controllerAs: '$ctrl'
         });
 }
@@ -145,6 +146,14 @@ function routeConfig($urlRouterProvider, $stateProvider) {
     librarySceneStates($stateProvider);
     libraryBucketStates($stateProvider);
     settingsStates($stateProvider);
+
+    $stateProvider
+        .state('error', {
+            url: '/error',
+            templateUrl: errorTpl,
+            controller: 'ErrorController',
+            controllerAs: '$ctrl'
+        });
 
     $urlRouterProvider.otherwise('/browse/');
 }

--- a/app-frontend/src/app/pages/settings/tokens/tokens.controller.js
+++ b/app-frontend/src/app/pages/settings/tokens/tokens.controller.js
@@ -1,0 +1,71 @@
+class TokensController {
+    constructor($log, tokenService, authService, $uibModal) {
+        'ngInject';
+        this.$log = $log;
+        this.tokenService = tokenService;
+        this.authService = authService;
+        this.$uibModal = $uibModal;
+        this.loading = true;
+
+        $log.debug('TokensController initialized');
+        this.fetchTokens();
+    }
+
+    fetchTokens() {
+        this.loading = true;
+        this.tokenService.query().then(
+            (tokens) => {
+                delete this.error;
+                this.tokens = tokens;
+                this.loading = false;
+            },
+            (error) => {
+                this.error = error;
+                this.loading = false;
+            });
+    }
+
+    createToken(name) {
+        this.$log.log('trying to create new refresh token with name', name);
+        this.authService.createRefreshToken(name).then((authResult) => {
+            this.$uibModal.open({
+                component: 'rfRefreshTokenModal',
+                resolve: {
+                    refreshToken: () => authResult.refreshToken,
+                    name: () => this.lastTokenName
+                }
+            });
+            this.fetchTokens();
+        }, (error) => {
+            this.$log.log('error while creating refresh token', error);
+            this.fetchTokens();
+        });
+    }
+
+    deleteToken(id) {
+        let deleteModal = this.$uibModal.open({
+            component: 'rfConfirmationModal',
+            resolve: {
+                title: () => 'Delete refresh token?',
+                content: () => 'Deleting this refresh token will make any ' +
+                    'further requests with it fail',
+                confirmText: () => 'Delete Refresh Token',
+                cancelText: () => 'Cancel'
+            }
+        });
+        deleteModal.result.then(
+            () => {
+                this.tokenService.delete({id: id}).then(
+                    () => {
+                        this.fetchTokens();
+                    },
+                    (err) => {
+                        this.$log.debug('error deleting refresh token', err);
+                        this.fetchTokens();
+                    }
+                );
+            });
+    }
+}
+
+export default TokensController;

--- a/app-frontend/src/app/pages/settings/tokens/tokens.html
+++ b/app-frontend/src/app/pages/settings/tokens/tokens.html
@@ -1,0 +1,34 @@
+<div class="row content stack-sm">
+  <div class="column">
+    <h1 class="h3 page-title">Api Tokens</h1>
+    <div class="list-group">
+      <div class=""ng-repeat="token in $ctrl.tokens track by token.id">
+        <span>{{token.device_name}}</span>
+        <button class="btn" ng-click="$ctrl.deleteToken(token.id)">
+          <i class="icon-trash"></i>
+        </button>
+      </div>
+    </div>
+    <div class="list-group"
+         ng-if="(!$ctrl.tokens || !$ctrl.tokens.length) && !$ctrl.loading">
+      You have not generated any tokens.
+    </div>
+    <div class="list-group" ng-show="$ctrl.loading">
+      <span class="list-placeholder">
+        <i class="icon-load"></i>
+      </span>
+    </div>
+
+
+    <form action="">
+      <div class="form-group">
+        <label for="new-token">Create token</label>
+        <input id="new-token" type="text" ng-model="$ctrl.newTokenName" class="form-control">
+        <button type="button" class="btn btn-default" ng-click="$ctrl.createToken($ctrl.newTokenName)">
+          <i class="icon-plus"></i>
+          Create
+        </button>
+      </div>
+    </form>
+  </div>
+</div>

--- a/app-frontend/src/app/pages/settings/tokens/tokens.module.js
+++ b/app-frontend/src/app/pages/settings/tokens/tokens.module.js
@@ -1,0 +1,7 @@
+import TokensController from './tokens.controller.js';
+
+const TokensModule = angular.module('pages.settings.tokens', []);
+
+TokensModule.controller('TokensController', TokensController);
+
+export default TokensModule;


### PR DESCRIPTION
## Overview

Add basic unstyled token page for token creation and viewing

### Notes

There isn't a prototype for this part of the application, so I've left the functionality / styling as minimal as possible.

## Testing Instructions

* Go to the settings view
* Go to the Tokens view
* create a token
* refresh the page to verify that state is persistent
* delete a token
* refresh the page to verify that state is persistent

Depends on #568 (only second commit is relevant for this PR, it will be merged after #568)
Discovered #573 