### PR TITLE
Reduce Slick Logging

### DIFF
--- a/app-backend/migrations/src/main/resources/logback.xml
+++ b/app-backend/migrations/src/main/resources/logback.xml
@@ -1,0 +1,3 @@
+<configuration>
+    <logger name="slick" level="INFO" />
+</configuration>


### PR DESCRIPTION
## Overview

Previously the testing output would be very verbose on local dev environments and Jenkins, making the result difficult to parse. By setting Slick's logging level to INFO, we reduce most of the noise.

We set the logging level for Slick as a whole. If instead we would like to be more selective, a full list of loggers can be found here: http://slick.lightbend.com/doc/3.2.0-M1/config.html#logging

### Notes

I tried extensively to turn off logging only for Unit tests, but preserve it for runtime, using guides like these: https://engineering.sharethrough.com/blog/2015/06/04/suppressing-slf4j-logs-during-tests-in-sbt/, but was ultimately unsuccessful.

## Testing Instructions

 * Check out the PR
 * Run the tests from your machine:

        $ vagrant ssh -c 'cd /opt/raster-foundry && ./scripts/console app-server "./sbt test"'

 * Ensure you don't see any verbose logging from Slick following the `mg update` and `mg apply` commands.

