### PR TITLE
Add Airflow remote log configuration via environment

### DIFF
--- a/app-tasks/usr/local/airflow/airflow.cfg
+++ b/app-tasks/usr/local/airflow/airflow.cfg
@@ -13,8 +13,8 @@ base_log_folder = /usr/local/airflow/logs
 # must supply a remote location URL (starting with either 's3://...' or
 # 'gs://...') and an Airflow connection id that provides access to the storage
 # location.
-remote_base_log_folder =
-remote_log_conn_id =
+remote_base_log_folder = ${AIRFLOW_REMOTE_LOG_FOLDER}
+remote_log_conn_id = ${AIRFLOW_REMOTE_LOG_CONN_ID}
 
 # Use server-side encryption for logs stored in S3
 encrypt_s3_logs = False

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -110,6 +110,8 @@ services:
     env_file: .env
     environment:
       - AIRFLOW_HOME=/usr/local/airflow
+      - AIRFLOW_REMOTE_LOG_FOLDER=
+      - AIRFLOW_REMOTE_LOG_CONN_ID=
       - AIRFLOW_PARALLELISM=2
       - AIRFLOW_FERNET_KEY=secret
       - AIRFLOW_BASE_URL=http://localhost:8080
@@ -139,6 +141,8 @@ services:
     env_file: .env
     environment:
       - AIRFLOW_HOME=/usr/local/airflow
+      - AIRFLOW_REMOTE_LOG_FOLDER=
+      - AIRFLOW_REMOTE_LOG_CONN_ID=
       - AIRFLOW_PARALLELISM=32
       - AIRFLOW_FERNET_KEY=secret
       - AIRFLOW_BASE_URL=http://localhost:8080
@@ -167,6 +171,8 @@ services:
     env_file: .env
     environment:
       - AIRFLOW_HOME=/usr/local/airflow
+      - AIRFLOW_REMOTE_LOG_FOLDER=
+      - AIRFLOW_REMOTE_LOG_CONN_ID=
       - AIRFLOW_PARALLELISM=32
       - AIRFLOW_FERNET_KEY=secret
       - AIRFLOW_BASE_URL=http://localhost:8080


### PR DESCRIPTION
## Overview

Use environment variables to configuration the `remote_base_log_folder` and `remote_log_conn_id` Airflow settings. Default to having the settings unset locally.

## Testing Instructions

Using `./scripts/server`, start all of the Airflow components and ensure that they don't complain about any of the passed-through settings changes.

The actual Airflow remote logging can be tested via https://github.com/azavea/raster-foundry-deployment/pull/14.