### PR TITLE
Add histogram and thumbnail endpoints in tiler app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,3 +115,4 @@ app-tasks/usr/local/airflow/logs/
 /app-tasks/usr/local/airflow/airflow-webserver.pid
 /app-tasks/usr/local/airflow/unittests.cfg
 .idea
+.ensime_cache

--- a/app-backend/tile/src/main/scala/Config.scala
+++ b/app-backend/tile/src/main/scala/Config.scala
@@ -26,4 +26,3 @@ trait Config {
   lazy val defaultProject:String =
     tileserverConfig.getString("project")
 }
-

--- a/app-backend/tile/src/main/scala/LayerCache.scala
+++ b/app-backend/tile/src/main/scala/LayerCache.scala
@@ -1,7 +1,5 @@
 package com.azavea.rf.tile
 
-import java.util.UUID
-
 import geotrellis.raster._
 import geotrellis.raster.histogram.Histogram
 import geotrellis.spark._
@@ -10,8 +8,7 @@ import geotrellis.spark.io._
 import geotrellis.spark.io.s3.{S3AttributeStore, S3ValueReader}
 import scala.concurrent.Future
 
-import com.github.blemale.scaffeine.{ AsyncLoadingCache, Scaffeine }
-import scala.concurrent.duration._
+import com.github.blemale.scaffeine.{ AsyncLoadingCache, Scaffeine, LoadingCache }
 import scala.concurrent.ExecutionContext.Implicits.global
 import spray.json.DefaultJsonProtocol._
 
@@ -20,57 +17,57 @@ import spray.json.DefaultJsonProtocol._
   * In this case it requires reading JSON files from S3, which are cached in the reader.
   * Naturally we want to cache this access to prevent every tile request from re-fetching layer metadata.
   * Same logic applies to other layer attributes like layer Histogram.
+  *
+  * Things that are cheap to construct but contain internal state we want to re-use use LoadingCache.
+  * things that require time to generate, usually a network fetch, use AsyncLoadingCache
   */
 object LayerCache extends Config {
-  val cacheReaders: AsyncLoadingCache[(String, String, UUID, Int), Reader[SpatialKey, MultibandTile]] =
-    Scaffeine()
-    .recordStats()
-    .expireAfterWrite(cacheExpiration)
-    .maximumSize(cacheSize)
-    .buildAsyncFuture { case (project: String, prefix: String, id: UUID, zoom: Int) =>
-      val layerId = LayerId(id.toString, zoom)
-      Future { S3ValueReader(project, prefix).reader[SpatialKey, MultibandTile](layerId) }
-    }
-
-  /**
-    * Fetch cached tile reader
-    *
-    * @param project S3 project
-    * @param prefix Key Prefix inside the S3 project
-    * @param layerId LayerId in catalog stored in prefix
-    * @param zoom    Pyramid zoom level
+  /** Cache AttributeStores.
+    * This is not Async cache as per usual because constructing S3AttributeStore is cheap.
+    * However it maintains an internal cache of layer attributes that are reused when reading tiles.
     */
-  def tileReader(project: String, prefix: String, layerId: UUID, zoom: Int): Future[Reader[SpatialKey, MultibandTile]] =
-    cacheReaders.get((project, prefix, layerId, zoom))
-
-  def tile(project: String, prefix: String, layerId: UUID, zoom: Int, key: SpatialKey): Future[MultibandTile] =
-    for ( reader <- tileReader(project, prefix, layerId, zoom))
-      yield reader.read(key)
-
-  def tile(prefix: String, layerId: UUID, zoom: Int, key: SpatialKey): Future[MultibandTile] =
-    tile(defaultProject, prefix, layerId, zoom, key)
-
-  val cacheHistogram: AsyncLoadingCache[(String, String, UUID, Int), Array[Histogram[Double]]] =
+  val cacheAttributeStore: LoadingCache[(String, String), S3AttributeStore] =
     Scaffeine()
       .recordStats()
       .expireAfterWrite(cacheExpiration)
       .maximumSize(cacheSize)
-      .buildAsyncFuture { case (project: String, prefix: String, id: UUID, zoom: Int) =>
-        val layerId = LayerId(id.toString, 0) // use the same histogram for all zoom levels
-        Future { S3AttributeStore(project, prefix).read[Array[Histogram[Double]]](layerId, "histogram") }
+      .build { case (bucket: String, prefix: String) => S3AttributeStore(bucket, prefix) }
+
+  val cacheHistogram: AsyncLoadingCache[(RfLayerId, Int), Array[Histogram[Double]]] =
+    Scaffeine()
+      .recordStats()
+      .expireAfterWrite(cacheExpiration)
+      .maximumSize(cacheSize)
+      .buildAsyncFuture { case (id, zoom: Int) =>
+        Future { S3AttributeStore(defaultProject, id.prefix).read[Array[Histogram[Double]]](id.catalogId(zoom), "histogram") }
       }
 
-  /**
-    * Fetch cached layer attribute, Histogram
-    *
-    * @param project S3 project
-    * @param prefix Key Prefix inside the S3 project
-    * @param layerId LayerId in catalog stored in prefix
-    * @param zoom    Pyramid zoom level
-    */
-  def bandHistogram(project: String, prefix: String, layerId: UUID, zoom: Int): Future[Array[Histogram[Double]]] =
-    cacheHistogram.get((project, prefix, layerId, zoom))
+  val cacheReaders: LoadingCache[(RfLayerId, Int), Reader[SpatialKey, MultibandTile]] =
+    Scaffeine()
+      .expireAfterWrite(cacheExpiration)
+      .maximumSize(cacheSize)
+      .build { case (id, zoom) =>
+        new S3ValueReader(attributeStore(defaultProject, id.prefix)).reader[SpatialKey, MultibandTile](id.catalogId(zoom))
+      }
 
-  def bandHistogram(prefix: String, layerId: UUID, zoom: Int): Future[Array[Histogram[Double]]] =
-    bandHistogram(defaultProject, prefix, layerId, zoom)
+  val cacheTiles: AsyncLoadingCache[(RfLayerId, Int, SpatialKey), MultibandTile] =
+    Scaffeine()
+      .recordStats()
+      .expireAfterWrite(cacheExpiration)
+      .maximumSize(cacheSize)
+      .buildAsyncFuture { case (id: RfLayerId, zoom, key: SpatialKey) =>
+        Future { cacheReaders.get((id, zoom)).read(key) }
+      }
+
+  def attributeStore(bucket: String, prefix: String): S3AttributeStore =
+    cacheAttributeStore.get((bucket, prefix))
+
+  def attributeStore(prefix: String): S3AttributeStore =
+    attributeStore(defaultProject, prefix)
+
+  def tile(id: RfLayerId, zoom: Int, key: SpatialKey): Future[MultibandTile] =
+    cacheTiles.get((id, zoom, key))
+
+  def bandHistogram(id: RfLayerId, zoom: Int): Future[Array[Histogram[Double]]] =
+    cacheHistogram.get((id, 0))
 }

--- a/app-backend/tile/src/main/scala/RfLayerId.scala
+++ b/app-backend/tile/src/main/scala/RfLayerId.scala
@@ -1,0 +1,17 @@
+package com.azavea.rf.tile
+
+import java.util.UUID
+
+import geotrellis.spark.LayerId
+
+/**
+  * RasterFoundry layers belong to user and organization.
+  * Eventually these must be mapped to an S3 prefix.
+  * This class encapsulates the relationship and gives a place to modify the mapping
+  */
+case class RfLayerId(org: UUID, user: String, scene: UUID) {
+  def prefix: String = s"${org.toString}/$user"
+  def catalogId(zoom: Int) = LayerId(scene.toString, zoom)
+}
+
+

--- a/app-backend/tile/src/main/scala/Routes.scala
+++ b/app-backend/tile/src/main/scala/Routes.scala
@@ -1,66 +1,116 @@
 package com.azavea.rf.tile
 
-import java.util.UUID
-
-import akka.http.scaladsl.model.{ContentType, HttpEntity, HttpResponse, MediaTypes}
 import com.azavea.rf.tile.image._
-import com.azavea.rf.tile.image.ImageParams._
+import com.azavea.rf.tile.image.ColorCorrectParams._
 import com.azavea.rf.tile.model._
 import com.azavea.rf.tile.model.ModelParams._
+
 import geotrellis.raster._
+import geotrellis.raster.io._
 import geotrellis.raster.histogram.Histogram
-import geotrellis.raster.render.{ColorRamp, ColorMap}
+import geotrellis.raster.render.{Png, ColorRamp, ColorMap}
 import geotrellis.spark._
 import akka.http.scaladsl.server._
 import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.model.{ContentType, HttpEntity, HttpResponse, MediaTypes}
+import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
 import com.typesafe.scalalogging.LazyLogging
+
+import spray.json._
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent._
 
-
 trait Routes extends LazyLogging {
-  def layerTile(prefix: String, layerId: UUID) =
+  def layerTile(layer: RfLayerId) =
     pathPrefix(IntNumber / IntNumber / IntNumber).tmap[Future[MultibandTile]] {
       case (zoom: Int, x: Int, y: Int) =>
-        LayerCache.tile(prefix, layerId, zoom, SpatialKey(x, y))
+        LayerCache.tile(layer, zoom, SpatialKey(x, y))
     }
 
-  def layerTileAndHistogram(prefix: String, layerId: UUID) =
+  def layerTileAndHistogram(id: RfLayerId) =
     pathPrefix(IntNumber / IntNumber / IntNumber).tmap[(Future[MultibandTile], Future[Array[Histogram[Double]]])] {
       case (zoom: Int, x: Int, y: Int) =>
-        val futureTile = LayerCache.tile(prefix, layerId, zoom, SpatialKey(x, y))
-        val futureHistogram = LayerCache.bandHistogram(prefix, layerId, zoom)
+        val futureTile = LayerCache.tile(id, zoom, SpatialKey(x, y))
+        val futureHistogram = LayerCache.bandHistogram(id, zoom)
         (futureTile, futureHistogram)
     }
 
+  def pngAsHttpResponse(png: Png): HttpResponse =
+    HttpResponse(entity = HttpEntity(ContentType(MediaTypes.`image/png`), png.bytes))
+
   def singleLayer: Route =
-    pathPrefix(Segment / JavaUUID) { (prefix, layerId) =>
-      (pathPrefix("rgb") & layerTileAndHistogram(prefix, layerId)){ (futureTile, futureHist) =>
-        imageRoute(futureTile, futureHist)
+    pathPrefix(JavaUUID / Segment / JavaUUID).as(RfLayerId) { id =>
+      pathPrefix("rgb") {
+        layerTileAndHistogram(id) { (futureTile, futureHist) =>
+          imageRoute(futureTile, futureHist)
+        } ~
+        pathPrefix("thumbnail") {
+          pathEndOrSingleSlash {
+            get { imageThumbnailRoute(id) }
+          }
+        } ~
+        pathPrefix("histogram") {
+          pathEndOrSingleSlash {
+            get { imageHistogramRoute(id) }
+          }
+        }
       } ~
-      (pathPrefix("ndvi") & layerTile(prefix, layerId)){ futureTile =>
-        modelRoute(futureTile, NDVI, Some(NDVI.colorRamp), Some(NDVI.breaks))
+      (pathPrefix("ndvi") & layerTile(id)){ futureTile =>
+        get { modelRoute(futureTile, NDVI, Some(NDVI.colorRamp), Some(NDVI.breaks)) }
       } ~
-      (pathPrefix("ndwi") & layerTile(prefix, layerId)){ futureTile =>
-        modelRoute(futureTile, NDWI, Some(NDWI.colorRamp), Some(NDWI.breaks))
+      (pathPrefix("ndwi") & layerTile(id)){ futureTile =>
+        get { modelRoute(futureTile, NDWI, Some(NDWI.colorRamp), Some(NDWI.breaks)) }
       } ~
-      (pathPrefix("grey") & layerTile(prefix, layerId)){ futureTile =>
-        modelRoute(futureTile, _.band(0), Some(ColorRamp(Array(0x000000, 0xFFFFFF))))
+      (pathPrefix("grey") & layerTile(id)){ futureTile =>
+        get { modelRoute(futureTile, _.band(0), Some(ColorRamp(Array(0x000000, 0xFFFFFF)))) }
       }
     }
 
+  def imageThumbnailRoute(id: RfLayerId) =
+    colorCorrectParams { params =>
+      parameters('size.as[Int].?(256)) { size =>
+      complete {
+        val futureHist = LayerCache.bandHistogram(id, 0)
+        val futureTile = StitchLayer(id, size)
+
+        for {
+          tile <- futureTile
+          layerHist <- futureHist
+        } yield {
+          val (rgbTile, rgbHist) = params.reorderBands(tile, layerHist)
+          pngAsHttpResponse(ColorCorrect(rgbTile, rgbHist, params).renderPng)
+        }
+      }
+    }
+  }
+
+  def imageHistogramRoute(id: RfLayerId) =
+    colorCorrectParams { params =>
+      parameters('size.as[Int].?(64)) { size =>
+      import DefaultJsonProtocol._
+      complete {
+        val futureTile = StitchLayer(id, size)
+        val futureHist = LayerCache.bandHistogram(id, 0)
+        for {
+          tile <- futureTile
+          layerHist <- futureHist
+        } yield {
+          val (rgbTile, rgbHist) = params.reorderBands(tile, layerHist)
+          ColorCorrect(rgbTile, rgbHist, params).bands.map(_.histogram).toArray
+        }
+      }
+    }
+  }
+
   def imageRoute(futureTile: Future[MultibandTile], futureHist: Future[Array[Histogram[Double]]]): Route =
-    imageParams { params =>
+    colorCorrectParams { params =>
       complete {
         for {
           tile <- futureTile
           layerHist <- futureHist
         } yield {
-          val rgbHist = Array(layerHist(params.redBand), layerHist(params.greenBand), layerHist(params.blueBand))
-          val rgbTile = tile.subsetBands(params.redBand, params.greenBand, params.blueBand)
-
-          val png = Render(rgbTile, rgbHist, params)
-          HttpResponse(entity = HttpEntity(ContentType(MediaTypes.`image/png`), png.bytes))
+          val (rgbTile, rgbHist) = params.reorderBands(tile, layerHist)
+          pngAsHttpResponse(ColorCorrect(rgbTile, rgbHist, params).renderPng)
         }
       }
     }
@@ -78,8 +128,7 @@ trait Routes extends LazyLogging {
           } yield {
             val subsetTile = tile.subsetBands(params.bands)
             val colorMap = ColorMap(params.breaks, params.ramp)
-            val png = index(subsetTile).renderPng(colorMap)
-            HttpResponse(entity = HttpEntity(ContentType(MediaTypes.`image/png`), png.bytes))
+            pngAsHttpResponse(index(subsetTile).renderPng(colorMap))
           }
         }
       }

--- a/app-backend/tile/src/main/scala/StitchLayer.scala
+++ b/app-backend/tile/src/main/scala/StitchLayer.scala
@@ -1,0 +1,80 @@
+package com.azavea.rf.tile
+
+import geotrellis.proj4._
+import geotrellis.raster._
+import geotrellis.vector._
+import geotrellis.vector.io._
+import geotrellis.spark._
+import geotrellis.spark.io._
+import geotrellis.spark.io.s3._
+import com.github.blemale.scaffeine.{AsyncLoadingCache, Scaffeine}
+import com.typesafe.scalalogging.LazyLogging
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent._
+import scala.util.Try
+
+object StitchLayer extends LazyLogging with Config {
+  /** Determining which zoom level is appropriate, fetching tiles and stitching
+    * should be cached before rendering the thumbnail.
+    */
+  val tileCache: AsyncLoadingCache[(RfLayerId, Int), MultibandTile] =
+    Scaffeine()
+    .recordStats()
+    .expireAfterWrite(cacheExpiration)
+    .maximumSize(cacheSize)
+    .buildAsyncFuture { case (id, size: Int) =>
+      Future { stitch(LayerCache.attributeStore(id.prefix), id.scene.toString, size) }
+    }
+
+  /** This function will iterate through zoom levels a layer, starting with 1, until it finds the level
+    * at which the data pixels stored in the layer cover at least size pixels in columns or rows.
+    * Because the layer extent can be skewed or skinny and warping is not an option we can't demand both cols and rows.
+    *
+    * Next it will pull the tiles stored at this zoom level, stitch them together and crop to layer extent.
+    * This can be used to generate a thumbnail when asking for a small sample, which will use high zoom level.
+    * This also can be used to export an image of the layer at higher resolution.
+    * However it is possible to overload this function when asking for a sample of too large a size.
+    *
+    * Because this is an expensive operation the stitched tile is cached.
+    * For non-cached version use [[stitch]] function.
+    */
+  def apply(id: RfLayerId, size: Int): Future[MultibandTile] =
+    tileCache.get((id, size))
+
+  def stitch(store: AttributeStore, layerName: String, size: Int): MultibandTile = {
+    require(size < 4096, s"$size is too large to stitch")
+    minZoomLevel(store, layerName, size).map { case (layerId, re) =>
+      logger.debug(s"Stitching from $layerId, ${re.extent.reproject(WebMercator, LatLng).toGeoJson}")
+      S3CollectionLayerReader(store)
+        .query[SpatialKey, MultibandTile, TileLayerMetadata[SpatialKey]](layerId)
+        .where(Intersects(re.extent))
+        .result
+        .stitch
+        .crop(re.extent)
+    }.get
+  }
+
+  /** Find the minimum zoom level with enough pixels covering the data region of the layer */
+  def minZoomLevel(store: AttributeStore, layerName: String, size: Int): Try[(LayerId, RasterExtent)] = {
+    def forZoom(zoom: Int): Try[(LayerId, RasterExtent)] = {
+      val currentId = LayerId(layerName, zoom)
+      val meta = Try { store.readMetadata[TileLayerMetadata[SpatialKey]](currentId) }
+      val rasterExtent = meta.map { tlm => (tlm, dataRasterExtent(tlm)) }
+      rasterExtent.map { case(tlm, re) =>
+        logger.info(s"Data Extent: ${tlm.extent.reproject(WebMercator, LatLng).toGeoJson()}")
+        logger.debug(s"$currentId has (${re.cols},${re.rows}) pixels")
+        if (re.cols >= size || re.rows >= size) (currentId, re)
+        else forZoom(zoom + 1).getOrElse((currentId, re))
+      }
+    }
+    forZoom(1)
+  }
+
+  def dataRasterExtent(md: TileLayerMetadata[_]): RasterExtent = {
+    val re = RasterExtent(md.layout.extent,
+      md.layout.tileLayout.totalCols.toInt,
+      md.layout.tileLayout.totalRows.toInt)
+    val gb = re.gridBoundsFor(md.extent)
+    re.rasterExtentFor(gb).toRasterExtent
+  }
+}

--- a/app-backend/tile/src/main/scala/image/ColorCorrectParams.scala
+++ b/app-backend/tile/src/main/scala/image/ColorCorrectParams.scala
@@ -3,17 +3,8 @@ package com.azavea.rf.tile.image
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server._
 
-case class ImageParams(
-  redBand: Int, greenBand: Int, blueBand: Int,
-  redGamma: Option[Double], greenGamma: Option[Double], blueGamma: Option[Double],
-  contrast: Option[Double], brightness: Option[Int],
-  alpha: Option[Double], beta: Option[Double],
-  min: Option[Int], max: Option[Int],
-  equalize: Boolean
-)
-
-object ImageParams {
-  def imageParams: Directive1[ImageParams] =
+object ColorCorrectParams {
+  def colorCorrectParams: Directive1[ColorCorrect.Params] =
     parameters(
       'redBand.as[Int].?(0), 'greenBand.as[Int].?(1), 'blueBand.as[Int].?(2),
       "redGamma".as[Double].?, "greenGamma".as[Double].?, "blueGamma".as[Double].?,
@@ -21,5 +12,5 @@ object ImageParams {
       'alpha.as[Double].?, 'beta.as[Double].?,
       "min".as[Int].?, "max".as[Int].?,
       'equalize.as[Boolean].?(false)
-    ).as(ImageParams.apply _)
+    ).as(ColorCorrect.Params.apply _)
 }


### PR DESCRIPTION
## Overview

- Add `rgb/histogram`endpoint to generate a color corrected histogram
  - This endpoint takes the same params as the `rgb/{z}/{x}/{y}` endpoint
- Add `rgb/thumbnail` endpoint to generate a color corrected layer thumbnail
  - This endpoint takes the same params as the `rgb/{z}/{x}/{y}` endpoint
  - Can generate large thumbnails with arbitrary limit of `4096` pixels per side
- Adds tile caching before the rendering step, speeding up color correction responsiveness
- Changes URL structure to include organization and user id
 - ex: `http://localhost:9900/tiles/<org_id>/<user_id>/<scene_id>/rgb/thumbnail?size=128&min=1000&max=50000&redBand=4&greenBand=3&blueBand=2`
 - Renames `Render` to `ColorCorrect` forced by the fact that I need the tile before it gets turned to PNG. This appears to be a better name for it anyway.

### Demo

```bash
export AWS_PROFILE=raster-foundry
export TILE_SERVER_BUCKET=rasterfoundry-staging-catalogs-us-east-1
sbt tile/run
curl http://localhost:9900/tiles/dfac6307-b5ef-43f7-beda-b9f208bb7726/rf_airflow-user/4b02cbbf-fdfb-44fc-8f79-8bc42b372208/rgb/thumbnail?size=128&min=1000&max=50000&redBand=4&greenBand=3&blueBand=2
```

Sample histogram: 
```json
[[[0, 19902], [44, 2], [45, 3], [46, 5], [47, 2], [48, 4], [49, 5], [50, 4], [51, 9], [52, 5], [53, 13], [54, 26], [55, 47], [56, 106], [57, 177], [58, 253], [59, 381], [60, 507], [61, 632], [62, 771], [63, 919], [64, 1012], [65, 1237], [66, 1276], [67, 1324], [68, 1310], [69, 1419], [70, 1436], [71, 1538], [72, 1457], [73, 1447], [74, 1509], [75, 1411], [76, 1432], [77, 1452], [78, 1468], [79, 1544], [80, 1516], [81, 1544], [82, 1521], [83, 1562], [84, 1644], [85, 1585], [86, 1682], [87, 1734], [88, 1762], [89, 1892], [90, 1850], [91, 1953], [92, 1998], [93, 2021], [94, 2021], [95, 2109], [96, 2132], [97, 1983], [98, 2155], [99, 2154], [100, 2125], [101, 2229], [102, 2153], [103, 2199], [104, 2183], [105, 2121], [106, 2017], [107, 2060], [108, 1998], [109, 1947], [110, 1981], [111, 1842], [112, 1882], [113, 1727], [114, 1796], [115, 1611], [116, 1602], [117, 1509], [118, 1339], [119, 1293], [120, 1153], [121, 1049], [122, 930], [123, 820], [124, 709], [125, 539], [126, 474], [127, 392], [128, 303], [129, 244], [130, 222], [131, 176], [132, 154], [133, 135], [134, 116], [135, 71], [136, 57], [137, 46], [138, 44], [139, 27], [140, 26], [141, 25], [142, 24], [143, 17], [144, 18], [145, 7], [146, 8], [147, 3], [148, 9], [149, 3], [150, 3], [151, 4], [152, 3], [153, 4], [154, 5], [155, 1], [158, 2], [159, 1], [160, 2], [163, 1], [164, 1], [168, 2], [169, 1], [170, 1], [172, 1], [174, 3], [176, 2], [178, 1]], [[0, 19900], [47, 4], [48, 7], [49, 18], [50, 65], [51, 176], [52, 397], [53, 695], [54, 1081], [55, 1480], [56, 1796], [57, 2039], [58, 2129], [59, 2254], [60, 2329], [61, 2219], [62, 2227], [63, 2376], [64, 2343], [65, 2516], [66, 2533], [67, 2612], [68, 2400], [69, 2522], [70, 2607], [71, 2568], [72, 2671], [73, 2673], [74, 2855], [75, 3149], [76, 3124], [77, 3004], [78, 2898], [79, 2769], [80, 2584], [81, 2521], [82, 2454], [83, 2458], [84, 2464], [85, 2522], [86, 2522], [87, 2531], [88, 2537], [89, 2428], [90, 2375], [91, 2240], [92, 2092], [93, 1839], [94, 1783], [95, 1586], [96, 1302], [97, 1099], [98, 964], [99, 792], [100, 617], [101, 474], [102, 320], [103, 287], [104, 227], [105, 158], [106, 115], [107, 125], [108, 75], [109, 65], [110, 52], [111, 38], [112, 37], [113, 29], [114, 25], [115, 12], [116, 17], [117, 15], [118, 13], [119, 15], [120, 10], [121, 7], [122, 8], [123, 4], [124, 3], [125, 2], [126, 5], [127, 3], [128, 3], [129, 2], [130, 2], [132, 2], [133, 1], [134, 3], [135, 1], [136, 1], [138, 2], [142, 1], [144, 1], [145, 1], [146, 1], [147, 1], [148, 1], [149, 1], [150, 1], [151, 1], [152, 2], [154, 1]], [[0, 19905], [48, 17], [49, 58], [50, 124], [51, 145], [52, 454], [53, 1239], [54, 2568], [55, 3450], [56, 3863], [57, 4207], [58, 4379], [59, 4212], [60, 4095], [61, 4063], [62, 4341], [63, 4943], [64, 5009], [65, 4937], [66, 4461], [67, 4111], [68, 3809], [69, 3661], [70, 3651], [71, 3608], [72, 3624], [73, 3823], [74, 3715], [75, 3687], [76, 3359], [77, 3027], [78, 2616], [79, 2204], [80, 1854], [81, 1412], [82, 1028], [83, 716], [84, 463], [85, 334], [86, 248], [87, 171], [88, 163], [89, 103], [90, 77], [91, 60], [92, 42], [93, 43], [94, 35], [95, 17], [96, 25], [97, 21], [98, 23], [99, 8], [100, 13], [101, 14], [102, 7], [103, 10], [104, 6], [105, 11], [106, 3], [107, 4], [108, 5], [109, 4], [110, 2], [111, 6], [113, 1], [114, 2], [115, 1], [116, 3], [117, 1], [118, 2], [119, 1], [124, 1], [126, 1], [127, 1], [129, 3], [130, 3], [131, 1], [134, 1], [138, 1]]]
```

### Notes

I have started making a "cache cascade" where the function that provides one item, like tile, requires another cached item, like reader, which requires another cached item like attribute store. 

It doesn't appear to be a "bad thing", but not a pattern that we have seen before.

Also this reveals that the egypt ingest layers do not have correct layer extent set as can be seen through this thumbnail:
![image](https://cloud.githubusercontent.com/assets/1158084/20579881/351735f6-b19d-11e6-9d3d-dda04d8c4eb3.png)

Verified visually:
![image](https://cloud.githubusercontent.com/assets/1158084/20579907/5e4094f4-b19d-11e6-8100-3b1b49dc3635.png)


The `Routes` file is getting a little fat but I keep forcing the implementations out of it. It will probably make sense to break it up when the "model" (NDVI/NDWI/etc) routes receive additional effort.

Connects https://github.com/azavea/raster-foundry/issues/696

