### PR TITLE
Add project name editing

### DIFF
--- a/app-frontend/src/app/core/services/project.service.js
+++ b/app-frontend/src/app/core/services/project.service.js
@@ -23,6 +23,13 @@ export default (app) => {
                     delete: {
                         method: 'DELETE'
                     },
+                    updateProject: {
+                        method: 'PUT',
+                        url: '/api/projects/:id',
+                        params: {
+                            id: '@id'
+                        }
+                    },
                     addScenes: {
                         method: 'POST',
                         url: '/api/projects/:projectId/scenes/',
@@ -97,6 +104,10 @@ export default (app) => {
 
         deleteProject(projectId) {
             return this.Project.delete({id: projectId}).$promise;
+        }
+
+        updateProject(params) {
+            return this.Project.updateProject(params).$promise;
         }
     }
 

--- a/app-frontend/src/app/pages/library/projects/detail/projectScenes/projectScenes.controller.js
+++ b/app-frontend/src/app/pages/library/projects/detail/projectScenes/projectScenes.controller.js
@@ -13,6 +13,9 @@ export default class ProjectScenesController {
         this.project = this.$state.params.project;
         this.projectId = this.$state.params.projectid;
 
+        this.isEditingProjectName = false;
+        this.isSavingProjectNameEdit = false;
+
         if (!this.project) {
             if (this.projectId) {
                 this.loading = true;
@@ -186,4 +189,37 @@ export default class ProjectScenesController {
             }
         );
     }
-}
+
+    toggleProjectNameEdit() {
+        if (this.isEditingProjectName) {
+            this.cancelProjectNameEdit();
+        } else {
+            this.startProjectNameEdit();
+        }
+    }
+
+    startProjectNameEdit() {
+        this.editedProjectName = this.project.name;
+        this.isEditingProjectName = true;
+    }
+
+    saveProjectNameEdit() {
+        this.isSavingProjectNameEdit = true;
+        this.isEditingProjectName = false;
+        this.project.name = this.editedProjectName;
+        this.projectService.updateProject(this.project).then(
+            () => {
+                this.isSavingProjectNameEdit = false;
+            },
+            (err) => {
+                this.$log.error('Error renaming project:', err);
+                this.isSavingProjectNameEdit = false;
+            }
+        );
+    }
+
+    cancelProjectNameEdit() {
+        this.isEditingProjectName = false;
+        this.editedProjectName = this.project.name;
+    }
+ }

--- a/app-frontend/src/app/pages/library/projects/detail/projectScenes/projectScenes.controller.js
+++ b/app-frontend/src/app/pages/library/projects/detail/projectScenes/projectScenes.controller.js
@@ -15,6 +15,7 @@ export default class ProjectScenesController {
 
         this.isEditingProjectName = false;
         this.isSavingProjectNameEdit = false;
+        this.showError = false;
 
         if (!this.project) {
             if (this.projectId) {
@@ -213,6 +214,7 @@ export default class ProjectScenesController {
                 this.isSavingProjectNameEdit = false;
             },
             (err) => {
+                this.showError = true;
                 this.$log.error('Error renaming project:', err);
                 this.project.name = cachedProjectName;
                 this.isSavingProjectNameEdit = false;
@@ -223,5 +225,9 @@ export default class ProjectScenesController {
     cancelProjectNameEdit() {
         this.isEditingProjectName = false;
         this.editedProjectName = this.project.name;
+    }
+
+    dismissErrorMessage() {
+        this.showError = false;
     }
  }

--- a/app-frontend/src/app/pages/library/projects/detail/projectScenes/projectScenes.controller.js
+++ b/app-frontend/src/app/pages/library/projects/detail/projectScenes/projectScenes.controller.js
@@ -204,15 +204,17 @@ export default class ProjectScenesController {
     }
 
     saveProjectNameEdit() {
+        const cachedProjectName = this.project.name;
         this.isSavingProjectNameEdit = true;
-        this.isEditingProjectName = false;
         this.project.name = this.editedProjectName;
+        this.isEditingProjectName = false;
         this.projectService.updateProject(this.project).then(
             () => {
                 this.isSavingProjectNameEdit = false;
             },
             (err) => {
                 this.$log.error('Error renaming project:', err);
+                this.project.name = cachedProjectName;
                 this.isSavingProjectNameEdit = false;
             }
         );

--- a/app-frontend/src/app/pages/library/projects/detail/projectScenes/projectScenes.html
+++ b/app-frontend/src/app/pages/library/projects/detail/projectScenes/projectScenes.html
@@ -2,17 +2,19 @@
   <div class="column" ng-if="!$ctrl.loading">
     <div class="library-header">
       <h1 class="h3 page-title"
-          ng-show="!$ctrl.$parent.selectedScenes.size">
+          ng-show="!$ctrl.$parent.selectedScenes.size && !$ctrl.isEditingProjectName">
         <a ui-sref="^.^.list">Projects</a><br>
         {{$ctrl.project.name}}
       </h1>
-      <button class="btn btn-tiny" ng-click="$ctrl.toggleProjectNameEdit()" ng-show="!$ctrl.$parent.selectedScenes.size">
+      <button class="btn btn-tiny" ng-click="$ctrl.toggleProjectNameEdit()" ng-show="!$ctrl.$parent.selectedScenes.size && !$ctrl.isEditingProjectName">
         <i class="icon-pencil"></i>
       </button>
       <div ng-show="$ctrl.isEditingProjectName">
+        <div class="page-title">
+          <a ui-sref="^.^.list">Projects</a>
+        </div>
         <form class="ng-pristine ng-valid">
           <div class="form-group all-in-one">
-            <label for="name"><i class="icon-bucket"></i></label>
             <input id="name" type="text" class="form-control"
                   placeholder="Edit project name" ng-model="$ctrl.editedProjectName">
             <button class="btn btn-link" type="submit"

--- a/app-frontend/src/app/pages/library/projects/detail/projectScenes/projectScenes.html
+++ b/app-frontend/src/app/pages/library/projects/detail/projectScenes/projectScenes.html
@@ -12,7 +12,13 @@
               ng-show="!$ctrl.$parent.selectedScenes.size && !$ctrl.isEditingProjectName && !$ctrl.isSavingProjectNameEdit">
         <i class="icon-pencil"></i>
       </button>
-      
+      <div class="color-danger" ng-show="$ctrl.showError">
+        There was an error renaming the project.
+        <button class="btn btn-tiny" type="submit"
+                ng-click="$ctrl.dismissErrorMessage()">
+          <i class="icon-cross color-danger"></i>
+        </button>         
+      </div>
       <div ng-show="$ctrl.isEditingProjectName">
         <div class="page-title">
           <a ui-sref="^.^.list">Projects</a>

--- a/app-frontend/src/app/pages/library/projects/detail/projectScenes/projectScenes.html
+++ b/app-frontend/src/app/pages/library/projects/detail/projectScenes/projectScenes.html
@@ -5,10 +5,14 @@
           ng-show="!$ctrl.$parent.selectedScenes.size && !$ctrl.isEditingProjectName">
         <a ui-sref="^.^.list">Projects</a><br>
         {{$ctrl.project.name}}
+        <i class="icon-load" ng-show="$ctrl.isSavingProjectNameEdit"></i>
       </h1>
-      <button class="btn btn-tiny" ng-click="$ctrl.toggleProjectNameEdit()" ng-show="!$ctrl.$parent.selectedScenes.size && !$ctrl.isEditingProjectName">
+      <button class="btn btn-tiny"
+              ng-click="$ctrl.toggleProjectNameEdit()"
+              ng-show="!$ctrl.$parent.selectedScenes.size && !$ctrl.isEditingProjectName && !$ctrl.isSavingProjectNameEdit">
         <i class="icon-pencil"></i>
       </button>
+      
       <div ng-show="$ctrl.isEditingProjectName">
         <div class="page-title">
           <a ui-sref="^.^.list">Projects</a>
@@ -19,12 +23,12 @@
                   placeholder="Edit project name" ng-model="$ctrl.editedProjectName">
             <button class="btn btn-link" type="submit"
                     ng-click="$ctrl.saveProjectNameEdit()"
-                    ng-disabled="$ctrl.isSavingProjectNameEdit">
+                    ng-show="!$ctrl.isSavingProjectNameEdit">
               <i class="icon-check"></i>
             </button>
             <button class="btn btn-link" type="submit"
                     ng-click="$ctrl.cancelProjectNameEdit()"
-                    ng-disabled="$ctrl.isSavingProjectNameEdit">
+                    ng-show="!$ctrl.isSavingProjectNameEdit">
               <i class="icon-cross"></i>
             </button>
           </div>

--- a/app-frontend/src/app/pages/library/projects/detail/projectScenes/projectScenes.html
+++ b/app-frontend/src/app/pages/library/projects/detail/projectScenes/projectScenes.html
@@ -6,9 +6,28 @@
         <a ui-sref="^.^.list">Projects</a><br>
         {{$ctrl.project.name}}
       </h1>
-      <button class="btn btn-tiny" ng-show="!$ctrl.$parent.selectedScenes.size">
+      <button class="btn btn-tiny" ng-click="$ctrl.toggleProjectNameEdit()" ng-show="!$ctrl.$parent.selectedScenes.size">
         <i class="icon-pencil"></i>
       </button>
+      <div ng-show="$ctrl.isEditingProjectName">
+        <form class="ng-pristine ng-valid">
+          <div class="form-group all-in-one">
+            <label for="name"><i class="icon-bucket"></i></label>
+            <input id="name" type="text" class="form-control"
+                  placeholder="Edit project name" ng-model="$ctrl.editedProjectName">
+            <button class="btn btn-link" type="submit"
+                    ng-click="$ctrl.saveProjectNameEdit()"
+                    ng-disabled="$ctrl.isSavingProjectNameEdit">
+              <i class="icon-check"></i>
+            </button>
+            <button class="btn btn-link" type="submit"
+                    ng-click="$ctrl.cancelProjectNameEdit()"
+                    ng-disabled="$ctrl.isSavingProjectNameEdit">
+              <i class="icon-cross"></i>
+            </button>
+          </div>
+        </form>
+      </div>
       <div ng-show="$ctrl.$parent.selectedScenes.size">
         <h1 class="h3 highlight">
           <ng-pluralize count="$ctrl.$parent.selectedScenes.size"


### PR DESCRIPTION
## Overview

Adds the ability for a user to change the name of a project from the 'Library.Project.Scenes' page.

### Demo

<img width="910" alt="screen shot 2016-12-05 at 10 17 07 pm" src="https://cloud.githubusercontent.com/assets/2442245/20911793/c19d3a44-bb38-11e6-964f-a9a4581a78a2.png">
<img width="915" alt="screen shot 2016-12-05 at 10 17 38 pm" src="https://cloud.githubusercontent.com/assets/2442245/20911794/c19df2ea-bb38-11e6-8f05-1353f10b0471.png">

### Notes

I don't know if the UX is optimal. For example, it would be nice to have the input field receive focus once the user clicks the edit button.


## Testing Instructions

 * Create a project or ensure that projects already exist
 * Go to 'My Library' -> 'Projects'
 * Click on a project
 * Click the edit button next to the Project name and enter a new value for the project name, and click the check button (or hit enter)
 * Click the edit button, make changes, and then click the 'x' instead of the check

Connects #742
