### PR TITLE
Run migrations for every test run

### DIFF
--- a/app-backend/app/src/main/scala/utils/PGUtils.scala
+++ b/app-backend/app/src/main/scala/utils/PGUtils.scala
@@ -64,27 +64,6 @@ object PGUtils {
   }
 
   /**
-    * Runs a function only if the database does not exist
-    *
-    * @param jdbcNoDBurl url of the database server (with no db component)
-    * @param user user name for the database
-    * @param pwd password for the database
-    * @param fnIfNoDB function to run if the database does not exist
-    */
-  def runIfNoDB(jdbcNoDBUrl: String, user: String, pwd: String)
-    (fnIfNoDB: () => Unit): Unit = {
-    using(Database.forURL(jdbcNoDBUrl, user = user, password = pwd, driver = driver)) { conn =>
-      Await.result(
-        conn.run(sql"SELECT 1 FROM pg_database WHERE datname='testing_template'".as[Int].headOption),
-        actionTimeout
-      ) match {
-        case None => fnIfNoDB()
-        case _ => // Do nothing. Only run the function when the DB doesn't exist (result is None)
-      }
-    }
-  }
-
-  /**
     * Automatically closes a resource with method 'close'
     */
   private def using[A <: {def close() : Unit}, B](resource: A)(f: A => B): B =

--- a/app-backend/app/src/test/scala/DBSpec.scala
+++ b/app-backend/app/src/test/scala/DBSpec.scala
@@ -54,15 +54,11 @@ object InitializeDB extends Config {
   // Working directory, needed for running %sbt commands
   implicit val wd = cwd
 
-  // Check if the testing template DB exist. Create DB and initialize migrations if needed.
-  PGUtils.runIfNoDB(jdbcNoDBUrl, dbUser, dbPassword) { () => {
-    // Create the testing template DB
-    PGUtils.createDB(jdbcNoDBUrl, "testing_template", dbUser, dbPassword)
+  // Recreate the test database
+  PGUtils.dropDB(jdbcNoDBUrl, "testing_template", dbUser, dbPassword)
+  PGUtils.createDB(jdbcNoDBUrl, "testing_template", dbUser, dbPassword)
 
-    //Initialize migrations. POSTGRES_URL is passed as an env variable to target the correct DB.
-    %sbt("mg init", POSTGRES_URL=s"${jdbcNoDBUrl}testing_template")
-  }}
-
-  // Run migrations -- scala-forklift requires that they be run twice
+  // Run migrations
+  %sbt("mg init", POSTGRES_URL=s"${jdbcNoDBUrl}testing_template")
   %sbt(";mg update ;mg apply", POSTGRES_URL=s"${jdbcNoDBUrl}testing_template")
 }


### PR DESCRIPTION
## Overview

This commit changes how migrations are applied when running
tests. Before this change migrations would run against a test template
database and then each test suite would run create a database from the
template and run its suite. Subsequent runs would not need to run
migrations if no new migrations were present.

This created a problem when the database was persisted across branches
if those branches had conflicts for migrations because those conflicting
migrations would not run.

This commit changes that behavior by recreating the test template before
each database run. Migrations still run against the template and are
copied; however, that template is _not_ persisted between runs.

### Checklist

- [x] Styleguide updated, if necessary
- [x] Swagger specification updated, if necessary

### Notes

This increases test run time somewhere between 15-30 seconds in my testing (`time ./sbt test`), but the trade-off seems preferable compared to constantly debugging broken builds in CI so I think it is worth it.

## Testing Instructions
Run tests and observe that migrations get run every time tests are run.
 * `./scripts/console app-server bash`
 * `./sbt test`

The following should be near the top of the test output:
`[info] Running RFMigrations apply
applying migrations: 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24`

Closes #474

