### PR TITLE
Add Ingest Parameters

### DIFF
--- a/app-backend/ingest/src/main/scala/com/azavea/rf/ingest/Ingest.scala
+++ b/app-backend/ingest/src/main/scala/com/azavea/rf/ingest/Ingest.scala
@@ -59,8 +59,11 @@ object Ingest extends SparkJob {
       .reduce(_ combine _)
 
     // Infer the base level of the TMS pyramid based on overall extent and cellSize
+    // We should use the LayoutLevel with the greatest resolution - hence maxBy here
     val LayoutLevel(maxZoom, baseLayoutDefinition) =
-      scheme.levelFor(overallExtent, layer.output.cellSize)
+      layer.sources.map({ source =>
+        scheme.levelFor(overallExtent, source.cellSize)
+      }).maxBy(_.zoom)
 
     maxZoom -> TileLayerMetadata(
       cellType = layer.output.cellType,

--- a/app-backend/ingest/src/main/scala/com/azavea/rf/ingest/model/OutputDefinition.scala
+++ b/app-backend/ingest/src/main/scala/com/azavea/rf/ingest/model/OutputDefinition.scala
@@ -2,6 +2,11 @@ package com.azavea.rf.ingest.model
 
 import geotrellis.proj4.CRS
 import geotrellis.raster._
+import geotrellis.raster.resample._
+import geotrellis.spark.io.{CRSFormat => _, _} // We must shade the default CRSFormat
+import geotrellis.spark._
+import geotrellis.spark.io.index._
+
 import spray.json._
 import DefaultJsonProtocol._
 import java.net.URI
@@ -12,20 +17,25 @@ import java.net.URI
   * @param crs              The CRS of the projection to target in tiling
   * @param cellType         A GeoTrellis CellType to be used in storing a tile layer
   * @param cellSize         The expected 'native resolution' size of each cell
-  * @param histogramProjects The number of bins with which to construct histograms used in coloring
+  * @param histogramBuckets The number of bins with which to construct histograms used in coloring
   * @param pyramid          Whether or not to pyramid multiple zoom levels on ingest
   * @param native           Whether or not to keep around a copy of the 'native resolution' images
+  * @param resampleMethod   The type of GeoTrellis resample method to use for cell value estimation
+  * @param keyIndexMethod   The GeoTrellis KeyIndexMethod to use when writing output indices
   */
 case class OutputDefinition(
   uri: URI,
   crs: CRS,
   cellType: CellType,
   cellSize: CellSize,
-  histogramProjects: Int = 256,
-  pyramid: Boolean,
-  native: Boolean
+  histogramBuckets: Int = 256,
+  tileSize: Int = 256,
+  pyramid: Boolean = true,
+  native: Boolean = false,
+  resampleMethod: ResampleMethod = NearestNeighbor,
+  keyIndexMethod: KeyIndexMethod[SpatialKey] = ZCurveKeyIndexMethod // TODO: read, no write
 )
 
 object OutputDefinition {
-  implicit val jsonFormat = jsonFormat7(OutputDefinition.apply _)
+  implicit val jsonFormat = jsonFormat10(OutputDefinition.apply _)
 }

--- a/app-backend/ingest/src/main/scala/com/azavea/rf/ingest/model/OutputDefinition.scala
+++ b/app-backend/ingest/src/main/scala/com/azavea/rf/ingest/model/OutputDefinition.scala
@@ -27,7 +27,6 @@ case class OutputDefinition(
   uri: URI,
   crs: CRS,
   cellType: CellType,
-  cellSize: CellSize,
   histogramBuckets: Int = 256,
   tileSize: Int = 256,
   pyramid: Boolean = true,
@@ -37,5 +36,5 @@ case class OutputDefinition(
 )
 
 object OutputDefinition {
-  implicit val jsonFormat = jsonFormat10(OutputDefinition.apply _)
+  implicit val jsonFormat = jsonFormat9(OutputDefinition.apply _)
 }

--- a/app-backend/ingest/src/main/scala/com/azavea/rf/ingest/model/SourceDefinition.scala
+++ b/app-backend/ingest/src/main/scala/com/azavea/rf/ingest/model/SourceDefinition.scala
@@ -10,16 +10,24 @@ import geotrellis.proj4.CRS
 
 /** This class provides all information required to read from a source
   *
-  * @param uri     The URI of the source imagery
-  * @param extent  The Extent of a source tile
+  * @param uri      The URI of the source imagery
+  * @param extent   The Extent of a source tile
+  * @param crs      The CRS of the projection to target in tiling
   * @param bandMaps A list of mappings from source to destination tile
   */
 case class SourceDefinition(
   uri: URI,
   extent: Extent,
+  crsExtent: Option[CRS],
+  crs: CRS,
   bandMaps: Array[BandMapping]
-)
+) {
+  def getCRSExtent: CRS = crsExtent match {
+    case Some(crs) => crs
+    case None => this.crs
+  }
+}
 
 object SourceDefinition {
-  implicit val jsonFormat = jsonFormat3(SourceDefinition.apply _)
+  implicit val jsonFormat = jsonFormat5(SourceDefinition.apply _)
 }

--- a/app-backend/ingest/src/main/scala/com/azavea/rf/ingest/model/SourceDefinition.scala
+++ b/app-backend/ingest/src/main/scala/com/azavea/rf/ingest/model/SourceDefinition.scala
@@ -20,6 +20,7 @@ case class SourceDefinition(
   extent: Extent,
   crsExtent: Option[CRS],
   crs: CRS,
+  cellSize: CellSize,
   bandMaps: Array[BandMapping]
 ) {
   def getCRSExtent: CRS = crsExtent match {
@@ -29,5 +30,5 @@ case class SourceDefinition(
 }
 
 object SourceDefinition {
-  implicit val jsonFormat = jsonFormat5(SourceDefinition.apply _)
+  implicit val jsonFormat = jsonFormat6(SourceDefinition.apply _)
 }

--- a/app-backend/ingest/src/main/scala/com/azavea/rf/ingest/model/package.scala
+++ b/app-backend/ingest/src/main/scala/com/azavea/rf/ingest/model/package.scala
@@ -1,27 +1,89 @@
 package com.azavea.rf.ingest
 
 import geotrellis.raster._
+import geotrellis.raster.resample._
 import geotrellis.proj4._
+import geotrellis.vector._
+import geotrellis.spark._
+import geotrellis.spark.io.index._
 import spray.json._
 import DefaultJsonProtocol._
 
 import java.util.UUID
 import java.net.URI
 
-import geotrellis.vector.Extent
-
 package object model {
-  implicit object RFExtentJsonFormat extends RootJsonFormat[Extent] {
-    def write(extent: Extent): JsValue =
-      JsArray(
-        JsNumber(extent.xmin),
-        JsNumber(extent.ymin),
-        JsNumber(extent.xmax),
-        JsNumber(extent.ymax)
-      )
+
+  implicit object KeyIndexMethodJsonFormat extends RootJsonFormat[KeyIndexMethod[SpatialKey]] {
+    def write(kim: KeyIndexMethod[SpatialKey]): JsValue =
+      JsString("Unable to serialize KeyIndexMethods")
+
+    def read(value: JsValue): KeyIndexMethod[SpatialKey] = value match {
+      case JsString(kim) if kim.toLowerCase == "zcurvekeyindexmethod" => ZCurveKeyIndexMethod
+      case JsString(kim) if kim.toLowerCase == "rowmajorkeyindexmethod" => RowMajorKeyIndexMethod
+      case JsString(kim) if kim.toLowerCase == "hilbertkeyindexmethod" => HilbertKeyIndexMethod
+      case _ =>
+        deserializationError("Failed to parse Key Index Method")
+    }
+  }
+
+  implicit object ResampleMethodJsonFormat extends RootJsonFormat[ResampleMethod] {
+    def write(rm: ResampleMethod): JsValue = rm match {
+      case NearestNeighbor => JsString("NearestNeighbor")
+      case Bilinear => JsString("Bilinear")
+      case CubicConvolution => JsString("CubicConvolution")
+      case CubicSpline => JsString("CubicSpline")
+      case Lanczos => JsString("Lanczos")
+      case Average => JsString("Average")
+      case Mode => JsString("Mode")
+      case Median => JsString("Median")
+      case Max => JsString("Max")
+      case Min => JsString("Min")
+    }
+
+    def read(value: JsValue): ResampleMethod = value match {
+      case JsString(rm) if rm.toLowerCase == "nearestneighbor" => NearestNeighbor
+      case JsString(rm) if rm.toLowerCase == "bilinear" => Bilinear
+      case JsString(rm) if rm.toLowerCase == "cubicconvolution" => CubicConvolution
+      case JsString(rm) if rm.toLowerCase == "cubicspline" => CubicSpline
+      case JsString(rm) if rm.toLowerCase == "lanczos" => Lanczos
+      case JsString(rm) if rm.toLowerCase == "average" => Average
+      case JsString(rm) if rm.toLowerCase == "mode" => Mode
+      case JsString(rm) if rm.toLowerCase == "median" => Median
+      case JsString(rm) if rm.toLowerCase == "max" => Max
+      case JsString(rm) if rm.toLowerCase == "min" => Min
+      case _ =>
+        deserializationError("Failed to parse resample method")
+    }
+  }
+
+  implicit object CRSJsonFormat extends JsonFormat[CRS] {
+    def write(crs: CRS) =
+      crs.epsgCode match {
+        case Some(epsg) =>
+          JsString(s"epsg:${epsg}")
+        case None =>
+          serializationError(s"Unknown epsg code for ${crs}")
+      }
+
+    def read(value: JsValue): CRS = value match {
+      case JsString(epsg) =>
+        CRS.fromName(epsg)
+      case _ =>
+        deserializationError(s"Failed to parse ${value} to CRS")
+    }
+  }
+
+  implicit object ExtentJsonFormat extends RootJsonFormat[Extent] {
+    def write(extent: Extent): JsValue = JsArray(
+      JsNumber(extent.xmin),
+      JsNumber(extent.ymin),
+      JsNumber(extent.xmax),
+      JsNumber(extent.ymax)
+    )
+
     def read(value: JsValue): Extent = value match {
-      case JsArray(extent) =>
-        assert(extent.size == 4)
+      case JsArray(extent) if extent.size == 4 =>
         val parsedExtent = extent.map({
           case JsNumber(minmax) =>
             minmax.toDouble
@@ -29,6 +91,25 @@ package object model {
             deserializationError("Failed to parse extent array")
         })
         Extent(parsedExtent(0), parsedExtent(1), parsedExtent(2), parsedExtent(3))
+      case _ =>
+        deserializationError("Failed to parse extent array")
+    }
+  }
+
+  implicit object ProjectedExtentJsonFormat extends RootJsonFormat[ProjectedExtent] {
+    def write(pe: ProjectedExtent): JsValue = pe.crs.epsgCode match {
+      case Some(epsg) =>
+        JsObject(
+          "bbox" -> pe.extent.toJson,
+          "crs" -> pe.crs.toJson
+        )
+      case None =>
+        serializationError(s"Unknown epsg code for ${pe.crs}")
+    }
+
+    def read(value: JsValue): ProjectedExtent = value.asJsObject.getFields("bbox", "crs") match {
+      case Seq(extent, crs) =>
+        ProjectedExtent(extent.convertTo[Extent], crs.convertTo[CRS])
       case _ =>
         deserializationError("Failed to parse extent array")
     }
@@ -67,7 +148,7 @@ package object model {
       case Seq(JsNumber(width), JsNumber(height)) =>
         CellSize(width.toDouble, height.toDouble)
       case _ =>
-        deserializationError("Failed to parse ${value} to cellsize")
+        deserializationError(s"Failed to parse ${value} to cellsize")
     }
   }
 
@@ -78,24 +159,7 @@ package object model {
       case JsString(ct) =>
         CellType.fromString(ct)
       case _ =>
-        deserializationError("Failed to parse ${value} to CellType")
-    }
-  }
-
-  implicit object crsJsonFormat extends JsonFormat[CRS] {
-    def write(crs: CRS) =
-      crs.epsgCode match {
-        case Some(epsg) =>
-          JsString(s"epsg:${epsg}")
-        case None =>
-          serializationError("Unknown epsg code for ${crs}")
-      }
-
-    def read(value: JsValue): CRS = value match {
-      case JsString(epsg) =>
-        CRS.fromName(epsg)
-      case _ =>
-        deserializationError("Failed to parse ${value} to CRS")
+        deserializationError(s"Failed to parse ${value} to CellType")
     }
   }
 }

--- a/app-backend/ingest/src/test/resources/awsJob.json
+++ b/app-backend/ingest/src/test/resources/awsJob.json
@@ -8,24 +8,35 @@
             "cellType": "uint16raw",
             "histogramBuckets": 512,
             "cellSize": {"width": 37.151447651062888, "height": -37.151447651062888},
+            "tileSize": 256,
+            "resampleMethod": "NearestNeighbor",
+            "keyIndexMethod": "ZCurveKeyIndexMethod",
             "pyramid": true,
             "native": true
         },
         "sources": [{
             "uri": "http://landsat-pds.s3.amazonaws.com/L8/107/035/LC81070352015218LGN00/LC81070352015218LGN00_B4.TIF",
             "extent": [138.8339238,  34.9569460, 141.4502449,  37.1094577],
+            "crsExtent": "epsg:32654",
+            "crs": "epsg:32654",
             "bandMaps": [{"source": 1, "target": 1}]
         }, {
             "uri": "http://landsat-pds.s3.amazonaws.com/L8/107/035/LC81070352015218LGN00/LC81070352015218LGN00_B3.TIF",
             "extent": [138.8339238,  34.9569460, 141.4502449,  37.1094577],
+            "crsExtent": "epsg:32654",
+            "crs": "epsg:32654",
             "bandMaps": [{"source": 1, "target": 2}]
         }, {
             "uri": "http://landsat-pds.s3.amazonaws.com/L8/107/035/LC81070352015218LGN00/LC81070352015218LGN00_B2.TIF",
             "extent": [138.8339238,  34.9569460, 141.4502449,  37.1094577],
+            "crsExtent": "epsg:32654",
+            "crs": "epsg:32654",
             "bandMaps": [{"source": 1, "target": 3}]
         }, {
             "uri": "http://landsat-pds.s3.amazonaws.com/L8/107/035/LC81070352015218LGN00/LC81070352015218LGN00_B5.TIF",
             "extent": [138.8339238,  34.9569460, 141.4502449,  37.1094577],
+            "crsExtent": "epsg:32654",
+            "crs": "epsg:32654",
             "bandMaps": [{"source": 1, "target": 4}]
         }]
     }]

--- a/app-backend/ingest/src/test/resources/awsJob.json
+++ b/app-backend/ingest/src/test/resources/awsJob.json
@@ -7,7 +7,6 @@
             "crs": "epsg:3857",
             "cellType": "uint16raw",
             "histogramBuckets": 512,
-            "cellSize": {"width": 37.151447651062888, "height": -37.151447651062888},
             "tileSize": 256,
             "resampleMethod": "NearestNeighbor",
             "keyIndexMethod": "ZCurveKeyIndexMethod",
@@ -17,24 +16,28 @@
         "sources": [{
             "uri": "http://landsat-pds.s3.amazonaws.com/L8/107/035/LC81070352015218LGN00/LC81070352015218LGN00_B4.TIF",
             "extent": [138.8339238,  34.9569460, 141.4502449,  37.1094577],
+            "cellSize": {"width": 37.151447651062888, "height": -37.151447651062888},
             "crsExtent": "epsg:32654",
             "crs": "epsg:32654",
             "bandMaps": [{"source": 1, "target": 1}]
         }, {
             "uri": "http://landsat-pds.s3.amazonaws.com/L8/107/035/LC81070352015218LGN00/LC81070352015218LGN00_B3.TIF",
             "extent": [138.8339238,  34.9569460, 141.4502449,  37.1094577],
+            "cellSize": {"width": 37.151447651062888, "height": -37.151447651062888},
             "crsExtent": "epsg:32654",
             "crs": "epsg:32654",
             "bandMaps": [{"source": 1, "target": 2}]
         }, {
             "uri": "http://landsat-pds.s3.amazonaws.com/L8/107/035/LC81070352015218LGN00/LC81070352015218LGN00_B2.TIF",
             "extent": [138.8339238,  34.9569460, 141.4502449,  37.1094577],
+            "cellSize": {"width": 37.151447651062888, "height": -37.151447651062888},
             "crsExtent": "epsg:32654",
             "crs": "epsg:32654",
             "bandMaps": [{"source": 1, "target": 3}]
         }, {
             "uri": "http://landsat-pds.s3.amazonaws.com/L8/107/035/LC81070352015218LGN00/LC81070352015218LGN00_B5.TIF",
             "extent": [138.8339238,  34.9569460, 141.4502449,  37.1094577],
+            "cellSize": {"width": 37.151447651062888, "height": -37.151447651062888},
             "crsExtent": "epsg:32654",
             "crs": "epsg:32654",
             "bandMaps": [{"source": 1, "target": 4}]

--- a/app-backend/ingest/src/test/resources/localJob.json
+++ b/app-backend/ingest/src/test/resources/localJob.json
@@ -7,7 +7,6 @@
             "crs": "epsg:3857",
             "cellType": "uint16raw",
             "histogramBuckets": 256,
-            "cellSize": {"width": 37.151447651062888, "height": -37.151447651062888},
             "tileSize": 256,
             "resampleMethod": "NearestNeighbor",
             "keyIndexMethod": "ZCurveKeyIndexMethod",
@@ -18,24 +17,28 @@
             "uri": "file:///opt/rf/test-resources/imagery/landsat-clipped-B4.tif",
             "extent": [138.8339238,  34.9569460, 141.4502449,  37.1094577],
             "crsExtent": "epsg:32654",
+            "cellSize": {"width": 37.151447651062888, "height": -37.151447651062888},
             "crs": "epsg:32654",
             "bandMaps": [{"source": 1, "target": 1}]
         }, {
             "uri": "file:///opt/rf/test-resources/imagery/landsat-clipped-B3.tif",
             "extent": [138.8339238,  34.9569460, 141.4502449,  37.1094577],
             "crsExtent": "epsg:32654",
+            "cellSize": {"width": 37.151447651062888, "height": -37.151447651062888},
             "crs": "epsg:32654",
             "bandMaps": [{"source": 1, "target": 2}]
         }, {
             "uri": "file:///opt/rf/test-resources/imagery/landsat-clipped-B2.tif",
             "extent": [138.8339238,  34.9569460, 141.4502449,  37.1094577],
             "crsExtent": "epsg:32654",
+            "cellSize": {"width": 37.151447651062888, "height": -37.151447651062888},
             "crs": "epsg:32654",
             "bandMaps": [{"source": 1, "target": 3}]
         }, {
             "uri": "file:///opt/rf/test-resources/imagery/landsat-clipped-B5.tif",
             "extent": [138.8339238,  34.9569460, 141.4502449,  37.1094577],
             "crsExtent": "epsg:32654",
+            "cellSize": {"width": 37.151447651062888, "height": -37.151447651062888},
             "crs": "epsg:32654",
             "bandMaps": [{"source": 1, "target": 4}]
         }]

--- a/app-backend/ingest/src/test/resources/localJob.json
+++ b/app-backend/ingest/src/test/resources/localJob.json
@@ -8,24 +8,35 @@
             "cellType": "uint16raw",
             "histogramBuckets": 256,
             "cellSize": {"width": 37.151447651062888, "height": -37.151447651062888},
+            "tileSize": 256,
+            "resampleMethod": "NearestNeighbor",
+            "keyIndexMethod": "ZCurveKeyIndexMethod",
             "pyramid": true,
             "native": true
         },
         "sources": [{
             "uri": "file:///opt/rf/test-resources/imagery/landsat-clipped-B4.tif",
             "extent": [138.8339238,  34.9569460, 141.4502449,  37.1094577],
+            "crsExtent": "epsg:32654",
+            "crs": "epsg:32654",
             "bandMaps": [{"source": 1, "target": 1}]
         }, {
             "uri": "file:///opt/rf/test-resources/imagery/landsat-clipped-B3.tif",
             "extent": [138.8339238,  34.9569460, 141.4502449,  37.1094577],
+            "crsExtent": "epsg:32654",
+            "crs": "epsg:32654",
             "bandMaps": [{"source": 1, "target": 2}]
         }, {
             "uri": "file:///opt/rf/test-resources/imagery/landsat-clipped-B2.tif",
             "extent": [138.8339238,  34.9569460, 141.4502449,  37.1094577],
+            "crsExtent": "epsg:32654",
+            "crs": "epsg:32654",
             "bandMaps": [{"source": 1, "target": 3}]
         }, {
             "uri": "file:///opt/rf/test-resources/imagery/landsat-clipped-B5.tif",
             "extent": [138.8339238,  34.9569460, 141.4502449,  37.1094577],
+            "crsExtent": "epsg:32654",
+            "crs": "epsg:32654",
             "bandMaps": [{"source": 1, "target": 4}]
         }]
     }]

--- a/docs/ingest/README.md
+++ b/docs/ingest/README.md
@@ -104,11 +104,6 @@ the ingest subproject](../../app-backend/ingest/src/test/resources/awsJob.json):
               */
             "uri": "s3://rasterfoundry-staging-catalogs-us-east-1/test",
             /**
-              * Output Layer CRS (projection identification)
-              * @type String
-              */
-            "crs": "epsg:3857",
-            /**
               * Output Layer CellType
               * @type String
               */
@@ -118,26 +113,30 @@ the ingest subproject](../../app-backend/ingest/src/test/resources/awsJob.json):
               * @type Number
               */
             "histogramBuckets": 512,
-            /** Output Layer Cell Size */
-            "cellSize": {
-                /**
-                  * Cell Size Width
-                  * @type Number
-                  */
-                "width": 37.151447651062888,
-                /**
-                  * Cell Size Height
-                  * @type Number
-                  */
-                "height": -37.151447651062888
-            },
+            /**
+              * Size of output tiles
+              * @type Number
+              */
+            "tileSize": 256,
+            /**
+              * GeoTrellis resample method to be used
+              * @type String
+              */
+            "resampleMethod": "NearestNeighbor",
+            /**
+              * GeoTrellis method for indexing keys
+              * @type String
+              */
+            "keyIndexMethod": "ZCurveKeyIndexMethod",
             /**
               * Whether or not to pyramid
               * @type Boolean
               */
             "pyramid": true,
             /**
-              * Output Layer Cell Size
+              * Whether or not to save the native resolution
+              *  (not yet implemented)
+              *
               * @type Boolean
               */
             "native": true
@@ -154,6 +153,29 @@ the ingest subproject](../../app-backend/ingest/src/test/resources/awsJob.json):
               * @type Array of Numbers
               */
             "extent": [138.8339238,  34.9569460, 141.4502449,  37.1094577],
+            /**
+              * Source extent CRS (projection identification)
+              * @type String
+              */
+            "crsExtent": "epsg:32654",
+            /**
+              * Source CRS (projection identification)
+              * @type String
+              */
+            "crs": "epsg:3857",
+            /** Source Cell Size */
+            "cellSize": {
+                /**
+                  * Cell Size Width
+                  * @type Number
+                  */
+                "width": 37.151447651062888,
+                /**
+                  * Cell Size Height
+                  * @type Number
+                  */
+                "height": -37.151447651062888
+            },
             /** Mapping from source image to target image band */
             "bandMaps": [
                 {


### PR DESCRIPTION
## Overview

This PR adds some missing parameters (overlooked and underspecified before).

### Added params

- [x] KeyIndexMethod parameter
- [x] ResampleMethod parameter
- [x] Source extent parameter
- [x] Source extent CRS parameter 
- [x] Use `output.pyramid` parameter in ingest

We decided not to support this right now. Do not use `output.native`
 
## Testing Instructions

 Ingest specifications have been updated so that `cibuild` and `citest` scripts continue to work and exercise the functionality provided by this PR

Connects #697 
Connects #698 
