### PR TITLE
Add model builder page with example UI

### DIFF
--- a/app-frontend/config/webpack/global.js
+++ b/app-frontend/config/webpack/global.js
@@ -135,6 +135,11 @@ module.exports = function (_path) {
                     'expose?L'
                 ]
             }, {
+                test: require.resolve('jointjs'),
+                loaders: [
+                    'expose?joint'
+                ]
+            },{
                 test: /node_modules[\\\/]auth0-lock[\\\/].*\.js$/,
                 loaders: ['transform-loader/cacheable?brfs',
                           'transform-loader/cacheable?packageify']

--- a/app-frontend/package.json
+++ b/app-frontend/package.json
@@ -43,6 +43,7 @@
     "bootstrap-sass": "~3.3.6",
     "d3": "~3.4.4",
     "es6-map": "~0.1.4",
+    "jointjs": "~1.0.3",
     "jquery": "~2.1.4",
     "leaflet": "~1.0.0",
     "leaflet-draw": "~0.4.7",

--- a/app-frontend/src/app/components/diagramContainer/diagramContainer.component.js
+++ b/app-frontend/src/app/components/diagramContainer/diagramContainer.component.js
@@ -1,0 +1,9 @@
+export default {
+    template: '<div class="main lab-workspace"></div>',
+    controller: 'DiagramContainerController',
+    bindings: {
+        shapes: '<?',
+        onCellClick: '&',
+        onPaperClick: '&'
+    }
+};

--- a/app-frontend/src/app/components/diagramContainer/diagramContainer.controller.js
+++ b/app-frontend/src/app/components/diagramContainer/diagramContainer.controller.js
@@ -1,0 +1,93 @@
+/* global joint */
+
+export default class DiagramContainerController {
+    constructor($element) {
+        'ngInject';
+        this.$element = $element;
+    }
+
+    $onInit() {
+        this.workspaceElement = this.$element[0].children[0];
+        this.initShapes();
+        this.initDiagram();
+    }
+
+    $onChanges(changes) {
+        if (this.graph && changes.shapes) {
+            this.graph.clear();
+            changes.shapes.forEach(s => this.graph.addCell(s));
+        }
+    }
+
+    initShapes() {
+        this.shapes = [];
+        this.shapes.push(new joint.shapes.basic.Rect({
+            position: {
+                x: ($(this.workspaceElement).width() - 225) / 2,
+                y: ($(this.workspaceElement).height() - 75) / 2
+            },
+            size: {
+                width: 225,
+                height: 75
+            },
+            attrs: {
+                rect: {
+                    rx: 4,
+                    ry: 7,
+                    fill: '#cfcfcf'
+                }
+            },
+            ports: {
+                groups: {
+                    inputs: {
+                        position: {
+                            name: 'top'
+                        }
+                    },
+                    functions: {
+                        position: {
+                            name: 'left'
+                        }
+                    }
+                },
+                items: [
+                    {
+                        group: 'inputs'
+                    },
+                    {
+                        group: 'functions'
+                    }
+                ]
+            }
+        }));
+    }
+
+    initDiagram() {
+        this.graph = new joint.dia.Graph();
+        this.paper = new joint.dia.Paper({
+            el: this.workspaceElement,
+            height: $(this.workspaceElement).height(),
+            width: $(this.workspaceElement).width(),
+            gridSize: 25,
+            drawGrid: true,
+            model: this.graph
+        });
+        this.paper.drawGrid({
+            color: '#aaa',
+            thickness: 1
+        });
+        this.paper.on('blank:pointerclick', () => {
+            if (this.onPaperClick) {
+                this.onPaperClick();
+            }
+        });
+        this.paper.on('cell:pointerclick', () => {
+            if (this.onCellClick) {
+                this.onCellClick();
+            }
+        });
+        if (this.shapes) {
+            this.shapes.forEach(s => this.graph.addCell(s));
+        }
+    }
+}

--- a/app-frontend/src/app/components/diagramContainer/diagramContainer.module.js
+++ b/app-frontend/src/app/components/diagramContainer/diagramContainer.module.js
@@ -1,0 +1,10 @@
+import angular from 'angular';
+import DiagramContainerComponent from './diagramContainer.component.js';
+import DiagramContainerController from './diagramContainer.controller.js';
+
+const DiagramContainerModule = angular.module('components.diagramContainer', []);
+
+DiagramContainerModule.component('rfDiagramContainer', DiagramContainerComponent);
+DiagramContainerModule.controller('DiagramContainerController', DiagramContainerController);
+
+export default DiagramContainerModule;

--- a/app-frontend/src/app/components/navBar/navBar.html
+++ b/app-frontend/src/app/components/navBar/navBar.html
@@ -1,33 +1,36 @@
 <div class="navbar primary-navbar" ng-show="!$ctrl.loadError">
-	<!-- Nav Left -->
-	<div class="navbar-left">
-	  <a href="#" class="brand">
-			<img ng-attr-src="{{$ctrl.assetLogo}}">
-	  </a>
-	  <span class="navbar-vertical-divider"></span>
-	  <nav>
-	    <a href ui-sref="browse" ui-sref-active="active">Scene browser</a>
-	    <a href ui-sref="market.search"
+  <!-- Nav Left -->
+  <div class="navbar-left">
+    <a href="#" class="brand">
+      <img ng-attr-src="{{$ctrl.assetLogo}}">
+    </a>
+    <span class="navbar-vertical-divider"></span>
+    <nav>
+      <a href ui-sref="browse" ui-sref-active="active">Scene browser</a>
+      <a href ui-sref="market.search"
          ng-class="{
                    active: $ctrl.$state.$current.name.includes('market')
                    }">Model market</a>
-	    <a href ui-sref="lab" ui-sref-active="active">Model lab</a>
-	  </nav>
-	  <span class="navbar-vertical-divider"></span>
-	</div>
+      <a href ui-sref="lab.edit"
+         ng-class="{
+                   active: $ctrl.$state.$current.name.includes('lab')
+                   }">Model lab</a>
+    </nav>
+    <span class="navbar-vertical-divider"></span>
+  </div>
 
-	<!-- Nav Right -->
-	<div class="navbar-right">
-	  <nav>
-	    <a href class="icon-link" title="Help">
-	      <i class="icon-help"></i>
-	    </a>
-	    <a href class="icon-link" title="Processing">
-	      <i class="icon-processing"></i>
-	    </a>
-	  </nav>
-	  <span class="navbar-vertical-divider"></span>
-	  <nav>
+  <!-- Nav Right -->
+  <div class="navbar-right">
+    <nav>
+      <a href class="icon-link" title="Help">
+        <i class="icon-help"></i>
+      </a>
+      <a href class="icon-link" title="Processing">
+        <i class="icon-processing"></i>
+      </a>
+    </nav>
+    <span class="navbar-vertical-divider"></span>
+    <nav>
       <div ng-if="!$ctrl.authService.isLoggedIn">
         <a href ng-click="$ctrl.signin()">
           Sign In
@@ -36,17 +39,17 @@
       <div ng-if="$ctrl.authService.isLoggedIn" uib-dropdown class="dropdown-my-account" on-toggle="toggled($ctrl.optionsOpen)">
         <a href uib-dropdown-toggle>
           <img ng-if="$ctrl.authService.profile().picture" class="avatar" ng-src="{{$ctrl.authService.profile().picture}}">
-	        <img ng-if="! $ctrl.authService.profile().picture" class="avatar" src="https://placehold.it/25x25">
+          <img ng-if="! $ctrl.authService.profile().picture" class="avatar" src="https://placehold.it/25x25">
           <span class="username">{{$ctrl.authService.profile().nickname}}</span>
-	        <i class="icon-caret-down"></i>
+          <i class="icon-caret-down"></i>
         </a>
-	      <ul class="dropdown-menu" aria-labelledby="dLabel">
+        <ul class="dropdown-menu" aria-labelledby="dLabel">
           <li><a href ui-sref="library.scenes.list">My library</a></li>
-	        <li><a href ui-sref="settings.profile">Settings</a></li>
-	        <li role="separator" class="divider"></li>
-	        <li><a href ng-click="$ctrl.logout()">Sign out</a></li>
-	      </ul>
+          <li><a href ui-sref="settings.profile">Settings</a></li>
+          <li role="separator" class="divider"></li>
+          <li><a href ng-click="$ctrl.logout()">Sign out</a></li>
+        </ul>
       </div>
-	  </nav>
-	</div>
+    </nav>
+  </div>
 </div>

--- a/app-frontend/src/app/index.components.js
+++ b/app-frontend/src/app/index.components.js
@@ -1,5 +1,6 @@
 export default angular.module('index.components', [
     require('./components/mapContainer/mapContainer.module.js').name,
+    require('./components/diagramContainer/diagramContainer.module.js').name,
     require('./components/navBar/navBar.module.js').name,
     require('./components/toolSearch/toolSearch.module.js').name,
     require('./components/toolItem/toolItem.module.js').name,

--- a/app-frontend/src/app/index.module.js
+++ b/app-frontend/src/app/index.module.js
@@ -36,6 +36,9 @@ const App = angular.module(
 
         // pages
         require('./pages/browse/browse.module.js').name,
+        require('./pages/lab/lab.module.js').name,
+        require('./pages/lab/edit/edit.module.js').name,
+        require('./pages/lab/run/run.module.js').name,
         require('./pages/market/market.module.js').name,
         require('./pages/market/search/search.module.js').name,
         require('./pages/market/tool/tool.module.js').name,

--- a/app-frontend/src/app/index.routes.js
+++ b/app-frontend/src/app/index.routes.js
@@ -1,4 +1,7 @@
 import browseTpl from './pages/browse/browse.html';
+import labTpl from './pages/lab/lab.html';
+import labEditTpl from './pages/lab/edit/edit.html';
+import labRunTpl from './pages/lab/run/run.html';
 import marketTpl from './pages/market/market.html';
 import marketSearchTpl from './pages/market/search/search.html';
 import marketToolTpl from './pages/market/tool/tool.html';
@@ -226,6 +229,29 @@ function marketStates($stateProvider) {
         });
 }
 
+function labStates($stateProvider) {
+    $stateProvider
+        .state('lab', {
+            url: '/lab',
+            templateUrl: labTpl,
+            controller: 'LabController',
+            controllerAs: '$ctrl',
+            abstract: true
+        })
+        .state('lab.edit', {
+            url: '/edit',
+            templateUrl: labEditTpl,
+            controller: 'LabEditController',
+            controllerAs: '$ctrl'
+        })
+        .state('lab.run', {
+            url: '/run',
+            templateUrl: labRunTpl,
+            controller: 'LabRunController',
+            controllerAs: '$ctrl'
+        });
+}
+
 function routeConfig($urlRouterProvider, $stateProvider) {
     'ngInject';
 
@@ -235,6 +261,7 @@ function routeConfig($urlRouterProvider, $stateProvider) {
     librarySceneStates($stateProvider);
     libraryProjectStates($stateProvider);
     settingsStates($stateProvider);
+    labStates($stateProvider);
 
     $stateProvider
         .state('error', {

--- a/app-frontend/src/app/index.vendor.js
+++ b/app-frontend/src/app/index.vendor.js
@@ -23,6 +23,7 @@ import 'angular-messages';
 import 'angular-aria';
 import 'angular-resource';
 import 'leaflet';
+import 'jointjs';
 
 
 // local scripts

--- a/app-frontend/src/app/pages/lab/edit/edit.component.js
+++ b/app-frontend/src/app/pages/lab/edit/edit.component.js
@@ -1,0 +1,11 @@
+import labEditTpl from './edit.html';
+
+const labEdit = {
+    templateUrl: labEditTpl,
+    controller: 'labEditController',
+    bindings: {
+        model: '<?'
+    }
+};
+
+export default labEdit;

--- a/app-frontend/src/app/pages/lab/edit/edit.controller.js
+++ b/app-frontend/src/app/pages/lab/edit/edit.controller.js
@@ -1,0 +1,18 @@
+export default class LabEditController {
+    constructor($scope, $element) {
+        'ngInject';
+        this.$scope = $scope;
+        this.$element = $element;
+        this.isShowingParams = false;
+    }
+
+    showParams() {
+        this.isShowingParams = true;
+        this.$scope.$evalAsync();
+    }
+
+    hideParams() {
+        this.isShowingParams = false;
+        this.$scope.$evalAsync();
+    }
+}

--- a/app-frontend/src/app/pages/lab/edit/edit.html
+++ b/app-frontend/src/app/pages/lab/edit/edit.html
@@ -1,0 +1,75 @@
+<!-- Workflow container -->
+<rf-diagram-container class="main"
+                      on-cell-click="$ctrl.showParams()"
+                      on-paper-click="$ctrl.hideParams()">
+</rf-diagram-container>
+<div class="sidebar sidebar-extended sidebar-scrollable" ng-show="$ctrl.isShowingParams">
+  <div class="sidebar-content flex-row with-padding with-border">
+    <h5 class="sidebar-title">
+        Function Name
+    </h5>
+    <div class="sidebar-actions">
+      <button class="btn btn-primary">
+        <i class="icon-parameters"></i> Parameters
+      </button>
+    </div>
+  </div>
+  <div class="sidebar-content with-padding with-border">
+    <h5 class="sidebar-title">
+        <div class="btn btn-square really-square">1</div><span>Input</span>
+    </h5>
+    <form class="inset">
+      <div class="form-group">
+        <label for="formGroupExampleInput">Example label</label>
+        <input type="text" class="form-control" id="formGroupExampleInput" placeholder="Example input">
+      </div>
+      <div class="form-group">
+        <label for="formGroupExampleInput">Example label</label>
+        <input type="text" class="form-control" id="formGroupExampleInput" placeholder="Example input">
+      </div>
+      <div class="form-group">
+        <label for="formGroupExampleInput">Example label</label>
+        <input type="text" class="form-control" id="formGroupExampleInput" placeholder="Example input">
+      </div>
+      <div class="form-group">
+        <label for="formGroupExampleInput">Example label</label>
+        <input type="text" class="form-control" id="formGroupExampleInput" placeholder="Example input">
+      </div>
+    </form>
+  </div>
+  <div class="sidebar-content with-padding with-border">
+    <h5 class="sidebar-title">
+        <div class="btn btn-square really-square">2</div><span>Input</span>
+    </h5>
+    <form class="inset">
+      <div class="form-group">
+        <label for="formGroupExampleInput">Example label</label>
+        <input type="text" class="form-control" id="formGroupExampleInput" placeholder="Example input">
+      </div>
+      <div class="form-group">
+        <label for="formGroupExampleInput">Example label</label>
+        <input type="text" class="form-control" id="formGroupExampleInput" placeholder="Example input">
+      </div>
+      <div class="form-group">
+        <label for="formGroupExampleInput">Example label</label>
+        <input type="text" class="form-control" id="formGroupExampleInput" placeholder="Example input">
+      </div>
+      <div class="form-group">
+        <label for="formGroupExampleInput">Example label</label>
+        <input type="text" class="form-control" id="formGroupExampleInput" placeholder="Example input">
+      </div>
+    </form>
+  </div>
+  <div class="sidebar-content flex-row with-padding with-border">
+    <div class="form-btn-row">
+      <div class="btn-group">
+        <button class="btn">
+          Cancel
+        </button>
+        <button class="btn btn-primary">
+          Save
+        </button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app-frontend/src/app/pages/lab/edit/edit.module.js
+++ b/app-frontend/src/app/pages/lab/edit/edit.module.js
@@ -1,0 +1,11 @@
+import angular from 'angular';
+
+import LabEditController from './edit.controller.js';
+import labEditComponent from './edit.component.js';
+
+const labEditModule = angular.module('pages.lab.edit', []);
+
+labEditModule.component('labEdit', labEditComponent);
+labEditModule.controller('LabEditController', LabEditController);
+
+export default labEditModule;

--- a/app-frontend/src/app/pages/lab/lab.controller.js
+++ b/app-frontend/src/app/pages/lab/lab.controller.js
@@ -1,0 +1,9 @@
+class labController {
+    constructor() {
+        'ngInject';
+
+        // This is an abstract view so it's just a container for its children
+    }
+}
+
+export default labController;

--- a/app-frontend/src/app/pages/lab/lab.html
+++ b/app-frontend/src/app/pages/lab/lab.html
@@ -1,0 +1,24 @@
+<div class="app-content">
+  <div class="navbar secondary-navbar">
+    <div class="navbar-left">
+      <nav>
+        <a class="active">Tool Name</a>
+      </nav>
+      <span class="navbar-vertical-divider"></span>
+      <nav>
+        <a>Properties</a>
+      </nav>
+    </div>
+    <div class="navbar-right">
+      <nav>
+        <a href ui-sref="lab.run" ui-sref-active="active">Run</a>
+        <a href ui-sref="lab.edit" ui-sref-active="active">Build</a>
+        <div class="btn-group">
+          <button class="btn btn-primary">Clone Model</button>
+          <button class="btn btn-primary">Publish</button>
+        </div>
+      </nav>
+    </div>
+  </div>
+  <ui-view class="container container-not-scrollable"></ui-view>
+</div>

--- a/app-frontend/src/app/pages/lab/lab.module.js
+++ b/app-frontend/src/app/pages/lab/lab.module.js
@@ -1,0 +1,8 @@
+import LabController from './lab.controller.js';
+require('./lab.scss');
+
+const LabModule = angular.module('pages.lab', []);
+
+LabModule.controller('LabController', LabController);
+
+export default LabModule;

--- a/app-frontend/src/app/pages/lab/lab.scss
+++ b/app-frontend/src/app/pages/lab/lab.scss
@@ -1,0 +1,72 @@
+nav .btn-group {
+    display: inline-flex !important;
+    margin: 0 1.5rem;
+}
+
+.secondary-navbar .navbar-right nav a {
+    padding: 2rem 1.5rem;
+}
+.sidebar.sidebar-dark.not-offset {
+    left: 0;
+    margin-left: 0;
+}
+
+.sidebar > .sidebar {
+    border-right: none;
+}
+
+.sidebar-content {
+    flex-shrink: 0;
+}
+
+.sidebar-content.with-padding{
+    padding: 1.5rem 1.5rem;
+}
+
+.sidebar-content.with-border,{
+    border-bottom: 1px solid #ddd;
+}
+    .sidebar-content.with-border:last-child {
+        border-bottom: none;
+    }
+
+.lab-workspace {
+    background: #aaa;
+    height: 100%;
+}
+
+.btn-square.really-square {
+    width: 4rem;
+    height: 4rem;
+    line-height: 2rem;
+}
+.sidebar-content.flex-row{
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+}
+.sidebar-content h5 {
+    margin: 0;
+    flex: 1;
+}
+.sidebar-content h5 span {
+    margin-left: 1.5rem;
+}
+
+form.inset {
+    padding: 0;
+    margin: 0;
+    margin-left: 2rem;
+    margin-top: 1.5rem;
+}
+
+.form-btn-row {
+    flex: 1;
+}
+    .form-btn-row .btn-group {
+        justify-content: flex-end;
+    }
+
+.sidebar-content .form-group:last-of-type {
+    margin-bottom: 0;
+}

--- a/app-frontend/src/app/pages/lab/run/run.component.js
+++ b/app-frontend/src/app/pages/lab/run/run.component.js
@@ -1,0 +1,11 @@
+import labRunTpl from './run.html';
+
+const labRun = {
+    templateUrl: labRunTpl,
+    controller: 'labRunController',
+    bindings: {
+        model: '<?'
+    }
+};
+
+export default labRun;

--- a/app-frontend/src/app/pages/lab/run/run.controller.js
+++ b/app-frontend/src/app/pages/lab/run/run.controller.js
@@ -1,0 +1,6 @@
+export default class LabRunController {
+    constructor($scope) {
+        'ngInject';
+        this.$scope = $scope;
+    }
+}

--- a/app-frontend/src/app/pages/lab/run/run.html
+++ b/app-frontend/src/app/pages/lab/run/run.html
@@ -1,0 +1,12 @@
+<div class="sidebar sidebar-extended sidebar-dark not-offset" ng-show="$ctrl.isShowingParams">
+    Params Sidebar
+    <!-- Sidebar -->
+    <!--
+        @TODO: this sidebar should not occupy the space of the main div
+        as we want to maximize the screen area of the workspace
+    -->
+</div>
+<!-- Workflow container -->
+<div class="main" style="background: #dadada;">
+    Model Running Workspace
+</div>

--- a/app-frontend/src/app/pages/lab/run/run.module.js
+++ b/app-frontend/src/app/pages/lab/run/run.module.js
@@ -1,0 +1,11 @@
+import angular from 'angular';
+
+import LabRunController from './run.controller.js';
+import labRunComponent from './run.component.js';
+
+const labRunModule = angular.module('pages.lab.run', []);
+
+labRunModule.component('labRun', labRunComponent);
+labRunModule.controller('LabRunController', LabRunController);
+
+export default labRunModule;


### PR DESCRIPTION
Adds routes and pages for building and running models.
Only addresses the UI of the model building page.
Uses JointJS to demonstrate possible interaction at a shallow level as full JointJS integration is beyond the scope of this PR.

When you click the diagram element, the input pane is shown. Clicking on the diagram surface but not the diagram element will close the pane.

## Overview

This PR adds pages for ModelLab (or whatever it is that we will end up calling it).
It adds the following routes:

- `/lab/run`
- `/lab/edit` (the default route for the Model lab link)

### Demo

<img width="1280" alt="screen shot 2016-12-21 at 2 30 44 pm" src="https://cloud.githubusercontent.com/assets/2442245/21403338/5e6f9c60-c78a-11e6-9d5c-338c9c35b966.png">

### Notes
- Implementing a grid background and a colored background will require additional work, as the grid functionality in JointJS creates an svg and uses that as a background image, which overwrites any background color applied with styling. For this reason, I've inverted the color scheme and made the diagram element darker than the background
- This is only a functioning example since we don't have services for models/tools
- There were many style overrides (found in the `lab.scss` file)

## Testing Instructions

 * Click on 'Model lab'
 * Ensure the UI matches mockups as closely as possible.