### PR TITLE
Allow selecting scenes to color correct by grid

### DIFF
--- a/app-frontend/src/app/components/colorCorrectScenes/colorCorrectScenes.component.js
+++ b/app-frontend/src/app/components/colorCorrectScenes/colorCorrectScenes.component.js
@@ -4,13 +4,16 @@ const colorCorrectScenes = {
     templateUrl: colorCorrectScenesTpl,
     controller: 'ColorCorrectScenesController',
     bindings: {
+        clickEvent: '<?',
+        mapZoom: '<?',
         selectedScenes: '=',
         selectedLayers: '=',
         sceneList: '=',
         sceneLayers: '=',
         layers: '=',
         onSceneMouseover: '&',
-        onSceneMouseleave: '&'
+        onSceneMouseleave: '&',
+        newGridSelection: '&'
     }
 };
 

--- a/app-frontend/src/app/components/colorCorrectScenes/colorCorrectScenes.module.js
+++ b/app-frontend/src/app/components/colorCorrectScenes/colorCorrectScenes.module.js
@@ -8,4 +8,6 @@ const ColorCorrectScenesModule = angular.module('components.colorCorrectScenes',
 ColorCorrectScenesModule.component('rfColorCorrectScenes', ColorCorrectScenes);
 ColorCorrectScenesModule.controller('ColorCorrectScenesController', ColorCorrectScenesController);
 
+require('./colorCorrectScenes.scss');
+
 export default ColorCorrectScenesModule;

--- a/app-frontend/src/app/components/colorCorrectScenes/colorCorrectScenes.scss
+++ b/app-frontend/src/app/components/colorCorrectScenes/colorCorrectScenes.scss
@@ -1,0 +1,3 @@
+rf-project-editor .leaflet-tile {
+  border: 1px solid black;
+}

--- a/app-frontend/src/app/components/colorCorrectScenes/colorCorrectScenes.state.html
+++ b/app-frontend/src/app/components/colorCorrectScenes/colorCorrectScenes.state.html
@@ -6,6 +6,9 @@
   layers="$ctrl.layers"
   on-layer-change="$ctrl.updateLayers({layers: layers})"
   on-scene-mouseover="$ctrl.setHoveredScene(scene)"
-  on-scene-mouseleave="$ctrl.removeHoveredScene()">
+  on-scene-mouseleave="$ctrl.removeHoveredScene()"
+  map-zoom="$ctrl.mapZoom"
+  click-event="$ctrl.clickEvent"
+  new-grid-selection="$ctrl.setHighlight(highlight)">
 </rf-color-correct-scenes>
 

--- a/app-frontend/src/app/components/leafletMap/leafletMap.component.js
+++ b/app-frontend/src/app/components/leafletMap/leafletMap.component.js
@@ -7,10 +7,12 @@ const leafletMap = {
     bindings: {
         static: '<?',
         footprint: '<?',
+        highlight: '<?',
         bypassFitBounds: '<?',
         grid: '<?',
         proposedBounds: '<?',
         onViewChange: '&',
+        onMapClick: '&',
         layers: '<?'
     }
 };

--- a/app-frontend/src/app/components/leafletMap/leafletMap.controller.js
+++ b/app-frontend/src/app/components/leafletMap/leafletMap.controller.js
@@ -14,6 +14,7 @@ export default class LeafletMapController {
 
     $onInit() {
         this.map.on('moveend', () => this.boundsChangeListener());
+        this.map.on('click', (ev) => this.mapClickListener(ev));
     }
 
     $onChanges(changes) {
@@ -49,6 +50,16 @@ export default class LeafletMapController {
             this.gridLayer.clearLayers();
             this.gridLayer.addData(changes.grid.currentValue);
         }
+
+        // Add a highlight to the map
+        if (changes.highlight) {
+            if (changes.highlight.previousValue && !changes.highlight.isFirstChange()) {
+                changes.highlight.previousValue.removeFrom(this.map);
+            }
+            if (changes.highlight.currentValue) {
+                changes.highlight.currentValue.addTo(this.map);
+            }
+        }
     }
 
     initLayers() {
@@ -66,6 +77,7 @@ export default class LeafletMapController {
                 layer.bindTooltip(`${count}`);
             }
         }).addTo(this.map);
+        this.highlightLayer = L.geoJSON().addTo(this.map);
     }
 
     initMap() {
@@ -117,7 +129,12 @@ export default class LeafletMapController {
         }, 400);
     }
 
+    // Listeners to provide interaction hooks to enclosing components
     boundsChangeListener() {
         this.onViewChange({newBounds: this.map.getBounds(), zoom: this.map.getZoom()});
+    }
+
+    mapClickListener(clickEvent) {
+        this.onMapClick({event: clickEvent});
     }
 }

--- a/app-frontend/src/app/components/mosaicScenes/mosaicScenes.controller.js
+++ b/app-frontend/src/app/components/mosaicScenes/mosaicScenes.controller.js
@@ -53,45 +53,17 @@ export default class MosaicScenesController {
         this.loading = true;
         // save off selected scenes so you don't lose them during the refresh
         this.sceneList = [];
-        let params = Object.assign({}, this.queryParams);
-        delete params.id;
-        // Figure out how many scenes there are
-        this.projectService.getProjectScenes({
-            projectId: this.project.id,
-            pageSize: '1'
-        }).then((sceneCount) => {
-            let self = this;
-            // We're going to use this in a moment to create the requests for API pages
-            let requestMaker = function *(totalResults, pageSize) {
-                let pageNum = 0;
-                while (pageNum * pageSize <= totalResults) {
-                    yield self.projectService.getProjectScenes({
-                        projectId: self.project.id,
-                        pageSize: pageSize,
-                        page: pageNum,
-                        sort: 'createdAt,desc'
-                    });
-                    pageNum = pageNum + 1;
-                }
-            };
-            let numScenes = sceneCount.count;
-            // The default API pagesize is 30 so we'll use that.
-            let pageSize = 30;
-            // Generate requests for all pages
-            let requests = Array.from(requestMaker(numScenes, pageSize));
-            // Unpack responses into a single scene list.
-            // The structure to unpack is:
-            // [{ results: [{},{},...] }, { results: [{},{},...]},...]
-            this.$q.all(requests).then((allResponses) => {
-                this.sceneList = [].concat(...Array.from(allResponses, (resp) => resp.results));
+        this.projectService.getAllProjectScenes({projectId: this.project.id}).then(
+            (allScenes) => {
+                this.sceneList = allScenes;
                 this.layersFromScenes();
             },
             () => {
                 this.errorMsg = 'Error loading scenes.';
             }).finally(() => {
                 this.loading = false;
-            });
-        });
+            }
+        );
     }
 
     layersFromScenes() {

--- a/app-frontend/src/app/pages/editor/project/projectEdit.controller.js
+++ b/app-frontend/src/app/pages/editor/project/projectEdit.controller.js
@@ -1,13 +1,30 @@
 const Map = require('es6-map');
 
 export default class ProjectEditController {
-    constructor( // eslint-disable-line max-params
+    constructor($scope // eslint-disable-line max-params
     ) {
+        'ngInject';
         this.selectedScenes = new Map();
         this.selectedLayers = new Map();
         this.sceneList = [];
         this.sceneLayers = new Map();
         this.layers = [];
+        this.highlight = null;
+        this.$scope = $scope;
+        // FIXME: Right now initialization doesn't work very well; this is just a hack that assumes
+        // we know what the map zoom initial zoom will be, which is fragile. This should be
+        // replaced when we refactor the map.
+        this.mapZoom = 2;
+    }
+
+    onMapClick(event) {
+        this.clickEvent = event;
+        this.$scope.$apply();
+    }
+
+    onViewChange(newBounds, zoom) {
+        this.mapZoom = zoom;
+        this.$scope.$apply();
     }
 
     setHoveredScene(scene) {
@@ -16,5 +33,9 @@ export default class ProjectEditController {
 
     removeHoveredScene() {
         this.hoveredScene = null;
+    }
+
+    setHighlight(highlight) {
+        this.highlight = highlight;
     }
 }

--- a/app-frontend/src/app/pages/editor/project/projectEdit.html
+++ b/app-frontend/src/app/pages/editor/project/projectEdit.html
@@ -13,6 +13,9 @@
     <rf-leaflet-map class="map-container"
                     footprint="$ctrl.hoveredScene.dataFootprint"
                     bypass-fit-bounds="true"
-                    layers="$ctrl.layers"></rf-leaflet-map>
+                    layers="$ctrl.layers"
+                    highlight="$ctrl.highlight"
+                    on-map-click="$ctrl.onMapClick(event)"
+                    on-view-change="$ctrl.onViewChange(newBounds, zoom)"></rf-leaflet-map>
   </div>
 </div>

--- a/app-frontend/src/app/pages/library/projects/list/list.controller.js
+++ b/app-frontend/src/app/pages/library/projects/list/list.controller.js
@@ -56,7 +56,7 @@ class ProjectsListController {
     }
 
     getProjectScenesCount(project) {
-        this.projectService.getProjectSceneCount(project.id).then(
+        this.projectService.getProjectSceneCount({projectId: project.id}).then(
             (sceneResult) => {
                 let bupdate = this.projectList.find((b) => b.id === project.id);
                 bupdate.scenes = sceneResult.count;


### PR DESCRIPTION
## Overview

This implements part of the color correction wireframes which show an interface for selecting scenes by clicking grid cells displayed on the map. Because we don't need to show a count of scenes like we do on the browse page, I was able to get away with generating the grid by drawing a border around the Leaflet tiles.

There is also some general cleanup, including removing an unused hook from the `colorCorrectScenes` component, moving the logic for getting all of a Project's Scenes into the Project service, and fixing an incorrect query parameter in the `getProjectSceneCount` method that was causing it to unnecessarily return a full page of results. 

### Checklist

- [ ] ~Styleguide updated, if necessary~
- [ ] ~Swagger specification updated, if necessary~

### Demo

![gridselect](https://cloud.githubusercontent.com/assets/447977/21204234/5f1ac466-c224-11e6-904d-1ef97bc0c9c2.png)

## Testing Instructions

 * Navigate to the color correction interface for a project containing the Egypt scenes.
 * Zoom in until the scenes are spread across more than one grid cell.
 * Click on a grid cell, verify that some scenes are selected.
 * Switch into color correction mode and verify that the selected scenes overlap with the clicked grid cell.

Closes #727 