### PR TITLE
Fix re-adding scenes to buckets

### DIFF
--- a/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Buckets.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Buckets.scala
@@ -198,7 +198,7 @@ object Buckets extends TableQuery(tag => new Buckets(tag)) with LazyLogging {
 
   /** Adds a list of scenes to a bucket
     *
-    * @param sceneIds Seq[UUID] list of primary keys of scens to add to bucket
+    * @param sceneIds Seq[UUID] list of primary keys of scenes to add to bucket
     * @param bucketId UUID primary key of back to add scenes to
     */
   def addScenesToBucket(sceneIds: Seq[UUID], bucketId: UUID)
@@ -206,7 +206,7 @@ object Buckets extends TableQuery(tag => new Buckets(tag)) with LazyLogging {
 
     val sceneBucketJoinQuery = for {
       s <- ScenesToBuckets if s.sceneId.inSet(sceneIds) && s.bucketId === bucketId
-    } yield s
+    } yield s.sceneId
 
     database.db.run {
       sceneBucketJoinQuery.result


### PR DESCRIPTION
## Overview

Bad filter was causing issues when adding a set of scenes to a bucket when some of them were already in it

## Testing Instructions

* Create a bucket and add a scene to it
* Check to make sure that the scene was added
* Add another scene, as well as the first scene to the bucket
* Check that the new scene was added

Fixes #670

