### PR TITLE
Optimize server side grouping of scenes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -86,12 +86,12 @@ services:
       - redis:cache.service.rasterfoundry.internal
     environment:
       - AIRFLOW_HOME=/usr/local/airflow
-      - AIRFLOW_PARALLELISM=32
+      - AIRFLOW_PARALLELISM=2
       - AIRFLOW_FERNET_KEY=secret
       - AIRFLOW_BASE_URL=http://localhost:8080
       - AIRFLOW_WEBSERVER_WORKERS=1
       - AIRFLOW_SECRET_KEY=secret
-      - AIRFLOW_CELERY_CONCURRENCY=16
+      - AIRFLOW_CELERY_CONCURRENCY=4
       - RF_HOST=http://rasterfoundry.com:9000
     ports:
       - "8080:8080"
@@ -110,12 +110,12 @@ services:
     env_file: .env
     environment:
       - AIRFLOW_HOME=/usr/local/airflow
-      - AIRFLOW_PARALLELISM=32
+      - AIRFLOW_PARALLELISM=2
       - AIRFLOW_FERNET_KEY=secret
       - AIRFLOW_BASE_URL=http://localhost:8080
       - AIRFLOW_WEBSERVER_WORKERS=1
       - AIRFLOW_SECRET_KEY=secret
-      - AIRFLOW_CELERY_CONCURRENCY=16
+      - AIRFLOW_CELERY_CONCURRENCY=4
       - RF_HOST=http://rasterfoundry.com:9000
     ports:
       - "5555:5555"


### PR DESCRIPTION
## Overview

This commit optimizes the server side join in the case where the set of
scenes returned from the database includes duplicate rows for scenes,
thumbnails, bands, and images. The original code seemed to be doing some
duplicate grouping and flattening that can be done slightly more
concisely.

### Checklist

- [X] Styleguide updated, if necessary
- [X] Swagger specification updated, if necessary

## Testing Instructions

 * Import some scenes with airflow to ensure that the scenes have bands
 * Try to hit `/api/scenes/` and also start the server and browse the application
 * Endpoints/servers should not crash

