### PR TITLE
Increase database copy timeout

### DIFF
--- a/app-backend/app/src/main/scala/utils/PGUtils.scala
+++ b/app-backend/app/src/main/scala/utils/PGUtils.scala
@@ -12,7 +12,7 @@ import slick.driver.PostgresDriver.api._
   */
 object PGUtils {
 
-  private val actionTimeout = 10 second
+  private val actionTimeout = 30 second
   private val driver = "org.postgresql.Driver"
 
 


### PR DESCRIPTION
## Overview

Increases the timeout set for copying the database in tests because this was causing test suites to be aborted.

## Testing Instructions

 * run `./scripts/test` and verify that tests pass
