### PR TITLE
Feature/feature flags

### DIFF
--- a/app-backend/app/src/main/resources/application.conf
+++ b/app-backend/app/src/main/resources/application.conf
@@ -57,3 +57,14 @@ auth0 {
   bearer = ""
   bearer = ${?AUTH0_MANAGEMENT_BEARER}
 }
+
+featureFlags {
+  features = [
+    {
+      key = "profile-org-edit",
+      active = false,
+      name = "Profile Organization Edit",
+      description = "Join / Create / Edit / Leave / Delete organizations in user profile settings"
+    }
+  ]
+}

--- a/app-backend/app/src/main/scala/config/Config.scala
+++ b/app-backend/app/src/main/scala/config/Config.scala
@@ -1,15 +1,28 @@
 package com.azavea.rf.config
 
 import scala.concurrent.{Future, ExecutionContext}
+import scala.collection.JavaConversions._
 import com.azavea.rf.utils.Config
 import com.azavea.rf.database.Database
 import com.azavea.rf.AkkaSystem
 
-case class AngularConfig(clientId: String, auth0Domain: String)
+case class FeatureFlag(key: String, active: Boolean, name: String, description: String)
+case class AngularConfig(clientId: String, auth0Domain: String, featureFlags: Seq[FeatureFlag])
 
 object AngularConfigService extends AkkaSystem.LoggerExecutor with Config {
   def getConfig():
       AngularConfig = {
-    return AngularConfig(auth0ClientId, auth0Domain)
+
+    val features: Seq[FeatureFlag] = featureFlags.map { featureConfig =>
+      FeatureFlag(
+        featureConfig.getString("key"),
+        featureConfig.getBoolean("active"),
+        featureConfig.getString("name"),
+        featureConfig.getString("description")
+      )
+    }.toSeq
+    implicit val featureFlagFormat = jsonFormat4(FeatureFlag)
+
+    return AngularConfig(auth0ClientId, auth0Domain, features)
   }
 }

--- a/app-backend/app/src/main/scala/config/package.scala
+++ b/app-backend/app/src/main/scala/config/package.scala
@@ -1,5 +1,6 @@
 package com.azavea.rf
 
 package object config extends RfJsonProtocols {
-  implicit val configFormat = jsonFormat2(AngularConfig)
+  implicit val featureFlagFormat = jsonFormat4(FeatureFlag)
+  implicit val configFormat = jsonFormat3(AngularConfig)
 }

--- a/app-backend/app/src/main/scala/utils/Config.scala
+++ b/app-backend/app/src/main/scala/utils/Config.scala
@@ -8,6 +8,7 @@ trait Config {
   private val httpConfig = config.getConfig("http")
   private val databaseConfig = config.getConfig("slick.db")
   private val auth0Config = config.getConfig("auth0")
+  private val featureFlagConfig = config.getConfig("featureFlags")
 
   val httpHost = httpConfig.getString("interface")
   val httpPort = httpConfig.getInt("port")
@@ -22,4 +23,6 @@ trait Config {
   val auth0Bearer = auth0Config.getString("bearer")
   val auth0Secret = java.util.Base64.getUrlDecoder.decode(auth0Config.getString("secret"))
   val auth0ClientId = auth0Config.getString("clientId")
+
+  val featureFlags = featureFlagConfig.getConfigList("features")
 }

--- a/app-frontend/config/webpack/global.js
+++ b/app-frontend/config/webpack/global.js
@@ -85,7 +85,7 @@ module.exports = function (_path) {
                 query: {
                     cacheDirectory: true,
                     plugins: ['transform-runtime', 'add-module-exports'],
-                    presets: ['angular', 'es2017']
+                    presets: ['angular', 'latest']
                 }
             }, {
                 test: /\.css$/,

--- a/app-frontend/package.json
+++ b/app-frontend/package.json
@@ -46,7 +46,6 @@
     "leaflet": "^1.0.0",
     "lodash": "~4.5.0",
     "ng-infinite-scroll": "^1.3.0",
-    "d3": "^3.4.4",
     "nvd3": "^1.8.4"
   },
   "devDependencies": {
@@ -59,7 +58,7 @@
     "babel-plugin-transform-runtime": "^6.7.5",
     "babel-polyfill": "^6.7.4",
     "babel-preset-angular": "^6.0.15",
-    "babel-preset-es2017": "^1.3.1",
+    "babel-preset-latest": "^6.16.0",
     "babel-runtime": "^6.6.1",
     "baggage-loader": "^0.2.4",
     "brfs": "^1.4.3",

--- a/app-frontend/src/app/components/featureFlagOverrides/featureFlagOverrides.component.js
+++ b/app-frontend/src/app/components/featureFlagOverrides/featureFlagOverrides.component.js
@@ -1,0 +1,8 @@
+import featureFlagOverridesTpl from './featureFlagOverrides.html';
+
+const rfFeatureFlagOverrides = {
+    templateUrl: featureFlagOverridesTpl,
+    controller: 'FeatureFlagOverridesController'
+};
+
+export default rfFeatureFlagOverrides;

--- a/app-frontend/src/app/components/featureFlagOverrides/featureFlagOverrides.controller.js
+++ b/app-frontend/src/app/components/featureFlagOverrides/featureFlagOverrides.controller.js
@@ -1,0 +1,7 @@
+export default class FeatureFlagOverrideController {
+    constructor(featureFlags) {
+        'ngInject';
+        this.featureFlags = featureFlags;
+        this.flags = featureFlags.get();
+    }
+}

--- a/app-frontend/src/app/components/featureFlagOverrides/featureFlagOverrides.html
+++ b/app-frontend/src/app/components/featureFlagOverrides/featureFlagOverrides.html
@@ -1,0 +1,28 @@
+<div class="feature-flags">
+  <h5>Feature Flags</h5>
+  <div id="feature-flag--{{flag.key}}" class="feature-flags-flag" ng-repeat="flag in $ctrl.flags">
+    <div class="feature-flags-name">Feature Name: {{flag.name || flag.key}}</div>
+    <div class="feature-flags-desc">Description: {{flag.description}}</div>
+    <div class="feature-flags-actions">
+      Flag:
+      <button id="feature-flag--{{flag.key}}--enable"
+              class="btn"
+              ng-click="$ctrl.featureFlags.enable(flag)"
+              ng-class="{'btn-primary': $ctrl.featureFlags.isOverridden(flag.key) && $ctrl.featureFlags.isOn(flag.key)}">
+        On
+      </button>
+      <button id="feature-flag--{{flag.key}}--disable"
+              class="btn"
+              ng-click="$ctrl.featureFlags.disable(flag)"
+              ng-class="{'btn-primary': $ctrl.featureFlags.isOverridden(flag.key) && !$ctrl.featureFlags.isOn(flag.key)}">
+        Off
+      </button>
+      <button id="feature-flag--{{flag.key}}--reset"
+              class="btn"
+              ng-click="$ctrl.featureFlags.reset(flag)"
+              ng-class="{'btn-primary': !$ctrl.featureFlags.isOverridden(flag.key)}">
+        Default ({{$ctrl.featureFlags.isOnByDefault(flag.key) ? 'On' : 'Off'}})
+      </button>
+    </div>
+  </div>
+</div>

--- a/app-frontend/src/app/components/featureFlagOverrides/featureFlagOverrides.module.js
+++ b/app-frontend/src/app/components/featureFlagOverrides/featureFlagOverrides.module.js
@@ -1,0 +1,19 @@
+import angular from 'angular';
+
+import FeatureFlagOverridesComponent from './featureFlagOverrides.component.js';
+import FeatureFlagOverridesController from './featureFlagOverrides.controller.js';
+
+const FeatureFlagOverridesModule = angular.module('components.featureFlagOverrides', []);
+
+require('./featureFlagOverrides.scss');
+
+FeatureFlagOverridesModule.component(
+    'rfFeatureFlagOverrides',
+    FeatureFlagOverridesComponent
+);
+FeatureFlagOverridesModule.controller(
+    'FeatureFlagOverridesController',
+    FeatureFlagOverridesController
+);
+
+export default FeatureFlagOverridesModule;

--- a/app-frontend/src/app/components/featureFlagOverrides/featureFlagOverrides.scss
+++ b/app-frontend/src/app/components/featureFlagOverrides/featureFlagOverrides.scss
@@ -1,0 +1,15 @@
+.feature-flags-desc {
+  border-bottom: 1px dashed black;
+  padding: 0.5em;
+}
+.feature-flags-name {
+  font-weight: bold;
+  border-bottom: 1px dashed black;
+  padding: 0.5em;
+}
+.feature-flags-flag {
+  border: 1px solid black;
+}
+.feature-flags-actions {
+  padding: 0.5em;
+}

--- a/app-frontend/src/app/components/filterPane/filterPane.module.js
+++ b/app-frontend/src/app/components/filterPane/filterPane.module.js
@@ -2,12 +2,12 @@ import angular from 'angular';
 import slider from 'angularjs-slider';
 require('../../../assets/font/fontello/css/fontello.css');
 
-import FilterPanComponent from './filterPane.component.js';
+import FilterPaneComponent from './filterPane.component.js';
 import FilterPaneController from './filterPane.controller.js';
 
 const FilterPaneModule = angular.module('components.filterPane', [slider]);
 
-FilterPaneModule.component('rfFilterPane', FilterPanComponent);
+FilterPaneModule.component('rfFilterPane', FilterPaneComponent);
 FilterPaneModule.controller('FilterPaneController', FilterPaneController);
 
 export default FilterPaneModule;

--- a/app-frontend/src/app/core/core.module.js
+++ b/app-frontend/src/app/core/core.module.js
@@ -8,4 +8,8 @@ require('./services/auth.service')(shared);
 require('./services/token.service')(shared);
 require('./services/layer.service')(shared);
 
+require('./services/featureFlagOverrides.service')(shared);
+require('./services/featureFlags.provider')(shared);
+require('./services/featureFlag.directive')(shared);
+
 export default shared;

--- a/app-frontend/src/app/core/services/featureFlag.directive.js
+++ b/app-frontend/src/app/core/services/featureFlag.directive.js
@@ -1,0 +1,72 @@
+/* Feature Flag directive
+ * Attribute directive to show or hide elements based on the presence of a feature flag
+ * Additional attribute: feature-flag-hide
+ *                       Hide the element in the presence of the feature flag, instead of showing it
+ * Usage:
+ *      <div feature-flag="some-feature-flag">
+ *          ...
+ *      </div>
+ *
+ *      <div feature-flag="some-other-flag" feature-flag-hide>
+ *          ...
+ *      </div>
+ */
+export default (app) => {
+    class FeatureFlagDirective {
+        constructor(featureFlags, $interpolate) {
+            this.featureFlags = featureFlags;
+            this.$interpolate = $interpolate;
+
+            this.transclude = 'element';
+            this.priority = 599;
+            this.terminal = true;
+            this.restrict = 'A';
+            this.$$tlb = true;
+        }
+
+        compile(tElement, tAttrs) {
+            let hasHideAttribute = 'featureFlagHide' in tAttrs;
+            tElement[0].textContent = ' featureFlag: ' + tAttrs.featureFlag +
+                ' is ' + (hasHideAttribute ? 'on' : 'off') + ' ';
+            return (
+                $scope, element, attrs, ctrl, $transclude
+            ) => {
+                let featureEl;
+                let childScope;
+                $scope.$watch(() => {
+                    let featureFlag = this.$interpolate(attrs.featureFlag)($scope);
+                    return this.featureFlags.isOn(featureFlag);
+                }, (isEnabled) => {
+                    let showElement = hasHideAttribute ? !isEnabled : isEnabled;
+
+                    if (showElement) {
+                        childScope = $scope.$new();
+                        $transclude(childScope, (clone) => {
+                            featureEl = clone;
+                            element.after(featureEl).remove();
+                        });
+                    } else {
+                        if (childScope) {
+                            childScope.$destroy();
+                            childScope = null;
+                        }
+                        if (featureEl) {
+                            featureEl.after(element).remove();
+                            featureEl = null;
+                        }
+                    }
+                });
+            };
+        }
+
+        static factory(featureFlags, $interpolate) {
+            'ngInject';
+            return new FeatureFlagDirective(featureFlags, $interpolate);
+        }
+    }
+
+    app.directive(
+        'featureFlag',
+        FeatureFlagDirective.factory
+    );
+};

--- a/app-frontend/src/app/core/services/featureFlagOverrides.service.js
+++ b/app-frontend/src/app/core/services/featureFlagOverrides.service.js
@@ -1,0 +1,76 @@
+/* Feature Flag Overrides service
+ * Feature flags can be set / overridden in a number of ways:
+ *    A) In app.config.js, feature flags are read from the /api/config endpoint and set.
+ *       This is the default global source of authority for feature flags.
+ *    B) In auth.service.js upon login, feature flags are read from the profile.user_metadata
+ *       object and override the global defaults.
+ *    C) Manual overrides are read from localstorage, and are mostly useful for development
+ *       purposes.  These can be set from the /settings/profile page if the application is
+ *       run in a node dev environment (IE run using `npm start` instead of loaded through nginx)
+ *       These settings are persistent across page reloads and override all other sources of
+ *       feature flags.
+ * Note: In B and C above, feature flags must exist in the global scope, or they are ignored.
+ */
+export default app => {
+    class FeatureFlagOverrides {
+        constructor($rootElement, store, $log) {
+            'ngInject';
+            this.store = store;
+            this.$log = $log;
+
+            let keyPrefix = 'featureFlags.';
+            this.prefixedKeyForUser = (user) => {
+                return (flagName) => keyPrefix + user + '.' + flagName;
+            };
+        }
+
+        /* Sets the user to store overrides for.
+           This method must be called before setting / fetching any overrides, since overrides
+           are stored per user
+        */
+        setUser(userId) {
+            this.prefixedKeyFor = this.prefixedKeyForUser(userId);
+        }
+
+        isPresent(key) {
+            if (!this.prefixedKeyFor) {
+                return false;
+            }
+            let val = this.store.get(this.prefixedKeyFor(key));
+            return typeof val !== 'undefined' && val !== null;
+        }
+
+        get(flagName) {
+            if (!this.prefixedKeyFor) {
+                this.$log.error('featureFlagOverrides.get called before setting a user.');
+                return false;
+            }
+            return this.store.get(this.prefixedKeyFor(flagName));
+        }
+
+        set(flag, value) {
+            if (!this.prefixedKeyFor) {
+                this.$log.error('featureFlagOverrides.set called before setting a user.');
+                return;
+            }
+            let setFlag = (val, flagName) => {
+                this.store.set(this.prefixedKeyFor(flagName), val);
+            };
+            if (angular.isObject(flag)) {
+                angular.forEach(flag, setFlag);
+            } else {
+                setFlag(value, flag);
+            }
+        }
+
+        remove(flagName) {
+            if (!this.prefixedKeyFor) {
+                this.$log.error('featureFlagOverrides.remove called before setting a user.');
+                return;
+            }
+            this.store.remove(this.prefixedKeyFor(flagName));
+        }
+    }
+
+    app.service('featureFlagOverrides', FeatureFlagOverrides);
+};

--- a/app-frontend/src/app/core/services/featureFlags.provider.js
+++ b/app-frontend/src/app/core/services/featureFlags.provider.js
@@ -1,0 +1,89 @@
+function updateFlagsAndGetAll(newFlags) {
+    Object.values(newFlags).forEach(flag => {
+        this.serverFlagCache[flag.key] = flag.active;
+        flag.active = this.isOn(flag.key);
+    });
+    angular.extend(this.flags, newFlags);
+    return this.flags;
+}
+
+function updateFlagsWithPromise(promise) {
+    return promise.then(value => {
+        return updateFlagsAndGetAll.bind(this)(value.data || value);
+    });
+}
+
+export default app => {
+    class FeatureFlags {
+        constructor($q, featureFlagOverrides, initialFlags) {
+            this.$q = $q;
+            this.serverFlagCache = {};
+            this.flags = [];
+            this.initialFlags = initialFlags ? initialFlags : [];
+            this.featureFlagOverrides = featureFlagOverrides;
+            if (this.initialFlags.length) {
+                this.set(initialFlags);
+            }
+        }
+
+        set(newFlags) {
+            if (angular.isArray(newFlags)) {
+                let deferred = this.$q.defer();
+                deferred.resolve(updateFlagsAndGetAll.bind(this)(newFlags));
+                return deferred.promise;
+            }
+            return updateFlagsWithPromise.bind(this)(newFlags);
+        }
+
+        get() {
+            return this.flags;
+        }
+
+        enable(flag) {
+            flag.active = true;
+            this.featureFlagOverrides.set(flag.key, true);
+        }
+
+        disable(flag) {
+            flag.active = false;
+            this.featureFlagOverrides.set(flag.key, false);
+        }
+
+        reset(flag) {
+            flag.active = this.serverFlagCache[flag.key];
+            this.featureFlagOverrides.remove(flag.key);
+        }
+
+        isOn(key) {
+            return this.isOverridden(key) ?
+                this.featureFlagOverrides.get(key) :
+                this.serverFlagCache[key];
+        }
+
+        isOnByDefault(key) {
+            return this.serverFlagCache[key];
+        }
+
+        isOverridden(key) {
+            return this.featureFlagOverrides.isPresent(key);
+        }
+
+    }
+
+    class FeatureFlagsProvider {
+        constructor() {
+            this.initialFlags = [];
+        }
+
+        setInitialFlags(flags) {
+            this.initialFlags = flags;
+        }
+
+        $get($q, featureFlagOverrides) {
+            'ngInject';
+            return new FeatureFlags($q, featureFlagOverrides, this.initialFlags);
+        }
+    }
+
+    app.provider('featureFlags', FeatureFlagsProvider);
+};

--- a/app-frontend/src/app/index.components.js
+++ b/app-frontend/src/app/index.components.js
@@ -13,5 +13,6 @@ export default angular.module('index.components', [
     require('./components/confirmationModal/confirmationModal.module.js').name,
     require('./components/projectAddModal/projectAddModal.module.js').name,
     require('./components/refreshTokenModal/refreshTokenModal.module.js').name,
-    require('./components/downloadModal/downloadModal.module.js').name
+    require('./components/downloadModal/downloadModal.module.js').name,
+    require('./components/featureFlagOverrides/featureFlagOverrides.module.js').name
 ]);

--- a/app-frontend/src/app/index.config.js
+++ b/app-frontend/src/app/index.config.js
@@ -7,7 +7,7 @@ function config( // eslint-disable-line max-params
     $logProvider, $compileProvider,
     jwtInterceptorProvider,
     $httpProvider, configProvider, APP_CONFIG,
-    lockProvider
+    lockProvider, featureFlagsProvider
 ) {
     'ngInject';
 
@@ -54,6 +54,8 @@ function config( // eslint-disable-line max-params
     $httpProvider.interceptors.push('jwtInterceptor');
 
     configProvider.init(process.env);
+
+    featureFlagsProvider.setInitialFlags(APP_CONFIG.featureFlags);
 }
 
 export default config;

--- a/app-frontend/src/app/pages/settings/account/account.controller.js
+++ b/app-frontend/src/app/pages/settings/account/account.controller.js
@@ -1,7 +1,9 @@
+/* globals process */
 class AccountController {
     constructor($log) {
         'ngInject';
         this.$log = $log;
+        this.env = process.env.NODE_ENV;
     }
 }
 

--- a/app-frontend/src/app/pages/settings/account/account.html
+++ b/app-frontend/src/app/pages/settings/account/account.html
@@ -16,7 +16,7 @@
       </div>
       <button type="submit" class="btn btn-primary btn-large">Update Profile</button>
     </form>
-
+    <rf-feature-flag-overrides ng-if="$ctrl.env === 'development'"></rf-feature-flag-overrides>
   </div>
   <div class="column-4">
     <div class="content">

--- a/app-frontend/src/app/pages/settings/settings.html
+++ b/app-frontend/src/app/pages/settings/settings.html
@@ -7,7 +7,10 @@
         <a ui-sref="settings.tokens" ui-sref-active="active">API tokens</a>
         <a ui-sref="settings.notifications" ui-sref-active="active">Notifications</a>
         <a ui-sref="settings.billing" ui-sref-active="active">Billing</a>
-        <a ui-sref="settings.organizations" ui-sref-active="active">Organizations</a>
+        <a ui-sref="settings.organizations"
+           ui-sref-active="active"
+           feature-flag="profile-org-edit"
+        >Organizations</a>
       </nav>
     </div>
   </div>


### PR DESCRIPTION
## Overview

Add feature flags to the /config endpoint, with flags contained in application.conf
Add feature flag directive, provider, and service
Add feature flag override override service and management component, visible in /settings/profile when in development node environment.  Overrides are also read from user profile metadata on login, which defers to local saved settings.

### Checklist

- [x] ~Styleguide updated, if necessary~
- [x] ~Swagger specification updated, if necessary~

### Notes

There are a couple of angular feature flag libraries, but I decided we would be better off writing our own code.  None of them really fit our use-case well, and all of them appear to have no active maintenance.  I used https://github.com/mjt01/angular-feature-flags as inspiration.

Later on, we'll want to read settings from s3 or something for the endpoint, so we have different config values on staging/production

## Testing Instructions

* Start the frontend via `npm start`
* Log into the frontend and navigate to /settings/profile
  * The organization subview link should no longer be visible
* Since you are in a development node environment, the feature flag management component should be visible under account management on the page.
* Turn on the `profile-org-edit` feature flag by clicking `ON`
  * The button should be highlighted to indicate that it is the currently selected option
  * The organizations subview link in the sidebar should appear again
  * Reloading the page should preserve settings
  * Feature flag settings are stored per user - logging out then onto another user should not show the link unless you've enabled the feature on there as well.
* Click the `DEFAULT` button to remove local overrides
* In `app-backend/app/src/main/resources/application.conf`, set the feature flag to be active then restart the server
  * Reloading the page once the server starts should reflect the new global setting unless you have a local override
  * The `DEFAULT` button should now read `DEFAULT (ON)`
* Undo your changes to application.conf & restart the server
* On the Auth0 Management dashboard, edit your user's metadata to read ```{
  "featureFlags": [
    {
      "key": "profile-org-edit",
      "active": true
    }
  ]
}```
  * Absent any local overrides, this should default the local override to be `active`, instead of the default on load.
  * Clicking `DEFAULT` will only reset it until the next page load, so to disable it, you need to click `OFF` to create different local override.  Reloading the page should not overwrite this setting.

Connects #497 
