### PR TITLE
Fix min/max slider in project/edit

### DIFF
--- a/app-frontend/src/app/components/colorCorrectAdjust/colorCorrectAdjust.controller.js
+++ b/app-frontend/src/app/components/colorCorrectAdjust/colorCorrectAdjust.controller.js
@@ -44,7 +44,10 @@ export default class ColorCorrectAdjustController {
             floor: 0,
             ceil: 20000,
             step: 10,
-            onEnd: (id, val) => this.onFilterChange(id, val)
+            onEnd: (id, low, high) => {
+                this.onFilterChange('min', low);
+                this.onFilterChange('max', high);
+            }
         };
 
         this.redGammaOptions = Object.assign({}, baseGammaOptions, {id: 'red'});


### PR DESCRIPTION
## Overview
Fix the min/max clipping slider

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~

### Demo
![image](https://cloud.githubusercontent.com/assets/4392704/21502340/1b82c43a-cc1d-11e6-87b8-143fef393077.png)

@designmatty Looks like the styling needs to be cleaned up a little here.  Also note that the animation for the min/max slider causes the dark portions of the slider bar to move with the mouse, while the actual marker lags behind.

## Testing Instructions

 * Open the project/edit view on a set of pre-processed egypt scenes
 * Verify that the min/max clipping slider functions and affects the output image.