### PR TITLE
Add mosaic mask view

### DIFF
--- a/app-frontend/package.json
+++ b/app-frontend/package.json
@@ -45,6 +45,7 @@
     "es6-map": "~0.1.4",
     "jquery": "~2.1.4",
     "leaflet": "~1.0.0",
+    "leaflet-draw": "~0.4.7",
     "lodash": "~4.5.0",
     "ng-infinite-scroll": "~1.3.0",
     "nvd3": "~1.8.4"

--- a/app-frontend/src/app/components/leafletMap/leafletMap.component.js
+++ b/app-frontend/src/app/components/leafletMap/leafletMap.component.js
@@ -15,8 +15,7 @@ const leafletMap = {
         onMapClick: '&',
         layers: '<?',
         drawnPolygons: '=?',
-        allowDrawing: '<?',
-        mapExtent: '<?'
+        allowDrawing: '<?'
     }
 };
 

--- a/app-frontend/src/app/components/leafletMap/leafletMap.component.js
+++ b/app-frontend/src/app/components/leafletMap/leafletMap.component.js
@@ -13,7 +13,10 @@ const leafletMap = {
         proposedBounds: '<?',
         onViewChange: '&',
         onMapClick: '&',
-        layers: '<?'
+        layers: '<?',
+        drawnPolygons: '=?',
+        allowDrawing: '<?',
+        mapExtent: '<?'
     }
 };
 

--- a/app-frontend/src/app/components/leafletMap/leafletMap.controller.js
+++ b/app-frontend/src/app/components/leafletMap/leafletMap.controller.js
@@ -15,11 +15,6 @@ export default class LeafletMapController {
         this.initLayers();
 
         this.$scope.$watchCollection('$ctrl.drawnPolygons', this.onDrawnPolygonsChange.bind(this));
-        this.$scope.$watchCollection('$ctrl.mapExtent', (mapExtent) => {
-            if (mapExtent) {
-                this.map.fitBounds(mapExtent);
-            }
-        });
     }
 
     $onInit() {
@@ -75,15 +70,12 @@ export default class LeafletMapController {
                 this.drawControl.addTo(this.map);
             } else {
                 this.drawControl.remove();
-                // this.drawLayer.clearLayers();
             }
-        }
-
-        if (changes.mapExtent && changes.mapExtent.currentValue) {
-            this.map.fitBounds(changes.mapExtent.currentValue);
         }
     }
 
+    // TODO: on refactor, track layers by id so that they don't need to all be deleted / added
+    //       every time there's an update.
     onDrawnPolygonsChange(polygons) {
         this.drawLayer.clearLayers();
         if (polygons && polygons.length) {
@@ -166,6 +158,7 @@ export default class LeafletMapController {
             this.$scope.$apply();
         });
 
+        // TODO: During the refactor, use e.layers.eachLayer if it makes more sense.
         this.map.on(L.Draw.Event.EDITED, (e) => {
             Object.values(
                 e.layers._layers // eslint-disable-line no-underscore-dangle
@@ -176,12 +169,17 @@ export default class LeafletMapController {
                 );
                 newPolygon.properties.area = calculateArea(layer);
                 this.drawnPolygons.splice(oldPolygonIndex, 1);
+                // TODO: drawn polygons should probably be a Map to make adding/removing/updating
+                //       more conceptually simple.
+                //       eg: this.drawnPolygons.delete(..); this.drawnPolygons.set(...)
+                //       instead of the weirdly named array equivalents.
                 this.drawnPolygons.push(newPolygon);
             });
             this.onDrawnPolygonsChange(this.drawnPolygons);
             this.$scope.$apply();
         });
 
+        // TODO: Same as with above
         this.map.on(L.Draw.Event.DELETED, (e) => {
             Object.values(
                 e.layers._layers // eslint-disable-line no-underscore-dangle

--- a/app-frontend/src/app/components/leafletMap/leafletMap.module.js
+++ b/app-frontend/src/app/components/leafletMap/leafletMap.module.js
@@ -2,6 +2,8 @@ import angular from 'angular';
 import LeafletMapComponent from './leafletMap.component.js';
 import LeafletMapController from './leafletMap.controller.js';
 require('leaflet/dist/leaflet.css');
+require('leaflet-draw/dist/leaflet.draw.css');
+require('leaflet-draw/dist/leaflet.draw.js');
 require('./leafletMap.scss');
 
 const LeafletMapModule = angular.module('components.leafletMap', []);

--- a/app-frontend/src/app/components/maskItem/maskItem.component.js
+++ b/app-frontend/src/app/components/maskItem/maskItem.component.js
@@ -1,0 +1,13 @@
+import mosaicMaskItemTpl from './maskItem.html';
+
+const rfMosaicMaskItem = {
+    templateUrl: mosaicMaskItemTpl,
+    controller: 'MosaicMaskItemController',
+    bindings: {
+        mask: '<',
+        onZoom: '&',
+        onDelete: '&'
+    }
+};
+export default rfMosaicMaskItem;
+

--- a/app-frontend/src/app/components/maskItem/maskItem.controller.js
+++ b/app-frontend/src/app/components/maskItem/maskItem.controller.js
@@ -1,0 +1,12 @@
+export default class MosaicMaskItemController {
+    constructor() {
+    }
+
+    onDeleteClick() {
+        this.onDelete({mask: this.mask});
+    }
+
+    onZoomClick() {
+        this.onZoom({mask: this.mask});
+    }
+}

--- a/app-frontend/src/app/components/maskItem/maskItem.html
+++ b/app-frontend/src/app/components/maskItem/maskItem.html
@@ -1,0 +1,9 @@
+<div class="mask-item">
+  {{$ctrl.mask.area | number : 1}} km&sup2;
+  <button class="btn btn-square" ng-click="$ctrl.onZoomClick()">
+    <i class="icon-search"></i>
+  </button>
+  <button class="btn btn-square" ng-click="$ctrl.onDeleteClick()">
+    <i class="icon-trash"></i>
+  </button>
+</div>

--- a/app-frontend/src/app/components/maskItem/maskItem.module.js
+++ b/app-frontend/src/app/components/maskItem/maskItem.module.js
@@ -1,0 +1,11 @@
+import angular from 'angular';
+
+import MosaicMaskItem from './maskItem.component.js';
+import MosaicMaskItemController from './maskItem.controller.js';
+
+const MosaicMaskItemModule = angular.module('components.mosaicMaskItem', []);
+
+MosaicMaskItemModule.component('rfMosaicMaskItem', MosaicMaskItem);
+MosaicMaskItemModule.controller('MosaicMaskItemController', MosaicMaskItemController);
+
+export default MosaicMaskItemModule;

--- a/app-frontend/src/app/components/mosaicMask/mosaicMask.component.js
+++ b/app-frontend/src/app/components/mosaicMask/mosaicMask.component.js
@@ -1,0 +1,16 @@
+import mosaicMaskTpl from './mosaicMask.html';
+
+const rfMosaicMask = {
+    templateUrl: mosaicMaskTpl,
+    controller: 'MosaicMaskController',
+    bindings: {
+        scene: '<',
+        sceneList: '=',
+        allowDrawing: '=',
+        drawnPolygons: '=',
+        mapExtent: '=',
+        layers: '='
+    }
+};
+
+export default rfMosaicMask;

--- a/app-frontend/src/app/components/mosaicMask/mosaicMask.component.js
+++ b/app-frontend/src/app/components/mosaicMask/mosaicMask.component.js
@@ -8,7 +8,6 @@ const rfMosaicMask = {
         sceneList: '=',
         allowDrawing: '=',
         drawnPolygons: '=',
-        mapExtent: '=',
         layers: '='
     }
 };

--- a/app-frontend/src/app/components/mosaicMask/mosaicMask.controller.js
+++ b/app-frontend/src/app/components/mosaicMask/mosaicMask.controller.js
@@ -100,39 +100,10 @@ export default class MosaicMaskController {
         let params = Object.assign({}, this.queryParams);
         delete params.id;
         // Figure out how many scenes there are
-        this.projectService.getProjectSceneCount(this.project.id).then(
-            (sceneCount) => {
-                let self = this;
-                // We're going to use this in a moment to create the requests for API pages
-                let requestMaker = function *(totalResults, pageSize) {
-                    let pageNum = 0;
-                    while (pageNum * pageSize <= totalResults) {
-                        yield self.projectService.getProjectScenes({
-                            projectid: self.project.id,
-                            pageSize: pageSize,
-                            page: pageNum,
-                            sort: 'createdAt,desc'
-                        });
-                        pageNum = pageNum + 1;
-                    }
-                };
-                let numScenes = sceneCount.count;
-                // The default API pagesize is 30 so we'll use that.
-                let pageSize = 30;
-                // Generate requests for all pages
-                let requests = Array.from(requestMaker(numScenes, pageSize));
-                // Unpack responses into a single scene list.
-                // The structure to unpack is:
-                // [{ results: [{},{},...] }, { results: [{},{},...]},...]
-                this.$q.all(requests).then((allResponses) => {
-                    this.sceneList = [].concat(...Array.from(allResponses, (resp) => resp.results));
-                    this.layersFromScenes();
-                },
-                () => {
-                    this.errorMsg = 'Error loading scenes.';
-                }).finally(() => this.loading = false); // eslint-disable-line no-return-assign
-            }
-        );
+        this.projectService.getAllProjectScenes(params).then((sceneList) => {
+            this.sceneList = sceneList;
+            this.layersFromScenes();
+        });
     }
 
     layersFromScenes() {

--- a/app-frontend/src/app/components/mosaicMask/mosaicMask.controller.js
+++ b/app-frontend/src/app/components/mosaicMask/mosaicMask.controller.js
@@ -1,0 +1,148 @@
+export default class MosaicMaskController {
+    constructor( // eslint-disable-line max-params
+        $log, $scope, $q, projectService, layerService, $state, $stateParams
+    ) {
+        'ngInject';
+        this.projectService = projectService;
+        this.layerService = layerService;
+        this.$state = $state;
+        this.$q = $q;
+        this.$log = $log;
+        this.$scope = $scope;
+        this.$stateParams = $stateParams;
+    }
+
+    $onInit() {
+        this.project = this.$state.params.project;
+        this.projectid = this.$state.params.projectid;
+        this.maskList = [];
+
+        this.scene = this.$stateParams.scene;
+        if (!this.scene) {
+            // temporary
+            this.$state.go('editor.project.mosaic.scenes');
+            // fetch scene info
+        }
+
+        this.opacity = {
+            model: 100,
+            options: {
+                floor: 0,
+                ceil: 100,
+                step: 1,
+                showTicks: 10,
+                showTicksValues: true
+            }
+        };
+
+        // fetch scene masks
+
+        // fetch project / scene list. probably not necessary, remove later if so.
+        if (!this.project) {
+            if (this.projectid) {
+                this.loading = true;
+                this.projectService.query({id: this.projectid}).then(
+                    (project) => {
+                        this.project = project;
+                        this.loading = false;
+                        this.populateSceneList();
+                    },
+                    () => {
+                        this.$state.go('library.projects.list');
+                    });
+            } else {
+                this.$state.go('library.projects.list');
+            }
+        } else {
+            this.populateSceneList();
+        }
+
+        this.$scope.$watchCollection('$ctrl.drawnPolygons', (polygons) => {
+            this.maskList = polygons.map((polygon) => {
+                return {
+                    area: polygon.properties.area,
+                    createdAt: polygon.properties.createdAt,
+                    numPoints: polygon.geometry.coordinates[0].length - 1
+                };
+            });
+        });
+    }
+
+    closePanel() {
+        this.$state.go(
+            'editor.project.mosaic.scenes',
+            {
+                projectid: this.projectid,
+                project: this.project,
+                sceneList: this.sceneList
+            }
+        );
+    }
+
+    enableDrawToolbar() {
+        this.allowDrawing = !this.allowDrawing;
+    }
+
+    populateSceneList() {
+        // If we are returning from a different state that might preserve the
+        // sceneList, like the color correction adjustments, then we don't need
+        // to re-request scenes.
+        if (this.loading || this.sceneList && this.sceneList.length > 0) {
+            this.layersFromScenes();
+            return;
+        }
+
+        delete this.errorMsg;
+        this.loading = true;
+
+        // save off selected scenes so you don't lose them during the refresh
+        this.sceneList = [];
+        let params = Object.assign({}, this.queryParams);
+        delete params.id;
+        // Figure out how many scenes there are
+        this.projectService.getProjectSceneCount(this.project.id).then(
+            (sceneCount) => {
+                let self = this;
+                // We're going to use this in a moment to create the requests for API pages
+                let requestMaker = function *(totalResults, pageSize) {
+                    let pageNum = 0;
+                    while (pageNum * pageSize <= totalResults) {
+                        yield self.projectService.getProjectScenes({
+                            projectid: self.project.id,
+                            pageSize: pageSize,
+                            page: pageNum,
+                            sort: 'createdAt,desc'
+                        });
+                        pageNum = pageNum + 1;
+                    }
+                };
+                let numScenes = sceneCount.count;
+                // The default API pagesize is 30 so we'll use that.
+                let pageSize = 30;
+                // Generate requests for all pages
+                let requests = Array.from(requestMaker(numScenes, pageSize));
+                // Unpack responses into a single scene list.
+                // The structure to unpack is:
+                // [{ results: [{},{},...] }, { results: [{},{},...]},...]
+                this.$q.all(requests).then((allResponses) => {
+                    this.sceneList = [].concat(...Array.from(allResponses, (resp) => resp.results));
+                    this.layersFromScenes();
+                },
+                () => {
+                    this.errorMsg = 'Error loading scenes.';
+                }).finally(() => this.loading = false); // eslint-disable-line no-return-assign
+            }
+        );
+    }
+
+    layersFromScenes() {
+        this.layers = this.sceneList.map((scene) => this.layerService.layerFromScene(scene));
+    }
+
+    onDeleteMask(mask) {
+        let polygonIndex = this.drawnPolygons.findIndex(
+            (polygon) => polygon.properties.area === mask.area
+        );
+        this.drawnPolygons.splice(polygonIndex, 1);
+    }
+}

--- a/app-frontend/src/app/components/mosaicMask/mosaicMask.html
+++ b/app-frontend/src/app/components/mosaicMask/mosaicMask.html
@@ -1,0 +1,38 @@
+<div class="scene-list-pane">
+  <div class="sidebar-static">
+    <h5 class="sidebar-title">
+      Mask
+    </h5>
+    <div class="sidebar-actions">
+      <button class="btn btn-square" ng-click="$ctrl.closePanel()">
+        <i class="icon-cross"></i>
+      </button>
+    </div>
+  </div>
+  <div class="sidebar-scrollable">
+    <div class="instructions-container">
+      <button class="btn btn-primary"
+              ng-click="$ctrl.enableDrawToolbar()">
+        <i class="icon-pencil"></i>
+        Draw Mask
+      </button>
+      <p>
+        Select a drawing tool from the toolbar and click on the map to start drawing.
+        To edit a mask, select the edit icon. Click and drag points to move them, and double click
+        them to delete them.
+        To save your changes, click "Save"
+        To delete masks, either click the <i class="icon-trash"></i> icon on the map to select polygons, or delete them below.
+      </p>
+    </div>
+    <rf-mosaic-mask-item on-delete="$ctrl.onDeleteMask(mask)"
+                         mask="mask"
+                         ng-repeat="mask in $ctrl.maskList track by mask.createdAt">
+    </rf-mosaic-mask-item>
+  </div>
+</div>
+<div class="opacity-slider">
+  <h3 class="h5">Opacity : {{$ctrl.opacity.model | number}} %</h3>
+  <rzslider rz-slider-model="$ctrl.opacity.model"
+            rz-slider-options="$ctrl.opacity.options"
+  ></rzslider>
+</div>

--- a/app-frontend/src/app/components/mosaicMask/mosaicMask.module.js
+++ b/app-frontend/src/app/components/mosaicMask/mosaicMask.module.js
@@ -1,0 +1,13 @@
+import angular from 'angular';
+
+import MosaicMask from './mosaicMask.component.js';
+import MosaicMaskController from './mosaicMask.controller.js';
+
+require('./mosaicMask.scss');
+
+const MosaicMaskModule = angular.module('components.mosaicMask', []);
+
+MosaicMaskModule.component('rfMosaicMask', MosaicMask);
+MosaicMaskModule.controller('MosaicMaskController', MosaicMaskController);
+
+export default MosaicMaskModule;

--- a/app-frontend/src/app/components/mosaicMask/mosaicMask.scss
+++ b/app-frontend/src/app/components/mosaicMask/mosaicMask.scss
@@ -1,0 +1,38 @@
+// TODO @designmatty delete this when styles are finished
+.instructions-container {
+  border: 1px solid #bbb;
+  border-radius: 2px;
+  margin: 1em;
+  padding: 1em;
+  text-align: center;
+  p {
+    text-align: left;
+    margin: 1em;
+  }
+}
+
+$navbar-height: 8rem;
+$secondary-navbar-height: 7rem;
+
+.container-not-scrollable {
+  height: calc(100vh - #{$navbar-height});
+  &.with-header {
+    height: calc(100vh - #{$navbar-height} - #{$secondary-navbar-height})
+  }
+}
+
+.opacity-slider {
+  bottom: 0;
+  position: absolute;
+  left: calc(50% - 310px);
+  height: 8rem;
+  width: 30%;
+  z-index: 9999;
+  background: #465076;
+  padding: 0.5rem 2rem 2rem 2rem;
+  transform: translateX(50%);
+  h3 {
+    margin: 0 0 0.5rem 0;
+    color: #959CAC;
+  }
+}

--- a/app-frontend/src/app/components/mosaicMask/mosaicMask.state.html
+++ b/app-frontend/src/app/components/mosaicMask/mosaicMask.state.html
@@ -2,6 +2,5 @@
     scene-list="$ctrl.sceneList"
     allow-drawing="$ctrl.allowDrawing"
     drawn-polygons="$ctrl.drawnPolygons"
-    layers="$ctrl.layers",
-    map-extent="$ctrl.mapExtent">
+    layers="$ctrl.layers">
 </rf-mosaic-mask>

--- a/app-frontend/src/app/components/mosaicMask/mosaicMask.state.html
+++ b/app-frontend/src/app/components/mosaicMask/mosaicMask.state.html
@@ -1,0 +1,7 @@
+<rf-mosaic-mask
+    scene-list="$ctrl.sceneList"
+    allow-drawing="$ctrl.allowDrawing"
+    drawn-polygons="$ctrl.drawnPolygons"
+    layers="$ctrl.layers",
+    map-extent="$ctrl.mapExtent">
+</rf-mosaic-mask>

--- a/app-frontend/src/app/components/mosaicScenes/mosaicScenes.component.js
+++ b/app-frontend/src/app/components/mosaicScenes/mosaicScenes.component.js
@@ -5,7 +5,9 @@ const mosaicScenes = {
     controller: 'MosaicScenesController',
     bindings: {
         sceneList: '=',
-        layers: '='
+        layers: '=',
+        onSceneMouseover: '&',
+        onSceneMouseleave: '&'
     }
 };
 

--- a/app-frontend/src/app/components/mosaicScenes/mosaicScenes.controller.js
+++ b/app-frontend/src/app/components/mosaicScenes/mosaicScenes.controller.js
@@ -9,6 +9,7 @@ export default class MosaicScenesController {
         this.layerService = layerService;
         this.$state = $state;
         this.$q = $q;
+        this.$log = $log;
     }
 
     $onInit() {
@@ -38,6 +39,8 @@ export default class MosaicScenesController {
         } else {
             this.populateSceneList();
         }
+
+        this.onSceneMouseleave();
     }
 
     // TODO: This and the ColorCorrectScenesController have nearly identical logic
@@ -68,5 +71,18 @@ export default class MosaicScenesController {
 
     layersFromScenes() {
         this.layers = this.sceneList.map((scene) => this.layerService.layerFromScene(scene));
+    }
+
+    onSceneClick($event, scene) {
+        $event.preventDefault();
+        this.$state.go('editor.project.mosaic.mask', {scene: scene, sceneid: scene.id});
+    }
+
+    setHoveredScene(scene) {
+        this.onSceneMouseover({scene: scene});
+    }
+
+    removeHoveredScene() {
+        this.onSceneMouseleave();
     }
 }

--- a/app-frontend/src/app/components/mosaicScenes/mosaicScenes.html
+++ b/app-frontend/src/app/components/mosaicScenes/mosaicScenes.html
@@ -11,7 +11,12 @@
     <div ui-tree class="list-group">
       <div ui-tree-nodes="" ng-model="$ctrl.sceneList">
         <div ng-repeat="scene in $ctrl.sceneList track by scene.id" ui-tree-node>
-          <rf-scene-item scene="scene" draggable></rf-scene-item>
+          <rf-scene-item scene="scene"
+                         action-icon="'icon-pencil'"
+                         ng-mouseover="$ctrl.setHoveredScene(scene)"
+                         ng-mouseleave="$ctrl.removeHoveredScene()"
+                         ng-click="$ctrl.onSceneClick($event, scene)"
+                         draggable></rf-scene-item>
         </div>
       </div>
     </div>

--- a/app-frontend/src/app/components/mosaicScenes/mosaicScenes.state.html
+++ b/app-frontend/src/app/components/mosaicScenes/mosaicScenes.state.html
@@ -1,5 +1,8 @@
-<rf-mosaic-scenes 
+<rf-mosaic-scenes
   class="flex-column"
-  scene-list="$ctrl.sceneList"
-  layers="$ctrl.layers">
+    scene-list="$ctrl.sceneList"
+    on-scene-select="$ctrl.onSceneMask(scene)"
+    layers="$ctrl.layers"
+    on-scene-mouseover="$ctrl.setHoveredScene(scene)"
+    on-scene-mouseleave="$ctrl.removeHoveredScene()">
 </rf-mosaic-scenes>

--- a/app-frontend/src/app/components/sceneItem/sceneItem.component.js
+++ b/app-frontend/src/app/components/sceneItem/sceneItem.component.js
@@ -7,7 +7,9 @@ const rfSceneItem = {
     bindings: {
         scene: '<',
         selected: '&',
-        onSelect: '&'
+        onSelect: '&',
+        onAction: '&',
+        actionIcon: '<'
     }
 };
 

--- a/app-frontend/src/app/components/sceneItem/sceneItem.controller.js
+++ b/app-frontend/src/app/components/sceneItem/sceneItem.controller.js
@@ -15,4 +15,9 @@ export default class SceneItemController {
         this.onSelect({scene: this.scene, selected: !this.selectedStatus});
         event.stopPropagation();
     }
+
+    onAction(event) {
+        this.onAction({scene: this.scene});
+        event.stopPropagation();
+    }
 }

--- a/app-frontend/src/app/components/sceneItem/sceneItem.html
+++ b/app-frontend/src/app/components/sceneItem/sceneItem.html
@@ -25,5 +25,10 @@
                    'icon-cross': $ctrl.selectedStatus
                    }"></i>
     </button>
+    <button class="btn btn-square"
+            ng-click="$ctrl.onAction($event)"
+            ng-if="$ctrl.actionIcon">
+      <i ng-class="$ctrl.actionIcon"></i>
+    </button>
   </div>
 </div>

--- a/app-frontend/src/app/index.components.js
+++ b/app-frontend/src/app/index.components.js
@@ -9,6 +9,8 @@ export default angular.module('index.components', [
     require('./components/colorCorrectAdjust/colorCorrectAdjust.module.js').name,
     require('./components/channelHistogram/channelHistogram.module.js').name,
     require('./components/mosaicScenes/mosaicScenes.module.js').name,
+    require('./components/mosaicMask/mosaicMask.module.js').name,
+    require('./components/maskItem/maskItem.module.js').name,
     require('./components/sceneItem/sceneItem.module.js').name,
     require('./components/sceneDetail/sceneDetail.module.js').name,
     require('./components/projectItem/projectItem.module.js').name,

--- a/app-frontend/src/app/index.routes.js
+++ b/app-frontend/src/app/index.routes.js
@@ -7,6 +7,7 @@ import colorCorrectScenesStateTpl from
     './components/colorCorrectScenes/colorCorrectScenes.state.html';
 import colorCorrectPaneStateTpl from './components/colorCorrectPane/colorCorrectPane.state.html';
 import mosaicScenesStateTpl from './components/mosaicScenes/mosaicScenes.state.html';
+import mosaicMaskStateTpl from './components/mosaicMask/mosaicMask.state.html';
 import libraryTpl from './pages/library/library.html';
 import scenesTpl from './pages/library/scenes/scenes.html';
 import scenesListTpl from './pages/library/scenes/list/list.html';
@@ -60,7 +61,7 @@ function editorStates($stateProvider) {
             resolve: {
                 project: () => null
             },
-            template: '<rf-project-editor></rf-project-editor>',
+            template: '<rf-project-editor class="app-content"></rf-project-editor>',
             abstract: true
         })
         .state('editor.project.color', {
@@ -91,6 +92,13 @@ function editorStates($stateProvider) {
         .state('editor.project.mosaic.params', {
             url: '/params',
             template: '<rf-mosaic-params></rf-mosaic-params>'
+        })
+        .state('editor.project.mosaic.mask', {
+            url: '/mask/:sceneid',
+            params: {
+                scene: null
+            },
+            templateUrl: mosaicMaskStateTpl
         });
 }
 

--- a/app-frontend/src/app/pages/browse/browse.controller.js
+++ b/app-frontend/src/app/pages/browse/browse.controller.js
@@ -174,7 +174,6 @@ export default class BrowseController {
         this.loadingGrid = true;
         let params = Object.assign({zoom: zoom}, this.queryParams);
         delete params.id;
-        this.$log.debug('Querying grid with params:', params);
         this.gridService.query(
             params
         ).then(

--- a/app-frontend/src/app/pages/editor/project/projectEdit.controller.js
+++ b/app-frontend/src/app/pages/editor/project/projectEdit.controller.js
@@ -1,7 +1,8 @@
 const Map = require('es6-map');
 
 export default class ProjectEditController {
-    constructor($scope // eslint-disable-line max-params
+    constructor( // eslint-disable-line max-params
+            $scope, $rootScope
     ) {
         'ngInject';
         this.selectedScenes = new Map();
@@ -15,6 +16,16 @@ export default class ProjectEditController {
         // we know what the map zoom initial zoom will be, which is fragile. This should be
         // replaced when we refactor the map.
         this.mapZoom = 2;
+
+        this.allowDrawing = false;
+        this.drawnPolygons = [];
+
+        $rootScope.$on('$stateChangeStart', (event, toState, toParams, fromState) => {
+            if (fromState.name === 'editor.project.mosaic.mask') {
+                this.allowDrawing = false;
+                this.drawnPolygons = [];
+            }
+        });
     }
 
     onMapClick(event) {

--- a/app-frontend/src/app/pages/editor/project/projectEdit.html
+++ b/app-frontend/src/app/pages/editor/project/projectEdit.html
@@ -18,7 +18,6 @@
                     on-map-click="$ctrl.onMapClick(event)"
                     allow-drawing="$ctrl.allowDrawing"
                     drawn-polygons="$ctrl.drawnPolygons"
-                    map-extent="$ctrl.mapExtent"
                     on-view-change="$ctrl.onViewChange(newBounds, zoom)">
     </rf-leaflet-map>
   </div>

--- a/app-frontend/src/app/pages/editor/project/projectEdit.html
+++ b/app-frontend/src/app/pages/editor/project/projectEdit.html
@@ -5,7 +5,7 @@
   </nav>
   <span class="navbar-vertical-divider"></span>
 </div>
-<div class="container column-stretch container-not-scrollable">
+<div class="container column-stretch container-not-scrollable with-header">
   <!-- Sidebar (container is in parent view) -->
   <div class="sidebar" ui-view></div>
   <!-- Map -->
@@ -16,6 +16,10 @@
                     layers="$ctrl.layers"
                     highlight="$ctrl.highlight"
                     on-map-click="$ctrl.onMapClick(event)"
-                    on-view-change="$ctrl.onViewChange(newBounds, zoom)"></rf-leaflet-map>
+                    allow-drawing="$ctrl.allowDrawing"
+                    drawn-polygons="$ctrl.drawnPolygons"
+                    map-extent="$ctrl.mapExtent"
+                    on-view-change="$ctrl.onViewChange(newBounds, zoom)">
+    </rf-leaflet-map>
   </div>
 </div>


### PR DESCRIPTION
## Overview

Add a mosaic masking view.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~

### Demo

Optional. Screenshots, `curl` examples, etc.
![image](https://cloud.githubusercontent.com/assets/4392704/21274315/8ef98254-c395-11e6-8625-a420f8474ace.png)


### Notes

There is currently no way to save / actually use the generated polygons / opacity slider
@designmatty I included a mosaicMask.scss file at `/app-frontend/src/app/components/mosaicMask/mosaicMask.scss` which can be deleted once you figure out how you want to do things there. 

## Testing Instructions

* On the frontend, navigate to a project and click "edit"
* click "mosaic"
* click any scene to go to the masking view.  Its polygon should stay on the map
* Click the "Draw Mask" button in the sidebar to enable the drawing toolbar
* Draw some masks, and delete / edit them.  You should be able to delete them from both the toolbar and the side panel.  Masks are identified by their area in the side panel.

Connects #731 