### PR TITLE
Per bucket scene order [WIP]

### DIFF
--- a/app-backend/database/src/main/scala/com/azavea/rf/database/QueryParameters.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/QueryParameters.scala
@@ -44,7 +44,8 @@ case class SceneQueryParameters(
   minSunElevation: Option[Float],
   bbox: Option[String],
   point: Option[String],
-  bucket: Option[UUID]
+  bucket: Option[UUID],
+  sorted: Boolean = false
 ) {
   val bboxPolygon: Option[Projected[Polygon]] = try {
     bbox

--- a/app-backend/database/src/main/scala/com/azavea/rf/database/tables/ScenesToBuckets.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/tables/ScenesToBuckets.scala
@@ -3,13 +3,18 @@ package com.azavea.rf.database.tables
 import com.azavea.rf.database.{Database => DB}
 import com.azavea.rf.database.ExtendedPostgresDriver.api._
 import com.azavea.rf.datamodel._
+import com.typesafe.scalalogging.LazyLogging
+
+import scala.concurrent.Future
+import java.util.UUID
 
 /** Table description of table scenes_to_buckets. Objects of this class serve as prototypes for rows in queries. */
 class ScenesToBuckets(_tableTag: Tag) extends Table[SceneToBucket](_tableTag, "scenes_to_buckets") {
-  def * = (sceneId, bucketId) <> (SceneToBucket.tupled, SceneToBucket.unapply)
+  def * = (sceneId, bucketId, sceneOrder) <> (SceneToBucket.tupled, SceneToBucket.unapply)
 
-  val sceneId: Rep[java.util.UUID] = column[java.util.UUID]("scene_id")
-  val bucketId: Rep[java.util.UUID] = column[java.util.UUID]("bucket_id")
+  val sceneId: Rep[UUID] = column[UUID]("scene_id")
+  val bucketId: Rep[UUID] = column[UUID]("bucket_id")
+  val sceneOrder: Rep[Option[Int]] = column[Option[Int]]("scene_order")
 
   val pk = primaryKey("scenes_to_buckets_pkey", (sceneId, bucketId))
 
@@ -18,4 +23,28 @@ class ScenesToBuckets(_tableTag: Tag) extends Table[SceneToBucket](_tableTag, "s
 }
 
 /** Collection-like TableQuery object for table ScenesToBuckets */
-object ScenesToBuckets extends TableQuery(tag => new ScenesToBuckets(tag))
+object ScenesToBuckets extends TableQuery(tag => new ScenesToBuckets(tag)) with LazyLogging {
+  val scenesToBuckets = TableQuery[ScenesToBuckets]
+
+  def resetSceneOrderAction(bucketId: UUID) = {
+    val query = for {
+      s2b <- scenesToBuckets if s2b.bucketId === bucketId
+    } yield s2b.sceneOrder
+
+    query.update(None)
+  }
+
+  def addSceneOrderAction(bucketId: UUID, orderedScenes: Seq[UUID]) =
+    DBIO.sequence(orderedScenes.zipWithIndex.map { case (sceneId, order) =>
+      val q = for {
+        s2b <- scenesToBuckets if s2b.bucketId === bucketId && s2b.sceneId === sceneId
+      } yield s2b.sceneOrder
+
+      q.update(Some(order))
+    })
+
+  def setSceneOrder(bucketId: UUID, orderedScenes: Seq[UUID])(implicit database: DB) = database.db.run {
+    resetSceneOrderAction(bucketId) andThen addSceneOrderAction(bucketId, orderedScenes)
+  }
+
+}

--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/SceneToBucket.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/SceneToBucket.scala
@@ -3,4 +3,10 @@ package com.azavea.rf.datamodel
 import java.util.UUID
 import java.sql.Timestamp
 
-case class SceneToBucket(sceneId: UUID, bucketId: UUID)
+/** The object which models data stored on the many-to-many scene <-> bucket table */
+case class SceneToBucket(
+  sceneId: UUID,
+  bucketId: UUID,
+  sceneOrder: Option[Int] = None
+)
+


### PR DESCRIPTION
## Overview

Per bucket scene ordering is not currently supported. This PR aims to provide that.

### Checklist

- [x] DB functions to set/get ordered scenes based on many-to-many join table
- [x] Endpoints for posting/getting ordered scenes
- [ ] Tests
- [ ] Migrations
- [ ] Documentation


Connects #701