### PR TITLE
cleaned up project scene list ui

### DIFF
--- a/app-frontend/src/app/pages/library/projects/detail/projectScenes/projectScenes.html
+++ b/app-frontend/src/app/pages/library/projects/detail/projectScenes/projectScenes.html
@@ -1,53 +1,56 @@
 <div class="row content stack-sm" >
   <div class="column-8" ng-if="!$ctrl.loading">
     <div class="library-header">
-      <h1 class="h3 page-title"
-          ng-class="{'invisible': $ctrl.$parent.selectedScenes.size}">
-        <a ui-sref="^.^.list">Projects</a><br>
-        {{$ctrl.project.name}}
-        <i class="icon-load" ng-show="$ctrl.isSavingProjectNameEdit"></i>
-      </h1>
-      <button class="btn btn-tiny"
-              ng-click="$ctrl.toggleProjectNameEdit()"
-              ng-show="!$ctrl.$parent.selectedScenes.size && !$ctrl.isEditingProjectName && !$ctrl.isSavingProjectNameEdit">
-        <i class="icon-pencil"></i>
-      </button>
-      <div class="color-danger" ng-show="$ctrl.showError">
-        There was an error renaming the project.
-        <button class="btn btn-tiny" type="submit"
-                ng-click="$ctrl.dismissErrorMessage()">
-          <i class="icon-cross color-danger"></i>
+      <div ng-class="{'invisible': $ctrl.$parent.selectedScenes.size}">
+        <h1 class="h3 page-title">
+          <a ui-sref="^.^.list">Projects</a><br>
+          <span ng-hide="$ctrl.isEditingProjectName">
+            {{$ctrl.project.name}}
+            <i class="icon-load" ng-show="$ctrl.isSavingProjectNameEdit"></i>
+          </span>
+        </h1>
+        <button class="btn btn-tiny"
+                ng-click="$ctrl.toggleProjectNameEdit()"
+                ng-show="!$ctrl.$parent.selectedScenes.size && !$ctrl.isEditingProjectName && !$ctrl.isSavingProjectNameEdit">
+          <i class="icon-pencil"></i>
         </button>
-      </div>
-      <div ng-show="$ctrl.isEditingProjectName">
-        <div class="page-title">
-          <a ui-sref="^.^.list">Projects</a>
+        <div class="color-danger" ng-show="$ctrl.showError">
+          There was an error renaming the project.
+          <button class="btn btn-tiny" type="submit"
+                  ng-click="$ctrl.dismissErrorMessage()">
+            <i class="icon-cross color-danger"></i>
+          </button>
         </div>
-        <form class="ng-pristine ng-valid">
-          <div class="form-group all-in-one">
-            <input id="name" type="text" class="form-control"
-                  placeholder="Edit project name" ng-model="$ctrl.editedProjectName">
-            <button class="btn btn-link" type="submit"
-                    ng-click="$ctrl.saveProjectNameEdit()"
-                    ng-show="!$ctrl.isSavingProjectNameEdit">
-              <i class="icon-check"></i>
-            </button>
-            <button class="btn btn-link" type="submit"
-                    ng-click="$ctrl.cancelProjectNameEdit()"
-                    ng-show="!$ctrl.isSavingProjectNameEdit">
-              <i class="icon-cross"></i>
-            </button>
-          </div>
-        </form>
+        <div ng-show="$ctrl.isEditingProjectName">
+          <form class="ng-pristine ng-valid">
+            <div class="form-group all-in-one">
+              <input id="name" type="text" class="form-control"
+                    placeholder="Edit project name" ng-model="$ctrl.editedProjectName"
+                    ng-attr-autofocus="{{$ctrl.isEditingProjectName || undefined }}">
+              <button class="btn btn-link" type="submit"
+                      ng-click="$ctrl.cancelProjectNameEdit()"
+                      ng-show="!$ctrl.isSavingProjectNameEdit">
+                <i class="icon-cross"></i>
+              </button>
+              <button class="btn btn-link" type="submit"
+                      ng-click="$ctrl.saveProjectNameEdit()"
+                      ng-show="!$ctrl.isSavingProjectNameEdit">
+                <i class="icon-check"></i>
+              </button>
+            </div>
+          </form>
+        </div>
       </div>
-      <div ng-show="$ctrl.$parent.selectedScenes.size">
-        <h1 class="h3 highlight">
+      <div class="library-header-reveal"
+           ng-show="$ctrl.$parent.selectedScenes.size">
+        <h1 class="h4">
           <ng-pluralize count="$ctrl.$parent.selectedScenes.size"
                         when="{'one': '1 scene selected.',
                               'other': '{} scenes selected.'}">
           </ng-pluralize>
         </h1>
         <div class="library-header-actions">
+          <a href ng-click="$ctrl.downloadModal()"><i class="icon-download"></i> Download</a>
           <a href ng-click="$ctrl.selectNone()">Deselect All</a>
           <a href class="link-danger" ng-click="$ctrl.removeScenes()">Remove from Project</a>
         </div>
@@ -99,7 +102,6 @@
     <div class="content">
       <nav>
         <a href ng-click="$ctrl.$state.go('editor.project.color.scenes', {projectid: $ctrl.projectId})"><i class="icon-mosaic"></i> Editor</a>
-        <a href ng-click="$ctrl.downloadModal()"><i class="icon-download"></i> Download</a>
         <hr>
         <a href class="color-danger"
            ng-click="$ctrl.deleteProject()">

--- a/app-frontend/src/assets/styles/sass/components/_form.scss
+++ b/app-frontend/src/assets/styles/sass/components/_form.scss
@@ -147,9 +147,20 @@ input[type=radio] {
     border: none;
     border-radius: 0;
   }
+
+  .btn {
+    border: none;
+    border-left: 1px solid #ddd;
+    border-radius: 0;
+  }
+
   &.input-dark {
     border-color: $shade-dark;
     background-color: $shade-dark;
+
+    .btn {
+      border-left-color: $shade-dark;
+    }
   }
 }
 

--- a/app-frontend/src/assets/styles/sass/pages/_library.scss
+++ b/app-frontend/src/assets/styles/sass/pages/_library.scss
@@ -7,6 +7,11 @@
     margin-top: 0;
     display: inline-block;
   }
+
+  .form-group.all-in-one {
+    margin-bottom: -15px;
+    margin-top: -18px;
+  }
 }
 
 .library-header-reveal {


### PR DESCRIPTION
## Overview

Cleans up the Project scene list view UI. Makes the title editor aligned better. Makes the scene selection tools appear in correct fashion. Moves scene download button into the scene selection toolbar.

### Demo

<img width="794" alt="screen shot 2016-12-14 at 2 46 16 pm" src="https://cloud.githubusercontent.com/assets/1928955/21198203/61a2188c-c20c-11e6-8375-da5c9300a791.png">
<img width="785" alt="screen shot 2016-12-14 at 2 46 22 pm" src="https://cloud.githubusercontent.com/assets/1928955/21198204/61a3aa8a-c20c-11e6-8d2c-ddee125065a9.png">
<img width="779" alt="screen shot 2016-12-14 at 2 46 27 pm" src="https://cloud.githubusercontent.com/assets/1928955/21198205/61a4690c-c20c-11e6-9d59-6532e2de4e54.png">


