### PR TITLE
Feature/add spark worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Helper and development scripts are located in the `./scripts` directory at the r
 | `cibuild`               | Invoked by CI server and makes use of `test`.                |
 | `cipublish`             | Publish container images to container image repositories.    |
 | `load_development_data` | Load data for development purposes                           |
+| `publish-jars`          | Publish java jar artifacts to s3                             |
 
 ## Testing
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -58,7 +58,8 @@ Vagrant.configure(2) do |config|
 
       cd /opt/raster-foundry/deployment/ansible && \
       ANSIBLE_FORCE_COLOR=1 PYTHONUNBUFFERED=1 ANSIBLE_CALLBACK_WHITELIST=profile_tasks \
-      ansible-playbook -u vagrant -i 'localhost,' --extra-vars "aws_profile=raster-foundry" \
+      ansible-playbook -u vagrant -i 'localhost,' \
+          --extra-vars "host_user=#{ENV.fetch("USER", "vagrant")} aws_profile=raster-foundry" \
           raster-foundry.yml
       cd /opt/raster-foundry
       export AWS_PROFILE=raster-foundry

--- a/app-tasks/Dockerfile
+++ b/app-tasks/Dockerfile
@@ -26,7 +26,7 @@ RUN set -ex \
        libgdal-dev \
     ' \
     && echo "deb http://ftp.debian.org/debian jessie-backports main" > /etc/apt/sources.list.d/backports.list \
-    && apt-get update && apt-get install -y --no-install-recommends ${buildDeps} ${gdal} ${sparkDeps}\
+    && apt-get update && apt-get install -y --no-install-recommends ${buildDeps} ${gdal} ${sparkDeps} \
     && pip install --no-cache-dir \
            numpy==$(grep "numpy" /tmp/requirements.txt | cut -d= -f3) \
     && pip install --no-cache-dir -r /tmp/requirements.txt \

--- a/app-tasks/Dockerfile
+++ b/app-tasks/Dockerfile
@@ -1,6 +1,9 @@
 FROM python:2.7
 
 ENV AIRFLOW_HOME /usr/local/airflow
+ENV SPARK_VERSION 2.0.1
+ENV HADOOP_VERSION 2.7
+ENV PATH=${PATH}:/usr/lib/spark/sbin:/usr/lib/spark/bin
 
 COPY requirements.txt /tmp/
 COPY rf/ /tmp/rf
@@ -14,18 +17,25 @@ RUN set -ex \
     && buildDeps=' \
        python-dev \
     ' \
+    && sparkDeps=' \
+       openjdk-8-jre \
+    ' \
     && gdal=' \
        gdal-bin \
        libgdal1h \
        libgdal-dev \
     ' \
-    && apt-get update && apt-get install -y --no-install-recommends ${buildDeps} ${gdal} \
+    && echo "deb http://ftp.debian.org/debian jessie-backports main" > /etc/apt/sources.list.d/backports.list \
+    && apt-get update && apt-get install -y --no-install-recommends ${buildDeps} ${gdal} ${sparkDeps}\
     && pip install --no-cache-dir \
            numpy==$(grep "numpy" /tmp/requirements.txt | cut -d= -f3) \
     && pip install --no-cache-dir -r /tmp/requirements.txt \
     && (cd /tmp/rf && python setup.py install) \
     && apt-get purge -y --auto-remove ${buildDeps} \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* \
+    && mkdir -p /usr/lib/spark \
+    && wget -qO- http://d3kbcqa49mib13.cloudfront.net/spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz \
+    | tar -xzC /usr/lib/spark --strip-components=1
 
 USER airflow
 WORKDIR ${AIRFLOW_HOME}

--- a/app-tasks/rf/src/rf/uploads/landsat8/io.py
+++ b/app-tasks/rf/src/rf/uploads/landsat8/io.py
@@ -128,7 +128,7 @@ def get_landsat_url(scene):
         str
     """
 
-    root_url = 'http://landsat-pds.s3.amazonaws.com/' + get_landsat_path(scene)
+    root_url = 'https://landsat-pds.s3.amazonaws.com/' + get_landsat_path(scene)
     logger.debug('Constructed Root URL: %s', root_url)
     return root_url
 

--- a/app-tasks/rf/src/rf/uploads/sentinel2/settings.py
+++ b/app-tasks/rf/src/rf/uploads/sentinel2/settings.py
@@ -43,7 +43,7 @@ band_lookup = {
 }
 
 # Base http path for constructing resource URLs for Sentinel 2 assets
-base_http_path = 'http://sentinel-s2-l1c.s3-website.eu-central-1.amazonaws.com/{key_path}'
+base_http_path = 'https://sentinel-s2-l1c.s3.amazonaws.com/{key_path}'
 
 # S3/AWS settings and objects
 bucket_name = 'sentinel-s2-l1c'

--- a/app-tasks/rf/tests/uploads/landsat8/test_io.py
+++ b/app-tasks/rf/tests/uploads/landsat8/test_io.py
@@ -17,7 +17,7 @@ class Landsat8IOTestCase(unittest.TestCase):
         scene = 'LC81390452014295LGN00'
         url = get_landsat_url(scene)
 
-        test_url = 'http://landsat-pds.s3.amazonaws.com/L8/139/045/LC81390452014295LGN00/'
+        test_url = 'https://landsat-pds.s3.amazonaws.com/L8/139/045/LC81390452014295LGN00/'
         self.assertEqual(
             url, test_url, 'URL should have been {}, instead got {}'.format(test_url, url)
         )

--- a/deployment/ansible/raster-foundry.yml
+++ b/deployment/ansible/raster-foundry.yml
@@ -18,3 +18,7 @@
     - name: Set Environment variable for AWS profile
       lineinfile: dest=/etc/environment regexp=^AWS_PROFILE line="AWS_PROFILE={{aws_profile}}"
       when: aws_profile is defined
+
+    - name: Set Environment variable for host user (used to namespace jars and other artifacts in development)
+      lineinfile: dest=/etc/environment regexp=^RF_HOST_USER line="RF_HOST_USER={{host_user}}"
+      when: host_user is defined

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -194,3 +194,33 @@ services:
       - RF_HOST=http://rasterfoundry.com:9000
       - C_FORCE_ROOT=True
     command: airflow worker
+
+  airflow-worker-spark:
+    image: raster-foundry-airflow
+    volumes:
+      - ./app-tasks/usr/local/airflow/:/usr/local/airflow/
+      - ./app-tasks/dags/:/opt/raster-foundry/app-tasks/dags/
+      - ./app-tasks/rf/:/opt/raster-foundry/app-tasks/rf/
+      - ./app-tasks/rf/src/rf/:/usr/local/bin/rf/
+      - $HOME/.aws:/usr/local/airflow/.aws:ro
+    build:
+      context: ./app-tasks
+      dockerfile: Dockerfile
+    links:
+      - postgres:database.service.rasterfoundry.internal
+      - redis:cache.service.rasterfoundry.internal
+      - app-server:rasterfoundry.com
+    env_file: .env
+    environment:
+      - AIRFLOW_HOME=/usr/local/airflow
+      - AIRFLOW_REMOTE_LOG_FOLDER=
+      - AIRFLOW_REMOTE_LOG_CONN_ID=
+      - AIRFLOW_PARALLELISM=32
+      - AIRFLOW_FERNET_KEY=secret
+      - AIRFLOW_BASE_URL=http://localhost:8080
+      - AIRFLOW_WEBSERVER_WORKERS=1
+      - AIRFLOW_SECRET_KEY=secret
+      - AIRFLOW_CELERY_CONCURRENCY=4
+      - RF_HOST=http://rasterfoundry.com:9000
+      - C_FORCE_ROOT=True
+    command: airflow worker -q spark

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -192,7 +192,6 @@ services:
       - AIRFLOW_SECRET_KEY=secret
       - AIRFLOW_CELERY_CONCURRENCY=4
       - RF_HOST=http://rasterfoundry.com:9000
-      - C_FORCE_ROOT=True
     command: airflow worker
 
   airflow-worker-spark:
@@ -222,5 +221,4 @@ services:
       - AIRFLOW_SECRET_KEY=secret
       - AIRFLOW_CELERY_CONCURRENCY=4
       - RF_HOST=http://rasterfoundry.com:9000
-      - C_FORCE_ROOT=True
     command: airflow worker -q spark

--- a/scripts/cibuild
+++ b/scripts/cibuild
@@ -11,6 +11,12 @@ else
     GIT_COMMIT="$(git rev-parse --short HEAD)"
 fi
 
+if [ -d "./scripts/cibuild.d" ]; then
+    for file in ./scripts/cibuild.d/*.sh; do
+        source "${file}"
+    done
+fi
+
 DIR="$(dirname "$0")"
 
 function usage() {
@@ -55,17 +61,10 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
         GIT_COMMIT="${GIT_COMMIT}" ./scripts/test
         echo "All tests pass!"
 
-        echo "Building application JAR"
-        GIT_COMMIT="${GIT_COMMIT}" docker-compose \
-            run --no-deps --entrypoint ./sbt --rm app-server app/assembly
-
-        echo "Building tile server JAR"
-        GIT_COMMIT="${GIT_COMMIT}" docker-compose \
-            run --no-deps --entrypoint ./sbt --rm tile-server tile/assembly
-
-        echo "Building ingest JAR"
-        GIT_COMMIT="${GIT_COMMIT}" docker-compose \
-            run --no-deps --rm --entrypoint ./sbt app-server ingest/assembly
+        # Build jars that are either published or included in other containers
+        build_application_jar
+        build_tile_server_jar
+        build_ingest_jar
 
         # Build app, airflow
         echo "Building app, airflow..."

--- a/scripts/cibuild.d/00-build-jars.sh
+++ b/scripts/cibuild.d/00-build-jars.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -e
+
+if [[ -n "${RF_DEBUG}" ]]; then
+    set -x
+fi
+
+function build_ingest_jar {
+    echo "Building ingest JAR"
+    docker-compose run --no-deps --rm --entrypoint ./sbt app-server ingest/assembly
+}
+
+function build_application_jar {
+    echo "Building application JAR"
+    docker-compose run --no-deps --entrypoint ./sbt --rm app-server app/assembly
+}
+
+function build_tile_server_jar {
+    echo "Building tile server JAR"
+    docker-compose run --no-deps --entrypoint ./sbt --rm tile-server tile/assembly
+}

--- a/scripts/cipublish
+++ b/scripts/cipublish
@@ -10,7 +10,8 @@ function usage() {
     echo -n \
 "Usage: $(basename "$0")
 
-Publish container images to Elastic Container Registry (ECR).
+Publish container images to Elastic Container Registry (ECR) and
+other artifacts to S3.
 "
 }
 
@@ -18,6 +19,12 @@ if [[ -n "${GIT_COMMIT}" ]]; then
     GIT_COMMIT="${GIT_COMMIT:0:7}"
 else
     GIT_COMMIT="$(git rev-parse --short HEAD)"
+fi
+
+if [ -d "./scripts/cipublish.d" ]; then
+    for file in ./scripts/cipublish.d/*.sh; do
+        source "${file}"
+    done
 fi
 
 if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
@@ -49,5 +56,6 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
             echo "ERROR: No AWS_ECR_ENDPOINT variable defined."
             exit 1
         fi
+        upload_ingest_jar "${GIT_COMMIT}"
     fi
 fi

--- a/scripts/cipublish.d/00-upload-ingest-jar.sh
+++ b/scripts/cipublish.d/00-upload-ingest-jar.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -e
+
+if [[ -n "${RF_DEBUG}" ]]; then
+    set -x
+fi
+
+DIR="$(dirname "$0")"
+
+function upload_ingest_jar {
+
+    if [[ -z "${1}" ]]; then
+        echo "This function requires a hash to uniquely identify the upload jar"
+        exit 1
+    else
+        echo "Using upload hash: ${1}"
+        UPLOAD_HASH="${1}"
+    fi
+
+    pushd "${DIR}/.."
+    echo "Uploading Spark Ingest Jar to S3"
+    aws s3 cp \
+        "app-backend/ingest/target/scala-2.11/rf-ingest.jar" \
+        "s3://rasterfoundry-global-artifacts-us-east-1/ingest/rf-ingest-${UPLOAD_HASH}.jar"
+    popd
+}

--- a/scripts/load_development_data
+++ b/scripts/load_development_data
@@ -27,6 +27,8 @@ function load_database_backup() {
     echo "Creating raster foundry database"
     docker-compose -f "${DIR}/../docker-compose.yml" exec -T postgres gosu postgres createdb rasterfoundry
     echo "Restoring Database from backup"
+    # Command to create database backup
+    # gosu postgres pg_dump -Fc rasterfoundry > database.pgdump
     docker-compose -f "${DIR}/../docker-compose.yml" exec -T postgres gosu postgres pg_restore -Fc -d rasterfoundry /tmp/data/database.pgdump > /dev/null
 
 }

--- a/scripts/publish-jars
+++ b/scripts/publish-jars
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+set -e
+
+if [[ -n "${RF_DEBUG}" ]]; then
+    set -x
+fi
+
+function usage() {
+    echo -n \
+"Usage: $(basename "$0" JAR_NAME)
+
+Publish jars to S3 for easy access
+"
+}
+
+
+if [ -d "./scripts/cibuild.d" ]; then
+    for file in ./scripts/cibuild.d/*.sh; do
+        source "${file}"
+    done
+fi
+
+if [ -d "./scripts/cipublish.d" ]; then
+    for file in ./scripts/cipublish.d/*.sh; do
+        source "${file}"
+    done
+fi
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+    if [ "${1:-}" = "--help" ]; then
+        usage
+    fi
+    build_ingest_jar
+    upload_ingest_jar "${RF_HOST_USER}"
+fi


### PR DESCRIPTION
## Overview

This pull request adds an Airflow worker that has Spark installed. This worker is necessary because this is how we will initially support submitting spark jobs via `spark-submit` and is necessary to start work on constructing Airflow jobs to ingest data into Raster RDDs.

Additionally, this pull request adds support for publishing jars and uploading them to S3. The CI server will publish jars tagged with a commit using the `GIT_COMMIT` environment variable. In development, users can publish jars using `./scripts/publish-jars`.

## Testing Instructions

 * Run `vagrant up --provision` after switching to this branch
 * SSH into machine: `vagrant ssh`
 * Run `./scripts/console airflow-worker-spark bash` and run `spark-submit --help`. Spark should be installed.
 * After exiting from the console in the previous step, run `./scripts/publish-jars`
 * Sign into AWS and verify a jar with your username is uploaded to S3

![ingest-jars](https://cloud.githubusercontent.com/assets/898060/20489046/39dd2540-afd7-11e6-9e0e-1a66d7cb6c1a.png)