### PR TITLE
Ensure that Airflow doesn't run as root

### DIFF
--- a/app-tasks/Dockerfile
+++ b/app-tasks/Dockerfile
@@ -3,32 +3,32 @@ FROM python:2.7
 ENV AIRFLOW_HOME /usr/local/airflow
 
 COPY requirements.txt /tmp/
+COPY rf/ /tmp/rf
 
 RUN set -ex \
-  && buildDeps=' \
-    python-dev \
-  ' \
-  && gdal=' \
-    gdal-bin \
-    libgdal1h \
-    libgdal-dev \
-  ' \
-  && apt-get update && apt-get install -y --no-install-recommends ${buildDeps} ${gdal} \
-  && pip install --no-cache-dir \
-         numpy==$(grep "numpy" /tmp/requirements.txt | cut -d= -f3) \
-  && pip install --no-cache-dir -r /tmp/requirements.txt \
-  && apt-get purge -y --auto-remove ${buildDeps} \
-  && rm -rf /var/lib/apt/lists/*
+    addgroup --system airflow \
+    && adduser --disabled-password --system --group \
+               --uid 1000 --home ${AIRFLOW_HOME} \
+               --shell /usr/sbin/nologin \
+               airflow \
+    && buildDeps=' \
+       python-dev \
+    ' \
+    && gdal=' \
+       gdal-bin \
+       libgdal1h \
+       libgdal-dev \
+    ' \
+    && apt-get update && apt-get install -y --no-install-recommends ${buildDeps} ${gdal} \
+    && pip install --no-cache-dir \
+           numpy==$(grep "numpy" /tmp/requirements.txt | cut -d= -f3) \
+    && pip install --no-cache-dir -r /tmp/requirements.txt \
+    && (cd /tmp/rf && python setup.py install) \
+    && apt-get purge -y --auto-remove ${buildDeps} \
+    && rm -rf /var/lib/apt/lists/*
+
+USER airflow
+WORKDIR ${AIRFLOW_HOME}
 
 COPY usr/local/airflow/airflow.cfg ${AIRFLOW_HOME}/airflow.cfg
-COPY rf/ /tmp/rf
 COPY dags/ /opt/raster-foundry/app-tasks/dags/
-
-RUN set -ex \
-    && cd /tmp/rf \
-    && python setup.py install \
-    && rm -rf /tmp/rf
-
-EXPOSE 8080 5555 8793
-
-WORKDIR ${AIRFLOW_HOME}

--- a/app-tasks/requirements.txt
+++ b/app-tasks/requirements.txt
@@ -1,5 +1,6 @@
 numpy==1.11.1
 boto3==1.3.1
+celery>=3.1.17,<3.1.99
 airflow[async,celery,crypto,hive,password,postgres,s3,slack]==1.7.1.3
 redis==2.10.5
 pytest==2.9.2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -88,7 +88,7 @@ services:
       - ./app-tasks/dags/:/opt/raster-foundry/app-tasks/dags/
       - ./app-tasks/rf/:/opt/raster-foundry/app-tasks/rf/
       - ./app-tasks/rf/src/rf/:/usr/local/bin/rf/
-      - $HOME/.aws:/root/.aws:ro
+      - $HOME/.aws:/usr/local/airflow/.aws:ro
     build:
       context: ./app-tasks
       dockerfile: Dockerfile
@@ -142,7 +142,7 @@ services:
       - ./app-tasks/dags/:/opt/raster-foundry/app-tasks/dags/
       - ./app-tasks/rf/:/opt/raster-foundry/app-tasks/rf/
       - ./app-tasks/rf/src/rf/:/usr/local/bin/rf/
-      - $HOME/.aws:/root/.aws:ro
+      - $HOME/.aws:/usr/local/airflow/.aws:ro
     build:
       context: ./app-tasks
       dockerfile: Dockerfile
@@ -172,7 +172,7 @@ services:
       - ./app-tasks/dags/:/opt/raster-foundry/app-tasks/dags/
       - ./app-tasks/rf/:/opt/raster-foundry/app-tasks/rf/
       - ./app-tasks/rf/src/rf/:/usr/local/bin/rf/
-      - $HOME/.aws:/root/.aws:ro
+      - $HOME/.aws:/usr/local/airflow/.aws:ro
     build:
       context: ./app-tasks
       dockerfile: Dockerfile

--- a/scripts/bootstrap
+++ b/scripts/bootstrap
@@ -19,7 +19,7 @@ function main() {
     echo "Pulling down development environment..."
     pushd "${DIR}/.."
     # Download environment configuration from S3
-    aws s3 cp "s3://config-development-raster-foundry/.env" ".env"
+    aws s3 cp "s3://rasterfoundry-development-config-us-east-1/.env" ".env"
     popd
 
     echo "Building/Pulling containers..."

--- a/scripts/load_development_data
+++ b/scripts/load_development_data
@@ -20,7 +20,7 @@ function load_database_backup() {
 
     check_database
     pushd "${DIR}/.."
-    aws s3 cp "s3://config-development-raster-foundry/database.pgdump" "data/database.pgdump"
+    aws s3 cp "s3://rasterfoundry-development-config-us-east-1/database.pgdump" "data/database.pgdump"
     popd
     echo "Dropping raster foundry database"
     docker-compose -f "${DIR}/../docker-compose.yml" exec -T postgres gosu postgres dropdb rasterfoundry

--- a/scripts/test
+++ b/scripts/test
@@ -31,15 +31,15 @@ then
         docker-compose \
             -f "${DIR}/../docker-compose.yml" run \
             --rm \
-            --entrypoint "/bin/bash -c" \
-            app-server "./sbt scapegoat"
+            --entrypoint ./sbt \
+            app-server scapegoat
 
         # Run scala tests for app-server
        docker-compose \
            -f "${DIR}/../docker-compose.yml" run \
            --rm \
-           --entrypoint "/bin/bash -c" \
-           app-server "./sbt test"
+           --entrypoint ./sbt \
+           app-server test
 
         # TODO: uncomment once https://github.com/azavea/raster-foundry/issues/435
         # is resolved
@@ -53,9 +53,12 @@ then
         # Run tests for app tasks library
         GIT_COMMIT="${GIT_COMMIT}" docker-compose \
             -f "${DIR}/../docker-compose.yml" \
-            -f "${DIR}/../docker-compose.test.yml" \
-            run --rm --entrypoint "/bin/bash -c" airflow \
-            "cd /opt/raster-foundry/app-tasks/rf && python setup.py test"
+            -f "${DIR}/../docker-compose.test.yml" run \
+            --rm \
+            --entrypoint python \
+            --user root \
+            --workdir /opt/raster-foundry/app-tasks/rf \
+            airflow setup.py test
     fi
     exit
 fi


### PR DESCRIPTION
## Overview

Create an `airflow` user that is responsible for running the various Airflow daemons. Ensure that its GID is `1000` so that it can read the AWS credentials in the development environment. Also, change the volume definition for the AWS credentials so that they map to the `airflow` user's home directory.

Resolves https://github.com/azavea/raster-foundry/issues/639 and #678

## Testing Instructions

From within the virtual machine, remove the current `.env` file:

```bash
vagrant@vagrant-ubuntu-trusty-64:/opt/raster-foundry$ rm .env
```

Then, execute `bootstrap` and ensure that the file exists again:

```bash
vagrant@vagrant-ubuntu-trusty-64:/opt/raster-foundry$ ./scripts/bootstrap
vagrant@vagrant-ubuntu-trusty-64:/opt/raster-foundry$ ls -la | grep env
-rw-r--r-- 1 vagrant vagrant   860 Nov 14 19:36 .env
```

Lastly, `bootstrap` should have taken care of rebuilding the Airflow container image. Use `server` to ensure that the services start up properly and can access their AWS credentials:

```bash
vagrant@vagrant-ubuntu-trusty-64:/opt/raster-foundry$ ./scripts/server
```