### PR TITLE
Standardize on internal database and cache hostname

### DIFF
--- a/app-backend/app/src/main/resources/application.conf
+++ b/app-backend/app/src/main/resources/application.conf
@@ -34,7 +34,7 @@ slick {
   driver = "slick.driver.PostgresDriver$"
   db {
     driver = org.postgresql.Driver
-    url = "jdbc:postgresql://database.raster-foundry.internal/"
+    url = "jdbc:postgresql://database.service.rasterfoundry.internal/"
     url = ${?POSTGRES_URL}
     name = "rasterfoundry"
     name = ${?POSTGRES_NAME}

--- a/app-tasks/usr/local/airflow/airflow.cfg
+++ b/app-tasks/usr/local/airflow/airflow.cfg
@@ -28,7 +28,7 @@ executor = CeleryExecutor
 # The SqlAlchemy connection string to the metadata database.
 # SqlAlchemy supports many different database engine, more information
 # their website
-sql_alchemy_conn = postgresql+psycopg2://${POSTGRES_USER}:${POSTGRES_PASSWORD}@database.raster-foundry.internal/${AIRFLOW_POSTGRES_DB}
+sql_alchemy_conn = postgresql+psycopg2://${POSTGRES_USER}:${POSTGRES_PASSWORD}@database.service.rasterfoundry.internal/${AIRFLOW_POSTGRES_DB}
 
 # The SqlAlchemy pool size is the maximum number of database connections
 # in the pool.
@@ -142,10 +142,10 @@ worker_log_server_port = 8793
 # The Celery broker URL. Celery supports RabbitMQ, Redis and experimentally
 # a sqlalchemy database. Refer to the Celery documentation for more
 # information.
-broker_url = redis://redis.raster-foundry.internal:6379/0
+broker_url = redis://cache.service.rasterfoundry.internal:6379/0
 
 # Another key Celery setting
-celery_result_backend = redis://redis.raster-foundry.internal:6379/0
+celery_result_backend = redis://cache.service.rasterfoundry.internal:6379/0
 
 # Celery Flower is a sweet UI for Celery. Airflow has a shortcut to start
 # it `airflow flower`. This defines the port that Celery Flower runs on

--- a/docker-compose.spark.yml
+++ b/docker-compose.spark.yml
@@ -29,7 +29,7 @@ services:
       context: ./worker-tasks
       dockerfile: Dockerfile
     links:
-      - spark-master:spark.services.rf.internal
+      - spark-master:spark.services.rasterfoundry.internal
     environment:
       SPARK_LOCAL_DIRS: "/tmp"
       SPARK_PUBLIC_DNS: "localhost"
@@ -42,7 +42,7 @@ services:
     entrypoint: spark-class
     command:
       - "org.apache.spark.deploy.worker.Worker"
-      - "spark://spark.services.rf.internal:7077"
+      - "spark://spark.services.rasterfoundry.internal:7077"
 
   spark-driver:
     image: raster-foundry-spark
@@ -50,7 +50,7 @@ services:
       context: ./worker-tasks
       dockerfile: Dockerfile
     links:
-      - spark-master:spark.services.rf.internal
+      - spark-master:spark.services.rasterfoundry.internal
     environment:
       SPARK_LOCAL_DIRS: "/tmp"
       SPARK_PUBLIC_DNS: "localhost"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,7 @@ services:
   app-server:
     image: quay.io/azavea/scala:2.11.8
     links:
-      - postgres:database.raster-foundry.internal
+      - postgres:database.service.rasterfoundry.internal
     env_file: .env
     ports:
       - "9000:9000"
@@ -79,8 +79,8 @@ services:
       dockerfile: Dockerfile
     env_file: .env
     links:
-      - postgres:database.raster-foundry.internal
-      - redis:redis.raster-foundry.internal
+      - postgres:database.service.rasterfoundry.internal
+      - redis:cache.service.rasterfoundry.internal
     environment:
       - AIRFLOW_HOME=/usr/local/airflow
       - RF_HOST=http://rasterfoundry.com:9000
@@ -96,8 +96,8 @@ services:
       context: ./app-tasks
       dockerfile: Dockerfile
     links:
-      - postgres:database.raster-foundry.internal
-      - redis:redis.raster-foundry.internal
+      - postgres:database.service.rasterfoundry.internal
+      - redis:cache.service.rasterfoundry.internal
     env_file: .env
     environment:
       - AIRFLOW_HOME=/usr/local/airflow
@@ -119,8 +119,8 @@ services:
       dockerfile: Dockerfile
     restart: always
     links:
-      - postgres:database.raster-foundry.internal
-      - redis:redis.raster-foundry.internal
+      - postgres:database.service.rasterfoundry.internal
+      - redis:cache.service.rasterfoundry.internal
     env_file: .env
     environment:
       - AIRFLOW_HOME=/usr/local/airflow
@@ -140,8 +140,8 @@ services:
       context: ./app-tasks
       dockerfile: Dockerfile
     links:
-      - postgres:database.raster-foundry.internal
-      - redis:redis.raster-foundry.internal
+      - postgres:database.service.rasterfoundry.internal
+      - redis:cache.service.rasterfoundry.internal
       - app-server:rasterfoundry.com
     env_file: .env
     environment:

--- a/docs/spark/README.md
+++ b/docs/spark/README.md
@@ -104,7 +104,7 @@ spark-worker_1  | 16/08/22 19:28:03 INFO Worker: Running Spark version 1.6.2
 spark-worker_1  | 16/08/22 19:28:03 INFO Worker: Spark home: /usr/lib/spark
 spark-worker_1  | 16/08/22 19:28:03 INFO Utils: Successfully started service 'WorkerUI' on port 8081.
 spark-worker_1  | 16/08/22 19:28:03 INFO WorkerWebUI: Started WorkerWebUI at http://172.18.0.5:8081
-spark-worker_1  | 16/08/22 19:28:03 INFO Worker: Connecting to master spark.services.rf.internal:7077...
+spark-worker_1  | 16/08/22 19:28:03 INFO Worker: Connecting to master spark.services.rasterfoundry.internal:7077...
 spark-worker_1  | 16/08/22 19:28:03 INFO Worker: Successfully registered with master spark://172.18.0.4:7077
 ```
 
@@ -115,7 +115,7 @@ $ docker-compose \
     -f docker-compose.spark.yml run --rm -p 4040:4040 \
     spark-driver \
         --class "com.rasterfoundry.worker.SparkPi" \
-        --master spark://spark.services.rf.internal:7077 \
+        --master spark://spark.services.rasterfoundry.internal:7077 \
         target/scala-2.11/rf-worker_2.11-0.1.0.jar 1000
 ```
 


### PR DESCRIPTION
## Overview

Whenever we reference an internal endpoint for external services (database, cache), use a consistent domain structure. Namely, `*.service.rasterfoundry.internal`.

## Testing Instructions

Spin up the development environment and ensure that all of the services that need to interact with the database and cache still can:

- `app-server`
- `airflow-webserver`
- `airflow-flower`
- `airflow-scheduler`
- `airflow-worker`

Using `./scripts/server` is a pretty good test. All of these services will complain on start if they can't connect to the database. Airflow connections to Redis will complain right away too. Mostly, `airflow-flower`.