### PR TITLE
Authenticate everything except insecure endpoints

### DIFF
--- a/app-backend/app/src/main/scala/bucket/Routes.scala
+++ b/app-backend/app/src/main/scala/bucket/Routes.scala
@@ -54,7 +54,7 @@ trait BucketRoutes extends Authentication
     }
   }
 
-  def listBuckets: Route = authenticateAndAllowAnonymous { user =>
+  def listBuckets: Route = authenticate { user =>
     (withPagination & bucketQueryParameters) { (page, bucketQueryParameters) =>
       complete {
         Buckets.listBuckets(page, bucketQueryParameters)
@@ -70,7 +70,7 @@ trait BucketRoutes extends Authentication
     }
   }
 
-  def getBucket(bucketId: UUID): Route = authenticateAndAllowAnonymous { user =>
+  def getBucket(bucketId: UUID): Route = authenticate { user =>
     rejectEmptyResponse {
       complete {
         Buckets.getBucket(bucketId)
@@ -99,7 +99,7 @@ trait BucketRoutes extends Authentication
     }
   }
 
-  def listBucketScenes(bucketId: UUID): Route = authenticateAndAllowAnonymous { user =>
+  def listBucketScenes(bucketId: UUID): Route = authenticate { user =>
     (withPagination & sceneQueryParameters) { (page, sceneParams) =>
       complete {
         Buckets.listBucketScenes(bucketId, page, sceneParams)

--- a/app-backend/app/src/main/scala/image/Routes.scala
+++ b/app-backend/app/src/main/scala/image/Routes.scala
@@ -35,7 +35,7 @@ trait ImageRoutes extends Authentication
   }
 
 
-  def listImages: Route = authenticateAndAllowAnonymous { user =>
+  def listImages: Route = authenticate { user =>
     (withPagination & imageQueryParameters) { (page, imageParams) =>
       complete {
         Images.listImages(page, imageParams)
@@ -51,7 +51,7 @@ trait ImageRoutes extends Authentication
     }
   }
 
-  def getImage(imageId: UUID): Route = authenticateAndAllowAnonymous { user =>
+  def getImage(imageId: UUID): Route = authenticate { user =>
     get {
       rejectEmptyResponse {
         complete {

--- a/app-backend/app/src/main/scala/scene/Routes.scala
+++ b/app-backend/app/src/main/scala/scene/Routes.scala
@@ -37,7 +37,7 @@ trait SceneRoutes extends Authentication
     }
   }
 
-  def listScenes: Route = authenticateAndAllowAnonymous { user =>
+  def listScenes: Route = authenticate { user =>
     (withPagination & sceneQueryParameters) { (page, sceneParams) =>
       complete {
         Scenes.listScenes(page, sceneParams)
@@ -53,7 +53,7 @@ trait SceneRoutes extends Authentication
     }
   }
 
-  def getScene(sceneId: UUID): Route = authenticateAndAllowAnonymous { user =>
+  def getScene(sceneId: UUID): Route = authenticate { user =>
     rejectEmptyResponse {
       complete {
         Scenes.getScene(sceneId)

--- a/app-backend/app/src/main/scala/thumbnail/Routes.scala
+++ b/app-backend/app/src/main/scala/thumbnail/Routes.scala
@@ -38,7 +38,7 @@ trait ThumbnailRoutes extends Authentication
     }
   }
 
-  def listThumbnails: Route = authenticateAndAllowAnonymous { user =>
+  def listThumbnails: Route = authenticate { user =>
     (withPagination & thumbnailSpecificQueryParameters) { (page, thumbnailParams) =>
       complete {
         Thumbnails.listThumbnails(page, thumbnailParams)
@@ -54,7 +54,7 @@ trait ThumbnailRoutes extends Authentication
     }
   }
 
-  def getThumbnail(thumbnailId: UUID): Route = authenticateAndAllowAnonymous { user =>
+  def getThumbnail(thumbnailId: UUID): Route = authenticate { user =>
     withPagination { page =>
       rejectEmptyResponse {
         complete {

--- a/app-backend/app/src/test/scala/organization/OrganizationSpec.scala
+++ b/app-backend/app/src/test/scala/organization/OrganizationSpec.scala
@@ -28,7 +28,7 @@ class OrganizationSpec extends WordSpec
   // Alias to baseRoutes to be explicit
   val baseRoutes = routes
 
-  val authorization = AuthUtils.generateAuthHeader("Default")
+  val authHeader = AuthUtils.generateAuthHeader("Default")
   "/api/organizations" should {
     "require authentication" in {
       Get("/api/organizations") ~> baseRoutes ~> check {
@@ -38,7 +38,7 @@ class OrganizationSpec extends WordSpec
 
     "return a paginated list of organizations" in {
       Get("/api/organizations")
-        .addHeader(authorization) ~> baseRoutes ~> check {
+        .addHeader(authHeader) ~> baseRoutes ~> check {
         responseAs[PaginatedResponse[Organization]]
       }
     }
@@ -46,7 +46,7 @@ class OrganizationSpec extends WordSpec
       val newOrg = Organization.Create("Test Organization")
       Post("/api/organizations")
         .withHeadersAndEntity(
-        List(authorization),
+        List(authHeader),
         HttpEntity(
           ContentTypes.`application/json`,
           newOrg.toJson.toString()
@@ -60,12 +60,12 @@ class OrganizationSpec extends WordSpec
   "/api/organizations/{uuid}" should {
     "return an organization" in {
       Get("/api/organizations")
-        .addHeader(authorization) ~> baseRoutes ~> check {
+        .addHeader(authHeader) ~> baseRoutes ~> check {
         val orgs = responseAs[PaginatedResponse[Organization]]
         val orgId = orgs.results.head.id
 
         Get(s"/api/organizations/$orgId")
-          .addHeader(authorization) ~> baseRoutes ~> check {
+          .addHeader(authHeader) ~> baseRoutes ~> check {
           responseAs[Organization]
         }
       }
@@ -74,7 +74,7 @@ class OrganizationSpec extends WordSpec
     "return a 404 for non-existent organizations" in {
       val orgUUID = java.util.UUID.randomUUID()
       Get(s"/api/organizations/$orgUUID")
-        .addHeader(authorization) ~> Route.seal(baseRoutes) ~> check {
+        .addHeader(authHeader) ~> Route.seal(baseRoutes) ~> check {
         status shouldEqual StatusCodes.NotFound
       }
     }
@@ -82,24 +82,24 @@ class OrganizationSpec extends WordSpec
   "/api/organizations/{uuid}/users" should {
     "return a list of user roles for the organization" in {
       Get("/api/organizations")
-        .addHeader(authorization) ~> baseRoutes ~> check {
+        .addHeader(authHeader) ~> baseRoutes ~> check {
         val orgs = responseAs[PaginatedResponse[Organization]]
         val orgId = orgs.results.head.id
         Get(s"/api/organizations/$orgId/users")
-          .addHeader(authorization) ~> baseRoutes ~> check {
+          .addHeader(authHeader) ~> baseRoutes ~> check {
           responseAs[PaginatedResponse[User.WithRole]]
         }
       }
     }
     "add a user to an organization" in {
       Get("/api/organizations")
-        .addHeader(authorization) ~> baseRoutes ~> check {
+        .addHeader(authHeader) ~> baseRoutes ~> check {
         val orgs = responseAs[PaginatedResponse[Organization]]
         val orgId = orgs.results.head.id
         val newUserWithRole = User.WithRoleCreate("Default", User.Viewer)
         Post(s"/api/organizations/$orgId/users")
           .withHeadersAndEntity(
-          List(authorization),
+          List(authHeader),
           HttpEntity(
             ContentTypes.`application/json`,
             newUserWithRole.toJson.toString()
@@ -107,7 +107,7 @@ class OrganizationSpec extends WordSpec
         ) ~> baseRoutes ~> check {
           val createdUser = responseAs[User.WithRole]
           Get(s"/api/organizations/$orgId/users/Default")
-            .addHeader(authorization) ~> baseRoutes ~> check {
+            .addHeader(authHeader) ~> baseRoutes ~> check {
             responseAs[User.WithRole] shouldEqual createdUser
           }
         }
@@ -117,20 +117,20 @@ class OrganizationSpec extends WordSpec
   "/api/organizations/{uuid}/users/{userId}" should {
     "return a user's role in the organization" in {
       Get("/api/organizations")
-        .addHeader(authorization) ~> baseRoutes ~> check {
+        .addHeader(authHeader) ~> baseRoutes ~> check {
         val orgs = responseAs[PaginatedResponse[Organization]]
         val orgId = orgs.results.head.id
         val newUserWithRole = User.WithRoleCreate("Default", User.Viewer)
         Post(s"/api/organizations/$orgId/users")
           .withHeadersAndEntity(
-          List(authorization),
+          List(authHeader),
           HttpEntity(
             ContentTypes.`application/json`,
             newUserWithRole.toJson.toString()
           )
         ) ~> baseRoutes ~> check {
           Get(s"/api/organizations/$orgId/users/Default")
-            .addHeader(authorization) ~> baseRoutes ~> check {
+            .addHeader(authHeader) ~> baseRoutes ~> check {
             responseAs[User.WithRole]
           }
         }
@@ -138,18 +138,18 @@ class OrganizationSpec extends WordSpec
     }
     "edit a user's role in the organization" in {
       Get("/api/organizations")
-        .addHeader(authorization) ~> baseRoutes ~> check {
+        .addHeader(authHeader) ~> baseRoutes ~> check {
         val orgs = responseAs[PaginatedResponse[Organization]]
         val orgId = orgs.results.head.id
         Get(s"/api/organizations/$orgId/users/Default")
-        .addHeader(authorization) ~> baseRoutes ~> check {
+        .addHeader(authHeader) ~> baseRoutes ~> check {
           responseAs[User.WithRole]
         }
       }
     }
     "delete a user's role in the organization" in {
       Get("/api/organizations")
-        .addHeader(authorization) ~> baseRoutes ~> check {
+        .addHeader(authHeader) ~> baseRoutes ~> check {
         //TODO
       }
     }

--- a/app-backend/app/src/test/scala/tags/ModelTagSpec.scala
+++ b/app-backend/app/src/test/scala/tags/ModelTagSpec.scala
@@ -21,7 +21,7 @@ class ModelTagSpec extends WordSpec
   implicit val ec = system.dispatcher
   implicit def database = db
 
-  val authorization = AuthUtils.generateAuthHeader("Default")
+  val authHeader = AuthUtils.generateAuthHeader("Default")
   val publicOrgId = UUID.fromString("dfac6307-b5ef-43f7-beda-b9f208bb7726")
   val baseModelTag = "/model-tags/"
   val newModelTag = ModelTag.Create(
@@ -64,9 +64,9 @@ class ModelTagSpec extends WordSpec
       }
     }
 
-    "create a model tag with authorization" in {
+    "create a model tag with authHeader" in {
       Post("/api/model-tags/").withHeadersAndEntity(
-        List(authorization),
+        List(authHeader),
         HttpEntity(
           ContentTypes.`application/json`,
           newModelTag.toJson.toString()

--- a/app-backend/app/src/test/scala/user/UserSpec.scala
+++ b/app-backend/app/src/test/scala/user/UserSpec.scala
@@ -20,15 +20,14 @@ class UserSpec extends WordSpec
   implicit def database = db
   implicit def default(implicit system: ActorSystem) = RouteTestTimeout(DurationInt(20).second)
 
-  val authorization = AuthUtils.generateAuthHeader("Default")
+  val authHeader = AuthUtils.generateAuthHeader("Default")
 
   // Alias to baseRoutes to be explicit
   val baseRoutes = routes
 
   "/api/users" should {
     "return a paginated list of users" in {
-      Get("/api/users")
-        .addHeader(authorization) ~> baseRoutes ~> check {
+      Get("/api/users").withHeaders(List(authHeader)) ~> baseRoutes ~> check {
         responseAs[PaginatedResponse[User.WithOrgs]]
       }
     }
@@ -43,7 +42,7 @@ class UserSpec extends WordSpec
   "/api/users/{UUID}" should {
     "return a single user" in {
       Get("/api/users/Default")
-        .addHeader(authorization)~> baseRoutes ~> check {
+        .addHeader(authHeader)~> baseRoutes ~> check {
         responseAs[User.WithOrgs]
       }
     }


### PR DESCRIPTION
## Overview

Users should only be able to access public resources or resources they have access to.
To implement authorization, we first need authentication everywhere, and so:

_This is Auth Nation
Pledge your allegiance
Get y'all auth tees on
All auth everything
Auth cards, auth cars
All auth everything_

except `tokens`, `healthcheck`, and `config` as specified in #695 

\- [Jay-Z, kind of](https://play.spotify.com/track/2a8CtZyPdd8w2csZh7oxpc)

### Checklist

- [x] Styleguide updated, if necessary (not necessary)
- [x] Swagger specification updated, if necessary (not necessary until we add authorization)

## Testing Instructions

- `./scripts/console app-server ./sbt`
- `project app`
- `test`

Closes #695 