### PR TITLE
Show scene thumbnails on map instead of data footprint

### DIFF
--- a/app-frontend/src/app/components/sceneDetail/sceneDetail.component.js
+++ b/app-frontend/src/app/components/sceneDetail/sceneDetail.component.js
@@ -4,7 +4,8 @@ import sceneDetailTpl from './sceneDetail.html';
 const rfSceneDetail = {
     templateUrl: sceneDetailTpl,
     bindings: {
-        scene: '<'
+        scene: '<',
+        showThumbnail: '<'
     },
     replace: true
 };

--- a/app-frontend/src/app/components/sceneDetail/sceneDetail.html
+++ b/app-frontend/src/app/components/sceneDetail/sceneDetail.html
@@ -1,8 +1,8 @@
 <div class="content">
-  <img ng-if="$ctrl.scene.thumbnails[0]"
+  <img ng-if="$ctrl.scene.thumbnails[0] && $ctrl.showThumbnail"
          ng-attr-src="{{$ctrl.scene.thumbnails[0].url}}"
          class="center-img rounded-img detail-img">
-  <img ng-if="!$ctrl.scene.thumbnails.length"
+  <img ng-if="!$ctrl.scene.thumbnails.length && $ctrl.showThumbnail"
        src="https://placehold.it/275x275"
        class="center-img rounded-img detail-img">
   <h5 class="color-dark">Scene properties</h5>

--- a/app-frontend/src/app/pages/browse/browse.controller.js
+++ b/app-frontend/src/app/pages/browse/browse.controller.js
@@ -256,12 +256,18 @@ export default class BrowseController {
         this.activeScene = scene;
         this.queryParams.id = scene.id;
         this.$state.go('.', this.queryParams, {notify: false, location: true});
+        this.getMap().then((map) => {
+            map.setThumbnail(scene);
+        });
     }
 
     closeDetailPane() {
         delete this.activeScene;
         this.queryParams.id = null;
         this.$state.go('.', this.queryParams, {notify: false});
+        this.getMap().then((map) => {
+            map.deleteThumbnail();
+        });
     }
 
     toggleFilterPane() {
@@ -291,14 +297,16 @@ export default class BrowseController {
 
     setHoveredScene(scene) {
         this.getMap().then((map) => {
-            map.setGeojson('hovered', scene.dataFootprint);
+            map.setThumbnail(scene);
         });
     }
 
     removeHoveredScene() {
-        this.getMap().then((map) => {
-            map.deleteGeojson('hovered');
-        });
+        if (!this.activeScene) {
+            this.getMap().then((map) => {
+                map.deleteThumbnail();
+            });
+        }
     }
 
     projectModal() {

--- a/app-frontend/src/app/pages/browse/browse.html
+++ b/app-frontend/src/app/pages/browse/browse.html
@@ -81,7 +81,9 @@
       </div>
     </div>
     <rf-scene-detail class="sidebar-scrollable"
-                     scene="$ctrl.activeScene"></rf-scene-detail>
+                     scene="$ctrl.activeScene"
+                     show-thumbnail="true"
+    ></rf-scene-detail>
     <div class="sidebar-static">
       <div class="sidebar-actions">
         <button class="btn btn-square btn-default"

--- a/app-frontend/src/app/pages/editor/project/projectEdit.controller.js
+++ b/app-frontend/src/app/pages/editor/project/projectEdit.controller.js
@@ -37,13 +37,8 @@ export default class ProjectEditController {
         let styledGeojson = Object.assign({}, scene.dataFootprint, {
             properties: {
                 options: {
-                    style: () => {
-                        return {
-                            dashArray: '10, 10',
-                            weight: 2,
-                            fillOpacity: 0.2
-                        };
-                    }
+                    weight: 2,
+                    fillOpacity: 0
                 }
             }
         });

--- a/app-frontend/src/app/pages/library/projects/detail/scene/scene.controller.js
+++ b/app-frontend/src/app/pages/library/projects/detail/scene/scene.controller.js
@@ -26,9 +26,7 @@ class ProjectSceneController {
                     (scene) => {
                         this.scene = scene;
                         this.loading = false;
-                        this.getMap().then((map)=> {
-                            map.addGeojson('footprint', this.scene.dataFootprint);
-                        });
+                        this.addThumbnailToMap();
                     },
                     () => {
                         this.$state.go('^.scenes');
@@ -38,10 +36,14 @@ class ProjectSceneController {
                 this.$state.go('^.scenes');
             }
         } else {
-            this.getMap().then((map) => {
-                map.addGeojson('footprint', this.scene.dataFootprint);
-            });
+            this.addThumbnailToMap();
         }
+    }
+
+    addThumbnailToMap() {
+        this.getMap().then((map) => {
+            map.setThumbnail(this.scene, true);
+        });
     }
 
     downloadModal() {

--- a/app-frontend/src/app/pages/library/projects/detail/scene/scene.html
+++ b/app-frontend/src/app/pages/library/projects/detail/scene/scene.html
@@ -10,7 +10,9 @@
     <rf-map-container class="map-preview-container"
                       map-id="scene"
                       options="$ctrl.mapOptions"></rf-map-container>
-    <rf-scene-detail scene="$ctrl.scene"></rf-scene-detail>
+    <rf-scene-detail scene="$ctrl.scene"
+                     show-thumbnail="false"
+    ></rf-scene-detail>
   </div>
   <div class="column-8" ng-if="$ctrl.loading">
     <div class="list-group">

--- a/app-frontend/src/app/pages/library/scenes/detail/detail.controller.js
+++ b/app-frontend/src/app/pages/library/scenes/detail/detail.controller.js
@@ -21,9 +21,7 @@ class SceneDetailController {
                     (scene) => {
                         this.scene = scene;
                         this.loading = false;
-                        this.getMap().then((map)=> {
-                            map.addGeojson('footprint', this.scene.dataFootprint);
-                        });
+                        this.addThumbnailToMap();
                     },
                     () => {
                         this.$state.go('^.list');
@@ -33,10 +31,16 @@ class SceneDetailController {
                 this.$state.go('^.list');
             }
         } else {
-            this.getMap().then((map) => {
-                map.addGeojson('footprint', this.scene.dataFootprint);
-            });
+            this.addThumbnailToMap();
         }
+    }
+
+    addThumbnailToMap() {
+        this.getMap().then(
+            (map)=> {
+                map.setThumbnail(this.scene, true);
+            }
+        );
     }
 
     downloadModal() {

--- a/app-frontend/src/app/pages/library/scenes/detail/detail.html
+++ b/app-frontend/src/app/pages/library/scenes/detail/detail.html
@@ -10,7 +10,9 @@
     <rf-map-container class="map-preview-container"
                       map-id="scene"
                       options="$ctrl.mapOptions"></rf-map-container>
-    <rf-scene-detail scene="$ctrl.scene"></rf-scene-detail>
+    <rf-scene-detail scene="$ctrl.scene"
+                     show-thumbnail="false"
+    ></rf-scene-detail>
   </div>
   <div class="column-8" ng-if="$ctrl.loading">
     <div class="list-group">


### PR DESCRIPTION
## Overview

Show the scene thumbnail on a map instead of using data footprints etc.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~

### Demo

![image](https://cloud.githubusercontent.com/assets/4392704/21507467/8d3ce74e-cc46-11e6-8802-57652b055564.png)
![image](https://cloud.githubusercontent.com/assets/4392704/21507480/a48435e2-cc46-11e6-828e-bcf965807ba6.png)

## Testing Instructions

 * Verify that you've loaded scene that contain tile footprints
 * Navigate to a scene with a tile footprint in the scene browser / project scene list
 * Verify that the thumbnail displays on the map (if no tile footprint is found, nothing will show)
 * In the browse view, mouse over a scene and verify that the thumbnail shows on the map
 * In a browse detail view, verify that the scene thumbnail is displayed on the map.
 *  For scenes with multiple thumbnails, the highest resolution one should be displayed in the browse view, and the lower resolution one in the scene/detail view

Connects #683
