### PR TITLE
Display scene footprints on hover for color correction

### DIFF
--- a/app-frontend/src/app/components/colorCorrectScenes/colorCorrectScenes.component.js
+++ b/app-frontend/src/app/components/colorCorrectScenes/colorCorrectScenes.component.js
@@ -8,7 +8,9 @@ const colorCorrectScenes = {
         selectedLayers: '=',
         sceneList: '=',
         sceneLayers: '=',
-        layers: '='
+        layers: '=',
+        onSceneMouseover: '&',
+        onSceneMouseleave: '&'
     }
 };
 

--- a/app-frontend/src/app/components/colorCorrectScenes/colorCorrectScenes.controller.js
+++ b/app-frontend/src/app/components/colorCorrectScenes/colorCorrectScenes.controller.js
@@ -161,4 +161,12 @@ export default class ColorCorrectScenesController {
             this.selectedLayers.delete(scene.id);
         }
     }
+
+    setHoveredScene(scene) {
+        this.onSceneMouseover({scene: scene});
+    }
+
+    removeHoveredScene() {
+        this.onSceneMouseleave();
+    }
 }

--- a/app-frontend/src/app/components/colorCorrectScenes/colorCorrectScenes.html
+++ b/app-frontend/src/app/components/colorCorrectScenes/colorCorrectScenes.html
@@ -44,6 +44,8 @@
           selected="$ctrl.isSelected(scene)"
           on-select="$ctrl.setSelected(scene, selected)"
           class="selectable"
+          ng-mouseover="$ctrl.setHoveredScene(scene)"
+          ng-mouseleave="$ctrl.removeHoveredScene()"
           ng-repeat="scene in $ctrl.sceneList track by scene.id">
       </rf-scene-item>
     </div>

--- a/app-frontend/src/app/components/colorCorrectScenes/colorCorrectScenes.state.html
+++ b/app-frontend/src/app/components/colorCorrectScenes/colorCorrectScenes.state.html
@@ -4,6 +4,8 @@
   scene-list="$ctrl.sceneList"
   scene-layers="$ctrl.sceneLayers"
   layers="$ctrl.layers"
-  on-layer-change="$ctrl.updateLayers({layers: layers})">
+  on-layer-change="$ctrl.updateLayers({layers: layers})"
+  on-scene-mouseover="$ctrl.setHoveredScene(scene)"
+  on-scene-mouseleave="$ctrl.removeHoveredScene()">
 </rf-color-correct-scenes>
 

--- a/app-frontend/src/app/pages/editor/project/projectEdit.controller.js
+++ b/app-frontend/src/app/pages/editor/project/projectEdit.controller.js
@@ -9,4 +9,12 @@ export default class ProjectEditController {
         this.sceneLayers = new Map();
         this.layers = [];
     }
+
+    setHoveredScene(scene) {
+        this.hoveredScene = scene;
+    }
+
+    removeHoveredScene() {
+        this.hoveredScene = null;
+    }
 }

--- a/app-frontend/src/app/pages/editor/project/projectEdit.html
+++ b/app-frontend/src/app/pages/editor/project/projectEdit.html
@@ -11,6 +11,8 @@
   <!-- Map -->
   <div class="main">
     <rf-leaflet-map class="map-container"
+                    footprint="$ctrl.hoveredScene.dataFootprint"
+                    bypass-fit-bounds="true"
                     layers="$ctrl.layers"></rf-leaflet-map>
   </div>
 </div>


### PR DESCRIPTION
## Overview

The second half to resolve #728. For the project editing scene list, show the hovered scene's data footprint on the map.

### Notes

Testing this is difficult until #774 is resolved. Once the map hits some errors, the footprints will not display.

Unlike the scene browser, there is no guarantee that the hovered scene is within the current map extent. As such, the user could hover over a scene and not see the footprint.


## Testing Instructions

 * Edit a project that can be successfully displayed on the edit page
 * Hover over a scene in the scene list and see if footprint is visible.

Connects #728

