### PR TITLE
WIP: Showing scene footprint on hover

### DIFF
--- a/app-frontend/src/app/components/leafletMap/leafletMap.component.js
+++ b/app-frontend/src/app/components/leafletMap/leafletMap.component.js
@@ -7,6 +7,7 @@ const leafletMap = {
     bindings: {
         static: '<?',
         footprint: '<?',
+        bypassFitBounds: '<?',
         proposedBounds: '<?',
         onBoundsChange: '&',
         layers: '<?'

--- a/app-frontend/src/app/components/leafletMap/leafletMap.controller.js
+++ b/app-frontend/src/app/components/leafletMap/leafletMap.controller.js
@@ -18,16 +18,22 @@ export default class LeafletMapController {
 
     $onChanges(changes) {
         if (changes.footprint) {
-            let geojsonFeature = {
-                type: 'Feature',
-                properties: {
-                    name: 'Scene Footprint'
-                },
-                geometry: changes.footprint.currentValue
-            };
-            this.geojsonLayer.clearLayers();
-            this.geojsonLayer.addData(geojsonFeature);
-            this.map.fitBounds(this.geojsonLayer.getBounds());
+            if (changes.footprint.currentValue) {
+                let geojsonFeature = {
+                    type: 'Feature',
+                    properties: {
+                        name: 'Scene Footprint'
+                    },
+                    geometry: changes.footprint.currentValue
+                };
+                this.geojsonLayer.clearLayers();
+                this.geojsonLayer.addData(geojsonFeature);
+                if (!this.bypassFitBounds) {
+                    this.map.fitBounds(this.geojsonLayer.getBounds());
+                }
+            } else {
+                this.geojsonLayer.clearLayers();
+            }
         }
         if (changes.proposedBounds && changes.proposedBounds.currentValue) {
             this.map.fitBounds(changes.proposedBounds.currentValue);

--- a/app-frontend/src/app/pages/browse/browse.controller.js
+++ b/app-frontend/src/app/pages/browse/browse.controller.js
@@ -228,6 +228,14 @@ export default class BrowseController {
         }
     }
 
+    setHoveredScene(scene) {
+        this.hoveredScene = scene;
+    }
+
+    removeHoveredScene() {
+        this.hoveredScene = null;
+    }
+
     projectModal() {
         if (!this.selectedScenes || this.selectedScenes.size === 0) {
             return;

--- a/app-frontend/src/app/pages/browse/browse.html
+++ b/app-frontend/src/app/pages/browse/browse.html
@@ -27,7 +27,10 @@
             selected="$ctrl.isSelected(scene)"
             on-select="$ctrl.setSelected(scene, selected)"
             class="selectable"
-            ng-repeat="scene in $ctrl.sceneList track by scene.id">
+            ng-repeat="scene in $ctrl.sceneList track by scene.id"
+            ng-mouseover="$ctrl.setHoveredScene(scene)"
+            ng-mouseleave="$ctrl.removeHoveredScene()"
+            >
         </rf-scene-item>
       </div>
       <div class="list-group" ng-show="$ctrl.loading">
@@ -117,6 +120,6 @@
   </div>
 
   <div class="main">
-    <rf-leaflet-map proposed-bounds="$ctrl.bounds" on-bounds-change="$ctrl.onBoundsChange(newBounds)" class="map-container"></rf-leaflet-map>
+    <rf-leaflet-map footprint="$ctrl.hoveredScene.dataFootprint" bypass-fit-bounds="true" proposed-bounds="$ctrl.bounds" on-bounds-change="$ctrl.onBoundsChange(newBounds)" class="map-container"></rf-leaflet-map>
   </div>
 </div>


### PR DESCRIPTION
## Overview

For the browse and color correction scene lists, show the hovered scene's footprint on the map. This also adds a `bypassFitBounds` bound attribute that when `true` will skip changing the map extent to fit the footprint extent.

- [x] Scene footprints are shown when hovering on a scene on browse scene page
- [ ] Scene footprints are shown when hovering on a scene on the color correction page

### Notes

Waiting for some other work to be completed (#733) to do this for the color correction page.

## Testing Instructions

* Hover over the scenes on the browse page and ensure the footprints are being displayed.
* Hover over the scenes on the color correction page and ensure the footprints are being displayed.

Connects #728

