### PR TITLE
Hide pagination on editor lists when appropriate

### DIFF
--- a/app-frontend/src/app/pages/library/projects/detail/projectScenes/projectScenes.html
+++ b/app-frontend/src/app/pages/library/projects/detail/projectScenes/projectScenes.html
@@ -65,7 +65,7 @@
       </rf-scene-item>
     </div>
     <div class="list-group text-center"
-         ng-show="!$ctrl.loading && $ctrl.lastSceneResult && $ctrl.lastSceneResult.count !== 0 && !$ctrl.errorMsg">
+         ng-show="!$ctrl.loading && $ctrl.lastSceneResult && $ctrl.lastSceneResult.count > $ctrl.lastSceneResult.pageSize && !$ctrl.errorMsg">
       <ul uib-pagination
           items-per-page="$ctrl.lastSceneResult.pageSize"
           total-items="$ctrl.lastSceneResult.count"

--- a/app-frontend/src/app/pages/library/projects/list/list.html
+++ b/app-frontend/src/app/pages/library/projects/list/list.html
@@ -35,7 +35,7 @@
       </span>
     </div>
     <div class="list-group text-center"
-         ng-show="!$ctrl.loading && $ctrl.lastProjectResult && $ctrl.lastProjectResult.count !== 0 && !$ctrl.errorMsg">
+         ng-show="!$ctrl.loading && $ctrl.lastProjectResult && $ctrl.lastProjectResult.count > $ctrl.lastProjectResult.pageSize && !$ctrl.errorMsg">
       <ul uib-pagination
           items-per-page="$ctrl.lastProjectResult.pageSize"
           total-items="$ctrl.lastProjectResult.count"

--- a/app-frontend/src/app/pages/library/scenes/list/list.html
+++ b/app-frontend/src/app/pages/library/scenes/list/list.html
@@ -35,7 +35,7 @@
       </span>
     </div>
     <div class="list-group text-center"
-         ng-show="!$ctrl.loading && $ctrl.lastSceneResult && $ctrl.lastSceneResult.count !== 0 && !$ctrl.errorMsg">
+         ng-show="!$ctrl.loading && $ctrl.lastSceneResult && $ctrl.lastSceneResult.count > $ctrl.lastSceneResult.pageSize && !$ctrl.errorMsg">
       <ul uib-pagination
           items-per-page="$ctrl.lastSceneResult.pageSize"
           total-items="$ctrl.lastSceneResult.count"


### PR DESCRIPTION
## Overview

Using the page size returned by the server, hide the pagination controls when the result count does not exceed the page size.


## Testing Instructions

 * When having a number of projects or scenes that is less than the page size (10), see that the pagination does not appear.

Resolves #720.

