### PR TITLE
Use latitude / longitude coordinates in footprints

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ The Vagrant configuration maps the following host ports to services running in t
 
 | Service                   | Port                            | Environment Variable |
 |---------------------------|---------------------------------|----------------------|
-| Application Frontend      | [`9090`](http://localhost:9091) | `RF_PORT_9091`       |
+| Application Frontend      | [`9091`](http://localhost:9091) | `RF_PORT_9091`       |
 | Nginx                     | [`9100`](http://localhost:9100) | `RF_PORT_9100`       |
 | Application Server (akka) | [`9000`](http://localhost:9000) | `RF_PORT_9000`       |
 | Database                  | `5432`                          | `RF_PORT_5432`       |

--- a/app-tasks/rf/src/rf/models/footprint.py
+++ b/app-tasks/rf/src/rf/models/footprint.py
@@ -37,19 +37,7 @@ class Footprint(BaseModel):
         )
 
     def to_dict(self):
-        footprint_dict = dict(
-            organizationId=self.organizationId,
-            multipolygon=self.multipolygon
-        )
-        if self.id:
-            footprint_dict['id'] = self.id
-        if self.sceneId:
-            footprint_dict['sceneId'] = self.sceneId
-        if self.createdAt:
-            footprint_dict['createdAt'] = self.createdAt
-        if self.modifiedAt:
-            footprint_dict['modifiedAt'] = self.modifiedAt
-        return footprint_dict
+        return self.multipolygon
 
     def create(self):
         assert self.sceneId, 'Scene ID is required to create a Footprint'

--- a/app-tasks/rf/src/rf/uploads/landsat8/create_footprint.py
+++ b/app-tasks/rf/src/rf/uploads/landsat8/create_footprint.py
@@ -7,7 +7,7 @@ from rf.models import Footprint
 from .settings import organization
 
 # target projection for footprints
-target_proj = Proj(init='epsg:3857')
+target_proj = Proj(init='epsg:4326')
 
 
 def create_footprint(csv_row):

--- a/app-tasks/rf/src/rf/uploads/sentinel2/create_footprint.py
+++ b/app-tasks/rf/src/rf/uploads/sentinel2/create_footprint.py
@@ -8,7 +8,7 @@ from .settings import organization
 
 
 # target projection for footprints
-target_proj = Proj(init='epsg:3857')
+target_proj = Proj(init='epsg:4326')
 
 
 def get_src_proj(crs_string):

--- a/scripts/console
+++ b/scripts/console
@@ -9,7 +9,7 @@ function usage() {
 
 Use docker compose to run a command for a service or drop into a console
 
-Example: ./scripts/console app-backend \"./sbt\"
+Example: ./scripts/console app-server \"./sbt\"
 "
 }
 


### PR DESCRIPTION
## Overview

The API has been updated to accept lat/lon coordinates for footprints rather than WebMercator; this updates the landsat8 and sentinel2 importers to match.

### Notes

This also updates some README and example text to match what appeared to be the current state of things.

Additionally, the JSON format being used by the importers is currently not what the API expects, so this includes an update to fix the structure used for footprints. However, there appear to be other areas where the importer JSON format doesn't match the API; I've opened #614 to track these.

## Testing Instructions

 * `vagrant ssh`
 * `./scripts/console airflow-worker bash`
 * `root@6119306149ef:/usr/local/airflow# ipython`
 * `from rf.uploads.sentinel2.create_scenes import create_sentinel2_scenes`
 * `s1, s2, s3 = create_sentinel2_scenes('tiles/54/M/XB/2016/9/25/0')`
 * `s1.to_json()`
 * Paste output into a json editor and note that the footprint coordinates are in 4326 and the geometry data is now at the root of the `footprint` field.

Closes #507 