### PR TITLE
Add download modal component

### DIFF
--- a/app-frontend/src/app/components/downloadModal/downloadModal.component.js
+++ b/app-frontend/src/app/components/downloadModal/downloadModal.component.js
@@ -1,0 +1,13 @@
+import downloadModalTpl from './downloadModal.html';
+
+const rfDownloadModal = {
+    templateUrl: downloadModalTpl,
+    bindings: {
+        close: '&',
+        dismiss: '&',
+        modalInstance: '<',
+        resolve: '<'
+    }
+};
+
+export default rfDownloadModal;

--- a/app-frontend/src/app/components/downloadModal/downloadModal.controller.js
+++ b/app-frontend/src/app/components/downloadModal/downloadModal.controller.js
@@ -1,0 +1,5 @@
+export default class DownloadModalController {
+    constructor() {
+        'ngInject';
+    }
+}

--- a/app-frontend/src/app/components/downloadModal/downloadModal.html
+++ b/app-frontend/src/app/components/downloadModal/downloadModal.html
@@ -1,0 +1,76 @@
+<div class="modal-header">
+	<button type="button" class="close" aria-label="Close"
+          ng-click="$ctrl.dismiss()">
+    <span aria-hidden="true">&times;</span>
+  </button>
+  <h4 class="modal-title">
+    Files
+  </h4>
+</div>
+<div class="modal-body">
+  <div class="list-group" ng-repeat=" downloadSet in $ctrl.resolve.downloads">
+    <div class="list-group-item">
+      <div class="list-group-overflow">
+        <strong class="color-dark">{{downloadSet.label}}</strong>
+      </div>
+    </div>
+    <div ng-init="show = false">
+      <div class="list-group-item selectable"
+           ng-click="show = !show">
+        <span class="badge color-dark selectable"><i class="icon-plus"></i></span>
+        <strong class="color-dark">Images</strong>
+        <ng-pluralize count="downloadSet.images.length"
+                      when="{'0': 'No images',
+                            'one': 'One image',
+                            'other': '{} images'}">
+        </ng-pluralize>
+        available
+      </div>
+      <div ng-show="show"
+           class="list-group-subitem"
+           ng-repeat-start="image in downloadSet.images"
+           ng-init="showImageDownloads = false">
+        <a class="color-dark" ng-attr-href="{{image.uri}}" download>
+          <span class="badge"><i class="icon-download"></i></span>
+        </a>
+        <div class="list-group-overflow">
+          <a ng-attr-href="{{image.uri}}" download>{{image.filename}}</a>
+        </div>
+      </div>
+      <div ng-repeat-end
+           ng-show="show"
+           class="list-group-subitem download"
+           ng-repeat="file in image.metadata">
+        <a class="color-dark" ng-attr-href="{{file}}" download>
+          <span class="badge"><i class="icon-download"></i></span>
+        </a>
+        <a class="color-dark" ng-attr-href="{{file}}" download>
+          {{file}}
+        </a>
+      </div>
+    </div>
+    <div ng-init="show = false" ng-if="downloadSet.metadata.length">
+      <div class="list-group-item selectable"
+           ng-click="show = !show">
+        <span class="badge color-dark selectable"><i class="icon-plus"></i></span>
+        <strong class="color-dark">Metadata</strong>
+        <ng-pluralize count="downloadSet.metadata.length"
+                      when="{'0': 'No metadata files',
+                            'one': 'One metadata file',
+                            'other': '{} metadata files'}">
+        </ng-pluralize>
+        available
+      </div>
+      <div ng-show="show"
+           class="list-group-subitem"
+           ng-repeat="download in downloadSet.metadata">
+        <a class="color-dark" ng-attr-href="{{download}}" download>
+          <span class="badge"><i class="icon-download"></i></span>
+        </a>
+        <div class="list-group-overflow">
+          <a ng-attr-href="{{download}}" download>{{download}}</a>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app-frontend/src/app/components/downloadModal/downloadModal.module.js
+++ b/app-frontend/src/app/components/downloadModal/downloadModal.module.js
@@ -1,0 +1,15 @@
+import angular from 'angular';
+import DownloadModalComponent from './downloadModal.component.js';
+import DownloadModalController from './downloadModal.controller.js';
+require('../../../assets/font/fontello/css/fontello.css');
+
+const DownloadModalModule = angular.module('components.downloadModal', []);
+
+DownloadModalModule.controller(
+    'DownloadModalController', DownloadModalController
+);
+DownloadModalModule.component(
+    'rfDownloadModal', DownloadModalComponent
+);
+
+export default DownloadModalModule;

--- a/app-frontend/src/app/index.components.js
+++ b/app-frontend/src/app/index.components.js
@@ -8,5 +8,6 @@ export default angular.module('index.components', [
     require('./components/selectedScenesModal/selectedScenesModal.module.js').name,
     require('./components/confirmationModal/confirmationModal.module.js').name,
     require('./components/bucketAddModal/bucketAddModal.module.js').name,
-    require('./components/refreshTokenModal/refreshTokenModal.module.js').name
+    require('./components/refreshTokenModal/refreshTokenModal.module.js').name,
+    require('./components/downloadModal/downloadModal.module.js').name
 ]);

--- a/app-frontend/src/app/pages/library/buckets/detail/bucketScenes/bucketScenes.controller.js
+++ b/app-frontend/src/app/pages/library/buckets/detail/bucketScenes/bucketScenes.controller.js
@@ -129,6 +129,36 @@ export default class BucketScenesController {
             });
     }
 
+    downloadModal() {
+        if (this.activeModal) {
+            this.activeModal.dismiss();
+        }
+        let downloadSets = Array.from(this.$parent.selectedScenes)
+            .map(([, val]) => {
+                let images = val.images.map((image) => {
+                    return {
+                        filename: image.filename,
+                        uri: image.sourceUri,
+                        metadata: image.metadataFiles || []
+                    };
+                });
+
+                return {
+                    label: val.name,
+                    images: images,
+                    metadata: val.metadataFiles || []
+                };
+            });
+        if (downloadSets.length > 0) {
+            this.activeModal = this.$uibModal.open({
+                component: 'rfDownloadModal',
+                resolve: {
+                    downloads: () => downloadSets
+                }
+            });
+        }
+    }
+
     shouldShowPagination() {
         return !this.loading &&
             this.lastSceneResult &&

--- a/app-frontend/src/app/pages/library/buckets/detail/bucketScenes/bucketScenes.html
+++ b/app-frontend/src/app/pages/library/buckets/detail/bucketScenes/bucketScenes.html
@@ -67,8 +67,8 @@
   <div class="column-4">
     <div class="content">
       <nav>
-        <a href="#"><i class="icon-mosaic"></i> Editor</a>
-        <a href="#"><i class="icon-download"></i> Download</a>
+        <a href><i class="icon-mosaic"></i> Editor</a>
+        <a href ng-click="$ctrl.downloadModal()"><i class="icon-download"></i> Download</a>
         <hr>
         <a href class="color-danger"
            ng-click="$ctrl.deleteBucket()">

--- a/app-frontend/src/app/pages/library/buckets/detail/scene/scene.controller.js
+++ b/app-frontend/src/app/pages/library/buckets/detail/scene/scene.controller.js
@@ -1,10 +1,11 @@
 class BucketSceneController {
-    constructor($log, $state, sceneService, bucketService) {
+    constructor($log, $state, sceneService, bucketService, $uibModal) {
         'ngInject';
         this.$log = $log;
         this.$state = $state;
         this.bucketService = bucketService;
         this.sceneService = sceneService;
+        this.$uibModal = $uibModal;
 
         this.scene = this.$state.params.scene;
         this.bucketId = this.$state.params.bucketid;
@@ -28,6 +29,33 @@ class BucketSceneController {
         }
 
         $log.debug('BucketSceneController initialized');
+    }
+
+    downloadModal() {
+        if (this.activeModal) {
+            this.activeModal.dismiss();
+        }
+
+        let images = this.scene.images.map((image) => {
+            return {
+                filename: image.filename,
+                uri: image.sourceUri,
+                metadata: image.metadataFiles || []
+            };
+        });
+
+        let downloadSets = [{
+            label: this.scene.name,
+            metadata: this.scene.metadataFiles || [],
+            images: images
+        }];
+
+        this.activeModal = this.$uibModal.open({
+            component: 'rfDownloadModal',
+            resolve: {
+                downloads: () => downloadSets
+            }
+        });
     }
 
     removeScene() {

--- a/app-frontend/src/app/pages/library/buckets/detail/scene/scene.html
+++ b/app-frontend/src/app/pages/library/buckets/detail/scene/scene.html
@@ -25,8 +25,8 @@
   <div class="column-4">
     <div class="content">
       <nav>
-        <a href ng-click="$ctrl.removeScene"><i class="icon-trash"></i> Remove from bucket</a>
-        <a href><i class="icon-download"></i> Download</a>
+        <a href ng-click="$ctrl.removeScene()"><i class="icon-trash"></i> Remove from bucket</a>
+        <a href ng-click="$ctrl.downloadModal()"><i class="icon-download"></i> Download</a>
       </nav>
     </div>
   </div>

--- a/app-frontend/src/app/pages/library/scenes/detail/detail.controller.js
+++ b/app-frontend/src/app/pages/library/scenes/detail/detail.controller.js
@@ -1,8 +1,9 @@
 class SceneDetailController {
-    constructor($log, $state, sceneService) {
+    constructor($log, $state, sceneService, $uibModal) {
         'ngInject';
 
         this.$state = $state;
+        this.$uibModal = $uibModal;
         this.$log = $log;
 
         this.scene = this.$state.params.scene;
@@ -23,6 +24,33 @@ class SceneDetailController {
                 this.$state.go('^.list');
             }
         }
+    }
+
+    downloadModal() {
+        if (this.activeModal) {
+            this.activeModal.dismiss();
+        }
+
+        let images = this.scene.images.map((image) => {
+            return {
+                filename: image.filename,
+                uri: image.sourceUri,
+                metadata: image.metadataFiles || []
+            };
+        });
+
+        let downloadSets = [{
+            label: this.scene.name,
+            metadata: this.scene.metadataFiles || [],
+            images: images
+        }];
+
+        this.activeModal = this.$uibModal.open({
+            component: 'rfDownloadModal',
+            resolve: {
+                downloads: () => downloadSets
+            }
+        });
     }
 }
 export default SceneDetailController;

--- a/app-frontend/src/app/pages/library/scenes/detail/detail.html
+++ b/app-frontend/src/app/pages/library/scenes/detail/detail.html
@@ -26,7 +26,10 @@
     <div class="content">
       <nav>
         <a href><i class="icon-bucket"></i> Add to bucket</a>
-        <a href><i class="icon-download"></i> Download</a>
+        <a href ng-click="$ctrl.downloadModal()">
+          <i class="icon-download"></i>
+          Download
+        </a>
         <a href><i class="icon-unlocked"></i> Make public</a>
 
         <a href><i class="icon-trash"></i> Delete</a>

--- a/app-frontend/src/assets/styles/sass/components/_badge.scss
+++ b/app-frontend/src/assets/styles/sass/components/_badge.scss
@@ -7,4 +7,7 @@
   >[class^=icon-] {
     font-size: 1.8rem;
   }
+  &.selectable {
+    cursor: pointer;
+  }
 }

--- a/app-frontend/src/assets/styles/sass/components/_list-group.scss
+++ b/app-frontend/src/assets/styles/sass/components/_list-group.scss
@@ -28,6 +28,33 @@
     cursor: pointer;
   }
 }
+
+.list-group-subitem {
+  padding: 1.5rem 1.5rem 1.5rem 1.5rem;
+  margin: 0 0 0 3rem;
+  display: flex;
+  align-items: center;
+  position: relative;
+  border-left: 1px solid #ddd;
+  border-right: 1px solid #ddd;
+  border-bottom: 1px solid #ddd;
+  > * {
+    margin: 0 5px;
+  }
+  p {
+    margin: 0;
+  }
+  span {
+    display: inline-block;
+    vertical-align: middle;
+  }
+  &.selectable {
+    cursor: pointer;
+  }
+  &.download {
+    margin: 0 0 0 6em;
+  }
+}
 .list-group-item {
   padding: 1.5rem;
   border-bottom: 1px solid #ddd;
@@ -69,6 +96,9 @@
     bottom: 0;
   }
 
+  &.selectable {
+    cursor: pointer;
+  }
 }
 
 .list-group-overflow {


### PR DESCRIPTION
## Overview

Add download modal to bucket/scenes and scenes/detail views

### Demo

No metadata (only images):  
![anim](https://cloud.githubusercontent.com/assets/4392704/19900872/6d5845a4-a03b-11e6-926a-5e473f6fc675.gif)

Layout with metadata on images and scene with example metadata files
![image](https://cloud.githubusercontent.com/assets/4392704/19901033/079dbdce-a03c-11e6-8dca-9cc3a9a7b006.png)


### Notes

Styling is kind of iffy. @designmatty probably will want to create better styles for nested lists such as this modal tends to create (It's basically exposing a file/folder structure that's at most 2 deep).  We may want to add toggles at the image level instead of always displaying metadata as well.

## Testing Instructions

* in the Bucket/scenes view, select a couple scenes and click download. Examine the http request that fetched the scenes and verify that all images show up.
* Modify the javascript in `buckeScenes.controller.js` to inject metadata or add metadata to scenes on the backend to verify that the modal shows them. 
