### PR TITLE
Revert d3 dep to v3.4.4

### DIFF
--- a/app-frontend/package.json
+++ b/app-frontend/package.json
@@ -41,7 +41,7 @@
     "angular-ui-tree": "^2.22.1",
     "auth0-lock": "^10.4.1",
     "bootstrap-sass": "^3.3.6",
-    "d3": "^4.3.0",
+    "d3": "^3.4.4",
     "es6-map": "^0.1.4",
     "jquery": "^2.1.4",
     "leaflet": "^1.0.0",


### PR DESCRIPTION
## Overview
NVD3 is dependent on v3.4.4, not v4 of d3

### Notes

Trivial, merging immediately

## Testing Instructions

 * Open color correction view and verify that nvd3 histogram renders

