### PR TITLE
Connect model market to API

### DIFF
--- a/app-backend/app/src/main/resources/application.conf
+++ b/app-backend/app/src/main/resources/application.conf
@@ -72,5 +72,11 @@ featureFlags {
       name = "Make source histogram"
       description = "Show or hide the 'make source histogram' link in color correction"
     }
+    {
+      key = "market-search"
+      active = false
+      name = "Market Search"
+      description = "Allow the market search feature to be visible"
+    }
   ]
 }

--- a/app-frontend/src/app/components/toolItem/toolItem.html
+++ b/app-frontend/src/app/components/toolItem/toolItem.html
@@ -7,13 +7,14 @@
        class="rounded-img item-img">
   <div>
     <div class="list-item-header">
-      {{$ctrl.toolData.name}}
+      {{$ctrl.toolData.title}}
     </div>
     <div class="list-item-description">
       {{$ctrl.toolData.description}}
     </div>
+    <!-- @TODO: This username will need to be dynamic once other users can create tools -->
     <div class="list-item-attribution">
-      Uploaded by: {{$ctrl.toolData.uploader}}
+      Uploaded by: Raster Foundry
     </div>
   </div>
 </div>

--- a/app-frontend/src/app/components/toolSearch/toolSearch.controller.js
+++ b/app-frontend/src/app/components/toolSearch/toolSearch.controller.js
@@ -9,7 +9,11 @@ export default class ToolSearchController {
         this.$state = $state;
     }
 
-    onSearchAction(searchText) {
-        this.onSearch({text: searchText});
+    onSearchAction() {
+        this.onSearch({text: this.searchText});
+    }
+
+    clearSearch() {
+        this.searchText = '';
     }
 }

--- a/app-frontend/src/app/components/toolSearch/toolSearch.html
+++ b/app-frontend/src/app/components/toolSearch/toolSearch.html
@@ -4,7 +4,7 @@
       <a href ui-sref="market.search" class="active"> < Back to search results</a>
     </nav>
     <nav ng-show="$ctrl.$state.$current.name === 'market.search'">
-      <ng-submit ng-submit="$ctrl.onSearchAction($ctrl.searchText)">
+      <ng-submit ng-submit="$ctrl.onSearchAction()">
         <div class="form-group all-in-one input-dark">
           <label for="search-input">
             <i class="icon-search"></i>
@@ -13,9 +13,10 @@
                  id="search-input"
                  class="form-control input-dark"
                  placeholder="Search for tools"
-                 ng-model="$ctrl.searchText"/>
-          <button type="button" class="btn btn-link">
-            <span class="close">x</span>
+                 ng-model="$ctrl.searchText"
+                 ng-keyup="$event.keyCode == 13 && $ctrl.onSearchAction()"/>
+          <button ng-click="$ctrl.clearSearch()" type="button" class="btn btn-link">
+            <i class="icon-cross close"></i>
           </button>
         </div>
       </ng-submit>

--- a/app-frontend/src/app/core/core.module.js
+++ b/app-frontend/src/app/core/core.module.js
@@ -10,6 +10,9 @@ require('./services/token.service')(shared);
 require('./services/layer.service')(shared);
 require('./services/map.service')(shared);
 require('./services/thumbnail.service')(shared);
+require('./services/tool.service')(shared);
+require('./services/toolTag.service')(shared);
+require('./services/toolCategory.service')(shared);
 
 require('./services/featureFlagOverrides.service')(shared);
 require('./services/featureFlags.provider')(shared);

--- a/app-frontend/src/app/core/services/tool.service.js
+++ b/app-frontend/src/app/core/services/tool.service.js
@@ -1,0 +1,34 @@
+export default (app) => {
+    class ToolService {
+        constructor($resource, $http) {
+            'ngInject';
+            this.$http = $http;
+            this.Tool = $resource(
+                '/api/tools/:id/', {
+                    id: '@properties.id'
+                }, {
+                    query: {
+                        method: 'GET',
+                        cache: false
+                    },
+                    get: {
+                        method: 'GET',
+                        cache: false
+                    }
+                }
+            );
+        }
+
+        query(params = {}) {
+            return this.Tool.query(params).$promise;
+        }
+
+        get(id) {
+            return this.Tool.get({id}).$promise;
+        }
+
+        // @TODO: implement getting related tags and categories
+    }
+
+    app.service('toolService', ToolService);
+};

--- a/app-frontend/src/app/core/services/toolCategory.service.js
+++ b/app-frontend/src/app/core/services/toolCategory.service.js
@@ -1,0 +1,28 @@
+export default (app) => {
+    class ToolCategoryService {
+        constructor($resource) {
+            'ngInject';
+
+            this.ToolCategory = $resource(
+                '/api/tool-categories/:id/', {
+                    id: '@properties.id'
+                }, {
+                    query: {
+                        method: 'GET',
+                        cache: false
+                    },
+                    get: {
+                        method: 'GET',
+                        cache: false
+                    }
+                }
+            );
+        }
+
+        query(params = {}) {
+            return this.ToolCategory.query(params).$promise;
+        }
+    }
+
+    app.service('toolCategoryService', ToolCategoryService);
+};

--- a/app-frontend/src/app/core/services/toolTag.service.js
+++ b/app-frontend/src/app/core/services/toolTag.service.js
@@ -1,0 +1,28 @@
+export default (app) => {
+    class ToolTagService {
+        constructor($resource) {
+            'ngInject';
+
+            this.ToolTag = $resource(
+                '/api/tool-tags/:id/', {
+                    id: '@properties.id'
+                }, {
+                    query: {
+                        method: 'GET',
+                        cache: false
+                    },
+                    get: {
+                        method: 'GET',
+                        cache: false
+                    }
+                }
+            );
+        }
+
+        query(params = {}) {
+            return this.ToolTag.query(params).$promise;
+        }
+    }
+
+    app.service('toolTagService', ToolTagService);
+};

--- a/app-frontend/src/app/index.routes.js
+++ b/app-frontend/src/app/index.routes.js
@@ -213,7 +213,7 @@ function marketStates($stateProvider) {
             abstract: true
         })
         .state('market.search', {
-            url: '/search?:query',
+            url: '/search?:query?toolcategory&tooltag',
             templateUrl: marketSearchTpl,
             controller: 'MarketSearchController',
             controllerAs: '$ctrl'

--- a/app-frontend/src/app/pages/market/market.controller.js
+++ b/app-frontend/src/app/pages/market/market.controller.js
@@ -7,7 +7,7 @@ export default class MarketController {
         this.$state = $state;
     }
 
-    onSearch(text) {
+    search(text) {
         this.$log.log('searched for:', text);
         this.$state.go('market.search', {query: text});
     }

--- a/app-frontend/src/app/pages/market/market.html
+++ b/app-frontend/src/app/pages/market/market.html
@@ -1,2 +1,2 @@
-<rf-tool-search on-search="$ctrl.search(text)"></rf-tool-search>
+<rf-tool-search feature-flag="market-search" on-search="$ctrl.search(text)"></rf-tool-search>
 <ui-view></ui-view>

--- a/app-frontend/src/app/pages/market/search/search.html
+++ b/app-frontend/src/app/pages/market/search/search.html
@@ -1,7 +1,7 @@
 <div class="container column-stretch dashboard-filter wide">
   <div class="sidebar">
     <div class="sidebar-scrollable">
-      <div class="sidebar-category">
+      <div feature-flag="market-search" class="sidebar-category">
         <div class="sidebar-category-title">
           Search Terms
         </div>
@@ -17,19 +17,16 @@
           <a href ng-click="$ctrl.clearSearch()">Clear All</a>
         </div>
       </div>
-      <div class="sidebar-separator"></div>
+      <div feature-flag="market-search" class="sidebar-separator"></div>
       <div class="sidebar-category">
         <div class="sidebar-category-title">
           Tags
         </div>
         <div class="sidebar-category-contents">
           <div class="sidebar-selection"
-               ng-repeat="tag in $ctrl.tags"
-               ng-click="$ctrl.toggleTag($index)">
-            <i ng-class="{'icon-check': tag.selected,
-                          'icon-cross': !tag.selected
-                         }"></i>
-            {{tag.label}}
+               ng-repeat="tag in $ctrl.toolTagList">
+            <input id="search-tag-{{$id}}" type="checkbox" ng-change="$ctrl.handleTagChange(tag)" ng-checked="tag.selected" ng-model="tag.selected"/>
+            <label for="search-tag-{{$id}}">{{tag.tag}}</label>
           </div>
         </div>
         <div class="sidebar-category-actions">
@@ -43,13 +40,9 @@
         </div>
         <div class="sidebar-category-contents">
           <div class="sidebar-selection"
-               ng-repeat="category in $ctrl.categories"
-               ng-click="$ctrl.toggleCategory($index)">
-            <i class="icon-check"
-             ng-class="{'icon-check': category.selected,
-                        'icon-cross': !category.selected
-                       }"></i>
-            {{category.label}}
+               ng-repeat="category in $ctrl.toolCategoryList">
+            <input id="search-category-{{$id}}" type="checkbox" ng-change="$ctrl.handleCategoryChange(category)" ng-checked="category.selected" ng-model="category.selected">
+            <label for="search-category-{{$id}}">{{category.category}}</label>
           </div>
         </div>
         <div class="sidebar-category-actions">
@@ -62,7 +55,7 @@
     <div class="content">
       <div class="row stack-sm">
         <h1 class="h3 page-title">
-          <a>Showing 1-10 of {{$ctrl.queryResult.count}} results</a>
+          <a>Showing {{$ctrl.pagination.startingItem}} - {{$ctrl.pagination.endingItem}} of {{$ctrl.pagination.count}} results</a>
         </h1>
       </div>
       <div class="row stack-sm">
@@ -70,7 +63,7 @@
           <div class="embedded-scrollable">
             <div class="list-group">
               <rf-tool-item
-                  ng-repeat="toolData in $ctrl.queryResult.results"
+                  ng-repeat="toolData in $ctrl.toolList"
                   tool-data="toolData"
                   ng-click="$ctrl.navTool(toolData)"
               ></rf-tool-item>
@@ -79,7 +72,7 @@
         </div>
       </div>
       <div class="list-group text-center"
-           ng-show="!$ctrl.loading && $ctrl.queryResult && $ctrl.queryResult.count !== 0 && !$ctrl.errorMsg">
+           ng-show="!$ctrl.loading && $ctrl.queryResult && $ctrl.pagination.show && !$ctrl.errorMsg">
         <ul uib-pagination
             items-per-page="$ctrl.queryResult.pageSize"
             total-items="$ctrl.queryResult.count"

--- a/app-frontend/src/app/pages/market/tool/tool.controller.js
+++ b/app-frontend/src/app/pages/market/tool/tool.controller.js
@@ -1,18 +1,35 @@
 export default class MarketToolController {
     constructor( // eslint-disable-line max-params
-        $log, $state
+        $log, $state, toolService
     ) {
         'ngInject';
         this.$log = $log;
         this.$state = $state;
 
+        this.toolService = toolService;
         this.toolData = this.$state.params.toolData;
         this.toolId = this.$state.params.id;
         this.activeSlide = 0;
+        this.fetchTool();
         this.populateTestData();
     }
 
+    fetchTool() {
+        this.loadingTool = true;
+        this.toolService.get(this.toolId).then(d => {
+            this.tool = d;
+            this.tool.createdAtFormatted = new Date(d.createdAt).toLocaleDateString();
+            this.tool.modifiedAtFormatted = new Date(d.modifiedAt).toLocaleDateString();
+            this.loadingTools = false;
+        });
+    }
+
     populateTestData() {
+        this.testScreenshots = [
+            {id: 1, url: 'https://placehold.it/1000x480'},
+            {id: 2, url: 'https://placehold.it/1000x480'},
+            {id: 3, url: 'https://placehold.it/1000x480'}
+        ];
         this.similarQueryResult = {
             count: 25,
             hasNext: true,
@@ -27,9 +44,9 @@ export default class MarketToolController {
                 uploader: 'Raster Foundry',
                 id: 'uuid1',
                 screenshots: [
-                    {id: 1, url: 'http://lorempixel.com/1000/480/'},
-                    {id: 2, url: 'http://lorempixel.com/1000/480/'},
-                    {id: 3, url: 'http://lorempixel.com/1000/480/'}
+                    {id: 1, url: 'https://placehold.it/1000x480'},
+                    {id: 2, url: 'https://placehold.it/1000x480'},
+                    {id: 3, url: 'https://placehold.it/1000x480'}
                 ],
                 tags: [
                     'Image Classification', 'Tagged'
@@ -48,9 +65,9 @@ export default class MarketToolController {
                 uploader: 'Raster Foundry',
                 id: 'uuid2',
                 screenshots: [
-                    {id: 1, url: 'http://lorempixel.com/1000/480/'},
-                    {id: 2, url: 'http://lorempixel.com/1000/480/'},
-                    {id: 3, url: 'http://lorempixel.com/1000/480/'}
+                    {id: 1, url: 'https://placehold.it/1000x480'},
+                    {id: 2, url: 'https://placehold.it/1000x480'},
+                    {id: 3, url: 'https://placehold.it/1000x480'}
                 ],
                 tags: [
                     'Image Classification', 'Tagged'
@@ -74,9 +91,9 @@ export default class MarketToolController {
                 uploader: 'Raster Foundry',
                 id: 'uuid3',
                 screenshots: [
-                    {id: 1, url: 'http://lorempixel.com/1000/480/'},
-                    {id: 2, url: 'http://lorempixel.com/1000/480/'},
-                    {id: 3, url: 'http://lorempixel.com/1000/480/'}
+                    {id: 1, url: 'https://placehold.it/1000x480'},
+                    {id: 2, url: 'https://placehold.it/1000x480'},
+                    {id: 3, url: 'https://placehold.it/1000x480'}
                 ],
                 tags: [
                     'Image Classification', 'Tagged'

--- a/app-frontend/src/app/pages/market/tool/tool.html
+++ b/app-frontend/src/app/pages/market/tool/tool.html
@@ -2,43 +2,43 @@
   <div class="main">
     <div class="row content stack-sm">
       <div class="column">
-        <div>
+        <div id="preview">
           <h1 class="h3 page-title">
-            {{$ctrl.toolData.name || 'Placeholder name'}}
+            {{$ctrl.tool.title}}
           </h1>
         </div>
         <div>
           <div uib-carousel
                active="$ctrl.activeSlide"
                template-url="carousel.html"
-               ng-if="$ctrl.toolData && $ctrl.toolData.screenshots.length"
+               ng-if="$ctrl.tool && $ctrl.testScreenshots.length"
           >
             <div uib-slide
                  index="$index"
-                 ng-repeat="screenshot in $ctrl.toolData.screenshots track by screenshot.id">
+                 ng-repeat="screenshot in $ctrl.testScreenshots track by screenshot.id">
               <img ng-src="{{screenshot.url}}" >
             </div>
           </div>
         </div>
         <div class="horizontal-separator"></div>
-        <div class="tool-detail-section">
+        <div id="description" class="tool-detail-section">
           <div class="tool-detail-header">
             <h5>Description</h5>
           </div>
           <div>
             <p>
-              {{$ctrl.toolData.description}}
+              {{$ctrl.tool.description}}
             </p>
           </div>
         </div>
-        <div class="tool-detail-section">
+        <div id="upload-info" class="tool-detail-section">
           <table class="upload-info">
             <tr>
               <th>
-                Uploaded By
+                Created By
               </th>
               <th>
-                Upload date
+                Creation date
               </th>
               <th>
                 Last modified
@@ -46,29 +46,29 @@
             </tr>
             <tr>
               <td>
-                <a>{{$ctrl.toolData.uploader}}</a>
+                Raster Foundry
               </td>
               <td>
-                {{$ctrl.toolData.createdAt | date}}
+                {{$ctrl.tool.createdAtFormatted}}
               </td>
               <td>
-                {{$ctrl.toolData.modifiedAt | date}}
+                {{$ctrl.tool.modifiedAtFormatted}}
               </td>
             </tr>
             </tbody>
           </table>
         </div>
-        <div class="tool-detail-section">
+        <div id="requirements" class="tool-detail-section">
           <div class="tool-detail-header">
             <h5>Requirements for use</h5>
           </div>
           <div>
             <p>
-              {{$ctrl.toolData.requirements}}
+              {{$ctrl.tool.requirements}}
             </p>
           </div>
         </div>
-        <div class="tool-detail-section">
+        <div id="tags" class="tool-detail-section">
           <div class="tool-detail-header">
             <h5>Tags</h5>
           </div>
@@ -79,7 +79,7 @@
             </button>
           </div>
         </div>
-        <div class="tool-detail-section">
+        <div id="category" class="tool-detail-section">
           <div class="tool-detail-header">
             <h5>Categories</h5>
           </div>
@@ -90,14 +90,17 @@
             </button>
           </div>
         </div>
-        <div class="tool-detail-section">
+        <div id="license" class="tool-detail-section">
           <div class="tool-detail-header">
             <h5>Usage License</h5>
-            <p>
+            <p ng-show="!$ctrl.tool.license">
               No license information was provided. If this work was prepared by
               Raster Foundry as part of the official Tool marketplace, it is
               considered a Raster Foundry work and usage should follow the general
               <a>terms of use</a>
+            </p>
+            <p ng-show="$ctrl.tool.license">
+              {{$ctrl.tool.license}}
             </p>
           </div>
         </div>

--- a/app-frontend/src/app/pages/market/tool/tool.module.js
+++ b/app-frontend/src/app/pages/market/tool/tool.module.js
@@ -1,6 +1,6 @@
 import carousel from 'angular-ui-bootstrap/src/carousel';
 import MarketToolController from './tool.controller.js';
-
+require('./tool.scss');
 const MarketToolModule = angular.module('pages.market.tool', [carousel]);
 
 MarketToolModule.controller('MarketToolController', MarketToolController);

--- a/app-frontend/src/app/pages/market/tool/tool.scss
+++ b/app-frontend/src/app/pages/market/tool/tool.scss
@@ -1,0 +1,16 @@
+// @TODO: need to incorporate a full width table style for upload info
+
+table.upload-info {
+    width: 100%;
+    th {
+        text-align: left;
+        padding-bottom: 0.5rem;
+    }
+}
+
+.reference-list {
+    margin-top: 1.5rem;
+    .reference {
+        margin-bottom: 1.5rem;
+    }
+}


### PR DESCRIPTION
## Overview

Adds functioning market search and tool details pages.

### Notes

- the search page builds the proper url and requests, but the `tool` endpoint does not take these params into account, thus, all tools are returned no matter what the search is.
- the API also lacks previews and thumbnails for tools, so placeholders remain in certain spots
- there is no straightforward way of retrieving the related tools and categories of a given tool -- the tool and category area of the detail page is blank
- the backend model for tags does not include a slug (as the category does), yet we allow spaces and caps (according to the mock-ups) as the tag value. Because of this, we need an alternate delimiter that is not a space. I've made it a variable that can be altered, but it is currently a pipe. For consistency, both tags and categories are delimited using this instead of spaces.
- At some point, team discussion settled upon hardcoding 'Raster Foundry' as the creator of the tools

## Testing Instructions

 * Go to the model market page
 * After adjusting search parameters, ensure URL and requests are formatted as the API expects
 * After clicking on a tool, the details for that tool, and not placeholder data, are present on the details page.