### PR TITLE
Make slider css more specific

### DIFF
--- a/app-frontend/package.json
+++ b/app-frontend/package.json
@@ -14,8 +14,8 @@
   "scripts": {
     "build": "npm run clean && cross-env NODE_ENV=production webpack --progress --colors",
     "clean": "rimraf dist/*",
+    "build-nginx": "rimraf ../nginx/srv/dist/* && npm run build && cp -R dist/* ../nginx/srv/dist/",
     "dev": "cross-env NODE_ENV=development webpack-dev-server",
-    "serve-static": "npm run build && serve --path dist --port 9001",
     "sort-packages": "sort-package-json",
     "start": "npm run dev",
     "test": "karma start karma.conf.js",
@@ -88,7 +88,6 @@
     "ng-annotate-loader": "0.0.10",
     "ngtemplate-loader": "^1.3.1",
     "node-sass": "^3.4.2",
-    "node-serve": "0.0.3",
     "null-loader": "^0.1.1",
     "oclazyload": "^1.0.9",
     "packageify": "^1.0.0",

--- a/app-frontend/src/app/index.vendor.js
+++ b/app-frontend/src/app/index.vendor.js
@@ -11,7 +11,6 @@ import 'angular-lock';
 import 'ng-infinite-scroll';
 import 'angular-jwt';
 import 'angular-resource';
-import 'auth0-angular';
 import 'oclazyload';
 import 'angular-animate';
 import 'angular-cookies';

--- a/app-frontend/src/assets/styles/sass/components/_map.scss
+++ b/app-frontend/src/assets/styles/sass/components/_map.scss
@@ -3,7 +3,7 @@
   z-index: 1;
 }
 
-.leaflet-right .map-control-panel {
+.leaflet-top.leaflet-right .map-control-panel {
   margin: 0;
   background: $shade-dark;
   padding: 1rem;

--- a/app-frontend/src/assets/styles/sass/components/_slider.scss
+++ b/app-frontend/src/assets/styles/sass/components/_slider.scss
@@ -1,31 +1,33 @@
 $slider-base: #353c58;
 $slider-selected: #728ffc;
 
-.rzslider .rz-pointer {
-  width: 24px;
-  height: 24px;
-  left: -12px;
-  top: -10px;
-  border-radius: 2px;
-  background: $slider-selected;
-  cursor: default;
-  &:after {
-    display: none;
-  }
-}
-
-.rzslider .rz-bar {
-  height: 12px;
-  top: 12px;
-  background: $slider-base;
-  &.rz-selection {
+.filter {
+  .rzslider .rz-pointer {
+    width: 24px;
+    height: 24px;
+    left: -12px;
+    top: -10px;
+    border-radius: 2px;
     background: $slider-selected;
+    cursor: default;
+    &:after {
+      display: none;
+    }
   }
-}
 
-.rzslider .rz-ticks .rz-tick{
-  background: none;
-  &.rz-selected {
+  .rzslider .rz-bar {
+    height: 12px;
+    top: 12px;
+    background: $slider-base;
+    &.rz-selection {
+      background: $slider-selected;
+    }
+  }
+
+  .rzslider .rz-ticks .rz-tick{
     background: none;
+    &.rz-selected {
+      background: none;
+    }
   }
 }


### PR DESCRIPTION
## Overview

Fix filter slider styling
Fix leaflet map control position

Both issues were caused by the sass not being specific enough - when unbundled, sass takes priority over equal depth css, but not when bundled.

## Notes:
Removed the `npm run serve-static` command since it doesn't work anymore, and we use nginx for that purpose. Added an `npm run build-nginx` command which builds then copies the files into the correct nginx folder for it to serve.

## Testing Instructions
* build static using `npm run build`
* copy assets to `/opt/raster-foundry/nginx/srv/dist` from `/opt/raster-foundry/app-frontend/dist` in the vagrant machine
* Open http://localhost:9100 and verify that both style issues are fixed

Fixes #571 

