### PR TITLE
Add instructions for backfilling DAG runs and DAG schedules

### DIFF
--- a/app-tasks/README.md
+++ b/app-tasks/README.md
@@ -23,8 +23,22 @@ To enhance `dags` likely requires editing two different sets of files:
 
 | Name                      | Purpose                                                                  | Schedule |
 |---------------------------|--------------------------------------------------------------------------|----------|
+| find\_landsat8\_scenes    | Finds and imports Landsat 8 scenes on execution date                     | Daily    |
 | find\_sentinel2\_scenes   | Finds Sentinel 2 scenes uploaded on execution date and kicks off imports | Daily    |
 | import\_sentinel2\_scenes | Imports metadata for a set of sentinel 2 scenes                          | None     |
+
+# Common Airflow Commands
+
+## Running DAGs
+
+When the airflow scheduler starts (as part of `./scripts/server` for example), airflow will automatically start backfilling the DAGs it finds back to their start dates if it doesn't have a record of a successful run. This means you shouldn't have to do anything to trigger DAG runs for those circumstances. However, you may want to backfill even farther than the configured start dates for the above DAGs. If that's the case, use the below:
+
+- `./scripts/console airflow-scheduler bash`
+- To clear prevoius task runs (necessary if tasks fail or inaccurately report success): `airflow clear [-f] dag name`, e.g., `airflow clear -f find_landsat8_scenes` to clear failed DAG runs for `find_landsat8_scenes` (without the `-f` it would have cleare _all_ runs for `find_landsat8_scenes`).
+- For one-off runs: `airflow run dag_id task_id execution_date`, e.g., `airflow run find_landsat8_scenes import_new_landsat8_scenes 2016-03-05` to run the `import_new_landsat8_scenes` task in the `find_landsat8_scenes` DAG for March 5, 2016
+- For backfills: `airflow run [-t task_regex] [-s start_date] [-e end_date] dag_id`, e.g., `airflow backfill -t import.* -s 2015-12-13 -e 2015-12-31 find_landsat8_scenes` to run all tasks matching `import.*` from the `find_landsat8_scenes` DAG each of December 13 through December 31, 2016. Note: only DAGs with a `schedule_interval` defined can be backfilled.
+
+DAGs need a `concurrency` value for the `airflow-scheduler` to run more than one at a time. Currently that value is set to 4 in the development config file stored in AWS and defaults to 24 if the environment variable is unavailable.
 
 # Testing
 

--- a/app-tasks/dags/landsat8/import_landsat8_scenes.py
+++ b/app-tasks/dags/landsat8/import_landsat8_scenes.py
@@ -18,7 +18,7 @@ rf_logger.addHandler(ch)
 
 logger = logging.getLogger(__name__)
 
-start_date = datetime(2016, 9, 25)
+start_date = datetime(2016, 11, 6)
 
 args = {
     'owner': 'raster-foundry',
@@ -28,7 +28,8 @@ args = {
 dag = DAG(
     dag_id='find_landsat8_scenes',
     default_args=args,
-    schedule_interval=None
+    schedule_interval='@daily',
+    concurrency=int(os.getenv('AIRFLOW_DAG_CONCURRENCY', 24))
 )
 
 

--- a/app-tasks/dags/sentinel2/find_sentinel2_scenes.py
+++ b/app-tasks/dags/sentinel2/find_sentinel2_scenes.py
@@ -1,6 +1,7 @@
 from collections import namedtuple
 import json
 import logging
+import os
 
 from airflow.bin.cli import trigger_dag
 from airflow.operators.python_operator import PythonOperator
@@ -19,7 +20,7 @@ rf_logger.addHandler(ch)
 logger = logging.getLogger(__name__)
 
 
-start_date = datetime(2016, 9, 25)
+start_date = datetime(2016, 11, 6)
 
 
 args = {
@@ -31,7 +32,8 @@ args = {
 dag = DAG(
     dag_id='find_sentinel2_scenes',
     default_args=args,
-    schedule_interval=None
+    schedule_interval='@daily',
+    concurrency=int(os.getenv('AIRFLOW_DAG_CONCURRENCY', 24))
 )
 
 

--- a/app-tasks/dags/sentinel2/import_sentinel2_scenes.py
+++ b/app-tasks/dags/sentinel2/import_sentinel2_scenes.py
@@ -30,7 +30,8 @@ args = {
 dag = DAG(
     dag_id='import_sentinel2_scenes',
     default_args=args,
-    schedule_interval=None
+    schedule_interval=None,
+    concurrency=int(os.getenv('AIRFLOW_DAG_CONCURRENCY', 24))
 )
 
 

--- a/app-tasks/rf/src/rf/uploads/landsat8/create_scenes.py
+++ b/app-tasks/rf/src/rf/uploads/landsat8/create_scenes.py
@@ -48,11 +48,12 @@ def create_landsat8_scenes(csv_row):
     landsat_id = csv_row.pop('sceneID')
     landsat_path = get_landsat_path(landsat_id)
     if not s3_obj_exists(aws_landsat_base + landsat_path + 'index.html'):
-        logger.error(
+        logger.warn(
             'AWS and USGS are not always in sync. Try again in several hours.\n'
             'If you believe this message is in error, check %s manually.',
             aws_landsat_base + landsat_path
         )
+        return []
     timestamp = csv_row.pop('acquisitionDate') + 'T00:00:00.000Z'
     cloud_cover = float(csv_row.pop('cloudCoverFull'))
     sun_elevation = float(csv_row.pop('sunElevation'))

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -144,7 +144,7 @@ services:
       - AIRFLOW_BASE_URL=http://localhost:8080
       - AIRFLOW_WEBSERVER_WORKERS=1
       - AIRFLOW_SECRET_KEY=secret
-      - AIRFLOW_CELERY_CONCURRENCY=16
+      - AIRFLOW_CELERY_CONCURRENCY=4
       - PYTHONPATH=/opt/raster-foundry/app-tasks/rf/src/
       - RF_HOST=http://rasterfoundry.com:9000
     command: airflow scheduler
@@ -172,7 +172,7 @@ services:
       - AIRFLOW_BASE_URL=http://localhost:8080
       - AIRFLOW_WEBSERVER_WORKERS=1
       - AIRFLOW_SECRET_KEY=secret
-      - AIRFLOW_CELERY_CONCURRENCY=16
+      - AIRFLOW_CELERY_CONCURRENCY=4
       - RF_HOST=http://rasterfoundry.com:9000
       - C_FORCE_ROOT=True
     command: airflow worker


### PR DESCRIPTION
## Overview

Adds an explanation to `app-tasks/README.md` for how to get backfills going for scene creation.
Additionally, sets DAG concurrency using the .env configuration file
downloaded from S3 and adds scheduling to the two existing import processes.

As noted in #611, it takes a lot of attention to get imports running. That's not great since we all want to have scenes in our local databases, and we should be able to get to that state using our importers.

### Checklist

- [x] Styleguide updated, if necessary
- [x] Swagger specification updated, if necessary

## Testing Instructions

To test that the scheduling works as described in the first paragraph of the `app-tasks/README.md` diff:

 * `vagrant ssh`
 * `./scripts/bootstrap` to pull in the concurrency setting
 * `./scripts/console airflow-scheduler bash` --> `airflow resetdb` to clear out any existing task runs you may have in your airflow db
 * `docker-compose stop` <-- the idea here is to keep only what's necessary running and to control a bit when things come up
 * Order matters: sometimes if `app-server` takes too long to come up, the airflow scheduler gets impatient and tries to hit it with new scenes before the API is ready
   * `docker-compose up -d nginx postgres`
   * `docker-compose up app-server`, then wait for `Running com.azavea.rf.Main` and binding types to DB types. Leave this up so you can see server side errors.
   * `docker-compose up -d airflow-scheduler airflow-worker`
 * Navigate to `localhost:8080`. You should have some little light green circles indicating running tasks in this area: 
![image](https://cloud.githubusercontent.com/assets/5702984/20117324/09ee0bfa-a5ce-11e6-9011-85f95e9bc38a.png)
If you don't, wait three minutes and refresh the page.
 * Wait a while. Those running tasks will add a bunch of scenes to your database. They're configured to start on `2016-11-06` right now, so to confirm that this is happening:
   * `./scripts/psql`, `select datasource, count(*) from scenes group by datasource;` every once in a while to see progress

To test the other instructions, just do what they say with the containers mentioned above running.

Closes #611 
