### PR TITLE
Reverse proxy to tiler from Nginx; add stub service health check

### DIFF
--- a/app-backend/tile/src/main/scala/Main.scala
+++ b/app-backend/tile/src/main/scala/Main.scala
@@ -4,6 +4,7 @@ import akka.actor.ActorSystem
 import akka.event.Logging
 import akka.http.scaladsl.Http
 import akka.stream.ActorMaterializer
+import akka.http.scaladsl.model.{HttpResponse, StatusCodes}
 import akka.http.scaladsl.server._
 import akka.http.scaladsl.server.Directives._
 
@@ -19,7 +20,17 @@ object AkkaSystem {
 object Main extends App with Config with AkkaSystem.LoggerExecutor {
   import AkkaSystem._
 
-  def rootRoute = pathPrefix("tiles") { Routes.singleLayer }
+  def rootRoute = pathPrefix("tiles") {
+    Routes.singleLayer ~ pathPrefix("healthcheck") {
+      pathEndOrSingleSlash {
+        get {
+          complete {
+            HttpResponse(StatusCodes.OK)
+          }
+        }
+      }
+    }
+  }
 
   Http().bindAndHandle(rootRoute, httpHost, httpPort)
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,14 +16,15 @@ services:
     ports:
       - "9100:443"
     links:
-      - app-server
       - airflow-webserver
       - airflow-flower
+      - app-server
+      - tile-server
     volumes:
       - ./nginx/srv/dist/:/srv/dist/
       - ./nginx/etc/nginx/nginx.conf:/etc/nginx/nginx.conf
-      - ./nginx/etc/nginx/conf.d/app.conf:/etc/nginx/conf.d/app.conf
-      - ./nginx/etc/nginx/conf.d/airflow.conf:/etc/nginx/conf.d/airflow.conf
+      - ./nginx/etc/nginx/includes/:/etc/nginx/includes/
+      - ./nginx/etc/nginx/conf.d/:/etc/nginx/conf.d/
 
   app-frontend:
     image: node:6.8-wheezy

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,11 +1,11 @@
 FROM nginx:1.10
 
-RUN mkdir -p /srv/dist/angular && \
+RUN mkdir -p /etc/nginx/includes && \
     mkdir -p /srv/dist/docs/swagger
 
 COPY srv/dist /srv/dist/
 RUN chown nginx:nginx -R /srv/dist/
 
 COPY etc/nginx/nginx.conf /etc/nginx/nginx.conf
-COPY etc/nginx/conf.d/app.conf /etc/nginx/conf.d/app.conf
-COPY etc/nginx/conf.d/airflow.conf /etc/nginx/conf.d/airflow.conf
+COPY etc/nginx/includes/*.conf /etc/nginx/includes/
+COPY etc/nginx/conf.d/*.conf /etc/nginx/conf.d/

--- a/nginx/etc/nginx/conf.d/airflow.conf
+++ b/nginx/etc/nginx/conf.d/airflow.conf
@@ -4,11 +4,6 @@ server {
     return 301 https://$host$request_uri;
 }
 
-map $http_x_forwarded_proto $policy {
-    default "";
-    https   "default-src https: data: blob: 'unsafe-inline' 'unsafe-eval'";
-}
-
 upstream airflow-webserver-upstream {
     server airflow-webserver:8080;
 }
@@ -17,15 +12,7 @@ server {
     listen 443;
     server_name airflow.staging.rasterfoundry.com airflow.rasterfoundry.com;
 
-    # A set of recommended security headers:
-    #
-    #   https://scotthelme.co.uk/hardening-your-http-response-headers/
-    #
-    add_header Strict-Transport-Security "max-age=15552000; preload" always;
-    add_header Content-Security-Policy $policy always;
-    add_header X-Content-Type-Options "nosniff" always;
-    add_header X-Frame-Options "SAMEORIGIN" always;
-    add_header X-XSS-Protection "1; mode=block" always;
+    include /etc/nginx/includes/security-headers.conf;
 
     location / {
         proxy_set_header Host $http_host;
@@ -44,15 +31,7 @@ server {
     listen 443;
     server_name flower.staging.rasterfoundry.com flower.rasterfoundry.com;
 
-    # A set of recommended security headers:
-    #
-    #   https://scotthelme.co.uk/hardening-your-http-response-headers/
-    #
-    add_header Strict-Transport-Security "max-age=15552000; preload" always;
-    add_header Content-Security-Policy $policy always;
-    add_header X-Content-Type-Options "nosniff" always;
-    add_header X-Frame-Options "SAMEORIGIN" always;
-    add_header X-XSS-Protection "1; mode=block" always;
+    include /etc/nginx/includes/security-headers.conf;
 
     location / {
         proxy_set_header Host $http_host;

--- a/nginx/etc/nginx/conf.d/app.conf
+++ b/nginx/etc/nginx/conf.d/app.conf
@@ -4,30 +4,20 @@ server {
     return 301 https://$host$request_uri;
 }
 
-map $http_x_forwarded_proto $policy {
-    default "";
-    https   "default-src https: data: blob: 'unsafe-inline' 'unsafe-eval'";
-}
-
 upstream app-server-upstream {
     server app-server:9000;
+}
+
+upstream tile-server-upstream {
+    server tile-server:9900;
 }
 
 server {
     listen 443 default_server;
     server_name app.staging.rasterfoundry.com app.rasterfoundry.com localhost;
 
-    # A set of recommended security headers:
-    #
-    #   https://scotthelme.co.uk/hardening-your-http-response-headers/
-    #
-    add_header Strict-Transport-Security "max-age=15552000; preload" always;
-    add_header Content-Security-Policy $policy always;
-    add_header X-Content-Type-Options "nosniff" always;
-    add_header X-Frame-Options "SAMEORIGIN" always;
-    add_header X-XSS-Protection "1; mode=block" always;
+    include /etc/nginx/includes/security-headers.conf;
 
-    # Akka-Http API
     location /api {
         proxy_set_header Host $http_host;
         proxy_set_header X-Forwarded-For $remote_addr;
@@ -36,7 +26,14 @@ server {
         proxy_pass http://app-server-upstream;
     }
 
-    # Health check
+    location /tiles {
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Forwarded-For $remote_addr;
+        proxy_redirect off;
+
+        proxy_pass http://tile-server-upstream;
+    }
+
     location = /healthcheck/ {
         proxy_set_header Host $http_host;
         proxy_set_header X-Forwarded-For $remote_addr;

--- a/nginx/etc/nginx/includes/security-headers.conf
+++ b/nginx/etc/nginx/includes/security-headers.conf
@@ -1,0 +1,9 @@
+# A set of recommended security headers:
+#
+#   https://scotthelme.co.uk/hardening-your-http-response-headers/
+#
+add_header Strict-Transport-Security "max-age=15552000; preload" always;
+add_header Content-Security-Policy $policy always;
+add_header X-Content-Type-Options "nosniff" always;
+add_header X-Frame-Options "SAMEORIGIN" always;
+add_header X-XSS-Protection "1; mode=block" always;

--- a/nginx/etc/nginx/nginx.conf
+++ b/nginx/etc/nginx/nginx.conf
@@ -35,5 +35,10 @@ http {
 
     real_ip_header X-Forwarded-For;
 
+    map $http_x_forwarded_proto $policy {
+        default "";
+        https   "default-src https: data: blob: 'unsafe-inline' 'unsafe-eval'";
+    }
+
     include /etc/nginx/conf.d/*.conf;
 }


### PR DESCRIPTION
## Overview

Puts the tile server service behind Nginx at `/tiles`. Also, consolidates the necessary security headers into an include that gets reused where needed.

Lastly, adds a stub health check to the tiler server so that ALB target groups can mark the service as healthy. This should be updated to better communicate the health of the tile service.

Resolves part of https://github.com/azavea/raster-foundry/issues/686

## Testing Instructions

Bring up the `nginx` services, which will ensure that the `tile-server` is up as well. Then, interact with the `tile-server` health check through Nginx.

Bring services up:

```bash
vagrant@vagrant-ubuntu-trusty-64:/opt/raster-foundry$ ./scripts/bootstrap
vagrant@vagrant-ubuntu-trusty-64:/opt/raster-foundry$ docker-compose up nginx
rasterfoundry_redis_1 is up-to-date
Recreating rasterfoundry_tile-server_1
Recreating rasterfoundry_postgres_1
Recreating rasterfoundry_airflow-webserver_1
Recreating rasterfoundry_airflow-flower_1
Recreating rasterfoundry_app-server_1
Recreating rasterfoundry_nginx_1
Attaching to rasterfoundry_nginx_1
nginx_1              | 172.18.0.1 - - [23/Nov/2016:16:26:30 +0000] "GET /tiles/healthcheck/ HTTP/1.1" 200 0 - "-" "curl/7.35.0" 0.043 0.043
```

Interact with `tile-server` via Nginx:

```bash
vagrant@vagrant-ubuntu-trusty-64:/opt/raster-foundry$ curl -v localhost:9100/tiles/healthcheck/                                                                                   
* Hostname was NOT found in DNS cache
*   Trying 127.0.0.1...
* Connected to localhost (127.0.0.1) port 9100 (#0)
> GET /tiles/healthcheck/ HTTP/1.1
> User-Agent: curl/7.35.0
> Host: localhost:9100
> Accept: */*
>
< HTTP/1.1 200 OK
* Server nginx is not blacklisted
< Server: nginx
< Date: Wed, 23 Nov 2016 16:26:30 GMT
< Content-Length: 0
< Connection: keep-alive
< Strict-Transport-Security: max-age=15552000; preload
< X-Content-Type-Options: nosniff
< X-Frame-Options: SAMEORIGIN
< X-XSS-Protection: 1; mode=block
<
* Connection #0 to host localhost left intact
```