### PR TITLE
Eliminate extra and duplicate requests

### DIFF
--- a/app-frontend/src/app/components/leafletMap/leafletMap.controller.js
+++ b/app-frontend/src/app/components/leafletMap/leafletMap.controller.js
@@ -13,12 +13,7 @@ export default class LeafletMapController {
     }
 
     $onInit() {
-        if (this.proposedBounds) {
-            this.map.fitBounds(this.proposedBounds);
-            this.onBoundsChange({newBounds: this.map.getBounds()});
-        }
         this.map.on('moveend', () => this.boundsChangeListener());
-        this.map.on('zoomend', () => this.boundsChangeListener());
     }
 
     $onChanges(changes) {

--- a/app-frontend/src/app/pages/browse/browse.controller.js
+++ b/app-frontend/src/app/pages/browse/browse.controller.js
@@ -106,7 +106,7 @@ export default class BrowseController {
     }
 
     onBoundsChange(newBounds) {
-        let bboxCoords = newBounds.toBBoxString();
+        const bboxCoords = newBounds.toBBoxString();
         this.queryParams = Object.assign({
             id: this.queryParams.id
         }, this.filters, {bbox: bboxCoords});
@@ -120,12 +120,12 @@ export default class BrowseController {
     }
 
     populateInitialSceneList() {
-        if (!this.authService.isLoggedIn) {
+        if (!this.queryParams.bbox ||
+            !this.authService.isLoggedIn ||
+            this.loading && _.isEqual(this.lastQueryParams, this.queryParams)) {
             return;
-        }
-
-        if (this.loading) {
-            this.reloadScenes = true;
+        } else if (this.loading) {
+            this.pendingSceneRequest = true;
             return;
         }
 
@@ -133,6 +133,7 @@ export default class BrowseController {
         this.sceneLoadingTime = new Date().toISOString();
         this.loading = true;
         this.infScrollPage = 0;
+        this.lastQueryParams = this.queryParams;
         // save off selected scenes so you don't lose them during the refresh
         this.sceneList = [];
         let params = Object.assign({}, this.queryParams);
@@ -148,8 +149,8 @@ export default class BrowseController {
                 this.lastSceneResult = sceneResult;
                 this.sceneList = sceneResult.results;
                 this.loading = false;
-                if (this.reloadScenes) {
-                    this.reloadScenes = false;
+                if (this.pendingSceneRequest) {
+                    this.pendingSceneRequest = false;
                     this.populateInitialSceneList();
                 }
             },

--- a/app-frontend/src/app/pages/browse/browse.html
+++ b/app-frontend/src/app/pages/browse/browse.html
@@ -15,9 +15,10 @@
     <!-- scene listing -->
     <div class="sidebar-scrollable" id="infscroll">
       <div
-          infinite-scroll="$ctrl.getMoreScenes()" infinite-scroll-distance=".5"
+          infinite-scroll="$ctrl.getMoreScenes()" infinite-scroll-distance="0.5"
           infinite-scroll-disabled="$ctrl.loading || ($ctrl.lastSceneResult && !$ctrl.lastSceneResult.hasNext) || $ctrl.errorMsg"
           infinite-scroll-container="'#infscroll'"
+          infinite-scroll-immediate-check=false
           class="list-group">
         <rf-scene-item
             ng-click="$ctrl.openDetailPane(scene)"


### PR DESCRIPTION
## Overview

App load causes one erroneous requests (wrong bounds) and then two duplicate requests (correct bounds).

Zoom events also cause duplicate events.

- [x] Fix events on load
- [x] Fix events on zoom

## Notes
- Leaflet's `moveend` event is triggered by any map view change, including zoom related changes. Listening to the `zoomend` event becomes superfluous.

## Testing Instructions

 * Open up dev tools and filter down to only requests to the `scenes` endpoint
 * Reload the app, ensure only one request to the scenes endpoint is issued
 * Pan the map, ensure only one request to the scenes endpoint is issued
 * Zoom the map, ensure only one request to the scenes endpoint is issued

Connects #745

