### PR TITLE
Bump Terraform to version 0.7.7

### DIFF
--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -9,4 +9,4 @@ shellcheck_version: "0.3.*"
 docker_users:
   - "{{ ansible_user }}"
 
-terraform_version: "0.7.6"
+terraform_version: "0.7.7"


### PR DESCRIPTION
## Overview

See: https://github.com/hashicorp/terraform/blob/master/CHANGELOG.md#077-october-18-2016

## Testing Instructions

From within the `raster-foundry-deployment` project, execute the following command. There should be no changes:

```bash
$ GIT_COMMIT="19897d9" AWS_PROFILE=raster-foundry RF_SETTINGS_BUCKET=rasterfoundry-staging-config-us-east-1 ./scripts/infra plan
```

**Note**: The value of `GIT_COMMIT` needs to reference the most recent commit SHA from `develop`, or else the ECS resources will show up as changed.