### PR TITLE
Add model search and detail views

### DIFF
--- a/app-frontend/src/app/components/modelItem/modelItem.component.js
+++ b/app-frontend/src/app/components/modelItem/modelItem.component.js
@@ -1,0 +1,11 @@
+import modelTpl from './modelItem.html';
+
+const rfModelItem = {
+    templateUrl: modelTpl,
+    controller: 'ModelItemController',
+    bindings: {
+        modelData: '<'
+    }
+};
+
+export default rfModelItem;

--- a/app-frontend/src/app/components/modelItem/modelItem.controller.js
+++ b/app-frontend/src/app/components/modelItem/modelItem.controller.js
@@ -1,0 +1,5 @@
+export default class ModelItemController {
+    constructor() {
+        'ngInject';
+    }
+}

--- a/app-frontend/src/app/components/modelItem/modelItem.html
+++ b/app-frontend/src/app/components/modelItem/modelItem.html
@@ -1,0 +1,19 @@
+<div class="list-group-item selectable wrap">
+  <img ng-if="$ctrl.modelData.screenshots[0]"
+       ng-src="{{$ctrl.modelData.screenshots[0].url}}"
+       class="rounded-img item-img">
+  <img ng-if="!$ctrl.modelData.screenshots.length"
+       src="https://placehold.it/75x75/"
+       class="rounded-img item-img">
+  <div>
+    <div class="list-item-header">
+      {{$ctrl.modelData.name}}
+    </div>
+    <div class="list-item-description">
+      {{$ctrl.modelData.description}}
+    </div>
+    <div class="list-item-attribution">
+      Uploaded by: {{$ctrl.modelData.uploader}}
+    </div>
+  </div>
+</div>

--- a/app-frontend/src/app/components/modelItem/modelItem.module.js
+++ b/app-frontend/src/app/components/modelItem/modelItem.module.js
@@ -1,0 +1,10 @@
+import angular from 'angular';
+import ModelItemComponent from './modelItem.component.js';
+import ModelItemController from './modelItem.controller.js';
+
+const ModelItemModule = angular.module('components.modelItem', []);
+
+ModelItemModule.component('rfModelItem', ModelItemComponent);
+ModelItemModule.controller('ModelItemController', ModelItemController);
+
+export default ModelItemModule;

--- a/app-frontend/src/app/components/modelSearch/modelSearch.component.js
+++ b/app-frontend/src/app/components/modelSearch/modelSearch.component.js
@@ -1,0 +1,11 @@
+import searchTpl from './modelSearch.html';
+
+const rfModelSearch = {
+    templateUrl: searchTpl,
+    controller: 'ModelSearchController',
+    bindings: {
+        onSearch: '&'
+    }
+};
+
+export default rfModelSearch;

--- a/app-frontend/src/app/components/modelSearch/modelSearch.controller.js
+++ b/app-frontend/src/app/components/modelSearch/modelSearch.controller.js
@@ -1,0 +1,15 @@
+// rfModelSearch controller class
+export default class ModelSearchController {
+    constructor( // eslint-disable-line max-params
+        $log, $state
+    ) {
+        'ngInject';
+
+        this.$log = $log;
+        this.$state = $state;
+    }
+
+    onSearchAction(searchText) {
+        this.onSearch({text: searchText});
+    }
+}

--- a/app-frontend/src/app/components/modelSearch/modelSearch.html
+++ b/app-frontend/src/app/components/modelSearch/modelSearch.html
@@ -1,0 +1,29 @@
+<div class="navbar secondary-navbar">
+  <div class="navbar-left">
+    <nav ng-show="$ctrl.$state.$current.name === 'market.model'">
+      <a href ui-sref="market.search" class="active"> < Back to search results</a>
+    </nav>
+    <nav ng-show="$ctrl.$state.$current.name === 'market.search'">
+      <ng-submit ng-submit="$ctrl.onSearchAction($ctrl.searchText)">
+        <div class="form-group all-in-one input-dark">
+          <label for="search-input">
+            <i class="icon-search"></i>
+          </label>
+          <input type="text"
+                 id="search-input"
+                 class="form-control input-dark"
+                 placeholder="Search for models"
+                 ng-model="$ctrl.searchText"/>
+          <button type="button" class="btn btn-link">
+            <span class="close">x</span>
+          </button>
+        </div>
+      </ng-submit>
+    </nav>
+  </div>
+  <div class="navbar-right">
+    <nav>
+      <a href ui-sref="lab/list">My Models</a>
+    </nav>
+  </div>
+</div>

--- a/app-frontend/src/app/components/modelSearch/modelSearch.module.js
+++ b/app-frontend/src/app/components/modelSearch/modelSearch.module.js
@@ -1,0 +1,11 @@
+import angular from 'angular';
+
+import ModelSearchComponent from './modelSearch.component.js';
+import ModelSearchController from './modelSearch.controller.js';
+
+const ModelSearchModule = angular.module('components.modelSearch', []);
+
+ModelSearchModule.component('rfModelSearch', ModelSearchComponent);
+ModelSearchModule.controller('ModelSearchController', ModelSearchController);
+
+export default ModelSearchModule;

--- a/app-frontend/src/app/components/navBar/navBar.controller.js
+++ b/app-frontend/src/app/components/navBar/navBar.controller.js
@@ -18,8 +18,6 @@ export default class NavBarController {
 
         this.optionsOpen = false;
         this.assetLogo = assetLogo;
-
-        $log.debug('Navbar controller initialized');
     }
 
     signin() {

--- a/app-frontend/src/app/components/navBar/navBar.html
+++ b/app-frontend/src/app/components/navBar/navBar.html
@@ -7,8 +7,11 @@
 	  <span class="navbar-vertical-divider"></span>
 	  <nav>
 	    <a href ui-sref="browse" ui-sref-active="active">Scene browser</a>
-	    <a href ui-sref-active="active">Model market</a>
-	    <a href ui-sref-active="active">Model lab</a>
+	    <a href ui-sref="market.search"
+         ng-class="{
+                   active: $ctrl.$state.$current.name.includes('market')
+                   }">Model market</a>
+	    <a href ui-sref="lab" ui-sref-active="active">Model lab</a>
 	  </nav>
 	  <span class="navbar-vertical-divider"></span>
 	</div>

--- a/app-frontend/src/app/index.components.js
+++ b/app-frontend/src/app/index.components.js
@@ -1,6 +1,8 @@
 export default angular.module('index.components', [
     require('./components/leafletMap/leafletMap.module.js').name,
     require('./components/navBar/navBar.module.js').name,
+    require('./components/modelSearch/modelSearch.module.js').name,
+    require('./components/modelItem/modelItem.module.js').name,
     require('./components/filterPane/filterPane.module.js').name,
     require('./components/sceneItem/sceneItem.module.js').name,
     require('./components/sceneDetail/sceneDetail.module.js').name,

--- a/app-frontend/src/app/index.module.js
+++ b/app-frontend/src/app/index.module.js
@@ -35,6 +35,9 @@ const App = angular.module(
 
         // pages
         require('./pages/browse/browse.module.js').name,
+        require('./pages/market/market.module.js').name,
+        require('./pages/market/search/search.module.js').name,
+        require('./pages/market/model/model.module.js').name,
         require('./pages/library/library.module.js').name,
         require('./pages/library/scenes/scenes.module.js').name,
         require('./pages/library/scenes/list/list.module.js').name,

--- a/app-frontend/src/app/index.routes.js
+++ b/app-frontend/src/app/index.routes.js
@@ -1,4 +1,7 @@
 import browseTpl from './pages/browse/browse.html';
+import marketTpl from './pages/market/market.html';
+import marketSearchTpl from './pages/market/search/search.html';
+import marketModelTpl from './pages/market/model/model.html';
 import libraryTpl from './pages/library/library.html';
 import scenesTpl from './pages/library/scenes/scenes.html';
 import scenesListTpl from './pages/library/scenes/list/list.html';
@@ -139,10 +142,37 @@ function browseStates($stateProvider) {
         });
 }
 
+function marketStates($stateProvider) {
+    $stateProvider
+        .state('market', {
+            url: '/market',
+            templateUrl: marketTpl,
+            controller: 'MarketController',
+            controllerAs: '$ctrl',
+            abstract: true
+        })
+        .state('market.search', {
+            url: '/search?:query',
+            templateUrl: marketSearchTpl,
+            controller: 'MarketSearchController',
+            controllerAs: '$ctrl'
+        })
+        .state('market.model', {
+            url: '/model/:id',
+            params: {
+                modelData: null
+            },
+            templateUrl: marketModelTpl,
+            controller: 'MarketModelController',
+            controllerAs: '$ctrl'
+        });
+}
+
 function routeConfig($urlRouterProvider, $stateProvider) {
     'ngInject';
 
     browseStates($stateProvider);
+    marketStates($stateProvider);
     librarySceneStates($stateProvider);
     libraryBucketStates($stateProvider);
     settingsStates($stateProvider);

--- a/app-frontend/src/app/pages/library/buckets/buckets.controller.js
+++ b/app-frontend/src/app/pages/library/buckets/buckets.controller.js
@@ -1,10 +1,7 @@
 class BucketsController {
     constructor($log) {
         'ngInject';
-        const self = this;
-        self.$log = $log;
-
-        $log.debug('BucketsController initialized');
+        this.$log = $log;
     }
 }
 

--- a/app-frontend/src/app/pages/library/buckets/detail/scene/scene.controller.js
+++ b/app-frontend/src/app/pages/library/buckets/detail/scene/scene.controller.js
@@ -27,8 +27,6 @@ class BucketSceneController {
                 this.$state.go('^.scenes');
             }
         }
-
-        $log.debug('BucketSceneController initialized');
     }
 
     downloadModal() {

--- a/app-frontend/src/app/pages/library/library.controller.js
+++ b/app-frontend/src/app/pages/library/library.controller.js
@@ -1,9 +1,8 @@
 class LibraryController {
     constructor($log, $state) {
         'ngInject';
-        const self = this;
-        self.$log = $log;
-        self.$state = $state;
+        this.$log = $log;
+        this.$state = $state;
 
         // container view, so right panel contains nothing unless it's in a sub-route
     }

--- a/app-frontend/src/app/pages/market/market.controller.js
+++ b/app-frontend/src/app/pages/market/market.controller.js
@@ -1,0 +1,14 @@
+export default class MarketController {
+    constructor( // eslint-disable-line max-params
+        $log, $state
+    ) {
+        'ngInject';
+        this.$log = $log;
+        this.$state = $state;
+    }
+
+    onSearch(text) {
+        this.$log.log('searched for:', text);
+        this.$state.go('market.search', {query: text});
+    }
+}

--- a/app-frontend/src/app/pages/market/market.html
+++ b/app-frontend/src/app/pages/market/market.html
@@ -1,0 +1,2 @@
+<rf-model-search on-search="$ctrl.search(text)"></rf-model-search>
+<ui-view></ui-view>

--- a/app-frontend/src/app/pages/market/market.module.js
+++ b/app-frontend/src/app/pages/market/market.module.js
@@ -1,0 +1,8 @@
+import angular from 'angular';
+import MarketController from './market.controller.js';
+
+const MarketModule = angular.module('pages.market', []);
+
+MarketModule.controller('MarketController', MarketController);
+
+export default MarketModule;

--- a/app-frontend/src/app/pages/market/model/model.controller.js
+++ b/app-frontend/src/app/pages/market/model/model.controller.js
@@ -1,0 +1,94 @@
+export default class MarketModelController {
+    constructor( // eslint-disable-line max-params
+        $log, $state
+    ) {
+        'ngInject';
+        this.$log = $log;
+        this.$state = $state;
+
+        this.modelData = this.$state.params.modelData;
+        this.modelId = this.$state.params.id;
+        this.activeSlide = 0;
+        this.populateTestData();
+    }
+
+    populateTestData() {
+        this.similarQueryResult = {
+            count: 25,
+            hasNext: true,
+            hasPrevious: false,
+            pageSize: 10,
+            page: 1,
+            results: [{
+                name: 'Normalized Difference Vegetation Index - NDVI',
+                description: 'Analyze remote sensing measurements, ' +
+                    'and assess whether the target being observed contains' +
+                    'live green vegetation or not.',
+                uploader: 'Raster Foundry',
+                id: 'uuid1',
+                screenshots: [
+                    {id: 1, url: 'http://lorempixel.com/1000/480/'},
+                    {id: 2, url: 'http://lorempixel.com/1000/480/'},
+                    {id: 3, url: 'http://lorempixel.com/1000/480/'}
+                ],
+                tags: [
+                    'Image Classification', 'Tagged'
+                ],
+                categories: [
+                    'Climate', 'Ecosystems', 'Forestry', 'Farming', 'Plant Growth',
+                    'Prevention'
+                ],
+                requirements: '1 scene with NIR-1 and red band information',
+                createdAt: (new Date()).toISOString(),
+                modifiedAt: (new Date()).toISOString()
+            }, {
+                name: 'Direction of Surface Change',
+                description: 'Measures to 2-dimensional rate of surface change.' +
+                    'Output will be an integer layer with values 0-360',
+                uploader: 'Raster Foundry',
+                id: 'uuid2',
+                screenshots: [
+                    {id: 1, url: 'http://lorempixel.com/1000/480/'},
+                    {id: 2, url: 'http://lorempixel.com/1000/480/'},
+                    {id: 3, url: 'http://lorempixel.com/1000/480/'}
+                ],
+                tags: [
+                    'Image Classification', 'Tagged'
+                ],
+                categories: [
+                    'Climate', 'Ecosystems', 'Forestry', 'Farming', 'Plant Growth',
+                    'Prevention'
+                ],
+                requirements: '1 scene with NIR-1 and red band information',
+                createdAt: (new Date()).toISOString(),
+                modifiedAt: (new Date()).toISOString()
+            }, {
+                name: 'Topographic Position Index (TPI)',
+                description: 'The Topographic Position index (TPI) is a relative' +
+                    'measure of a location\'s elevation with respect to its ' +
+                    'surroundings.  It is calculated by subtracting the mean ' +
+                    'elevation of the 8 cells surrounding the cell from the ' +
+                    'cell\'s elevation. Given that TPI is calculated by comparing ' +
+                    'a central point to the surrounding elevation, there is the ' +
+                    'possibility of both positive and negative values.',
+                uploader: 'Raster Foundry',
+                id: 'uuid3',
+                screenshots: [
+                    {id: 1, url: 'http://lorempixel.com/1000/480/'},
+                    {id: 2, url: 'http://lorempixel.com/1000/480/'},
+                    {id: 3, url: 'http://lorempixel.com/1000/480/'}
+                ],
+                tags: [
+                    'Image Classification', 'Tagged'
+                ],
+                categories: [
+                    'Climate', 'Ecosystems', 'Forestry', 'Farming', 'Plant Growth',
+                    'Prevention'
+                ],
+                requirements: '1 scene with NIR-1 and red band information',
+                createdAt: (new Date()).toISOString(),
+                modifiedAt: (new Date()).toISOString()
+            }]
+        };
+    }
+}

--- a/app-frontend/src/app/pages/market/model/model.html
+++ b/app-frontend/src/app/pages/market/model/model.html
@@ -1,0 +1,183 @@
+<div class="container column-stretch dashboard">
+  <div class="main">
+    <div class="row content stack-sm">
+      <div class="column">
+        <div>
+          <h1 class="h3 page-title">
+            {{$ctrl.modelData.name || 'Placeholder name'}}
+          </h1>
+        </div>
+        <div>
+          <div uib-carousel
+               active="$ctrl.activeSlide"
+               template-url="carousel.html"
+               ng-if="$ctrl.modelData && $ctrl.modelData.screenshots.length"
+          >
+            <div uib-slide
+                 index="$index"
+                 ng-repeat="screenshot in $ctrl.modelData.screenshots track by screenshot.id">
+              <img ng-src="{{screenshot.url}}" >
+            </div>
+          </div>
+        </div>
+        <div class="horizontal-separator"></div>
+        <div class="model-detail-section">
+          <div class="model-detail-header">
+            <h5>Description</h5>
+          </div>
+          <div>
+            <p>
+              {{$ctrl.modelData.description}}
+            </p>
+          </div>
+        </div>
+        <div class="model-detail-section">
+          <table class="upload-info">
+            <tr>
+              <th>
+                Uploaded By
+              </th>
+              <th>
+                Upload date
+              </th>
+              <th>
+                Last modified
+              </th>
+            </tr>
+            <tr>
+              <td>
+                <a>{{$ctrl.modelData.uploader}}</a>
+              </td>
+              <td>
+                {{$ctrl.modelData.createdAt | date}}
+              </td>
+              <td>
+                {{$ctrl.modelData.modifiedAt | date}}
+              </td>
+            </tr>
+            </tbody>
+          </table>
+        </div>
+        <div class="model-detail-section">
+          <div class="model-detail-header">
+            <h5>Requirements for use</h5>
+          </div>
+          <div>
+            <p>
+              {{$ctrl.modelData.requirements}}
+            </p>
+          </div>
+        </div>
+        <div class="model-detail-section">
+          <div class="model-detail-header">
+            <h5>Tags</h5>
+          </div>
+          <div class="sidebar-category">
+            <button class="btn btn-tag"
+                    ng-repeat="tag in $ctrl.modelData.tags">
+              {{tag}}
+            </button>
+          </div>
+        </div>
+        <div class="model-detail-section">
+          <div class="model-detail-header">
+            <h5>Categories</h5>
+          </div>
+          <div class="sidebar-category">
+            <button class="btn btn-tag"
+                    ng-repeat="category in $ctrl.modelData.categories">
+              {{category}}
+            </button>
+          </div>
+        </div>
+        <div class="model-detail-section">
+          <div class="model-detail-header">
+            <h5>Usage License</h5>
+            <p>
+              No license information was provided. If this work was prepared by
+              Raster Foundry as part of the official Model marketplace, it is
+              considered a Raster Foundry work and usage should follow the general
+              <a>terms of use</a>
+            </p>
+          </div>
+        </div>
+        <div class="horizontal-separator"></div>
+        <div class="model-detail-section">
+          <div class="model-detail-header">
+            <h3>Compatible Data Sources</h3>
+          </div>
+          <div>
+          </div>
+        </div>
+        <div class="model-detail-section">
+          <div class="model-detail-header">
+            <h3>Similar Models</h3>
+          </div>
+          <div class="list-group">
+            <rf-model-item
+                ng-repeat="modelData in $ctrl.similarQueryResult.results"
+                model-data="modelData"
+            ></rf-model-item>
+          </div>
+        </div>
+      </div>
+      <div class="column-3">
+        <div class="content">
+          <button class="btn btn-flat" style="width: 100%;">Save to My models</button>
+          <div class="panel">
+            <div class="panel-body centered">
+              <h5>Free to use</h5>
+              <button class="btn btn-primary">Execute Model</button>
+            </div>
+          </div>
+          <div class="reference-list">
+            <div class="reference">
+              Preview
+            </div>
+            <div class="reference">
+              Description
+            </div>
+            <div class="reference">
+              Upload Info
+            </div>
+            <div class="reference">
+              Requirements
+            </div>
+            <div class="reference">
+              Tags
+            </div>
+            <div class="reference">
+              Category
+            </div>
+            <div class="reference">
+              License
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- TODO: Find another way to inject the carousel template into the angular cache -->
+<script type="text/ng-template" id="carousel.html">
+  <div class="carousel-inner" ng-transclude></div>
+  <button class="btn left carousel-control" ng-click="prev()"
+          ng-class="{ disabled: isPrevDisabled() }"
+          ng-show="slides.length > 1">
+    < Previous
+  </button>
+  <button class="btn right carousel-control"
+          ng-click="next()" ng-class="{ disabled: isNextDisabled() }"
+          ng-show="slides.length > 1">
+    Next >
+  </button>
+  <ol class="carousel-indicators" ng-show="slides.length > 1">
+    <li ng-repeat="slide in slides | orderBy:indexOfSlide track by $index" ng-class="{ active: isActive(slide) }" ng-click="select(slide)">
+      <span class="sr-only">
+        slide {{ $index + 1 }} of {{ slides.length }}
+        <span ng-if="isActive(slide)">, currently active</span>
+      </span>
+    </li>
+  </ol>
+</script>

--- a/app-frontend/src/app/pages/market/model/model.module.js
+++ b/app-frontend/src/app/pages/market/model/model.module.js
@@ -1,0 +1,8 @@
+import carousel from 'angular-ui-bootstrap/src/carousel';
+import MarketModelController from './model.controller.js';
+
+const MarketModelModule = angular.module('pages.market.model', [carousel]);
+
+MarketModelModule.controller('MarketModelController', MarketModelController);
+
+export default MarketModelModule;

--- a/app-frontend/src/app/pages/market/search/search.controller.js
+++ b/app-frontend/src/app/pages/market/search/search.controller.js
@@ -1,0 +1,131 @@
+export default class MarketSearchController {
+    constructor( // eslint-disable-line max-params
+        $log, $state
+    ) {
+        'ngInject';
+        this.$state = $state;
+
+        this.populatePlaceholderData();
+    }
+
+    populatePlaceholderData() {
+        this.searchTerms = ['NDVI', 'TERM', 'Vegetation', 'Azavea'];
+        this.tags = [
+            {
+                label: 'Vegetation Index',
+                selected: true
+            },
+            {
+                label: 'Image Classification',
+                selected: true
+            }
+        ];
+        this.categories = [
+            {
+                label: 'Agriculture',
+                selected: true
+            },
+            {
+                label: 'Aggregates',
+                selected: true
+            }
+        ];
+        this.queryResult = {
+            count: 25,
+            hasNext: true,
+            hasPrevious: false,
+            pageSize: 10,
+            page: 1,
+            results: [{
+                name: 'Normalized Difference Vegetation Index - NDVI',
+                description: 'Analyze remote sensing measurements, ' +
+                    'and assess whether the target being observed contains' +
+                    'live green vegetation or not.',
+                uploader: 'Raster Foundry',
+                id: 'uuid1',
+                screenshots: [
+                    {id: 1, url: 'https://placehold.it/800x480'},
+                    {id: 2, url: 'https://placehold.it/800x480'},
+                    {id: 3, url: 'https://placehold.it/800x480'}
+                ],
+                tags: [
+                    'Image Classification', 'Tagged'
+                ],
+                categories: [
+                    'Climate', 'Ecosystems', 'Forestry', 'Farming', 'Plant Growth',
+                    'Prevention'
+                ],
+                requirements: '1 scene with NIR-1 and red band information',
+                createdAt: (new Date()).toISOString(),
+                modifiedAt: (new Date()).toISOString()
+            }, {
+                name: 'Direction of Surface Change',
+                description: 'Measures to 2-dimensional rate of surface change.' +
+                    'Output will be an integer layer with values 0-360',
+                uploader: 'Raster Foundry',
+                id: 'uuid2',
+                screenshots: [
+                    {id: 1, url: 'https://placehold.it/800x480'},
+                    {id: 2, url: 'https://placehold.it/800x480'},
+                    {id: 3, url: 'https://placehold.it/800x480'}
+                ],
+                tags: [
+                    'Image Classification', 'Tagged'
+                ],
+                categories: [
+                    'Climate', 'Ecosystems', 'Forestry', 'Farming', 'Plant Growth',
+                    'Prevention'
+                ],
+                requirements: '1 scene with NIR-1 and red band information',
+                createdAt: (new Date()).toISOString(),
+                modifiedAt: (new Date()).toISOString()
+            }, {
+                name: 'Topographic Position Index (TPI)',
+                description: 'The Topographic Position index (TPI) is a relative' +
+                    'measure of a location\'s elevation with respect to its ' +
+                    'surroundings.  It is calculated by subtracting the mean ' +
+                    'elevation of the 8 cells surrounding the cell from the ' +
+                    'cell\'s elevation. Given that TPI is calculated by comparing ' +
+                    'a central point to the surrounding elevation, there is the ' +
+                    'possibility of both positive and negative values.',
+                uploader: 'Raster Foundry',
+                id: 'uuid3',
+                screenshots: [
+                    {id: 1, url: 'https://placehold.it/800x480'},
+                    {id: 2, url: 'https://placehold.it/800x480'},
+                    {id: 3, url: 'https://placehold.it/800x480'}
+                ],
+                tags: [
+                    'Image Classification', 'Tagged'
+                ],
+                categories: [
+                    'Climate', 'Ecosystems', 'Forestry', 'Farming', 'Plant Growth',
+                    'Prevention'
+                ],
+                requirements: '1 scene with NIR-1 and red band information',
+                createdAt: (new Date()).toISOString(),
+                modifiedAt: (new Date()).toISOString()
+            }]
+        };
+    }
+
+    removeSearchTerm(index) {
+        this.searchTerms.splice(index, 1);
+    }
+
+    clearSearch() {
+        this.searchTerms = [];
+    }
+
+    toggleTag(index) {
+        this.tags[index].selected = !this.tags[index].selected;
+    }
+
+    toggleCategory(index) {
+        this.categories[index].selected = !this.categories[index].selected;
+    }
+
+    navModel(model) {
+        this.$state.go('market.model', {id: model.id, modelData: model});
+    }
+}

--- a/app-frontend/src/app/pages/market/search/search.html
+++ b/app-frontend/src/app/pages/market/search/search.html
@@ -1,0 +1,96 @@
+<div class="container column-stretch dashboard-filter wide">
+  <div class="sidebar">
+    <div class="sidebar-scrollable">
+      <div class="sidebar-category">
+        <div class="sidebar-category-title">
+          Search Terms
+        </div>
+        <div class="sidebar-category-contents">
+          <button class="btn btn-tag"
+                  ng-repeat="searchTerm in $ctrl.searchTerms"
+                  ng-click="$ctrl.removeSearchTerm($index)">
+            {{searchTerm}}
+            <i class="icon-cross" ></i>
+          </button>
+        </div>
+        <div class="sidebar-category-actions">
+          <a href ng-click="$ctrl.clearSearch()">Clear All</a>
+        </div>
+      </div>
+      <div class="sidebar-separator"></div>
+      <div class="sidebar-category">
+        <div class="sidebar-category-title">
+          Tags
+        </div>
+        <div class="sidebar-category-contents">
+          <div class="sidebar-selection"
+               ng-repeat="tag in $ctrl.tags"
+               ng-click="$ctrl.toggleTag($index)">
+            <i ng-class="{'icon-check': tag.selected,
+                          'icon-cross': !tag.selected
+                         }"></i>
+            {{tag.label}}
+          </div>
+        </div>
+        <div class="sidebar-category-actions">
+          <a href ng-click="$ctrl.viewMoreTags()">View More</a>
+        </div>
+      </div>
+      <div class="sidebar-separator"></div>
+      <div class="sidebar-category">
+        <div class="sidebar-category-title">
+          Category
+        </div>
+        <div class="sidebar-category-contents">
+          <div class="sidebar-selection"
+               ng-repeat="category in $ctrl.categories"
+               ng-click="$ctrl.toggleCategory($index)">
+            <i class="icon-check"
+             ng-class="{'icon-check': category.selected,
+                        'icon-cross': !category.selected
+                       }"></i>
+            {{category.label}}
+          </div>
+        </div>
+        <div class="sidebar-category-actions">
+          <a href ng-click="$ctrl.viewMoreCategories()">View More</a>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="main">
+    <div class="content">
+      <div class="row stack-sm">
+        <h1 class="h3 page-title">
+          <a>Showing 1-10 of {{$ctrl.queryResult.count}} results</a>
+        </h1>
+      </div>
+      <div class="row stack-sm">
+        <div class="column">
+          <div class="embedded-scrollable">
+            <div class="list-group">
+              <rf-model-item
+                  ng-repeat="modelData in $ctrl.queryResult.results"
+                  model-data="modelData"
+                  ng-click="$ctrl.navModel(modelData)"
+              ></rf-model-item>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="list-group text-center"
+           ng-show="!$ctrl.loading && $ctrl.queryResult && $ctrl.queryResult.count !== 0 && !$ctrl.errorMsg">
+        <ul uib-pagination
+            items-per-page="$ctrl.queryResult.pageSize"
+            total-items="$ctrl.queryResult.count"
+            ng-model="$ctrl.currentPage"
+            max-size="4"
+            rotate="true"
+            boundary-link-numbers="true"
+            force-ellipses="true"
+            ng-change="$ctrl.populateModelList($ctrl.currentPage)">
+        </ul>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app-frontend/src/app/pages/market/search/search.module.js
+++ b/app-frontend/src/app/pages/market/search/search.module.js
@@ -1,0 +1,8 @@
+import angular from 'angular';
+import MarketSearchController from './search.controller.js';
+
+const MarketSearchModule = angular.module('pages.market.search', []);
+
+MarketSearchModule.controller('MarketSearchController', MarketSearchController);
+
+export default MarketSearchModule;

--- a/app-frontend/src/app/pages/settings/account/account.controller.js
+++ b/app-frontend/src/app/pages/settings/account/account.controller.js
@@ -1,10 +1,7 @@
 class AccountController {
     constructor($log) {
         'ngInject';
-        const self = this;
-        self.$log = $log;
-
-        $log.debug('AccountController initialized');
+        this.$log = $log;
     }
 }
 

--- a/app-frontend/src/app/pages/settings/profile/profile.controller.js
+++ b/app-frontend/src/app/pages/settings/profile/profile.controller.js
@@ -1,10 +1,8 @@
 class ProfileController {
     constructor($log, store) {
         'ngInject';
-        const self = this;
-        self.$log = $log;
+        this.$log = $log;
 
-        $log.debug('ProfileController initialized');
         this.profile = store.get('profile');
     }
 }

--- a/app-frontend/src/app/pages/settings/settings.controller.js
+++ b/app-frontend/src/app/pages/settings/settings.controller.js
@@ -1,10 +1,7 @@
 class SettingsController {
     constructor($log) {
         'ngInject';
-        const self = this;
-        self.$log = $log;
-
-        $log.debug('SettingsController initialized');
+        this.$log = $log;
     }
 }
 

--- a/app-frontend/src/app/pages/settings/tokens/tokens.controller.js
+++ b/app-frontend/src/app/pages/settings/tokens/tokens.controller.js
@@ -7,7 +7,6 @@ class TokensController {
         this.$uibModal = $uibModal;
         this.loading = true;
 
-        $log.debug('TokensController initialized');
         this.fetchTokens();
     }
 

--- a/app-frontend/src/assets/styles/sass/app.scss
+++ b/app-frontend/src/assets/styles/sass/app.scss
@@ -63,7 +63,8 @@
   "components/login",
   "components/item-detail",
   "components/pagination",
-  "components/slider";
+  "components/slider",
+  "components/carousel";
 
 /**
  * Pages

--- a/app-frontend/src/assets/styles/sass/base/_helpers.scss
+++ b/app-frontend/src/assets/styles/sass/base/_helpers.scss
@@ -62,3 +62,18 @@
 .hide {
   display: none !important;
 }
+
+// Only display content to screen readers
+//
+// See: http://a11yproject.com/posts/how-to-hide-content
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0,0,0,0);
+  border: 0;
+}

--- a/app-frontend/src/assets/styles/sass/components/_button.scss
+++ b/app-frontend/src/assets/styles/sass/components/_button.scss
@@ -120,6 +120,29 @@
   @include button-states($danger);
 }
 
+.btn-tag {
+  background-color: $brand-primary;
+  color: #fff;
+  font-weight: 700;
+  padding: 0.5rem;
+  border-radius: 1px;
+}
+
+
+.btn-flat {
+  border-color: transparent;
+  color: $brand-primary;
+  background-color: transparent;
+  font-weight: 700;
+
+  &:hover, &.hover,
+  &:active, &.active, {
+    background-color: transparent;
+    border-color: transparent;
+    color: $brand-secondary;
+  }
+}
+
 /* 
  * Button Sizes
  */
@@ -145,6 +168,7 @@
   display: block;
   width: 100%;
 }
+
 
 /* 
  * Button actions

--- a/app-frontend/src/assets/styles/sass/components/_carousel.scss
+++ b/app-frontend/src/assets/styles/sass/components/_carousel.scss
@@ -1,0 +1,228 @@
+//
+// Carousel
+// --------------------------------------------------
+
+$carousel-text-shadow:                        0 1px 2px rgba(0,0,0,.6) !default;
+
+$carousel-control-color:                      #fff !default;
+$carousel-control-width:                      15% !default;
+$carousel-control-opacity:                    1 !default;
+$carousel-control-font-size:                  20px !default;
+
+$carousel-indicator-active-bg:                $brand-primary !default;
+$carousel-indicator-border-color:             $shade-light !default;
+
+$carousel-caption-color:                      #fff !default;
+
+$screen-sm:                  768px !default;
+$screen-sm-min:              $screen-sm !default;
+
+
+// Wrapper for the slide container and indicators
+.carousel {
+  position: relative;
+  padding-bottom: 4rem;
+  img {
+    margin: auto;
+    height: 480px;
+  }
+}
+
+.carousel-inner {
+  position: relative;
+  overflow: hidden;
+  width: 100%;
+
+  > .item {
+    display: none;
+    position: relative;
+    @include transition(.6s ease-in-out left);
+
+    // Account for jankitude on images
+    > img,
+    > a > img {
+      @include img-responsive;
+      line-height: 1;
+    }
+
+    // WebKit CSS3 transforms for supported devices
+    @media all and (transform-3d), (-webkit-transform-3d) {
+      @include transition-transform(0.6s ease-in-out);
+      @include backface-visibility(hidden);
+      @include perspective(1000px);
+
+      &.next,
+      &.active.right {
+        @include translate3d(100%, 0, 0);
+        left: 0;
+      }
+      &.prev,
+      &.active.left {
+        @include translate3d(-100%, 0, 0);
+        left: 0;
+      }
+      &.next.left,
+      &.prev.right,
+      &.active {
+        @include translate3d(0, 0, 0);
+        left: 0;
+      }
+    }
+  }
+
+  > .active,
+  > .next,
+  > .prev {
+    display: block;
+  }
+
+  > .active {
+    left: 0;
+  }
+
+  > .next,
+  > .prev {
+    position: absolute;
+    top: 0;
+    width: 100%;
+  }
+
+  > .next {
+    left: 100%;
+  }
+  > .prev {
+    left: -100%;
+  }
+  > .next.left,
+  > .prev.right {
+    left: 0;
+  }
+
+  > .active.left {
+    left: -100%;
+  }
+  > .active.right {
+    left: 100%;
+  }
+
+}
+
+// Left/right controls for nav
+// ---------------------------
+
+.carousel-control {
+  position: absolute;
+  bottom: 0;
+  &.right {
+    left: auto;
+    right: 0;
+  }
+}
+
+// Optional indicator pips
+//
+// Add an unordered list with the following class and add a list item for each
+// slide your carousel holds.
+
+.carousel-indicators {
+  position: absolute;
+  bottom: 10px;
+  left: 50%;
+  z-index: 15;
+  width: 60%;
+  margin-left: -30%;
+  padding-left: 0;
+  list-style: none;
+  text-align: center;
+
+  li {
+    display: inline-block;
+    width:  10px;
+    height: 10px;
+    margin: 1px;
+    text-indent: -999px;
+    border: 1px solid $carousel-indicator-border-color;
+    border-radius: 10px;
+    cursor: pointer;
+
+    // IE8-9 hack for event handling
+    //
+    // Internet Explorer 8-9 does not support clicks on elements without a set
+    // `background-color`. We cannot use `filter` since that's not viewed as a
+    // background color by the browser. Thus, a hack is needed.
+    // See https://developer.mozilla.org/en-US/docs/Web/Events/click#Internet_Explorer
+    //
+    // For IE8, we set solid black as it doesn't support `rgba()`. For IE9, we
+    // set alpha transparency for the best results possible.
+    background-color: #000 \9; // IE8
+    background-color: rgba(0,0,0,0); // IE9
+  }
+  .active {
+    margin: 0;
+    width:  12px;
+    height: 12px;
+    background-color: $carousel-indicator-active-bg;
+  }
+}
+
+// Optional captions
+// -----------------------------
+// Hidden by default for smaller viewports
+.carousel-caption {
+  position: absolute;
+  left: 15%;
+  right: 15%;
+  bottom: 20px;
+  z-index: 10;
+  padding-top: 20px;
+  padding-bottom: 20px;
+  color: $carousel-caption-color;
+  text-align: center;
+  text-shadow: $carousel-text-shadow;
+  & .btn {
+    text-shadow: none; // No shadow for button elements in carousel-caption
+  }
+}
+
+
+// Scale up controls for tablets and up
+@media screen and (min-width: $screen-sm-min) {
+
+  // Scale up the controls a smidge
+  .carousel-control {
+    .glyphicon-chevron-left,
+    .glyphicon-chevron-right,
+    .icon-prev,
+    .icon-next {
+      width: ($carousel-control-font-size * 1.5);
+      height: ($carousel-control-font-size * 1.5);
+      margin-top: ($carousel-control-font-size / -2);
+      font-size: ($carousel-control-font-size * 1.5);
+    }
+    .glyphicon-chevron-left,
+    .icon-prev {
+      margin-left: ($carousel-control-font-size / -2);
+    }
+    .glyphicon-chevron-right,
+    .icon-next {
+      margin-right: ($carousel-control-font-size / -2);
+    }
+  }
+
+  // Show and left align the captions
+  .carousel-caption {
+    left: 20%;
+    right: 20%;
+    padding-bottom: 30px;
+  }
+
+  // Move down the indicators
+  .carousel-indicators {
+    bottom: -5px;
+  }
+}
+
+.ng-animate.item:not(.left):not(.right) {
+  -webkit-transition: 0s ease-in-out left;
+  transition: 0s ease-in-out left;
+}

--- a/app-frontend/src/assets/styles/sass/components/_dropdown.scss
+++ b/app-frontend/src/assets/styles/sass/components/_dropdown.scss
@@ -18,7 +18,7 @@
   position: absolute;
   top: 100%;
   left: 0;
-  z-index: 1000;
+  z-index: 1050;
   display: none; // none by default, but block on "open" of the menu
   float: left;
   min-width: 130px;
@@ -129,7 +129,7 @@
   right: 0;
   bottom: 0;
   top: 0;
-  z-index: 990;
+  z-index: 1049;
 }
 
 // Right aligned dropdowns

--- a/app-frontend/src/assets/styles/sass/components/_form.scss
+++ b/app-frontend/src/assets/styles/sass/components/_form.scss
@@ -5,6 +5,24 @@ form {
 
 .form-group {
   margin-bottom: 2rem;
+
+  &.input-dark {
+    border-color: $shade-dark;
+    background-color: $shade-dark;
+
+    &:focus {
+      border-color: $shade-normal;
+      outline: 0;
+      box-shadow: 0 0 8px rgba($shade-normal, .5);
+    }
+
+    .close {
+      color: $shade-light;
+    }
+    .btn:focus {
+      box-shadow: 0 0 8px rgba($brand-primary, .5);
+    }
+  }
 }
 
 label {
@@ -34,6 +52,16 @@ label {
     box-shadow: 0 0 8px rgba($brand-primary, .5);
   }
 
+  &.input-dark {
+    border-color: $shade-dark;
+    background-color: $shade-dark;
+
+    &:focus {
+      border-color: $shade-normal;
+      outline: 0;
+      box-shadow: 0 0 8px rgba($shade-normal, .5);
+    }
+  }
   // Placeholders
   &::-moz-placeholder {
     color: $shade-light;
@@ -62,6 +90,7 @@ label {
   &[disabled] {
     cursor: not-allowed;
   }
+
 }
 
 textarea.form-control {
@@ -114,5 +143,9 @@ input[type=radio] {
   .form-control {
     border: none;
     border-radius: 0;
+  }
+  &.input-dark {
+    border-color: $shade-dark;
+    background-color: $shade-dark;
   }
 }

--- a/app-frontend/src/assets/styles/sass/components/_list-group.scss
+++ b/app-frontend/src/assets/styles/sass/components/_list-group.scss
@@ -29,6 +29,20 @@
   }
 }
 
+
+.list-item-header {
+  color: $shade-dark;
+  font-weight: bold;
+}
+
+.list-item-description {
+}
+
+.list-item-attribution {
+  color: $shade-light;
+  font-weight: bold;
+}
+
 .list-group-subitem {
   padding: 1.5rem 1.5rem 1.5rem 1.5rem;
   margin: 0 0 0 3rem;
@@ -55,6 +69,7 @@
     margin: 0 0 0 6em;
   }
 }
+
 .list-group-item {
   padding: 1.5rem;
   border-bottom: 1px solid #ddd;
@@ -94,6 +109,10 @@
     left: 0;
     right: 0;
     bottom: 0;
+  }
+
+  &.wrap {
+    align-items: flex-start;
   }
 
   &.selectable {

--- a/app-frontend/src/assets/styles/sass/components/_nav.scss
+++ b/app-frontend/src/assets/styles/sass/components/_nav.scss
@@ -20,4 +20,8 @@ nav {
       }
     }
   }
+
+  .form-group {
+    margin: 0.5rem 0.5rem 0.5rem 2rem;
+  }
 }

--- a/app-frontend/src/assets/styles/sass/components/_panel.scss
+++ b/app-frontend/src/assets/styles/sass/components/_panel.scss
@@ -1,9 +1,16 @@
 .panel {
-  border: 1px solid #ddd;
+  border: 1px solid #ccc;
   border-radius: 2px;
 
   .panel-body {
     padding: 2rem;
+    &.centered {
+      text-align: center;
+    }
+    h5 {
+      margin: 0 0 1rem 0;
+      color: $shade-light;
+    }
   }
 }
 

--- a/app-frontend/src/assets/styles/sass/layout/_container.scss
+++ b/app-frontend/src/assets/styles/sass/layout/_container.scss
@@ -19,6 +19,14 @@
 	    max-width: 1160px;
       flex: 1;
     }
+    &.dashboard-filter {
+      width: 100%;
+      max-width: 1160px;
+      flex: 1;
+      &.wide {
+        max-width: initial;
+      }
+    }
   }
 }
 

--- a/app-frontend/src/assets/styles/sass/layout/_library.scss
+++ b/app-frontend/src/assets/styles/sass/layout/_library.scss
@@ -19,3 +19,25 @@
     }
   }
 }
+
+.horizontal-separator {
+  margin-top: 1em;
+  border-bottom: 1px solid #ddd;
+}
+
+.upload-info {
+  tr {
+    th {
+      font-weight: 700;
+      padding-right: 10em;
+      color: $shade-dark;
+    }
+  }
+  a {
+    cursor: pointer;
+    color: $brand-primary;
+    &:hover {
+      color: $brand-secondary;
+    }
+  }
+}

--- a/app-frontend/src/assets/styles/sass/layout/_navbar.scss
+++ b/app-frontend/src/assets/styles/sass/layout/_navbar.scss
@@ -2,7 +2,6 @@
   @extend %clearfix;
   background: $shade-normal;
   position: relative;
-  z-index: 1030;
   padding: 1rem;
   flex: none;
 
@@ -45,6 +44,11 @@
   }
   .username {
     padding-left: .5em;
+  }
+
+  &.secondary-navbar {
+    border-top: 1px solid $shade-dark;
+    padding: 0;
   }
 }
 

--- a/app-frontend/src/assets/styles/sass/layout/_sidebar.scss
+++ b/app-frontend/src/assets/styles/sass/layout/_sidebar.scss
@@ -12,6 +12,12 @@
     width: 22rem;
   }
 
+  .dashboard-filter & {
+    border-right: 1px solid #ddd;
+    padding: 2rem;
+    width: 25rem;
+  }
+
   .btn ~ nav {
     margin: 2rem 0;
   }
@@ -67,6 +73,40 @@
 .sidebar-scrollable {
   overflow: auto;
   flex: 1;
+}
+
+.sidebar-category {
+  * {
+    margin: 0.2em;
+  }
+}
+
+.sidebar-category-title {
+  font-weight: 700;
+}
+
+.sidebar-category-contents {
+
+}
+.sidebar-selection {
+  cursor: pointer;
+  &:hover {
+    color: $brand-primary;
+  }
+}
+
+.sidebar-category-actions {
+  * {
+    color: $brand-primary;
+    &:hover {
+      color: $shade-light;
+    }
+  }
+}
+
+.sidebar-separator {
+  height: 1em;
+  border-bottom: 1px solid #ddd;
 }
 
 .sidebar-extended {

--- a/app-frontend/src/assets/styles/sass/utils/_mixins.scss
+++ b/app-frontend/src/assets/styles/sass/utils/_mixins.scss
@@ -39,3 +39,68 @@
   border-bottom-left-radius: $radius;
   border-top-left-radius: $radius;
 }
+
+// Transitions
+@mixin transition($transition...) {
+  -webkit-transition: $transition;
+  -o-transition: $transition;
+  transition: $transition;
+}
+@mixin transition-transform($transition...) {
+  -webkit-transition: -webkit-transform $transition;
+  -moz-transition: -moz-transform $transition;
+  -o-transition: -o-transform $transition;
+  transition: transform $transition;
+}
+
+// Transformation
+@mixin translate3d($x, $y, $z) {
+  -webkit-transform: translate3d($x, $y, $z);
+  transform: translate3d($x, $y, $z);
+}
+@mixin perspective($perspective) {
+  -webkit-perspective: $perspective;
+  -moz-perspective: $perspective;
+  perspective: $perspective;
+}
+
+
+// Responsive image
+//
+// Keep images from scaling beyond the width of their parents.
+@mixin img-responsive($display: block) {
+  display: $display;
+  max-width: 100%; // Part 1: Set a maximum relative to the parent
+  height: auto; // Part 2: Scale the height according to the width, otherwise you get stretching
+}
+
+// Backface visibility
+// Prevent browsers from flickering when using CSS 3D transforms.
+// Default value is `visible`, but can be changed to `hidden`
+
+@mixin backface-visibility($visibility) {
+  -webkit-backface-visibility: $visibility;
+  -moz-backface-visibility: $visibility;
+  backface-visibility: $visibility;
+}
+
+// Opacity
+
+@mixin opacity($opacity) {
+  opacity: $opacity;
+  // IE8 filter
+  $opacity-ie: ($opacity * 100);
+  filter: alpha(opacity=$opacity-ie);
+}
+
+// Horizontal gradient, from left to right
+//
+// Creates two color stops, start and end, by specifying a color and position for each color stop.
+// Color stops are not available in IE9 and below.
+@mixin gradient-horizontal($start-color: #555, $end-color: #333, $start-percent: 0%, $end-percent: 100%) {
+  background-image: -webkit-linear-gradient(left, $start-color $start-percent, $end-color $end-percent); // Safari 5.1-6, Chrome 10+
+  background-image: -o-linear-gradient(left, $start-color $start-percent, $end-color $end-percent); // Opera 12
+  background-image: linear-gradient(to right, $start-color $start-percent, $end-color $end-percent); // Standard, IE10, Firefox 16+, Opera 12.10+, Safari 7+, Chrome 26+
+  background-repeat: repeat-x;
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#{ie-hex-str($start-color)}', endColorstr='#{ie-hex-str($end-color)}', GradientType=1); // IE9 and down
+}


### PR DESCRIPTION
## Overview

Add skeletons for market models and search views

### Demo

![anim](https://cloud.githubusercontent.com/assets/4392704/20112366/18e44b24-a5ba-11e6-9bd1-038e4ef87add.gif)

## Testing Instructions

* Start the frontend with `npm start` and navigate to localhost:9091
* Open the marketplace from the browse view by clicking on the Model Market link at the top of the page
* Click search terms to remove them from the list
* toggle tags / categories by clicking them
* Click into a model to view its detail view. Directly opening using a url doesn't work, as there isn't a backend to retrieve it directly, and placeholder data is generated in the search view
* Verify that the carousel works

Closes #627, Closes #628

