### PR TITLE
Filter scene query by createdAt

### DIFF
--- a/app-frontend/src/app/pages/browse/browse.controller.js
+++ b/app-frontend/src/app/pages/browse/browse.controller.js
@@ -130,6 +130,7 @@ export default class BrowseController {
         }
 
         delete this.errorMsg;
+        this.sceneLoadingTime = new Date().toISOString();
         this.loading = true;
         this.infScrollPage = 0;
         // save off selected scenes so you don't lose them during the refresh
@@ -139,7 +140,8 @@ export default class BrowseController {
         this.sceneService.query(
             Object.assign({
                 sort: 'createdAt,desc',
-                pageSize: '20'
+                pageSize: '20',
+                maxCreateDatetime: this.sceneLoadingTime
             }, params)
         ).then(
             (sceneResult) => {
@@ -171,7 +173,8 @@ export default class BrowseController {
             Object.assign({
                 sort: 'createdAt,desc',
                 pageSize: '20',
-                page: this.infScrollPage
+                page: this.infScrollPage,
+                maxCreateDatetime: this.sceneLoadingTime
             }, params)
         ).then(
             (sceneResult) => {


### PR DESCRIPTION
## Overview

Filter scene requests using the `maxCreateDatetime` query parameter to ensure scenes ingested after the initial scene list is loaded do not create paging offset issues.

### Notes

The timestamp that is used is created whenever the scene list is refreshed (i.e. any map extent change). This could be more useful for long sessions rather than creating a single time-stamp on page load.


## Testing Instructions

 * Monitor outgoing requests to ensure timestamp is being updated when scene list is refreshed.
 * Directly set the timestamp with the `browse.controller.js` and analyze response to ensure that no later scenes are loaded.

Connects #743

