### PR TITLE
Filter Scenes by resolution (and other image parameters)

### DIFF
--- a/app-backend/app/src/main/scala/image/QueryParams.scala
+++ b/app-backend/app/src/main/scala/image/QueryParams.scala
@@ -14,6 +14,8 @@ trait ImageQueryParametersDirective extends QueryParametersCommon {
   val imageSpecificQueryParams = parameters(
     'minRawDataBytes.as[Int].?,
     'maxRawDataBytes.as[Int].?,
+    'minResolution.as[Float].?,
+    'maxResolution.as[Float].?,
     'scene.as[UUID].*
   ).as(ImageQueryParameters)
 

--- a/app-backend/app/src/main/scala/scene/QueryParameters.scala
+++ b/app-backend/app/src/main/scala/scene/QueryParameters.scala
@@ -2,12 +2,14 @@ package com.azavea.rf.scene
 
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.directives.ParameterDirectives.parameters
-import com.azavea.rf.database.query._
 
+import com.azavea.rf.database.query._
+import com.azavea.rf.image.ImageQueryParametersDirective
 import com.azavea.rf.utils.queryparams._
 
 ///** Trait to abstract out query parameters for scenes */
-trait SceneQueryParameterDirective extends QueryParametersCommon {
+trait SceneQueryParameterDirective extends QueryParametersCommon
+    with ImageQueryParametersDirective {
 
   val sceneSpecificQueryParams = parameters((
     'maxCloudCover.as[Float].?,
@@ -27,6 +29,7 @@ trait SceneQueryParameterDirective extends QueryParametersCommon {
   val sceneQueryParameters = (orgQueryParams &
     userQueryParameters &
     timestampQueryParameters &
-    sceneSpecificQueryParams
+    sceneSpecificQueryParams &
+    imageSpecificQueryParams
   ).as(CombinedSceneQueryParams)
 }

--- a/app-backend/app/src/test/scala/scene/SceneSpec.scala
+++ b/app-backend/app/src/test/scala/scene/SceneSpec.scala
@@ -77,12 +77,17 @@ class SceneSpec extends WordSpec
       MultiPolygon(Polygon(Seq(Point(100,100), Point(110,100), Point(110,110),
         Point(100,110), Point(100,100)))), 3857))
 
+    val newSceneDatasource1Image = Image.Identified(
+      None, 0, Visibility.Public, "newSceneDatasource1Image", "",
+      Map.empty[String, Any], 20f, List.empty[String]
+    )
+
     val newSceneDatasource1 = Scene.Create(
       publicOrgId, 0, Visibility.Public, List("Test", "Public", "Low Resolution"), "TEST_ORG",
       Map("instrument type" -> "satellite", "splines reticulated" -> 0):Map[String, Any], None,
       Some(Timestamp.from(Instant.parse("2016-09-19T14:41:58.408544Z"))),
       JobStatus.Processing, JobStatus.Processing, JobStatus.Processing, None, None, "test scene datasource 1",
-      mpoly, List.empty[String], List.empty[Image.Identified], List.empty[Thumbnail.Identified]
+      mpoly, List.empty[String], List(newSceneDatasource1Image), List.empty[Thumbnail.Identified]
     )
 
     val newSceneDatasource2 = Scene.Create(
@@ -194,6 +199,18 @@ class SceneSpec extends WordSpec
         res.count shouldEqual 1
       }
       Get("/api/scenes/?point=1,1") ~> baseRoutes ~> check {
+        val res = responseAs[PaginatedResponse[Scene.WithRelated]]
+        res.count shouldEqual 0
+      }
+    }
+
+    "filter scenes by image resolution" in {
+      Get("/api/scenes/?minResolution=15.0") ~> baseRoutes ~> check {
+        val res = responseAs[PaginatedResponse[Scene.WithRelated]]
+        res.count shouldEqual 1
+      }
+
+      Get("/api/scenes/?maxResolution=15.0") ~> baseRoutes ~> check {
         val res = responseAs[PaginatedResponse[Scene.WithRelated]]
         res.count shouldEqual 0
       }

--- a/app-backend/database/src/main/scala/com/azavea/rf/database/query.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/query.scala
@@ -72,7 +72,8 @@ case class CombinedSceneQueryParams(
   orgParams: OrgQueryParameters,
   userParams: UserQueryParameters,
   timestampParams: TimestampQueryParameters,
-  sceneParams: SceneQueryParameters
+  sceneParams: SceneQueryParameters,
+  imageQueryParameters: ImageQueryParameters
 )
 
 

--- a/app-backend/database/src/main/scala/com/azavea/rf/database/query.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/query.scala
@@ -23,6 +23,8 @@ case class CombinedImageQueryParams(
 case class ImageQueryParameters(
   minRawDataBytes: Option[Int],
   maxRawDataBytes: Option[Int],
+  minResolution: Option[Float],
+  maxResolution: Option[Float],
   scene: Iterable[UUID]
 )
 

--- a/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Images.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Images.scala
@@ -217,7 +217,9 @@ class ImagesDefaultQuery[M, U, C[_]](images: Images.TableQuery) {
     images.filter{ image =>
       val imageFilterConditions = List(
         imageParams.minRawDataBytes.map(image.rawDataBytes > _),
-        imageParams.maxRawDataBytes.map(image.rawDataBytes < _)
+        imageParams.maxRawDataBytes.map(image.rawDataBytes < _),
+        imageParams.minResolution.map(image.resolutionMeters > _),
+        imageParams.maxResolution.map(image.resolutionMeters < _)
       )
       imageFilterConditions
         .collect({case Some(criteria)  => criteria})

--- a/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Scenes.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Scenes.scala
@@ -150,6 +150,7 @@ object Scenes extends TableQuery(tag => new Scenes(tag)) with LazyLogging {
         .filterByUser(combinedParams.userParams)
         .filterByTimestamp(combinedParams.timestampParams)
         .filterBySceneParams(combinedParams.sceneParams)
+        .filterByImageParams(combinedParams.imageQueryParameters)
         .length
         .result
       logger.debug(s"Total Query for scenes -- SQL: ${action.statements.headOption}")
@@ -251,6 +252,15 @@ class ScenesTableQuery[M, U, C[_]](scenes: Scenes.TableQuery) {
     }
   }
 
+  def filterByImageParams(imageParams: ImageQueryParameters): Scenes.TableQuery = {
+    imageParams match {
+      case ImageQueryParameters(None, None, None, None, _) => scenes
+      case _ => scenes.filter { scene =>
+        scene.id in Images.filterByImageParams(imageParams).map(_.scene)
+      }
+    }
+  }
+
   /** Return a join query for scenes */
   def joinWithRelated: Scenes.JoinQuery = {
     for {
@@ -278,6 +288,7 @@ class ScenesJoinQuery[M, U, C[_]](sceneJoin: Scenes.JoinQuery) {
       .filterByUser(combinedParams.userParams)
       .filterByTimestamp(combinedParams.timestampParams)
       .filterBySceneParams(combinedParams.sceneParams)
+      .filterByImageParams(combinedParams.imageQueryParameters)
       .sort(pageRequest.sort)
       .drop(pageRequest.offset * pageRequest.limit)
       .take(pageRequest.limit)


### PR DESCRIPTION
## Overview

Since #588, the `resolutionMeters` field has been moved from scenes to images. However, we would still like to filter scenes by resolution. Rather than adding filtering by only one field, I added a mechanism to filter all scenes by image parameters. The general approach is as follows:

 1. Add `min` and `max` resolution filtering to the image endpoint
 2. Update `SceneQueryParameterDirective` to also extend `ImageQueryParametersDirective`
 3. If image query parameters are specified, find all images that satisfy them and restrict to only scenes that contain these images

Thus, we can now use not just resolution by any parameters that are used for filtering images.

It is important to note that we are filtering for _Scenes_, not _Images_. For example, consider the following setup:

 * Scene S1 with Images I11 (resolution=10) and I12 (resolution=20)
 * Scene S2 with Images I21 (resolution=10) and I22 (resolution=10)
 * Scene S3 with Image I31 (resolution=50)
 * Scene S4 with no images

The output of the following filters will be:

 * `maxResolution=100 -> S1(I11, I12), S2(I21, I22), S3(I31)`: S4 is not included because it has no images to filter by.
 * `maxResolution=30 -> S1(I11, I12), S2(I21, I22)`: S3 is not included because it has no image which passes the filter.
 * `maxResolution=15 -> S1(I11, I12), S2(I21, I22)`: S2 is included because it has at least one image I21 that passes the filter. I22 is included in the output even though it doesn't pass the filter because we are filtering scenes, not images.
 * `minResolution=30 -> S3(I31)`: S1 and S2 are not included because neither has a single image that passes the filter.

### Notes

Is this the desired behavior? _Should_ we also be filtering images if the user has specified a certain resolution?

Currently we use the hard `<` and `>` inequality tests. I feel it may be worth while to switch to `<=` and `>=`, since I can imagine API clients asking for `?minResolution=10` and expecting those with resolution = 10 to be included.

## Testing Instructions

Check out the branch, run the tests. Run the server. If you have loaded the development data and ran all migrations, you should have images in the database with resolutions of 10, 20, or 60:

```sql
SELECT DISTINCT resolution_meters FROM images;

 resolution_meters
-------------------
                10
                60
                20
(3 rows)
```

Try using a `maxResolution=55` query parameter, and ensure that the values you see are only 10s and 20s. Reverse it using `minResolution=55`, and ensure that the values you see are only 60s.

This can be easily done with [`http`](https://httpie.org/) and [`jq`](https://stedolan.github.io/jq/):

```fish
> http :9000/api/scenes minResolution==55 | jq '.results[].images[].resolutionMeters'
60
60
60
60
60
60
...
```

```fish
> http :9000/api/scenes maxResolution==55 | jq '.results[].images[].resolutionMeters'
20
20
20
10
10
10
...
```

Connects #582 
