### PR TITLE
Change 'Landsat-8' to 'Landsat 8' on the frontend

### DIFF
--- a/app-frontend/src/app/components/filterPane/filterPane.controller.js
+++ b/app-frontend/src/app/components/filterPane/filterPane.controller.js
@@ -199,7 +199,7 @@ export default class FilterPaneController {
             self: {label: 'My Imports', enabled: false},
             users: {label: 'Raster Foundry Users', enabled: false},
             'Sentinel-2': {label: 'Sentinel-2', enabled: false},
-            'Landsat-8': {label: 'Landsat-8', enabled: false}
+            'Landsat 8': {label: 'Landsat 8', enabled: false}
         };
         if (this.filters.datasource) {
             if (


### PR DESCRIPTION
## Overview

Trivial fix - datasource name needs to be `Landsat 8` not `Landsat-8` on the frontend to match the datasource

### Notes

Trivial - Merging

