### PR TITLE
Add bucket filtering to scene specific query params

### DIFF
--- a/app-backend/app/src/main/scala/scene/QueryParameters.scala
+++ b/app-backend/app/src/main/scala/scene/QueryParameters.scala
@@ -1,5 +1,7 @@
 package com.azavea.rf.scene
 
+import java.util.UUID
+
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.directives.ParameterDirectives.parameters
 
@@ -23,7 +25,8 @@ trait SceneQueryParameterDirective extends QueryParametersCommon
     'maxSunElevation.as[Float].?,
     'minSunElevation.as[Float].?,
     'bbox.as[String].?,
-    'point.as[String].?
+    'point.as[String].?,
+    'bucket.as[UUID].?
   )).as(SceneQueryParameters)
 
   val sceneQueryParameters = (orgQueryParams &

--- a/app-backend/database/src/main/scala/com/azavea/rf/database/query.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/query.scala
@@ -43,7 +43,8 @@ case class SceneQueryParameters(
   maxSunElevation: Option[Float],
   minSunElevation: Option[Float],
   bbox: Option[String],
-  point: Option[String]
+  point: Option[String],
+  bucket: Option[UUID]
 ) {
   val bboxPolygon: Option[Projected[Polygon]] = try {
     bbox

--- a/docs/swagger/spec.yml
+++ b/docs/swagger/spec.yml
@@ -298,6 +298,7 @@ paths:
         - $ref: '#/parameters/maxResolution'
         - $ref: '#/parameters/tags'
         - $ref: '#/parameters/bbox'
+        - $ref: '#/parameters/bucket'
       responses:
         200:
           description: Paginated list of scenes
@@ -1160,6 +1161,13 @@ parameters:
     description: Bounding box. eg "bbox=southwest_lng,southwest_lat,northeast_lng,northeast_lat"
     in: query
     type: string
+    required: false
+  bucket:
+    name: bucket
+    description: Bucket uuid to filter only
+    in: query
+    type: string
+    format: uuid
     required: false
 definitions:
   BaseModel:


### PR DESCRIPTION
## Overview

Add a bucket filter parameter to scenes
For /bucket/scenes, delegate filtering by injecting the bucket parameter into the CombinedSceneQueryParams

### Checklist

- [x] Swagger specification updated, if necessary

### Demo

Without sort:
![image](https://cloud.githubusercontent.com/assets/4392704/20444928/0923b1a4-ada1-11e6-85e3-1d8f0d58c4f5.png)
With sort:
![image](https://cloud.githubusercontent.com/assets/4392704/20444944/21d1e266-ada1-11e6-93a1-4889e744bb4a.png)


### Notes

## Testing Instructions

* Follow reproduction steps in #675 
* Verify that the same steps work in the scene endpoint

Fixes https://github.com/azavea/raster-foundry/issues/675
