### PR TITLE
Feature/update importer with data footprints

### DIFF
--- a/app-tasks/rf/src/rf/models/scene.py
+++ b/app-tasks/rf/src/rf/models/scene.py
@@ -13,7 +13,7 @@ class Scene(BaseModel):
     def __init__(self, organizationId, ingestSizeBytes, visibility, tags,
                  datasource, sceneMetadata, name, thumbnailStatus, boundaryStatus,
                  status, metadataFiles, sunAzimuth=None, sunElevation=None, cloudCover=None, acquisitionDate=None,
-                 id=None, thumbnails=None, footprint=None, images=None):
+                 id=None, thumbnails=None, tileFootprint=None, dataFootprint=None, images=None):
         """Create a new Scene
 
         Args:
@@ -33,7 +33,8 @@ class Scene(BaseModel):
             acquisitionDate (datetime): date when scene was acquired
             id (str): UUID primary key for scene
             thumbnails (List[Thumbnail]): list of thumbnails associated with scene
-            footprint (Footprint): footprint associated with scene
+            tileFootprint (Footprint): footprint of the tile associated with scene
+            dataFootprint (Footprint): footprint of this scene's data
             images (List[Image]): list of images associated with scene
         """
 
@@ -56,7 +57,8 @@ class Scene(BaseModel):
         self.acquisitionDate = acquisitionDate
         self.id = id or str(uuid.uuid4())
         self.thumbnails = thumbnails
-        self.footprint = footprint
+        self.tileFootprint = tileFootprint
+        self.dataFootprint = dataFootprint
         self.images = images
 
     def __repr__(self):
@@ -98,7 +100,9 @@ class Scene(BaseModel):
         else:
             scene_dict['images'] = []
 
-        if self.footprint:
-            scene_dict['footprint'] = self.footprint.to_dict()
+        if self.tileFootprint:
+            scene_dict['tileFootprint'] = self.tileFootprint.to_dict()
+        if self.dataFootprint:
+            scene_dict['dataFootprint'] = self.dataFootprint.to_dict()
 
         return scene_dict

--- a/app-tasks/rf/src/rf/uploads/landsat8/create_footprint.py
+++ b/app-tasks/rf/src/rf/uploads/landsat8/create_footprint.py
@@ -10,7 +10,7 @@ from .settings import organization
 target_proj = Proj(init='epsg:4326')
 
 
-def create_footprint(csv_row):
+def create_footprints(csv_row):
     """Extract footprint from a Landsat 8 csv row
 
     Args:
@@ -20,15 +20,29 @@ def create_footprint(csv_row):
         Footprint
     """
     src_proj = Proj(init='epsg:4326')
-    coords = [
-        [csv_row['lowerLeftCornerLongitude'], csv_row['lowerLeftCornerLatitude']],
-        [csv_row['lowerRightCornerLongitude'], csv_row['lowerRightCornerLatitude']],
-        [csv_row['upperRightCornerLongitude'], csv_row['upperRightCornerLatitude']],
-        [csv_row['upperLeftCornerLongitude'], csv_row['upperLeftCornerLatitude']]
-    ]
+    ll = (csv_row['lowerLeftCornerLongitude'], csv_row['lowerLeftCornerLatitude'])
+    lr = (csv_row['lowerRightCornerLongitude'], csv_row['lowerRightCornerLatitude'])
+    ul = (csv_row['upperLeftCornerLongitude'], csv_row['upperLeftCornerLatitude'])
+    ur = (csv_row['upperRightCornerLongitude'], csv_row['upperRightCornerLatitude'])
+    src_coords = [ll, lr, ur, ul]
+
+    min_x = min([coord[0] for coord in src_coords])
+    min_y = min([coord[1] for coord in src_coords])
+    max_x = max([coord[0] for coord in src_coords])
+    max_y = max([coord[1] for coord in src_coords])
 
     transformed_coords = [[
-        [transform(src_proj, target_proj, coord[0], coord[1]) for coord in coords]
+        [transform(src_proj, target_proj, coord[0], coord[1]) for coord in src_coords]
     ]]
-    geojson = {'type': 'MultiPolygon', 'coordinates': transformed_coords}
-    return Footprint(organization, geojson)
+
+    data_geojson = {'type': 'MultiPolygon', 'coordinates': transformed_coords}
+    data_footprint = Footprint(organization, data_geojson)
+
+    transformed_tile_coords = [[
+        [transform(src_proj, target_proj, coord[0], coord[1]) for coord in
+         [(min_x, min_y), (max_x, min_y), (max_x, max_y), (min_x, max_y)]]
+    ]]
+    tile_geojson = {'type': 'MultiPolygon', 'coordinates': transformed_tile_coords}
+    tile_footprint = Footprint(organization, tile_geojson)
+
+    return tile_footprint, data_footprint

--- a/app-tasks/rf/src/rf/uploads/landsat8/create_scenes.py
+++ b/app-tasks/rf/src/rf/uploads/landsat8/create_scenes.py
@@ -10,7 +10,7 @@ from rf.utils.io import JobStatus, Visibility, s3_obj_exists
 from .create_bands import create_bands
 from .create_images import create_images
 from .create_thumbnails import create_thumbnails
-from .create_footprint import create_footprint
+from .create_footprint import create_footprints
 from .settings import organization, aws_landsat_base
 from .io import get_landsat_path
 
@@ -46,6 +46,7 @@ def create_landsat8_scenes(csv_row):
 
     scene_id = str(uuid.uuid4())
     landsat_id = csv_row.pop('sceneID')
+    tileFootprint, dataFootprint = create_footprints(csv_row)
     landsat_path = get_landsat_path(landsat_id)
     if not s3_obj_exists(aws_landsat_base + landsat_path + 'index.html'):
         logger.warn(
@@ -85,7 +86,8 @@ def create_landsat8_scenes(csv_row):
         cloudCover=cloud_cover,
         sunAzimuth=sun_azimuth,
         sunElevation=sun_elevation,
-        footprint=create_footprint(csv_row),
+        tileFootprint=tileFootprint,
+        dataFootprint=dataFootprint,
         metadataFiles=[aws_landsat_base + landsat_path + landsat_id + '_MTL.txt'],
         thumbnails=create_thumbnails(scene_id, landsat_id),
         images=(

--- a/app-tasks/rf/src/rf/uploads/landsat8/settings.py
+++ b/app-tasks/rf/src/rf/uploads/landsat8/settings.py
@@ -36,7 +36,7 @@ band_lookup = {
 }
 
 usgs_landsat_url = (
-    'http://landsat.usgs.gov/metadata_service/bulk_metadata_files/LANDSAT_8.csv'
+    'https://landsat.usgs.gov/landsat/metadata_service/bulk_metadata_files/LANDSAT_8.csv'
 )
 
 aws_landsat_base = 'http://landsat-pds.s3.amazonaws.com/'

--- a/app-tasks/rf/src/rf/uploads/sentinel2/settings.py
+++ b/app-tasks/rf/src/rf/uploads/sentinel2/settings.py
@@ -1,5 +1,7 @@
 """Settings shared by functions for indexing Sentinel 2 data"""
 
+from pyproj import Proj
+
 from rf.utils.io import s3
 
 # Public Organization UUID in Raster Foundry
@@ -48,3 +50,7 @@ base_http_path = 'https://sentinel-s2-l1c.s3.amazonaws.com/{key_path}'
 # S3/AWS settings and objects
 bucket_name = 'sentinel-s2-l1c'
 bucket = s3.Bucket(bucket_name)
+
+# target projection for footprints
+target_proj = Proj(init='epsg:4326')
+

--- a/docs/swagger/spec.yml
+++ b/docs/swagger/spec.yml
@@ -1432,9 +1432,13 @@ definitions:
             type: string
             format: datetime
             description: Date scene was acquired from instrument (e.g. satellite, drone)
-          footprint:
-            type: object
-            description: URI to boundary for this image
+          dataFootprint:
+            type: geojson
+            description: polygon for which this scene has data
+            readOnly: true
+          tileFootprint:
+            type: geojson
+            description: polygon enclosing this scene
             readOnly: true
           sceneMetadata:
             type: object
@@ -1459,7 +1463,7 @@ definitions:
               - PROCESSING
           footprintStatus:
             type: string
-            description: status of thumbnail generation
+            description: status of footprint generation
             enum:
               - SUCCESS
               - FAILURE


### PR DESCRIPTION
## Overview

To display footprints in the UI we need data footprints and tile footprints. We have data footprints in the API, but we didn't have them coming in the importers yet. With this commit we do.

### Checklist

- [x] ~Styleguide updated, if necessary~
- [x] Swagger specification updated

### Notes

One thing we should add probably is a strategy for testing airflow while actually hitting the database.
We don't have a great way right now to end-to-end test the tasks aside from running them.

## Testing Instructions

 * Pull down this branch
 * `./scripts/server | grep app-server\|airflow-scheduler`
 * wait a bit, then turn off the Landsat 8 task from the airflow ui once you have some Landsat 8 scenes successfully post
 * Inspect records created today to verify that they have data and tile footprints
 * Throw the geojson for both data and tilefootprints onto a map to ensure they are behaving

Closes #735
