### PR TITLE
Initialize filter pane with empty filters

### DIFF
--- a/app-frontend/src/app/components/filterPane/filterPane.controller.js
+++ b/app-frontend/src/app/components/filterPane/filterPane.controller.js
@@ -1,9 +1,11 @@
 import _ from 'lodash';
+
 export default class FilterPaneController {
     constructor() {
         'ngInject';
 
         this.toggleDrag = {toggle: false, enabled: false};
+        this.filters = {};
         this.initFilters();
     }
 


### PR DESCRIPTION
## Overview

This fixes a javascript error that happens when the filter is
initialized and attempts to set default values/ranges for the
filters. Without initializing an empty object, the controller tries to
add filters to an undefined object.

### Checklist

~~- [ ] Styleguide updated, if necessary~~
~~- [ ] Swagger specification updated, if necessary~~

## Testing Instructions

 * Switch to the current `develop` branch, start the server and frontend
 * Go to the scene browser and observe a javascript error in the console
![staging-rf](https://cloud.githubusercontent.com/assets/898060/21238811/6b5951e4-c2d2-11e6-9e09-c1a4b076eb80.png)
 * Switch to this branch and restart the frontend
 * Refresh the page and open the filters, observe that they are no longer broken

