### PR TITLE
Feature/add model tags endpoint

### DIFF
--- a/app-backend/app/src/main/scala/Router.scala
+++ b/app-backend/app/src/main/scala/Router.scala
@@ -2,10 +2,8 @@ package com.azavea.rf
 
 
 import scala.concurrent.ExecutionContext
-
 import ch.megard.akka.http.cors.CorsDirectives._
 import ch.megard.akka.http.cors.CorsSettings
-
 import com.azavea.rf.bucket.BucketRoutes
 import com.azavea.rf.healthcheck._
 import com.azavea.rf.organization.OrganizationRoutes
@@ -15,6 +13,7 @@ import com.azavea.rf.user.UserRoutes
 import com.azavea.rf.image.ImageRoutes
 import com.azavea.rf.config.ConfigRoutes
 import com.azavea.rf.database.Database
+import com.azavea.rf.modeltag.ModelTagRoutes
 import com.azavea.rf.token.TokenRoutes
 
 
@@ -32,6 +31,7 @@ trait Router extends HealthCheckRoutes
     with ImageRoutes
     with TokenRoutes
     with ThumbnailRoutes
+    with ModelTagRoutes
     with ConfigRoutes {
 
   implicit def database: Database
@@ -49,7 +49,8 @@ trait Router extends HealthCheckRoutes
       pathPrefix("scenes") { sceneRoutes } ~
       pathPrefix("thumbnails") { thumbnailRoutes } ~
       pathPrefix("tokens") { tokenRoutes } ~
-      pathPrefix("users") { userRoutes }
+      pathPrefix("users") { userRoutes } ~
+      pathPrefix("model-tags") { modelTagRoutes }
     } ~
     pathPrefix("config") {
       configRoutes

--- a/app-backend/app/src/main/scala/tags/Routes.scala
+++ b/app-backend/app/src/main/scala/tags/Routes.scala
@@ -1,0 +1,80 @@
+package com.azavea.rf.modeltag
+
+import java.util.UUID
+
+import scala.util.{Success, Failure}
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.server.Route
+import com.azavea.rf.auth.Authentication
+import com.azavea.rf.database.Database
+import com.azavea.rf.database.tables.ModelTags
+import com.azavea.rf.datamodel._
+import com.azavea.rf.utils.UserErrorHandler
+import com.lonelyplanet.akka.http.extensions.PaginationDirectives
+
+trait ModelTagRoutes extends Authentication with PaginationDirectives with UserErrorHandler {
+  implicit def database: Database
+
+  val modelTagRoutes: Route = handleExceptions(userExceptionHandler) {
+    pathEndOrSingleSlash {
+      get { listModelTags } ~
+      post { createModelTag }
+    } ~
+    pathPrefix(JavaUUID) { modelTagId =>
+      pathEndOrSingleSlash {
+        get { getModelTag(modelTagId) } ~
+        put { updateModelTag(modelTagId) } ~
+        delete { deleteModelTag(modelTagId) }
+      }
+    }
+  }
+
+  def listModelTags: Route = authenticate { user =>
+    (withPagination) { (page) =>
+      complete {
+        ModelTags.listModelTags(page)
+      }
+    }
+  }
+
+  def createModelTag: Route = authenticate { user =>
+    entity(as[ModelTag.Create]) { newModelTag =>
+      onSuccess(ModelTags.insertModelTag(newModelTag, user.id)) { modelTag =>
+        complete(StatusCodes.Created, modelTag)
+      }
+    }
+  }
+
+  def getModelTag(modelTagId: UUID): Route = authenticate { user =>
+    rejectEmptyResponse {
+      complete(ModelTags.getModelTag(modelTagId))
+    }
+  }
+
+  def updateModelTag(modelTagId: UUID): Route = authenticate { user =>
+    entity(as[ModelTag]) { updatedModelTag =>
+      onComplete(ModelTags.updateModelTag(updatedModelTag, modelTagId, user)) {
+        case Success(result) => {
+          result match {
+            case 1 => complete(StatusCodes.NoContent)
+            case count => throw new IllegalStateException(
+              s"Error updating model tag: update result expected to be 1, was $count"
+            )
+          }
+        }
+        case Failure(e) => throw e
+      }
+    }
+  }
+
+  def deleteModelTag(modelTagId: UUID): Route = authenticate { user =>
+    onSuccess(ModelTags.deleteModelTag(modelTagId)) {
+      case 1 => complete(StatusCodes.NoContent)
+      case 0 => complete(StatusCodes.NotFound)
+      case count => throw new IllegalStateException(
+        s"Error deleting tag: delete result expected to be 1, was $count"
+      )
+    }
+  }
+
+}

--- a/app-backend/app/src/main/scala/tags/package.scala
+++ b/app-backend/app/src/main/scala/tags/package.scala
@@ -1,0 +1,8 @@
+package com.azavea.rf
+
+import com.azavea.rf.datamodel._
+
+
+package object modeltag extends RfJsonProtocols {
+  implicit val paginatedModelTagsFormat = jsonFormat6(PaginatedResponse[ModelTag])
+}

--- a/app-backend/app/src/test/scala/tags/ModelTagSpec.scala
+++ b/app-backend/app/src/test/scala/tags/ModelTagSpec.scala
@@ -1,0 +1,85 @@
+package com.azavea.rf.modeltag
+
+import java.util.UUID
+
+import akka.http.scaladsl.model.{ContentTypes, HttpEntity, StatusCodes}
+import akka.http.scaladsl.server.Route
+import akka.http.scaladsl.testkit.ScalatestRouteTest
+import com.azavea.rf.datamodel._
+import com.azavea.rf.utils.Config
+import com.azavea.rf.{AuthUtils, DBSpec, Router}
+import org.scalatest.{Matchers, WordSpec}
+import spray.json._
+
+class ModelTagSpec extends WordSpec
+    with Matchers
+    with ScalatestRouteTest
+    with Config
+    with Router
+    with DBSpec {
+
+  implicit val ec = system.dispatcher
+  implicit def database = db
+
+  val authorization = AuthUtils.generateAuthHeader("Default")
+  val publicOrgId = UUID.fromString("dfac6307-b5ef-43f7-beda-b9f208bb7726")
+  val baseModelTag = "/model-tags/"
+  val newModelTag = ModelTag.Create(
+    publicOrgId,
+    "test tag"
+  )
+
+  // Alias to baseRoutes to be explicit
+  val baseRoutes = routes
+
+  "/api/model-tags/{uuid}" should {
+    "return a 404 for non-existent model tag" ignore {
+      Get(s"${baseModelTag}${publicOrgId}") ~> Route.seal(baseRoutes) ~> check {
+        status shouldEqual StatusCodes.NotFound
+      }
+    }
+
+    "update a model tag" ignore {
+      // TODO: Add model update when DB interaction is fixed
+    }
+
+    "delete a model tag" ignore {
+      val modelTagId = ""
+      Delete(s"${baseModelTag}${modelTagId}/") ~> baseRoutes ~> check {
+        status shouldEqual StatusCodes.NoContent
+      }
+    }
+  }
+
+  "/api/model-tags/" should {
+
+    "reject creating model tags without authentication" in {
+      Post("/api/model-tags/").withEntity(
+        HttpEntity(
+          ContentTypes.`application/json`,
+          newModelTag.toJson.toString()
+        )
+      ) ~> baseRoutes ~> check {
+        reject
+      }
+    }
+
+    "create a model tag with authorization" in {
+      Post("/api/model-tags/").withHeadersAndEntity(
+        List(authorization),
+        HttpEntity(
+          ContentTypes.`application/json`,
+          newModelTag.toJson.toString()
+        )
+      ) ~> baseRoutes ~> check {
+        responseAs[ModelTag]
+      }
+    }
+
+    "require authentication for list" in {
+      Get("/api/model-tags/") ~> baseRoutes ~> check {
+        reject
+      }
+    }
+  }
+}

--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/ModelTag.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/ModelTag.scala
@@ -32,6 +32,11 @@ object ModelTag {
 
   implicit val defaultModelTagFormat = jsonFormat7(ModelTag.apply _)
 
+  /** Case class to handle creating a new model tag
+    *
+    * @param organizationId UUID organization to create tag for
+    * @param tag String user supplied string to use for tag
+    */
   case class Create(
       organizationId: UUID,
       tag: String

--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/Scene.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/Scene.scala
@@ -176,7 +176,7 @@ object Scene extends GeoJsonSupport {
           case (_, image, _, thumbnail) => (image, thumbnail)
         }.unzip
         val imagesWithComponents: Seq[Image.WithRelated] = seqImages.flatten.map {
-          case (image) => image.withRelatedFromComponents(groupedBands(image.id))
+          image => image.withRelatedFromComponents(groupedBands.getOrElse(image.id, Seq[Band]()))
         }
         scene.withRelatedFromComponents(imagesWithComponents, seqThumbnails.flatten.distinct)
       }


### PR DESCRIPTION
## Overview

This commit adds API endpoints with tests for model tags.
Tags for geo-processing models are user-defined tags used to
remember and improve searchability for user-created
geo-processing models.

### Checklist

- [X] Styleguide updated, if necessary
- [X] Swagger specification updated, if necessary

## Testing Instructions

 * Start development VM once on this branch
 * If you have not done so, load development data (`./scripts/load_development_data`) and run migrations (`mg update` and `mg apply` once in an `sbt` shell)
 * Start API: `./scripts/console app-server "./sbt app/run"`
 * Test that Scenes API does not return 500 errors
`curl localhost:9000/api/scenes/`
 * Test that a `401` status is returned for un-authenticated requests:
```bash
curl -H "Content-Type: application/json" \
     http://localhost:9000/api/model-tags/

 * Test that authenticated requests succeed:
```bash
curl -H "Content-Type: application/json" \
     -H "Authorization: Bearer <TOKEN>" \
     http://localhost:9000/api/model-tags/
```
* Test that tags can be created:
```bash
curl -H "Content-Type: application/json" \
     -X POST \
     -d '{"organizationId": "dfac6307-b5ef-43f7-beda-b9f208bb7726", "tag":"xyz"}' \
     -H "Authorization: Bearer <TOKEN>" \
     http://localhost:9000/api/model-tags/
```
* Test that newly created tag is returned:
```
curl -H "Content-Type: application/json" \
     -H "Authorization: Bearer <TOKEN>" \
     http://localhost:9000/api/model-tags/
```

Closes #631 and #632
