### PR TITLE
Update Airflow configuration; add Flower reverse proxy

### DIFF
--- a/app-tasks/usr/local/airflow/airflow.cfg
+++ b/app-tasks/usr/local/airflow/airflow.cfg
@@ -42,7 +42,7 @@ sql_alchemy_pool_recycle = 3600
 # The amount of parallelism as a setting to the executor. This defines
 # the max number of task instances that should run simultaneously
 # on this airflow installation
-parallelism = 32
+parallelism = ${AIRFLOW_PARALLELISM}
 
 # The number of task instances allowed to run concurrently by the scheduler
 dag_concurrency = 24
@@ -62,7 +62,7 @@ load_examples = False
 plugins_folder = /usr/local/airflow/plugins
 
 # Secret key to save connection passwords in the db
-fernet_key = ${AIRFLOW_SECRET_KEY}
+fernet_key = ${AIRFLOW_FERNET_KEY}
 
 # Whether to disable pickling dags
 donot_pickle = False
@@ -86,10 +86,10 @@ web_server_port = 8080
 web_server_worker_timeout = 120
 
 # Secret key used to run your flask app
-secret_key = temporary_key
+secret_key = ${AIRFLOW_SECRET_KEY}
 
 # Number of workers to run the Gunicorn web server
-workers = 2
+workers = ${AIRFLOW_WEBSERVER_WORKERS}
 
 # The worker class gunicorn should use. Choices include
 # sync (default), eventlet, gevent
@@ -130,7 +130,7 @@ celery_app_name = airflow.executors.celery_executor
 # "airflow worker" command. This defines the number of task instances that
 # a worker will take, so size up your workers based on the resources on
 # your worker box and the nature of your tasks
-celeryd_concurrency = 16
+celeryd_concurrency = ${AIRFLOW_CELERY_CONCURRENCY}
 
 # When you start an airflow worker, airflow starts a tiny web server
 # subprocess to serve the workers local log files to the airflow main
@@ -175,40 +175,3 @@ scheduler_heartbeat_sec = 5
 # This defines how many threads will run. However airflow will never
 # use more threads than the amount of cpu cores available.
 max_threads = 1
-
-[mesos]
-# Mesos master address which MesosExecutor will connect to.
-master = localhost:5050
-
-# The framework name which Airflow scheduler will register itself as on mesos
-framework_name = Airflow
-
-# Number of cpu cores required for running one task instance using
-# 'airflow run <dag_id> <task_id> <execution_date> --local -p <pickle_id>'
-# command on a mesos slave
-task_cpu = 1
-
-# Memory in MB required for running one task instance using
-# 'airflow run <dag_id> <task_id> <execution_date> --local -p <pickle_id>'
-# command on a mesos slave
-task_memory = 256
-
-# Enable framework checkpointing for mesos
-# See http://mesos.apache.org/documentation/latest/slave-recovery/
-checkpoint = False
-
-# Failover timeout in milliseconds.
-# When checkpointing is enabled and this option is set, Mesos waits
-# until the configured timeout for
-# the MesosExecutor framework to re-register after a failover. Mesos
-# shuts down running tasks if the
-# MesosExecutor framework fails to re-register within this timeframe.
-# failover_timeout = 604800
-
-# Enable framework authentication for mesos
-# See http://mesos.apache.org/documentation/latest/configuration/
-authenticate = False
-
-# Mesos credentials, if authentication is enabled
-# default_principal = admin
-# default_secret = admin

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,7 +85,12 @@ services:
       - redis:cache.service.rasterfoundry.internal
     environment:
       - AIRFLOW_HOME=/usr/local/airflow
+      - AIRFLOW_PARALLELISM=32
+      - AIRFLOW_FERNET_KEY=secret
       - AIRFLOW_BASE_URL=http://localhost:8080
+      - AIRFLOW_WEBSERVER_WORKERS=1
+      - AIRFLOW_SECRET_KEY=secret
+      - AIRFLOW_CELERY_CONCURRENCY=16
       - RF_HOST=http://rasterfoundry.com:9000
     ports:
       - "8080:8080"
@@ -104,7 +109,12 @@ services:
     env_file: .env
     environment:
       - AIRFLOW_HOME=/usr/local/airflow
+      - AIRFLOW_PARALLELISM=32
+      - AIRFLOW_FERNET_KEY=secret
       - AIRFLOW_BASE_URL=http://localhost:8080
+      - AIRFLOW_WEBSERVER_WORKERS=1
+      - AIRFLOW_SECRET_KEY=secret
+      - AIRFLOW_CELERY_CONCURRENCY=16
       - RF_HOST=http://rasterfoundry.com:9000
     ports:
       - "5555:5555"
@@ -128,7 +138,12 @@ services:
     env_file: .env
     environment:
       - AIRFLOW_HOME=/usr/local/airflow
+      - AIRFLOW_PARALLELISM=32
+      - AIRFLOW_FERNET_KEY=secret
       - AIRFLOW_BASE_URL=http://localhost:8080
+      - AIRFLOW_WEBSERVER_WORKERS=1
+      - AIRFLOW_SECRET_KEY=secret
+      - AIRFLOW_CELERY_CONCURRENCY=16
       - PYTHONPATH=/opt/raster-foundry/app-tasks/rf/src/
       - RF_HOST=http://rasterfoundry.com:9000
     command: airflow scheduler
@@ -151,7 +166,12 @@ services:
     env_file: .env
     environment:
       - AIRFLOW_HOME=/usr/local/airflow
+      - AIRFLOW_PARALLELISM=32
+      - AIRFLOW_FERNET_KEY=secret
       - AIRFLOW_BASE_URL=http://localhost:8080
+      - AIRFLOW_WEBSERVER_WORKERS=1
+      - AIRFLOW_SECRET_KEY=secret
+      - AIRFLOW_CELERY_CONCURRENCY=16
       - RF_HOST=http://rasterfoundry.com:9000
       - C_FORCE_ROOT=True
     command: airflow worker

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
     links:
       - app-server
       - airflow-webserver
+      - airflow-flower
     volumes:
       - ./nginx/srv/dist/:/srv/dist/
       - ./nginx/etc/nginx/nginx.conf:/etc/nginx/nginx.conf

--- a/nginx/etc/nginx/conf.d/airflow.conf
+++ b/nginx/etc/nginx/conf.d/airflow.conf
@@ -1,6 +1,6 @@
 server {
     listen 80;
-    server_name airflow.staging.rasterfoundry.com airflow.rasterfoundry.com;
+    server_name airflow.staging.rasterfoundry.com flower.staging.rasterfoundry.com airflow.rasterfoundry.com flower.rasterfoundry.com;
     return 301 https://$host$request_uri;
 }
 
@@ -33,5 +33,32 @@ server {
         proxy_redirect off;
 
         proxy_pass http://airflow-webserver-upstream;
+    }
+}
+
+upstream airflow-flower-upstream {
+    server airflow-flower:5555;
+}
+
+server {
+    listen 443;
+    server_name flower.staging.rasterfoundry.com flower.rasterfoundry.com;
+
+    # A set of recommended security headers:
+    #
+    #   https://scotthelme.co.uk/hardening-your-http-response-headers/
+    #
+    add_header Strict-Transport-Security "max-age=15552000; preload" always;
+    add_header Content-Security-Policy $policy always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header X-XSS-Protection "1; mode=block" always;
+
+    location / {
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Forwarded-For $remote_addr;
+        proxy_redirect off;
+
+        proxy_pass http://airflow-flower-upstream;
     }
 }


### PR DESCRIPTION
## Overview

Add support for setting the following Airflow settings via environment variables:

- `core.parallelism`
- `core.fernet_key`
- `webserver.secret_key`
- `webserver.workers`
- `celery.celeryd_concurrency`

Also, remove all Mesos configuration settings because we're not using it, and add a virtual host to the Nginx configuration for the Flower service.

Resolves:

- https://github.com/azavea/raster-foundry/issues/586
- https://github.com/azavea/raster-foundry/issues/607

## Testing Instructions

Using `./scripts/server`, start all of the Airflow components and ensure that they don't complain about any of the passed-through settings changes.

The Flower reverse proxy changes can be tested via https://github.com/azavea/raster-foundry-deployment/pull/13.