### PR TITLE
Add mosaic parameters page

### DIFF
--- a/app-frontend/src/app/components/mosaicParameters/mosaicScenesParameters.component.js
+++ b/app-frontend/src/app/components/mosaicParameters/mosaicScenesParameters.component.js
@@ -1,0 +1,8 @@
+import mosaicScenesParametersTpl from './mosaicScenesParameters.html';
+
+const mosaicScenesParameters = {
+    templateUrl: mosaicScenesParametersTpl,
+    controller: 'MosaicScenesParametersController'
+};
+
+export default mosaicScenesParameters;

--- a/app-frontend/src/app/components/mosaicParameters/mosaicScenesParameters.controller.js
+++ b/app-frontend/src/app/components/mosaicParameters/mosaicScenesParameters.controller.js
@@ -1,0 +1,146 @@
+export default class MosaicScenesParametersController {
+    constructor( // eslint-disable-line max-params
+        $state, $scope, mapService
+    ) {
+        'ngInject';
+        this.$scope = $scope;
+        this.$state = $state;
+        this.getMap = () => mapService.getMap('project');
+    }
+
+    $onInit() {
+        this.mosaicType = 'Manual';
+        this.mosaicOptions = [
+            {name: 'Cloudiness Level'},
+            {name: 'Acquisition Date'},
+            {name: 'Upload Date'}
+        ];
+
+        this.extentBounds = {};
+        this.extentType = 'sceneExtent';
+    }
+
+    $onDestroy() {
+        this.getMap().then((map) => {
+            this.listeners.forEach((listener) => {
+                map.off(listener);
+            });
+        });
+        this.removeDrawControl();
+    }
+
+    /** Gets bounds of all scenes combined
+     *
+     * @returns {L.LatLngBounds} Bounds for combined scenes
+     */
+    getSceneBounds() {
+        this.getMap().then((map) => {
+            let layerBounds = map.getLayers('scenes').map((layer) => layer.options.bounds);
+            return layerBounds.reduce((originalBnds, newBnds) => originalBnds.extend(newBnds));
+        });
+    }
+
+    /** Adds draw control to map
+     *
+     * @returns {undefined}
+     */
+    addDrawControl() {
+        this.getMap().then((map) => {
+            let extentLayer = L.geoJSON(null, {
+                style: () => {
+                    return {
+                        dashArray: '10, 10',
+                        weight: 2,
+                        fillOpacity: 0.2
+                    };
+                }
+            });
+
+            map.addLayer('extent', extentLayer);
+
+            let drawCtlOptions = {
+                position: 'topleft',
+                draw: {
+                    polyline: false,
+                    marker: false,
+                    circle: false,
+                    polygon: false,
+                    rectangle: {
+                        shapeOptions: {
+                            dashArray: '10, 10',
+                            weight: 2,
+                            fillOpacity: 0.2
+                        }
+                    }
+                },
+                edit: {
+                    featureGroup: extentLayer,
+                    remove: true
+                }
+            };
+            this.drawControl = new L.Control.Draw(drawCtlOptions);
+            map.map.addControl(this.drawControl);
+            this.listeners = [
+                map.on(L.Draw.Event.CREATED, this.addExtent.bind(this)),
+                map.on(L.Draw.Event.EDITED, this.editExtent.bind(this)),
+                map.on(L.Draw.Event.DELETED, this.deleteExtent.bind(this))
+            ];
+        });
+    }
+
+    /** Called when scene extent is chosen, reset to scene bounds
+     *
+     * @returns {undefined}
+     */
+    removeDrawControl() {
+        this.getMap().then((map) => {
+            this.drawControl.remove();
+            map.deleteLayers('extent');
+        });
+        this.extentLayer = this.getSceneBounds();
+    }
+
+    /** Set extent bounds from drawn layer, add to map
+     *
+     * @param {object} $event Map draw event
+     * @returns {undefined}
+     */
+    addExtent($event) {
+        let layer = $event.layer;
+        layer.properties = {
+            id: new Date()
+        };
+        this.getMap().then((map) => {
+            let extentLayer = map.getLayers('extent')[0];
+            extentLayer.addLayer(layer);
+            this.extentBounds = extentLayer.options.bounds;
+            this.$scope.$evalAsync();
+        });
+    }
+
+    /** Reset extent to scene bounds if custom extent is deleted
+     *
+     * @returns {undefined}
+     */
+    deleteExtent() {
+        this.extentBounds = this.getSceneBounds();
+        this.$scope.$evalAsync();
+    }
+
+    /** Called when extent is edited, will update definition via API
+     *
+     * @returns {undefined}
+     */
+    editExtent() {
+        // TODO: hook up to API when created
+    }
+
+    /** Sets mosaic type when selected from drop down
+     *
+     * @param {string} mosaicType Selected mosaic option (auto/manual)
+     * @returns {undefined}
+     */
+    selectMosaicType(mosaicType) {
+        this.mosaicType = mosaicType;
+    }
+}

--- a/app-frontend/src/app/components/mosaicParameters/mosaicScenesParameters.html
+++ b/app-frontend/src/app/components/mosaicParameters/mosaicScenesParameters.html
@@ -1,0 +1,55 @@
+<div class="mosaic-parameters-pane">
+  <div class="sidebar-static">
+    <h5>Parameters</h5>
+    <button class="btn"
+            ng-click="$ctrl.$state.go('^.scenes')">
+      Close
+    </button>
+  </div>
+  <div class="sidebar-scrollable">
+    <div class="mosaic-scene-order">
+      <h3>Scene Order</h3>
+      <h4>Ordering Method</h4>
+      <div class="btn-group" uib-dropdown dropdown-append-to-body>
+        <button id="btn-append-to-body" type="button" class="btn btn-primary" uib-dropdown-toggle>
+          {{ $ctrl.mosaicType }} &#9661;<span class="caret"></span>
+        </button>
+        <ul class="dropdown-menu" uib-dropdown-menu role="menu">
+          <li role="menuitem"
+              ng-click="$ctrl.selectMosaicType('Manual')">
+            Manual
+          </li>
+          <li role="menuitem"
+              ng-click="$ctrl.selectMosaicType('Automatic')">
+            Automatic
+          </li>
+        </ul>
+      </div>
+      <div class="mosaic-scene-prioritization">
+        <!--TODO: design - disable mouse pointer events when disable class (or other) is applied-->
+        <h4>Scene Prioritization</h4>
+        <div ui-tree class="list-group"
+             ng-class="{'disabled': $ctrl.mosaicType === 'Manual'}">
+          <div ui-tree-nodes="" ng-model="$ctrl.mosaicOptions">
+            <div class="mosaic-priority-option" ui-tree-node ng-repeat="option in $ctrl.mosaicOptions"
+                 draggable>{{ option.name }}</div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="mosaic-extent-selection">
+      <h3>Mosaic Extent</h3>
+      <h4>Extent Option</h4>
+      <div class="btn-group">
+        <label class="btn btn-primary"
+               ng-click="$ctrl.removeDrawControl()"
+               ng-model="$ctrl.extentType"
+               uib-btn-radio="'sceneExtent'">Extent of Scenes</label>
+        <label class="btn btn-primary"
+               ng-model="$ctrl.extentType"
+               ng-click="$ctrl.addDrawControl()"
+               uib-btn-radio="'customExtent'">Draw Extent</label>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app-frontend/src/app/components/mosaicParameters/mosaicScenesParameters.module.js
+++ b/app-frontend/src/app/components/mosaicParameters/mosaicScenesParameters.module.js
@@ -1,0 +1,19 @@
+require('angular-ui-tree/source/angular-ui-tree.css');
+
+import angular from 'angular';
+import uiTree from 'angular-ui-tree';
+import buttons from 'angular-ui-bootstrap/src/buttons';
+
+import MosaicScenesParameters from './mosaicScenesParameters.component.js';
+import MosaicScenesParametersController from './mosaicScenesParameters.controller.js';
+
+const MosaicScenesParametersModule = angular.module(
+    'components.mosaicScenesParameters', [uiTree, buttons]
+);
+
+MosaicScenesParametersModule.component('rfMosaicParams', MosaicScenesParameters);
+MosaicScenesParametersModule.controller('MosaicScenesParametersController',
+    MosaicScenesParametersController
+);
+
+export default MosaicScenesParametersModule;

--- a/app-frontend/src/app/index.components.js
+++ b/app-frontend/src/app/index.components.js
@@ -11,6 +11,7 @@ export default angular.module('index.components', [
     require('./components/mosaicScenes/mosaicScenes.module.js').name,
     require('./components/mosaicMask/mosaicMask.module.js').name,
     require('./components/maskItem/maskItem.module.js').name,
+    require('./components/mosaicParameters/mosaicScenesParameters.module.js').name,
     require('./components/sceneItem/sceneItem.module.js').name,
     require('./components/sceneDetail/sceneDetail.module.js').name,
     require('./components/projectItem/projectItem.module.js').name,


### PR DESCRIPTION
## Overview

This commit adds the mosaic parameters page, unstyled.

Users should be able to do the following:
 - choose between manual and automatic scene prioritization
 - re-order scene prioritization strategies
 - choose between project extent and manually drawing an extent
 - draw extent

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~

## Testing Instructions

 * Navigate to the mosaic page for a project
 * Choose "Parameters"
 * Exercise different parameter options (manual/automatic, re-arrange sorting parameters, drawing/deleting mask)
 * Verify back button works as expected
