### PR TITLE
Fit map to scenes being color-corrected

### DIFF
--- a/app-frontend/src/app/components/colorCorrectPane/colorCorrectPane.controller.js
+++ b/app-frontend/src/app/components/colorCorrectPane/colorCorrectPane.controller.js
@@ -3,6 +3,7 @@ export default class ColorCorrectPaneController {
         $log, $scope, $q, projectService, $state
     ) {
         'ngInject';
+        this.$parent = $scope.$parent.$ctrl;
         this.bucketService = projectService;
         this.$state = $state;
         this.$q = $q;
@@ -15,10 +16,16 @@ export default class ColorCorrectPaneController {
             this.$state.go('^.scenes');
             return;
         }
+        this.$parent.fitSelectedScenes();
+        this.$parent.bringSelectedScenesToFront();
         // Initialize correction to first selected layer (if there are multiple)
         this.firstLayer = this.selectedLayers.values().next().value;
         this.correction = this.firstLayer.baseColorCorrection();
         this.updateHistogram();
+    }
+
+    $onDestroy() {
+        this.$parent.fitAllScenes();
     }
 
     resetCorrection() {

--- a/app-frontend/src/app/pages/editor/project/projectEdit.controller.js
+++ b/app-frontend/src/app/pages/editor/project/projectEdit.controller.js
@@ -35,9 +35,8 @@ export default class ProjectEditController {
 
     onViewChange(newBounds, zoom) {
         this.mapZoom = zoom;
-        this.$scope.$apply();
+        this.$scope.$evalAsync();
     }
-
     setHoveredScene(scene) {
         this.hoveredScene = scene;
     }
@@ -48,5 +47,37 @@ export default class ProjectEditController {
 
     setHighlight(highlight) {
         this.highlight = highlight;
+    }
+
+    applyCachedZOrder() {
+        if (this.cachedZIndices) {
+            for (const [id, l] of this.selectedLayers) {
+                l.tiles.setZIndex(this.cachedZIndices.get(id));
+            }
+        }
+    }
+
+    fitSelectedScenes() {
+        this.fitScenes(Array.from(this.selectedScenes.values()));
+    }
+
+    bringSelectedScenesToFront() {
+        this.cachedZIndices = new Map();
+        for (const [id, l] of this.selectedLayers) {
+            this.cachedZIndices.set(id, l.tiles.options.zIndex);
+            l.tiles.bringToFront();
+        }
+    }
+
+    fitAllScenes() {
+        if (this.sceneList.length) {
+            this.fitScenes(this.sceneList);
+        }
+    }
+
+    fitScenes(scenes) {
+        this.proposedBounds =
+            L.featureGroup(scenes.map(v => L.geoJSON(v.dataFootprint)))
+                .getBounds();
     }
 }

--- a/app-frontend/src/app/pages/editor/project/projectEdit.html
+++ b/app-frontend/src/app/pages/editor/project/projectEdit.html
@@ -18,7 +18,8 @@
                     on-map-click="$ctrl.onMapClick(event)"
                     allow-drawing="$ctrl.allowDrawing"
                     drawn-polygons="$ctrl.drawnPolygons"
-                    on-view-change="$ctrl.onViewChange(newBounds, zoom)">
+                    on-view-change="$ctrl.onViewChange(newBounds, zoom)"
+                    proposed-bounds="$ctrl.proposedBounds">
     </rf-leaflet-map>
   </div>
 </div>


### PR DESCRIPTION
## Overview
Fits the map to the scenes being color-corrected. This will also cache the z-order of the layers, and then bring the scenes being color-corrected to the front. After editing is complete, the scenes are returned to their original z-order.

## Notes

If layers previously have the same z-index param, their rendering order determined their 'actual' z-order. This 'actual' z-order is not maintained as the rendering order does not actual alter the `options.zIndex` property of the layer. In this case, the 'actual' z-order may change throughout the process of entering and exiting color-correction.

## Testing Instructions

 * Select a project that contains the Egypt scenes and go into edit mode
 * Select a scene(s) and enter color correction
 * Ensure the map alters its bounds to fit the scenes being editing
 * Ensure the scenes being edited are brought to the front
 * Exit color correction
 * Ensure original z-ordering is preserved (taking into account the note above)

Connects #726
