### PR TITLE
Redirect from add-to-project modal to project list/detail

### DIFF
--- a/app-frontend/src/app/components/projectAddModal/projectAddModal.controller.js
+++ b/app-frontend/src/app/components/projectAddModal/projectAddModal.controller.js
@@ -1,11 +1,12 @@
 const Map = require('es6-map');
 
 export default class ProjectAddModalController {
-    constructor(projectService, $log) {
+    constructor(projectService, $log, $state) {
         'ngInject';
 
         this.projectService = projectService;
         this.$log = $log;
+        this.$state = $state;
 
         this.projectList = [];
         this.populateProjectList(1);
@@ -65,13 +66,23 @@ export default class ProjectAddModalController {
 
     addScenesToProjects() {
         let sceneIds = Array.from(this.resolve.scenes.keys());
+        let numProjects = this.selectedProjects.size;
         this.selectedProjects.forEach((project, projectId) => {
             this.projectService.addScenes(projectId, sceneIds).then(
                 () => {
                     this.selectedProjects.delete(projectId);
                     if (this.selectedProjects.size === 0) {
                         this.resolve.scenes.clear();
-                        this.close();
+                        if (numProjects > 1) {
+                            this.$state.go('library.projects.list');
+                            this.close();
+                        } else {
+                            this.$state.go(
+                                'library.projects.detail.scenes',
+                                {projectid: projectId}
+                            );
+                            this.close();
+                        }
                     }
                 },
                 (err) => {


### PR DESCRIPTION
## Overview
Once you add scenes to a project, navigates to a page where you can see the results: either the project list if you added the scenes to multiple projects, or the project detail if you added it to 1

### Checklist

- [x] ~Styleguide updated, if necessary~
- [x] ~Swagger specification updated, if necessary~

## Testing Instructions

* In the `browse` or `library/scenes` view, add scenes to a single project. Clicking "add scenes" should navigate to the correct project once the operation is complete
* In the `browse` or `library/scenes` view, add scenes to multiple projects. Clicking "add scenes" should navigate to the project list