### PR TITLE
Fix Jenkins executor reset when running Ansible

### DIFF
--- a/deployment/ansible/roles/raster-foundry.jenkins/tasks/main.yml
+++ b/deployment/ansible/roles/raster-foundry.jenkins/tasks/main.yml
@@ -14,7 +14,7 @@
         state: present,
         backrefs: yes }
     - { regexp: '(.*<numExecutors>)\d+(</numExecutors>.*)',
-        line: '\1 1\2',
+        line: '\g<1>1\g<2>',
         state: present,
         backrefs: yes }
 


### PR DESCRIPTION
## Overview

Instead of using backreference group numbers directly, use the `\g<NUMBER>` syntax to remove ambiguity if the characters following a backreference need to be numbers as well.

See: https://docs.python.org/2.7/library/re.html

Resolves https://github.com/azavea/raster-foundry/issues/593

## Testing Instructions

Execute the Jenkins role and ensure that none of the `raster-foundry.jenkins` tasks are marked as `changed`:

```bash
~/Projects/raster-foundry feature/hmc/fix-jenkins-exec-reset 34s
❯ ansible-playbook -i deployment/ansible/inventory/jenkins deployment/ansible/raster-foundry-jenkins.yml
```

Also, wait until no Jenkins jobs are in progress and restart the service. Afterwards, confirm that the executor count is still `1` within **Configure System**.

<img width="897" alt="configure_system__jenkins_" src="https://cloud.githubusercontent.com/assets/43639/19864118/37eef7a6-9f6d-11e6-813b-bc2caf09072e.png">
