### PR TITLE
Add Airflow DAGs at container image build time

### DIFF
--- a/app-tasks/Dockerfile
+++ b/app-tasks/Dockerfile
@@ -13,24 +13,22 @@ RUN set -ex \
     libgdal1h \
     libgdal-dev \
   ' \
-  && apt-get update && apt-get install -y ${buildDeps} ${gdal} --no-install-recommends \
-  && pip install --no-cache-dir --no-binary \
-         pycparser \
+  && apt-get update && apt-get install -y --no-install-recommends ${buildDeps} ${gdal} \
   && pip install --no-cache-dir \
          numpy==$(grep "numpy" /tmp/requirements.txt | cut -d= -f3) \
   && pip install --no-cache-dir -r /tmp/requirements.txt \
-  && rm /tmp/requirements.txt \
   && apt-get purge -y --auto-remove ${buildDeps} \
   && rm -rf /var/lib/apt/lists/*
 
 COPY usr/local/airflow/airflow.cfg ${AIRFLOW_HOME}/airflow.cfg
-
-EXPOSE 8080 5555 8793
-
 COPY rf/ /tmp/rf
+COPY dags/ /opt/raster-foundry/app-tasks/dags/
+
 RUN set -ex \
     && cd /tmp/rf \
     && python setup.py install \
     && rm -rf /tmp/rf
+
+EXPOSE 8080 5555 8793
 
 WORKDIR ${AIRFLOW_HOME}


### PR DESCRIPTION
## Overview

Update Airflow `Dockerfile` so that DAGs are added to the image at build time.

Builds off of https://github.com/azavea/raster-foundry/pull/638. Only the last 4 commits are relevant.

## Testing Instructions

Because this is so closely tied to https://github.com/azavea/raster-foundry-deployment/pull/12, view the Airflow UI on staging and ensure that the DAGs show up correctly.