### PR TITLE
Make Spark execution environment ADR-0013

### DIFF
--- a/docs/architecture/adr-0013-spark-execution-environment.md
+++ b/docs/architecture/adr-0013-spark-execution-environment.md
@@ -1,4 +1,4 @@
-# 0012 - Spark Execution Environment
+# 0013 - Spark Execution Environment
 
 ## Context
 


### PR DESCRIPTION
It was previously ADR-0012, but there is already an ADR-0012.