### PR TITLE
Wait for login before requesting scenes

### DIFF
--- a/app-frontend/src/app/pages/browse/browse.controller.js
+++ b/app-frontend/src/app/pages/browse/browse.controller.js
@@ -4,11 +4,12 @@ const _ = require('lodash');
 
 export default class BrowseController {
     constructor( // eslint-disable-line max-params
-        $log, $scope, sceneService, $state, $uibModal
+        $log, $scope, sceneService, authService, $state, $uibModal
     ) {
         'ngInject';
         this.$log = $log;
         this.sceneService = sceneService;
+        this.authService = authService;
         this.$state = $state;
         this.$uibModal = $uibModal;
 
@@ -58,7 +59,12 @@ export default class BrowseController {
         // TODO: Switch to one-way &-binding from child component
         $scope.$watchCollection('$ctrl.filters', this.onFilterChange.bind(this));
 
-        this.populateInitialSceneList();
+        $scope.$watch(
+            function () {
+                return authService.isLoggedIn;
+            },
+            this.onLoggedInChange.bind(this)
+        );
     }
 
     onStateChangeStart(event, toState, toParams, fromState) {
@@ -107,7 +113,17 @@ export default class BrowseController {
         this.onQueryParamsChange();
     }
 
+    onLoggedInChange(newValue) {
+        if (newValue) {
+            this.populateInitialSceneList();
+        }
+    }
+
     populateInitialSceneList() {
+        if (!this.authService.isLoggedIn) {
+            return;
+        }
+
         if (this.loading) {
             this.reloadScenes = true;
             return;


### PR DESCRIPTION
## Overview

Loading the page triggers a request to scenes, which doesn't work when we're not authenticated.
This PR adds a watcher to the browser controller that requests scenes once the logged in state is
`true`.

### Checklist

(both not necessary)

- [x] Styleguide updated, if necessary
- [x] Swagger specification updated, if necessary

### Demo

No error in the scenes list:

![image](https://cloud.githubusercontent.com/assets/5702984/20544669/26dadd22-b0d9-11e6-8132-f9f1aabc6234.png)

## Testing Instructions

 * Start the front-end
 * Note that there's no error
 * Log in
 * Note that a scenes request occurs and the list populates
 * Log out
 * Refresh the page and note that there's still no error even though state didn't change

Closes #692 
