### PR TITLE
cleaned up the color correction UI

### DIFF
--- a/app-frontend/src/app/components/channelHistogram/channelHistogram.controller.js
+++ b/app-frontend/src/app/components/channelHistogram/channelHistogram.controller.js
@@ -17,6 +17,7 @@ export default class ChannelHistogramController {
                     bottom: 0,
                     left: 0
                 },
+                height: 100,
                 xAxis: {
                     showLabel: false
                 },

--- a/app-frontend/src/app/components/colorCorrectAdjust/colorCorrectAdjust.html
+++ b/app-frontend/src/app/components/colorCorrectAdjust/colorCorrectAdjust.html
@@ -1,7 +1,7 @@
-<div class="content">
+<div class="content histogram-filters">
   <div class="color-filters-container">
     <!-- Color correction -->
-    <h6>Gamma Correction</h6>
+    <p class="h5">Gamma Correction</p>
     <div class="filter">
       <label>Red</label>
       <div class="filter-item slider-filter">
@@ -31,7 +31,7 @@
     </div>
 
     <!--TODO: Add Sigmoidal Back When Fixed ISSUE: 761-->
-    <!--<h6>Sigmoidal Correction</h6>-->
+    <!--<p class="h5">Sigmoidal Correction</p>-->
     <!--<div class="filter">-->
       <!--<label>Alpha</label>-->
       <!--<div class="filter-item slider-filter">-->
@@ -52,7 +52,7 @@
     <!--</div>-->
   </div>
   <div class="bc-filters-container">
-    <h6>Brightness/Contrast</h6>
+    <p class="h5">Brightness/Contrast</p>
     <div class="filter">
       <label>Brightness</label>
       <rzslider rz-slider-model="$ctrl.correction.brightness"

--- a/app-frontend/src/app/components/colorCorrectPane/colorCorrectPane.html
+++ b/app-frontend/src/app/components/colorCorrectPane/colorCorrectPane.html
@@ -1,6 +1,13 @@
 <div class="color-correct-pane">
+  <div class="sidebar-static">
+    <a href ng-click="$ctrl.resetCorrection()" class="link-histogram-reset">Reset Changes</a>
+    <div class="sidebar-actions">
+      <a href class="btn btn-default btn-small" ng-click="$ctrl.$state.go('^.scenes')">Back</a>
+    </div>
+  </div>
   <div ng-show="!$ctrl.errorLoadingHistogram" class="sidebar-static histogram">
     <rf-channel-histogram data="$ctrl.data"></rf-channel-histogram>
+    <a ng-click="" class="btn btn-link btn-block">Make source histogram</a>
   </div>
   <div ng-show="$ctrl.errorLoadingHistogram" class="sidebar-static">
     Error loading histogram
@@ -12,12 +19,5 @@
         reset="$ctrl.resetToggle"
         class="color-correct-panel">
     </rf-color-correct-adjust>
-  </div>
-  <div class="sidebar-static">
-    <a href ng-click="$ctrl.$state.go('^.scenes')">Back</a>
-    <div class="sidebar-actions">
-      <a href ng-click="$ctrl.resetCorrection()">Reset</a>
-      <a href ng-click="$ctrl.applyColors()">Apply changes</a>
-    </div>
   </div>
 </div>

--- a/app-frontend/src/app/components/colorCorrectPane/colorCorrectPane.state.html
+++ b/app-frontend/src/app/components/colorCorrectPane/colorCorrectPane.state.html
@@ -1,2 +1,2 @@
-<rf-color-correct-pane selected-layers="$ctrl.selectedLayers">
+<rf-color-correct-pane class="flex-column sidebar-dark" selected-layers="$ctrl.selectedLayers">
 </rf-color-correct-pane>

--- a/app-frontend/src/app/components/colorCorrectScenes/colorCorrectScenes.html
+++ b/app-frontend/src/app/components/colorCorrectScenes/colorCorrectScenes.html
@@ -1,39 +1,41 @@
-<div class="scene-list-pane">
+<div class="flex-column">
   <!-- scene listing -->
   <div class="sidebar-static">
-      <div class="btn-group" uib-dropdown dropdown-append-to-body>
-        <a href uib-dropdown-toggle>
+      <div class="btn-group sidebar-dropdown" uib-dropdown>
+        <a href class="btn btn-small" uib-dropdown-toggle>
           Color mode <i class="icon-caret-down"></i>
         </a>
-        <ul class="dropdown-menu" uib-dropdown-menu role="menu">
-          <li role="menuitem" ng-click="$ctrl.setBands('natural')">Natural color</li>
-          <li role="menuitem" ng-click="$ctrl.setBands('cir')">Color Infrared</li>
-          <li role="menuitem" ng-click="$ctrl.setBands('urban')">Urban</li>
-          <li role="menuitem" ng-click="$ctrl.setBands('water')">Water</li>
-          <li role="menuitem" ng-click="$ctrl.setBands('atmosphere')">Atmosphere Penetration</li>
-          <li role="menuitem" ng-click="$ctrl.setBands('agriculture')">Agriculture</li>
-          <li role="menuitem" ng-click="$ctrl.setBands('forestfire')">Forest Fire</li>
-          <li role="menuitem" ng-click="$ctrl.setBands('bareearth')">Bare Earth Change Detection</li>
-          <li role="menuitem" ng-click="$ctrl.setBands('vegwater')">Vegetation & Water</li>
+        <ul class="dropdown-menu dropdown-menu-light" uib-dropdown-menu role="menu">
+          <li role="menuitem"><a href ng-click="$ctrl.setBands('natural')">Natural color</a></li>
+          <li role="menuitem"><a href ng-click="$ctrl.setBands('cir')">Color infrared</a></li>
+          <li role="menuitem"><a href ng-click="$ctrl.setBands('urban')">Urban</a></li>
+          <li role="menuitem"><a href ng-click="$ctrl.setBands('water')">Water</a></li>
+          <li role="menuitem"><a href ng-click="$ctrl.setBands('atmosphere')">Atmosphere penetration</a></li>
+          <li role="menuitem"><a href ng-click="$ctrl.setBands('agriculture')">Agriculture</a></li>
+          <li role="menuitem"><a href ng-click="$ctrl.setBands('forestfire')">Forest fire</a></li>
+          <li role="menuitem"><a href ng-click="$ctrl.setBands('bareearth')">Bare Earth change detection</a></li>
+          <li role="menuitem"><a href ng-click="$ctrl.setBands('vegwater')">Vegetation & water</a></li>
         </ul>
       </div>
-      <div class="btn-group" uib-dropdown dropdown-append-to-body>
-        <a href uib-dropdown-toggle>
-          Action <i class="icon-caret-down"></i>
-        </a>
-        <ul class="dropdown-menu" uib-dropdown-menu role="menu">
-          <li role="menuitem"><i class="icon-load"></i> Sync histogram</li>
-          <li role="menuitem"><i class="icon-arrows-cw"></i> Reset changes</li>
-          <li role="menuitem"><i class="icon-trash"></i> Delete</li>
-        </ul>
-        <button ng-disabled="$ctrl.selectedScenes.size === 0" ng-click="$ctrl.$state.go('editor.project.color.adjust')" class="btn">Color Correct</button>
+      <div class="sidebar-actions">
+        <div class="btn-group sidebar-dropdown cc-actions" uib-dropdown>
+          <a href class="btn btn-small" uib-dropdown-toggle>
+            Action <i class="icon-caret-down"></i>
+          </a>
+          <ul class="dropdown-menu dropdown-menu-light" uib-dropdown-menu role="menu">
+            <li role="menuitem"><a ng-disabled="$ctrl.selectedScenes.size === 0" ng-click="$ctrl.$state.go('editor.project.color.adjust')">Color correct</a></li>
+            <li role="menuitem"><a href="#"><i class="icon-load"></i> Sync histogram</a></li>
+            <li role="menuitem"><a href="#"><i class="icon-arrows-cw"></i> Reset changes</a></li>
+            <li role="menuitem"><a href="#" class="color-danger"><i class="icon-trash"></i> Delete</a></li>
+          </ul>
+          <button class="btn btn-small"
+                  ng-class="{'btn-secondary': !$ctrl.shouldSelectAll()}"
+                  ng-click="$ctrl.onToggleSelection()">
+            <i ng-class="{'icon-plus': $ctrl.shouldSelectAll(),
+                          'icon-cross': !$ctrl.shouldSelectAll()}"></i>
+          </button>
+        </div>
       </div>
-      <button class="btn btn-square"
-              ng-class="{'btn-secondary': !$ctrl.shouldSelectAll()}"
-              ng-click="$ctrl.onToggleSelection()">
-        <i ng-class="{'icon-plus': $ctrl.shouldSelectAll(),
-                      'icon-cross': !$ctrl.shouldSelectAll()}"></i>
-      </button>
   </div>
   <div class="sidebar-scrollable">
     <div class="list-group">

--- a/app-frontend/src/app/components/colorCorrectScenes/colorCorrectScenes.state.html
+++ b/app-frontend/src/app/components/colorCorrectScenes/colorCorrectScenes.state.html
@@ -1,4 +1,5 @@
 <rf-color-correct-scenes
+  class="flex-column"
   selected-scenes="$ctrl.selectedScenes"
   selected-layers="$ctrl.selectedLayers"
   scene-list="$ctrl.sceneList"

--- a/app-frontend/src/app/components/mosaicScenes/mosaicScenes.html
+++ b/app-frontend/src/app/components/mosaicScenes/mosaicScenes.html
@@ -1,4 +1,4 @@
-<div class="scene-list-pane">
+<div class="flex-column">
   <!-- scene listing -->
   <div class="sidebar-static">
     <h5>Scene z-index order</h5>

--- a/app-frontend/src/app/components/mosaicScenes/mosaicScenes.state.html
+++ b/app-frontend/src/app/components/mosaicScenes/mosaicScenes.state.html
@@ -1,4 +1,5 @@
 <rf-mosaic-scenes 
+  class="flex-column"
   scene-list="$ctrl.sceneList"
   layers="$ctrl.layers">
 </rf-mosaic-scenes>

--- a/app-frontend/src/app/index.routes.js
+++ b/app-frontend/src/app/index.routes.js
@@ -65,7 +65,7 @@ function editorStates($stateProvider) {
         })
         .state('editor.project.color', {
             url: '/color-correct',
-            template: '<ui-view></ui-view>',
+            template: '<ui-view class="flex-column"></ui-view>',
             abstract: true
         })
         .state('editor.project.color.scenes', {
@@ -81,7 +81,7 @@ function editorStates($stateProvider) {
         })
         .state('editor.project.mosaic', {
             url: '/mosaic',
-            template: '<ui-view></ui-view>',
+            template: '<ui-view class="flex-column"></ui-view>',
             abstract: true
         })
         .state('editor.project.mosaic.scenes', {

--- a/app-frontend/src/app/pages/editor/project/projectEdit.html
+++ b/app-frontend/src/app/pages/editor/project/projectEdit.html
@@ -5,9 +5,9 @@
   </nav>
   <span class="navbar-vertical-divider"></span>
 </div>
-<div class="container column-stretch">
+<div class="container column-stretch container-not-scrollable">
   <!-- Sidebar (container is in parent view) -->
-  <ui-view class="sidebar"></ui-view>
+  <div class="sidebar" ui-view></div>
   <!-- Map -->
   <div class="main">
     <rf-leaflet-map class="map-container"

--- a/app-frontend/src/assets/styles/sass/app.scss
+++ b/app-frontend/src/assets/styles/sass/app.scss
@@ -71,7 +71,8 @@
 **/
 @import
   "pages/default",
-  "pages/library";
+  "pages/library",
+  "pages/editor";
 
 
 /**

--- a/app-frontend/src/assets/styles/sass/base/_base.scss
+++ b/app-frontend/src/assets/styles/sass/base/_base.scss
@@ -22,6 +22,16 @@ a {
 
   &:hover {
     color: $brand-primary;
+    cursor: pointer;
+  }
+
+  &:disabled, &.disabled, &[disabled] {
+    opacity: .5;
+    cursor: not-allowed;
+
+    &:hover {
+      color: $shade-light;
+    }
   }
 }
 

--- a/app-frontend/src/assets/styles/sass/base/_helpers.scss
+++ b/app-frontend/src/assets/styles/sass/base/_helpers.scss
@@ -23,68 +23,68 @@
 
 // Color helpers
 .color-primary {
-  color: $brand-primary;
+  color: $brand-primary !important;
 }
 
 .color-secondary {
-  color: $brand-secondary;
+  color: $brand-secondary !important;
 }
 
 .color-warning {
-  color: $warning;
+  color: $warning !important;
 }
 
 .color-danger {
-  color: $danger;
+  color: $danger !important;
 }
 
 .color-dark {
-  color: $shade-dark;
+  color: $shade-dark !important;
 }
 
 // background helpers
 .bg-primary {
-  background-color: $brand-primary;
+  background-color: $brand-primary !important;
 }
 
 .bg-secondary {
-  background-color: $brand-secondary;
+  background-color: $brand-secondary !important;
 }
 
 .bg-warning {
-  background-color: $warning;
+  background-color: $warning !important;
 }
 
 .bg-danger {
-  background-color: $danger;
+  background-color: $danger !important;
 }
 
 // link helpers
 .link-primary {
-  color: $brand-primary;
+  color: $brand-primary !important;
   &:hover {
-    color: darken($brand-primary, 5%);
+    color: darken($brand-primary, 5%) !important;
   }
 }
 
 .link-secondary {
-  color: $brand-secondary;
+  color: $brand-secondary !important;
   &:hover {
-    color: darken($brand-secondary, 5%);
+    color: darken($brand-secondary, 5%) !important;
   }
 }
 
 .link-warning {
-  color: $warning;
+  color: $warning !important;
   &:hover {
-    color: darken($warning, 5%);
+    color: darken($warning, 5%) !important;
   }
 }
 
 .link-danger {
-  color: $danger;
+  color: $danger !important;
   &:hover {
-    color: darken($danger, 5%);
+    color: darken($danger, 5%) !important;
   }
 }
 
@@ -108,4 +108,10 @@
   overflow: hidden;
   clip: rect(0,0,0,0);
   border: 0;
+}
+
+// Flexbox helpers
+.flex-column {
+  display: flex;
+  flex-direction: column;
 }

--- a/app-frontend/src/assets/styles/sass/components/_button.scss
+++ b/app-frontend/src/assets/styles/sass/components/_button.scss
@@ -45,7 +45,7 @@
   &:hover, &.hover,
   &:active, &.active, {
     color: #fff;
-    background-color: $shade-light;
+    background-color: lighten($shade-light, 10%);
   }
 
   &:active, &.active {
@@ -221,3 +221,36 @@
     }
   }
 }
+
+
+/* 
+ * Button groups
+ */
+ .btn-group {
+  display: flex !important;
+
+  .btn {
+    margin: 0 !important;
+
+
+    // FIX ISSUE WHERE ONLY ONE BUTTON HAS MESSED UP RADIUS
+    &:not(:last-child):not(.dropdown-toggle) {
+      border-top-right-radius: 0;
+      border-bottom-right-radius: 0;
+    }
+
+    &:last-child:not(:first-child) {
+      border-top-left-radius: 0;
+      border-bottom-left-radius: 0;
+    }
+
+    &:not(:first-child):not(:last-child):not(.dropdown-toggle) {
+      border-radius: 0;
+    }
+  }
+
+
+  .btn ~ .btn {
+    margin-left: -1px !important;
+  }
+ }

--- a/app-frontend/src/assets/styles/sass/components/_color-correct.scss
+++ b/app-frontend/src/assets/styles/sass/components/_color-correct.scss
@@ -1,6 +1,0 @@
-.color-correct-pane {
-    background: $shade-normal;
-    .histogram {
-        background: $shade-dark;
-    }
-}

--- a/app-frontend/src/assets/styles/sass/components/_dropdown.scss
+++ b/app-frontend/src/assets/styles/sass/components/_dropdown.scss
@@ -69,6 +69,37 @@
   }
 }
 
+// The dropdown menu (ul) light color theme
+.dropdown-menu.dropdown-menu-light {
+  background-color: white;
+  border: 1px solid $shade-light;
+
+  // Dividers (basically an hr) within the dropdown
+  .divider {
+    background-color: $shade-light;
+  }
+}
+
+// Hover/Focus state
+.dropdown-menu.dropdown-menu-light > li > a {
+  &:hover,
+  &:focus {
+    text-decoration: none;
+    color: $brand-primary;
+  }
+}
+
+// Active state
+.dropdown-menu.dropdown-menu-light > .active > a {
+  &,
+  &:hover,
+  &:focus {
+    color: $brand-primary;
+    text-decoration: none;
+    outline: 0;
+  }
+}
+
 // Disabled state
 //
 // Gray out text and ensure the hover/focus state remains gray
@@ -151,6 +182,33 @@
     // Will remove come v4 in all likelihood.
     .dropdown-menu-left {
       left: 0; right: auto;
+    }
+  }
+}
+
+/* 
+ * sidebar-dropdown which is generally seen in color correction UI
+ */
+.sidebar-dropdown {
+  .dropdown-toggle {
+    min-width: 100px;
+    text-align: left;
+
+    i {
+      float: right;
+    }
+  }
+
+  .dropdown-menu {
+    margin: -1px 0;
+    border-radius: 0 0 $border-radius-base $border-radius-base;
+    padding: 5px 0;
+
+    li a {
+      margin: 0;
+      padding: 5px 10px;
+      font-size: 13px;
+      font-weight: 400;
     }
   }
 }

--- a/app-frontend/src/assets/styles/sass/layout/_container.scss
+++ b/app-frontend/src/assets/styles/sass/layout/_container.scss
@@ -43,7 +43,12 @@
 }
 
 $navbar-height: 8rem;
+$navbar-secondary-height: 6rem;
 
 .container-not-scrollable {
   height: calc(100vh - #{$navbar-height});
+
+  .secondary-navbar ~ & {
+    height: calc(100vh - #{$navbar-height + $navbar-secondary-height});    
+  }
 }

--- a/app-frontend/src/assets/styles/sass/layout/_sidebar.scss
+++ b/app-frontend/src/assets/styles/sass/layout/_sidebar.scss
@@ -36,7 +36,6 @@
 .sidebar-static {
   flex: none;
   position: relative;
-  overflow: hidden;
   border-bottom: 2px solid #ddd;
   padding: 1rem 1.5rem;
   display: flex;
@@ -58,7 +57,7 @@
   .sidebar-actions {
     margin-left: auto;
 
-    * {
+    > * {
       display: inline-block;
     }
 
@@ -119,7 +118,8 @@
   z-index: 1000;
 }
 
-.map-filters {
+.map-filters,
+.sidebar-dark {
   left: 40rem;
   margin-left: -2px;
   background: $shade-normal;
@@ -127,11 +127,12 @@
 
   .sidebar-static {
     background: $shade-dark;
-    border: none;
+    border-color: $shade-normal;
+  }
 
-    h5, p {
-      color: #fff;
-    }
+  h5, .h5,
+  p {
+    color: #fff;
   }
 }
 

--- a/app-frontend/src/assets/styles/sass/pages/_editor.scss
+++ b/app-frontend/src/assets/styles/sass/pages/_editor.scss
@@ -1,0 +1,34 @@
+/* 
+ * Color Correction image list sidebar
+ */
+
+// Adjust the dropdown menu of the color corrections 
+// action so it is flush right with the .btn-group
+.cc-actions .dropdown-menu {
+  right: 0;
+}
+
+/* 
+ * Color Correction filter sidebar
+ */
+.color-correct-pane {
+
+  .content {
+    padding-top: 1rem;
+  }
+
+  .filter {
+    padding-top: 1rem;
+    padding-bottom: 1rem;
+  }
+}
+
+/* 
+ * Histogram
+ * for color correction
+ */
+.histogram {
+  position: relative;
+  display: block;
+  padding: 1rem 2rem 0;
+}


### PR DESCRIPTION
## Overview

The color correction ui had many styling issues which made working with it very difficult.

- Fixes issue where number of scenes affected height of map
- Entire page no longer scrolls.
- Moves color correct button into actions dropdown, as its an action.
- Update styling of dropdowns within sidebar
- Cleaned up color correction histogram panel
- Additionally, applied same fixes as checkbox 1 and 2 to mosaic UI.

### Demo
**Height of map no longer controlled by scene total**
<img width="955" alt="screen shot 2016-12-15 at 3 18 37 pm" src="https://cloud.githubusercontent.com/assets/1928955/21240799/d86af776-c2da-11e6-84e0-18d36a943c19.png">
<img width="790" alt="screen shot 2016-12-15 at 3 18 54 pm" src="https://cloud.githubusercontent.com/assets/1928955/21240822/edb92d50-c2da-11e6-9c08-9c86f0544967.png">

**Cleaned up dropdowns & moved color correct action into actions dropdown**
<img width="400" alt="screen shot 2016-12-15 at 3 19 02 pm" src="https://cloud.githubusercontent.com/assets/1928955/21240840/fcb967a2-c2da-11e6-9179-e1aa89f2c5cc.png">
<img width="408" alt="screen shot 2016-12-15 at 3 19 13 pm" src="https://cloud.githubusercontent.com/assets/1928955/21240844/0b068f60-c2db-11e6-97c4-9536599eac93.png">
<img width="396" alt="screen shot 2016-12-15 at 3 19 23 pm" src="https://cloud.githubusercontent.com/assets/1928955/21240845/11cb6ffa-c2db-11e6-9e23-b43fad73077c.png">

**Cleaned up color correction panel**
<img width="397" alt="screen shot 2016-12-15 at 3 19 30 pm" src="https://cloud.githubusercontent.com/assets/1928955/21240861/1c709976-c2db-11e6-8873-a87dda042c0c.png">


### Notes

This PR does not attempt to address the bulk of Mosaic issues. This is purely focused on Color Correction UI.


### Fixes 
fixes #774