### PR TITLE
Manually set GIT_COMMIT in Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -43,6 +43,10 @@ node {
       // cycle in the newest version of the application into Amazon
       // ECS.
       stage('infra') {
+        // Use `git` to get the primary repository's current commmit SHA and
+        // set it as the value of the `GIT_COMMIT` environment variable.
+        env.GIT_COMMIT = sh(returnStdout: true, script: 'git rev-parse --short HEAD').trim()
+
         checkout scm: [$class: 'GitSCM',
                        branches: [[name: 'develop']],
                        extensions: [[$class: 'RelativeTargetDirectory',


### PR DESCRIPTION
## Overview

As JENKINS-26100 notes, the GIT_COMMIT environment variable does not
exist in a Jenkins Pipeline. In order to populate it for the downstream
deployment stages, use the shell wrapper to execute the Git CLI and
return the current revision.

See: https://issues.jenkins-ci.org/browse/JENKINS-26100

## Testing Instructions

Easiest way may be to merge this PR and inspect the output of the `develop` Jenkins job.