### PR TITLE
Increase route test timeout to 3 seconds

### DIFF
--- a/app-backend/app/src/test/scala/tools/ToolSpec.scala
+++ b/app-backend/app/src/test/scala/tools/ToolSpec.scala
@@ -2,12 +2,14 @@ package com.azavea.rf.tool
 
 import java.util.UUID
 
+import akka.actor.ActorSystem
 import akka.http.scaladsl.model.{ContentTypes, HttpEntity, StatusCodes}
 import akka.http.scaladsl.server.Route
-import akka.http.scaladsl.testkit.ScalatestRouteTest
+import akka.http.scaladsl.testkit.{RouteTestTimeout, ScalatestRouteTest}
 import com.azavea.rf.datamodel._
 import com.azavea.rf.utils.Config
 import com.azavea.rf.{AuthUtils, DBSpec, Router}
+import concurrent.duration._
 import org.scalatest.{Matchers, WordSpec}
 import spray.json._
 
@@ -20,6 +22,7 @@ class ToolSpec extends WordSpec
 
   implicit val ec = system.dispatcher
   implicit def database = db
+  implicit def default(implicit system: ActorSystem) = RouteTestTimeout(DurationInt(3).second)
 
   val authorization = AuthUtils.generateAuthHeader("Default")
   val publicOrgId = UUID.fromString("dfac6307-b5ef-43f7-beda-b9f208bb7726")


### PR DESCRIPTION
## Overview

For whatever reason, the test suite was failing repeatedly when I run it locally after spinning up a fresh environment. Increasing the timeout to 3 seconds allowed all tests to pass repeatedly without issues.

### Notes

Below is an example of the trace I was seeing before:

```
[info] /api/tools/
[info] - should reject creating tools without authentication
[info] - should create a tool with authorization *** FAILED ***
[info]   Request was neither completed nor rejected within 1 second (DynamicVariable.scala:58)
[info] - should require authentication for list
14:50:01.518 [com-azavea-rf-tooltag-ToolTagSpec-akka.actor.default-dispatcher-3] INFO  akka.event.slf4j.Slf4jLogger - Slf4jLogger started
[ERROR] [12/20/2016 14:50:01.544] [com-azavea-rf-tool-ToolSpec-akka.actor.default-dispatcher-13] [akka.actor.ActorSystemImpl(com-azavea-rf-tool-ToolSpec)] Error during processing of request HttpRequest(HttpMethod(POST),http://example.com/api/tools/,List(Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE0ODIyNDUzOTUsImV4cCI6MTQ4MjMzMTc5NSwic3ViIjoiRGVmYXVsdCJ9.fzzGVDor-roKKIQ6jMkWvC2tu1sd8Ggq24tlO8a4DXo),HttpEntity.Strict(application/json,{"compatibleDataSources":["Test tool datasource"],"stars":2.5,"description":"Test tool description","tags":[],"license":"Test tool license","requirements":"Test tool requirements","categories":[],"organizationId":"dfac6307-b5ef-43f7-beda-b9f208bb7726","title":"Test tool label","visibility":"PUBLIC"}),HttpProtocol(HTTP/1.1))
org.postgresql.util.PSQLException: This connection has been closed.
        at org.postgresql.jdbc2.AbstractJdbc2Connection.checkClosed(AbstractJdbc2Connection.java:820)
        at org.postgresql.jdbc3.AbstractJdbc3Connection.prepareStatement(AbstractJdbc3Connection.java:275)
        at org.postgresql.jdbc2.AbstractJdbc2Connection.prepareStatement(AbstractJdbc2Connection.java:293)
        at com.zaxxer.hikari.proxy.ConnectionProxy.prepareStatement(ConnectionProxy.java:268)
        at com.zaxxer.hikari.proxy.ConnectionJavassistProxy.prepareStatement(ConnectionJavassistProxy.java)
        at slick.jdbc.JdbcBackend$SessionDef$class.prepareStatement(JdbcBackend.scala:297)
        at slick.jdbc.JdbcBackend$BaseSession.prepareStatement(JdbcBackend.scala:407)
        at slick.jdbc.JdbcBackend$SessionDef$class.withPreparedStatement(JdbcBackend.scala:346)
        at slick.jdbc.JdbcBackend$BaseSession.withPreparedStatement(JdbcBackend.scala:407)
        at slick.driver.JdbcActionComponent$InsertActionComposerImpl.preparedInsert(JdbcActionComponent.scala:498)
        at slick.driver.JdbcActionComponent$InsertActionComposerImpl$MultiInsertAction.run(JdbcActionComponent.scala:523)
        at slick.driver.JdbcActionComponent$SimpleJdbcDriverAction.run(JdbcActionComponent.scala:32)
        at slick.driver.JdbcActionComponent$SimpleJdbcDriverAction.run(JdbcActionComponent.scala:29)
        at slick.backend.DatabaseComponent$DatabaseDef$$anon$2.liftedTree1$1(DatabaseComponent.scala:237)
        at slick.backend.DatabaseComponent$DatabaseDef$$anon$2.run(DatabaseComponent.scala:237)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
        at java.lang.Thread.run(Thread.java:745)
```

## Testing Instructions

From within the virtual machine, run the following command and confirm that it completes successfully:

```bash
$ ./scripts/test
```