### PR TITLE
Airflow reverse proxy and base URL override

### DIFF
--- a/app-tasks/usr/local/airflow/airflow.cfg
+++ b/app-tasks/usr/local/airflow/airflow.cfg
@@ -74,7 +74,7 @@ dagbag_import_timeout = 30
 # The base url of your website as airflow cannot guess what domain or
 # cname you are using. This is use in automated emails that
 # airflow sends to point links to the right web server
-base_url = http://localhost:8080
+base_url = ${AIRFLOW_BASE_URL}
 
 # The ip specified when starting the web server
 web_server_host = 0.0.0.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -83,6 +83,7 @@ services:
       - redis:cache.service.rasterfoundry.internal
     environment:
       - AIRFLOW_HOME=/usr/local/airflow
+      - AIRFLOW_BASE_URL=http://localhost:8080
       - RF_HOST=http://rasterfoundry.com:9000
     ports:
       - "8080:8080"
@@ -101,6 +102,7 @@ services:
     env_file: .env
     environment:
       - AIRFLOW_HOME=/usr/local/airflow
+      - AIRFLOW_BASE_URL=http://localhost:8080
       - RF_HOST=http://rasterfoundry.com:9000
     ports:
       - "5555:5555"
@@ -124,6 +126,7 @@ services:
     env_file: .env
     environment:
       - AIRFLOW_HOME=/usr/local/airflow
+      - AIRFLOW_BASE_URL=http://localhost:8080
       - PYTHONPATH=/opt/raster-foundry/app-tasks/rf/src/
       - RF_HOST=http://rasterfoundry.com:9000
     command: airflow scheduler
@@ -146,6 +149,7 @@ services:
     env_file: .env
     environment:
       - AIRFLOW_HOME=/usr/local/airflow
+      - AIRFLOW_BASE_URL=http://localhost:8080
       - RF_HOST=http://rasterfoundry.com:9000
       - C_FORCE_ROOT=True
     command: airflow worker

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       - "5432"
 
   nginx:
-    image: rf-nginx
+    image: raster-foundry-nginx
     build:
       context: ./nginx
       dockerfile: Dockerfile
@@ -17,10 +17,12 @@ services:
       - "9100:443"
     links:
       - app-server
+      - airflow-webserver
     volumes:
       - ./nginx/srv/dist/:/srv/dist/
       - ./nginx/etc/nginx/nginx.conf:/etc/nginx/nginx.conf
-      - ./nginx/etc/nginx/conf.d/default.conf:/etc/nginx/conf.d/default.conf
+      - ./nginx/etc/nginx/conf.d/app.conf:/etc/nginx/conf.d/app.conf
+      - ./nginx/etc/nginx/conf.d/airflow.conf:/etc/nginx/conf.d/airflow.conf
 
   app-frontend:
     image: node:6.8-wheezy

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -7,4 +7,5 @@ COPY srv/dist /srv/dist/
 RUN chown nginx:nginx -R /srv/dist/
 
 COPY etc/nginx/nginx.conf /etc/nginx/nginx.conf
-COPY etc/nginx/conf.d/default.conf /etc/nginx/conf.d/default.conf
+COPY etc/nginx/conf.d/app.conf /etc/nginx/conf.d/app.conf
+COPY etc/nginx/conf.d/airflow.conf /etc/nginx/conf.d/airflow.conf

--- a/nginx/etc/nginx/conf.d/airflow.conf
+++ b/nginx/etc/nginx/conf.d/airflow.conf
@@ -1,0 +1,37 @@
+server {
+    listen 80;
+    server_name airflow.staging.rasterfoundry.com airflow.rasterfoundry.com;
+    return 301 https://$host$request_uri;
+}
+
+map $http_x_forwarded_proto $policy {
+    default "";
+    https   "default-src https: data: blob: 'unsafe-inline' 'unsafe-eval'";
+}
+
+upstream airflow-webserver-upstream {
+    server airflow-webserver:8080;
+}
+
+server {
+    listen 443;
+    server_name airflow.staging.rasterfoundry.com airflow.rasterfoundry.com;
+
+    # A set of recommended security headers:
+    #
+    #   https://scotthelme.co.uk/hardening-your-http-response-headers/
+    #
+    add_header Strict-Transport-Security "max-age=15552000; preload" always;
+    add_header Content-Security-Policy $policy always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header X-XSS-Protection "1; mode=block" always;
+
+    location / {
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Forwarded-For $remote_addr;
+        proxy_redirect off;
+
+        proxy_pass http://airflow-webserver-upstream;
+    }
+}

--- a/nginx/etc/nginx/conf.d/app.conf
+++ b/nginx/etc/nginx/conf.d/app.conf
@@ -1,7 +1,6 @@
-
 server {
     listen 80;
-    server_name staging.rasterfoundry.com rasterfoundry.com;
+    server_name app.staging.rasterfoundry.com app.rasterfoundry.com;
     return 301 https://$host$request_uri;
 }
 
@@ -16,7 +15,7 @@ upstream app-server-upstream {
 
 server {
     listen 443 default_server;
-    server_name staging.rasterfoundry.com rasterfoundry.com localhost;
+    server_name app.staging.rasterfoundry.com app.rasterfoundry.com localhost;
 
     # A set of recommended security headers:
     #


### PR DESCRIPTION
## Overview

In order to easily handle HTTP and HTTPS traffic in ECS, reverse proxy the Airflow web server with Nginx. Using Nginx virtual hosts allows us to reuse the existing Nginx container image, instead of building a new one just for Airflow.

Also, make use of the `AIRFLOW_BASE_URL` environment variable to override the Airflow `base_url` web server configuration setting. This provides a way to override it when Airflow is running in different environments with different URLs.

## Testing Instructions

Since the Airflow `base_url` setting mostly involves outbound emails, I don't really have a good way to test it. For now, I think it would be OK to let it slide until we actually setup outbound email.

To test the Nginx configuration changes, login to the ensure that `./scripts/server` is running. Then use execute the following command and ensure that Airflow attempts to issue a redirect:

```bash
vagrant@vagrant-ubuntu-trusty-64:/opt/raster-foundry$ curl -I -H "Host: airflow.rasterfoundry.com" localhost:9100
HTTP/1.1 302 FOUND
Server: nginx
Date: Mon, 07 Nov 2016 22:27:01 GMT
Content-Type: text/html; charset=utf-8
Content-Length: 221
Connection: keep-alive
Location: http://airflow.rasterfoundry.com/admin/
Strict-Transport-Security: max-age=15552000; preload
X-Content-Type-Options: nosniff
X-Frame-Options: SAMEORIGIN
X-XSS-Protection: 1; mode=block
```