### PR TITLE
Render actual histogram for first scene in cc

### DIFF
--- a/app-frontend/src/app/components/channelHistogram/channelHistogram.controller.js
+++ b/app-frontend/src/app/components/channelHistogram/channelHistogram.controller.js
@@ -31,7 +31,7 @@ export default class ChannelHistogramController {
     }
 
     $onChanges(changesObj) {
-        if ('data' in changesObj) {
+        if ('data' in changesObj && 'currentValue' in changesObj.data) {
             this.histData = Array.from(changesObj.data.currentValue);
         }
     }

--- a/app-frontend/src/app/components/channelHistogram/channelHistogram.controller.js
+++ b/app-frontend/src/app/components/channelHistogram/channelHistogram.controller.js
@@ -31,7 +31,7 @@ export default class ChannelHistogramController {
     }
 
     $onChanges(changesObj) {
-        if ('data' in changesObj && 'currentValue' in changesObj.data) {
+        if ('data' in changesObj && changesObj.data.currentValue) {
             this.histData = Array.from(changesObj.data.currentValue);
         }
     }

--- a/app-frontend/src/app/components/channelHistogram/channelHistogram.controller.js
+++ b/app-frontend/src/app/components/channelHistogram/channelHistogram.controller.js
@@ -10,6 +10,7 @@ export default class ChannelHistogramController {
                 showLegend: false,
                 showXAxis: false,
                 showYAxis: false,
+                interactive: false,
                 margin: {
                     top: 0,
                     right: 0,

--- a/app-frontend/src/app/components/colorCorrectAdjust/colorCorrectAdjust.controller.js
+++ b/app-frontend/src/app/components/colorCorrectAdjust/colorCorrectAdjust.controller.js
@@ -56,7 +56,7 @@ export default class ColorCorrectAdjustController {
     }
 
     $onChanges(changesObj) {
-        if ('correction' in changesObj) {
+        if ('correction' in changesObj && 'currentValue' in changesObj.correction) {
             this.myCorrection = Object.assign({}, changesObj.correction.currentValue);
         }
     }

--- a/app-frontend/src/app/components/colorCorrectPane/colorCorrectPane.controller.js
+++ b/app-frontend/src/app/components/colorCorrectPane/colorCorrectPane.controller.js
@@ -1,9 +1,8 @@
 export default class ColorCorrectPaneController {
     constructor( // eslint-disable-line max-params
-        $http, $log, $scope, $q, projectService, $state
+        $log, $scope, $q, projectService, $state
     ) {
         'ngInject';
-        this.$http = $http;
         this.bucketService = projectService;
         this.$state = $state;
         this.$q = $q;
@@ -19,7 +18,7 @@ export default class ColorCorrectPaneController {
         // Initialize correction to first selected layer (if there are multiple)
         this.firstLayer = this.selectedLayers.values().next().value;
         this.correction = this.firstLayer.baseColorCorrection();
-        this.fetchHistogramData();
+        this.updateHistogram();
     }
 
     resetCorrection() {
@@ -43,12 +42,12 @@ export default class ColorCorrectPaneController {
             for (let layer of this.selectedLayers.values()) {
                 layer.colorCorrect(this.correction);
             }
-            this.fetchHistogramData();
+            this.updateHistogram();
         }
     }
 
-    fetchHistogramData() {
-        this.$http.get(this.firstLayer.getHistogramURL()).then(
+    updateHistogram() {
+        this.firstLayer.fetchHistogramData().then(
             (resp) => {
                 this.errorLoadingHistogram = false;
                 this.data = this.generateHistogramData(resp.data);

--- a/app-frontend/src/app/components/colorCorrectPane/colorCorrectPane.html
+++ b/app-frontend/src/app/components/colorCorrectPane/colorCorrectPane.html
@@ -1,9 +1,9 @@
 <div class="color-correct-pane">
-  <div class="sidebar-static histogram">
+  <div ng-show="!$ctrl.errorLoadingHistogram" class="sidebar-static histogram">
     <rf-channel-histogram data="$ctrl.data"></rf-channel-histogram>
-    <div>
-      <a ng-click="">Make source histogram</a>
-    </div>
+  </div>
+  <div ng-show="$ctrl.errorLoadingHistogram" class="sidebar-static">
+    Error loading histogram
   </div>
   <div class="sidebar-scrollable">
     <rf-color-correct-adjust

--- a/app-frontend/src/app/components/colorCorrectScenes/colorCorrectScenes.html
+++ b/app-frontend/src/app/components/colorCorrectScenes/colorCorrectScenes.html
@@ -38,7 +38,7 @@
   <div class="sidebar-scrollable">
     <div class="list-group">
       <rf-scene-item
-          ng-click="$ctrl.$state.go('editor.project.color.adjust')"
+          ng-click="$ctrl.setSelected(scene, !$ctrl.isSelected(scene))"
           scene="scene"
           selectable
           selected="$ctrl.isSelected(scene)"

--- a/app-frontend/src/app/core/services/layer.service.js
+++ b/app-frontend/src/app/core/services/layer.service.js
@@ -67,6 +67,18 @@ export default (app) => {
         }
 
         /**
+         * Helper function to return histogram data for a tile layer
+         * @returns {string} URL for the histogram
+         */
+        getHistogramURL() {
+            let organizationId = this.scene.organizationId;
+            // TODO: replace this once user IDs are URL safe ISSUE: 766
+            let userId = this.scene.createdBy.replace('|', '_');
+            return `/tiles/${organizationId}/` +
+                `${userId}/${this.scene.id}/rgb/histogram/?${this.formatColorParams()}`;
+        }
+
+        /**
          * Helper function to add bands to query string for tile layer
          * @returns {string} formatted query string for bands in tile layer
          */
@@ -96,26 +108,27 @@ export default (app) => {
 
         formatColorParams() {
             let colorCorrectParams = '';
-
-            if (this.gammaCorrect) {
+            if (this.colorCorrection) {
+                if (this.gammaCorrect) {
+                    colorCorrectParams = `${colorCorrectParams}` +
+                        `&redGamma=${this.colorCorrection.red}` +
+                        `&greenGamma=${this.colorCorrection.green}` +
+                        `&blueGamma=${this.colorCorrection.blue}`;
+                }
+                if (this.sigmoidCorrect) {
+                    colorCorrectParams = `${colorCorrectParams}` +
+                        `&alpha=${this.colorCorrection.alpha}` +
+                        `&beta=${this.colorCorrection.beta}`;
+                }
+                if (this.colorClipCorrect) {
+                    colorCorrectParams = `${colorCorrectParams}`
+                        + `&min=${this.colorCorrection.min}`
+                        + `&max=${this.colorCorrection.max}`;
+                }
                 colorCorrectParams = `${colorCorrectParams}` +
-                    `&redGamma=${this.colorCorrection.red}` +
-                    `&greenGamma=${this.colorCorrection.green}` +
-                    `&blueGamma=${this.colorCorrection.blue}`;
+                    `&brightness=${this.colorCorrection.brightness}` +
+                    `&contrast=${this.colorCorrection.contrast}`;
             }
-            if (this.sigmoidCorrect) {
-                colorCorrectParams = `${colorCorrectParams}` +
-                    `&alpha=${this.colorCorrection.alpha}` +
-                    `&beta=${this.colorCorrection.beta}`;
-            }
-            if (this.colorClipCorrect) {
-                colorCorrectParams = `${colorCorrectParams}`
-                    + `&min=${this.colorCorrection.min}`
-                    + `&max=${this.colorCorrection.max}`;
-            }
-            colorCorrectParams = `${colorCorrectParams}` +
-                `&brightness=${this.colorCorrection.brightness}` +
-                `&contrast=${this.colorCorrection.contrast}`;
             return colorCorrectParams;
         }
 

--- a/app-frontend/src/app/core/services/layer.service.js
+++ b/app-frontend/src/app/core/services/layer.service.js
@@ -21,16 +21,18 @@ export default (app) => {
 
         /**
          * Creates a layer from a scene -- this may need to be expanded
+         * @param {object} $http injected angular $http service
          * @param {object} scene response from the API
          * @param {boolean} gammaCorrect flag to enable gamma correction
          * @param {boolean} sigmoidCorrect flag to enable sigmoidal correction
          * @param {boolean} colorClipCorrect flag to enable color clipping
          * @param {object} bands keys = band type, values = band number
          */
-        constructor(
-            scene, gammaCorrect = true, sigmoidCorrect = false,
+        constructor( // eslint-disable-line max-params
+            $http, scene, gammaCorrect = true, sigmoidCorrect = false,
             colorClipCorrect = true, bands = {red: 3, green: 2, blue: 1}
         ) {
+            this.$http = $http;
             this.scene = scene;
             this.gammaCorrect = gammaCorrect;
             this.sigmoidCorrect = sigmoidCorrect;
@@ -67,7 +69,7 @@ export default (app) => {
         }
 
         /**
-         * Helper function to return histogram data for a tile layer
+         * Helper function to return histogram endpoint url for a tile layer
          * @returns {string} URL for the histogram
          */
         getHistogramURL() {
@@ -76,6 +78,14 @@ export default (app) => {
             let userId = this.scene.createdBy.replace('|', '_');
             return `/tiles/${organizationId}/` +
                 `${userId}/${this.scene.id}/rgb/histogram/?${this.formatColorParams()}`;
+        }
+
+        /**
+         * Helper function to fetch histogram data for a tile layer
+         * @returns {Promise} which should be resolved with an array
+         */
+        fetchHistogramData() {
+            return this.$http.get(this.getHistogramURL());
         }
 
         /**
@@ -147,14 +157,17 @@ export default (app) => {
     }
 
     class LayerService {
-
+        constructor($http) {
+            'ngInject';
+            this.$http = $http;
+        }
         /**
          * Constructor for layer via a service
          * @param {object} scene resource returned via API
          * @returns {Layer} layer created
          */
         layerFromScene(scene) {
-            return new Layer(scene);
+            return new Layer(this.$http, scene);
         }
     }
 


### PR DESCRIPTION
## Overview

Hooks up histogram to endpoints to display real histogram of selected scenes with color corrections applied.

### Demo

<img width="463" alt="screen shot 2016-12-15 at 3 23 56 pm" src="https://cloud.githubusercontent.com/assets/2442245/21240736/92e592b0-c2da-11e6-863d-7f8d27b0ec3b.png">
<img width="425" alt="screen shot 2016-12-15 at 3 24 13 pm" src="https://cloud.githubusercontent.com/assets/2442245/21240741/95f5c100-c2da-11e6-8956-7a583c3bf3b5.png">

### Notes

Color correction sliders start at their minimum, so any initial adjustment to the sliders throws off the color correction values.

Would also be beneficial to enforce some min-height of the histogram containing `div` so that loading would not be so jarring.

## Testing Instructions

 * Select scenes to color correct
 * Enter color correction
 * See that histogram loads
 * Adjust sliders and ensure histogram updates