### PR TITLE
Create ingest definition from scene ID

### DIFF
--- a/app-tasks/rf/src/rf/ingest/ingest.py
+++ b/app-tasks/rf/src/rf/ingest/ingest.py
@@ -1,22 +1,38 @@
+"""Python class representation of a Raster Foundry Ingest"""
+
 import uuid
 
-class Ingest():
 
-    def __init__(self, layers=[]):
+class Ingest(object):
+    def __init__(self, id, layers):
+
         """
             Create a new Ingest
 
             Args:
-                layers (List[Layers]): A list of all layers included in the ingest
+                layers (List[Layer]): A list of all layers included in the ingest
         """
-        self.id = uuid.uuid4()
+
+        assert len(layers), "An ingest requires at least one Layer"
+        self.id = id or str(uuid.uuid4())
         self.layers = layers
+
+    @classmethod
+    def from_dict(cls, d):
+        return cls(
+            d.get('id'),
+            d.get('layers')
+        )
 
     def to_dict(self):
         return {
-            'id': str(self.id),
-            'layers': map(lambda l: l.to_dict(), self.layers)
+            'id': self.id,
+            'layers': [l.to_dict() for l in self.layers]
         }
 
-    def create(self):
-        return super(Ingest, self).create()
+    def to_ingest_dict(self):
+        """ Return a dict formatted specifically for serialization to an ingest definition """
+        return {
+            'id': self.id,
+            'layers': [l.to_ingest_dict() for l in self.layers]
+        }

--- a/app-tasks/rf/src/rf/ingest/ingest.py
+++ b/app-tasks/rf/src/rf/ingest/ingest.py
@@ -1,0 +1,22 @@
+import uuid
+
+class Ingest():
+
+    def __init__(self, layers=[]):
+        """
+            Create a new Ingest
+
+            Args:
+                layers (List[Layers]): A list of all layers included in the ingest
+        """
+        self.id = uuid.uuid4()
+        self.layers = layers
+
+    def to_dict(self):
+        return {
+            'id': str(self.id),
+            'layers': map(lambda l: l.to_dict(), self.layers)
+        }
+
+    def create(self):
+        return super(Ingest, self).create()

--- a/app-tasks/rf/src/rf/ingest/layer.py
+++ b/app-tasks/rf/src/rf/ingest/layer.py
@@ -1,7 +1,9 @@
 """ Python class to represent a layer within an ingest """
+
 from .source import Source
 
-class Layer():
+
+class Layer(object):
     def __init__(self, scene,
                  output_uri, output_crs="epsg:3857", output_pyramid=True, output_native=False,
                  output_cell_type="uint16raw", output_histogram_buckets=512, output_tile_size=256,
@@ -41,19 +43,44 @@ class Layer():
     @classmethod
     def from_dict(cls, d):
         return cls(
-            d.get('id'),
-            d.get('output'),
-            d.get('sources')
+            d.get('scene'),
+            d.get('output_uri'),
+            d.get('output_crs'),
+            d.get('output_pyramid'),
+            d.get('output_native'),
+            d.get('output_cell_type'),
+            d.get('output_histogram_buckets'),
+            d.get('output_tile_size'),
+            d.get('output_resample_method'),
+            d.get('output_key_index_method'),
+            d.get('ingest_resolution_meters')
         )
 
     def to_dict(self):
         return {
+            'scene': self.scene.to_dict(),
+            'output_uri': self.output_uri,
+            'output_crs': self.output_crs,
+            'output_pyramid': self.output_pyramid,
+            'output_native': self.output_native,
+            'output_cell_type': self.output_cell_type,
+            'output_histogram_buckets': self.output_histogram_buckets,
+            'output_tile_size': self.output_tile_size,
+            'output_resample_method': self.output_resample_method,
+            'output_key_index_method': self.output_key_index_method,
+            'ingest_resolution_meters': self.ingest_resolution_meters
+        }
+
+    def to_ingest_dict(self):
+        """ Return a dict formatted specifically for serialization to an ingest definition component """
+        return {
             'id': str(self.scene.id),
             'output': self.get_output(),
-            'sources': map(lambda s: s.to_dict(), self.get_sources()),
+            'sources': [s.to_dict() for s in self.get_sources()]
         }
 
     def get_sources(self):
+        """ Return a list of sources created from the images within the layer's scene """
         sources = []
         target_band_index = 1
         for image in self.scene.images:
@@ -63,6 +90,7 @@ class Layer():
         return sources
 
     def get_output(self):
+        """ Return a dict with the layer's output parameters as needed for an ingest definition """
         return {
             'crs': self.output_crs,
             'pyramid': self.output_pyramid,
@@ -76,6 +104,7 @@ class Layer():
         }
 
     def get_extent(self):
+        """ Return a list of floats that represents the extent of the layer's data (not tile) """
         coords = self.scene.dataFootprint['coordinates'][0][0]
         x_coords = map(lambda c: c[0], coords)
         y_coords = map(lambda c: c[1], coords)
@@ -87,6 +116,7 @@ class Layer():
         ]
 
     def get_tile_size(self):
+        """ Return a dict with width and height keys to represent a square tile size """
         return {
             'width': self.output_tile_size,
             'height': self.output_tile_size

--- a/app-tasks/rf/src/rf/ingest/layer.py
+++ b/app-tasks/rf/src/rf/ingest/layer.py
@@ -1,0 +1,93 @@
+""" Python class to represent a layer within an ingest """
+from .source import Source
+
+class Layer():
+    def __init__(self, scene,
+                 output_uri, output_crs="epsg:3857", output_pyramid=True, output_native=False,
+                 output_cell_type="uint16raw", output_histogram_buckets=512, output_tile_size=256,
+                 output_resample_method="NearestNeighbor", output_key_index_method="ZCurveKeyIndexMethod",
+                 ingest_resolution_meters=None):
+
+        """
+            Create a new ingest Layer
+
+            Args:
+                scene (rf.models.Scene): Scene instance the layer is based on
+                output_uri (str): Output layer URI
+                output_crs (str): Output layer CRS
+                output_pyramid (bool): Whether or not to pyramid
+                output_native (bool): Whether or not to save native resolution
+                output_cell_type (bool): Output layer cell-type
+                output_histogram_buckets (int): Output histogram bin count
+                output_tile_size (int): Size of output tiles
+                output_resample_method (str): GeoTrellis resample method
+                output_key_index_method (str): GeoTrellis method for indexing keys
+                ingest_resolution_meters (float): Optional resolution that will dictate which images
+                    from the scene are used
+        """
+
+        self.scene = scene
+        self.output_uri = output_uri
+        self.output_crs = output_crs
+        self.output_pyramid = output_pyramid
+        self.output_native = output_native
+        self.output_cell_type = output_cell_type
+        self.output_histogram_buckets = output_histogram_buckets
+        self.output_tile_size = output_tile_size
+        self.output_resample_method = output_resample_method
+        self.output_key_index_method = output_key_index_method
+        self.ingest_resolution_meters = ingest_resolution_meters
+
+    @classmethod
+    def from_dict(cls, d):
+        return cls(
+            d.get('id'),
+            d.get('output'),
+            d.get('sources')
+        )
+
+    def to_dict(self):
+        return {
+            'id': str(self.scene.id),
+            'output': self.get_output(),
+            'sources': map(lambda s: s.to_dict(), self.get_sources()),
+        }
+
+    def get_sources(self):
+        sources = []
+        target_band_index = 1
+        for image in self.scene.images:
+            new_source = Source(image, self.get_extent(), target_band_index)
+            sources.append(new_source)
+            target_band_index += len(new_source.band_maps)
+        return sources
+
+    def get_output(self):
+        return {
+            'crs': self.output_crs,
+            'pyramid': self.output_pyramid,
+            'histogramBuckets': self.output_histogram_buckets,
+            'uri': self.output_uri,
+            'tileSize': self.get_tile_size(),
+            'cellType': self.output_cell_type,
+            'resampleMethod': self.output_resample_method,
+            'keyIndexMethod': self.output_key_index_method,
+            'native': self.output_native
+        }
+
+    def get_extent(self):
+        coords = self.scene.dataFootprint['coordinates'][0][0]
+        x_coords = map(lambda c: c[0], coords)
+        y_coords = map(lambda c: c[1], coords)
+        return [
+            min(x_coords),
+            min(y_coords),
+            max(x_coords),
+            max(y_coords)
+        ]
+
+    def get_tile_size(self):
+        return {
+            'width': self.output_tile_size,
+            'height': self.output_tile_size
+        }

--- a/app-tasks/rf/src/rf/ingest/source.py
+++ b/app-tasks/rf/src/rf/ingest/source.py
@@ -1,7 +1,9 @@
 """ Python class to represent the sources within an ingest layer """
-class Source():
+
+
+class Source(object):
     def __init__(self, image, extent, starting_target_band, band_maps=None,
-                 crs="epsg:3857", extent_crs="epsg:3857"):
+                 source_crs="epsg:4326", extent_crs="epsg:4326"):
 
         """
             Create a new ingest Source
@@ -14,11 +16,12 @@ class Source():
                 crs (str): CRS of the Source (@TODO: figure out why this is needed)
                 extent_crs (str): CRS of the extent (@TODO: figure out why this is needed)
         """
+
         self.image = image
         self.extent = extent
         self.starting_target_band = starting_target_band
-        self.band_maps = self.get_band_maps()
-        self.crs = crs
+        self.band_maps = band_maps or self.create_band_maps()
+        self.source_crs = source_crs
         self.extent_crs = extent_crs
 
 
@@ -27,19 +30,40 @@ class Source():
         return cls(
             d.get('image'),
             d.get('extent'),
-            d.get('starting_target_band')
+            d.get('starting_target_band'),
+            d.get('band_maps'),
+            d.get('source_crs'),
+            d.get('extent_crs')
         )
 
     def to_dict(self):
         return {
+            'image': self.image.to_dict(),
             'extent': self.extent,
-            'crsExtent': self.extent_crs,
-            'crs': self.crs,
-            'uri': self.image['sourceUri'],
-            'bandMaps': self.get_band_maps()
+            'starting_target_band': self.starting_target_band,
+            'band_maps': self.band_maps,
+            'source_crs': self.source_crs,
+            'extent_crs': self.extent_crs
         }
 
-    def get_band_maps(self):
+    def to_ingest_dict(self):
+        """
+            Return a dict of the source formatted to be serialized and included within an ingest
+            definition
+        """
+        return {
+            'extent': self.extent,
+            'crsExtent': self.extent_crs,
+            'bandMaps': self.band_maps,
+            'crs': self.source_crs,
+            'uri': self.image['sourceUri'],
+        }
+
+    def create_band_maps(self):
+        """
+            Return a list of dicts, each representing the mapping of a band within the source's
+            image to a band of the target output
+        """
         band_maps = []
         source_band_index = 1
         target_band_index = self.starting_target_band

--- a/app-tasks/rf/src/rf/ingest/source.py
+++ b/app-tasks/rf/src/rf/ingest/source.py
@@ -1,0 +1,53 @@
+""" Python class to represent the sources within an ingest layer """
+class Source():
+    def __init__(self, image, extent, starting_target_band, band_maps=None,
+                 crs="epsg:3857", extent_crs="epsg:3857"):
+
+        """
+            Create a new ingest Source
+
+            Args:
+                image (rf.models.Image): Image instance the source is based on
+                extent (List[float]): extent of the source
+                starting_target_band (int): index of first target band
+                band_maps (List[dict]): list of mappings for each band within the image
+                crs (str): CRS of the Source (@TODO: figure out why this is needed)
+                extent_crs (str): CRS of the extent (@TODO: figure out why this is needed)
+        """
+        self.image = image
+        self.extent = extent
+        self.starting_target_band = starting_target_band
+        self.band_maps = self.get_band_maps()
+        self.crs = crs
+        self.extent_crs = extent_crs
+
+
+    @classmethod
+    def from_dict(cls, d):
+        return cls(
+            d.get('image'),
+            d.get('extent'),
+            d.get('starting_target_band')
+        )
+
+    def to_dict(self):
+        return {
+            'extent': self.extent,
+            'crsExtent': self.extent_crs,
+            'crs': self.crs,
+            'uri': self.image['sourceUri'],
+            'bandMaps': self.get_band_maps()
+        }
+
+    def get_band_maps(self):
+        band_maps = []
+        source_band_index = 1
+        target_band_index = self.starting_target_band
+        for band in self.image['bands']:
+            band_maps.append({
+                'source': source_band_index,
+                'target': target_band_index
+            })
+            source_band_index += 1
+            target_band_index += 1
+        return band_maps

--- a/app-tasks/rf/src/rf/models/base.py
+++ b/app-tasks/rf/src/rf/models/base.py
@@ -36,10 +36,11 @@ class BaseModel(object):
 
     @classmethod
     def from_id(cls, id):
-        url = '{HOST}/{URL_PATH}/{id}'.format(HOST=cls.HOST, URL_PATH=cls.URL_PATH, id=id)
+        url = '{HOST}{URL_PATH}{id}'.format(HOST=cls.HOST, URL_PATH=cls.URL_PATH, id=id)
         session = get_session()
         response = session.get(url)
         response.raise_for_status()
+
         return cls.from_json(response.json())
 
     @classmethod
@@ -54,8 +55,7 @@ class BaseModel(object):
 
     @classmethod
     def from_json(cls, json_string):
-        d = json.loads(json_string)
-        return cls.from_dict(d)
+        return cls.from_dict(json_string)
 
     def create(self):
         url = '{HOST}{URL_PATH}'.format(HOST=self.HOST, URL_PATH=self.URL_PATH)

--- a/app-tasks/rf/src/rf/models/scene.py
+++ b/app-tasks/rf/src/rf/models/scene.py
@@ -69,8 +69,9 @@ class Scene(BaseModel):
         return cls(
             d.get('organizationId'), d.get('ingestSizeBytes'), d.get('visibility'),
             d.get('tags'), d.get('datasource'), d.get('sceneMetadata'), d.get('name'), d.get('thumbnailStatus'),
-            d.get('boundaryStatus'), d.get('status'), d.get('sunAzimuth'), d.get('sunElevation'),
-            d.get('cloudCover'), d.get('acquisitionDate'), d.get('id')
+            d.get('boundaryStatus'), d.get('status'), d.get('metadataFiles'), d.get('sunAzimuth'), d.get('sunElevation'),
+            d.get('cloudCover'), d.get('acquisitionDate'), d.get('id'), d.get('thumbnails'), d.get('tileFootprint'), d.get('dataFootprint'),
+            d.get('images')
         )
 
     def to_dict(self):


### PR DESCRIPTION
## Overview

Given a scene ID, will return a dict that can be serialized to a JSON ingest job definition.

### Demo

Attached is a sample of the serialized output.

### Notes

- Unsure if the file naming/location is ideal.
- Unsure of how to properly handle scenes that contain images with varying resolutions (being that the ingest definition is defining a cell-size at the layer level rather than the source level). For now, we are using the resolution of the first image within a scene.
- Unsure of how the URI of the layer will be handled, it is currently hard-coded
- There was no example I could find of `bandMaps` for images with multiple bands, so some assumptions were made.

## Testing Instructions

* vagrant ssh into the dev VM
* `./scripts/server`

Separately:
* `docker-compose exec airflow-worker bash`
* `cd /opt/raster-foundry/app-tasks/rf/src/`
* Run a python interactive console and run the function using a scene ID

Connects #737
