### PR TITLE
WIP: added nonfunctioning select all btn to scene browser

### DIFF
--- a/app-frontend/src/app/pages/browse/browse.controller.js
+++ b/app-frontend/src/app/pages/browse/browse.controller.js
@@ -19,6 +19,7 @@ export default class BrowseController {
             count: 0,
             results: []
         };
+        this.allSelected = false;
         this.selectedScenes = new Map();
         this.sceneList = [];
         // initial data
@@ -150,6 +151,7 @@ export default class BrowseController {
             (sceneResult) => {
                 this.lastSceneResult = sceneResult;
                 this.sceneList = sceneResult.results;
+                this.allSelected = this.sceneList.every((scene) => scene.isSelected);
                 this.loadingScenes = false;
                 if (this.pendingSceneRequest) {
                     this.pendingSceneRequest = false;
@@ -202,6 +204,7 @@ export default class BrowseController {
             return;
         }
 
+        this.allSelected = false;
         delete this.errorMsg;
         this.loadingScenes = true;
         this.infScrollPage = this.infScrollPage + 1;
@@ -263,6 +266,15 @@ export default class BrowseController {
         } else {
             this.selectedScenes.delete(scene.id);
         }
+    }
+
+    selectAllScenes() {
+        if (this.allSelected && this.sceneList.length) {
+            this.sceneList.map((scene) => this.setSelected(scene, false));
+        } else if (this.sceneList.length) {
+            this.sceneList.map((scene) => this.setSelected(scene, true));
+        }
+        this.allSelected = !this.allSelected;
     }
 
     setHoveredScene(scene) {

--- a/app-frontend/src/app/pages/browse/browse.html
+++ b/app-frontend/src/app/pages/browse/browse.html
@@ -7,7 +7,8 @@
       <h5 class="sidebar-title">{{$ctrl.lastSceneResult.count | number}} Results Found</h5>
       <div class="sidebar-actions">
         <button class="btn btn-default btn-square" ng-click="$ctrl.toggleFilterPane()">
-          <i class="icon-filter"></i>
+          <i ng-class="{'icon-filter': !$ctrl.showFilterPane,
+                        'icon-cross': $ctrl.showFilterPane}"></i>
         </button>
       </div>
     </div>
@@ -57,12 +58,22 @@
 
     <div class="sidebar-static">
       <div class="sidebar-actions">
-        <a href class="btn"
-           ng-class="$ctrl.selectedScenes.size === 0 ? 'disabled' : 'btn-primary'"
-           ng-disabled="!$ctrl.selectedScenes || $ctrl.selectedScenes.size === 0"
-           ng-click="$ctrl.sceneModal()">
-          {{$ctrl.selectedScenes.size || 'No'}} scenes selected
-        </a>
+        <div class="btn-group">
+          <button class="btn"
+             ng-class="$ctrl.selectedScenes.size === 0 ? 'disabled' : 'btn-primary'"
+             ng-disabled="!$ctrl.selectedScenes || $ctrl.selectedScenes.size === 0"
+             ng-click="$ctrl.sceneModal()">
+            {{$ctrl.selectedScenes.size || 'No'}} scenes selected
+          </button>
+
+          <!-- TODO : Developers need to make this function please. -->
+          <button class="btn btn-small"
+                  ng-class="{'btn-primary': $ctrl.selectAllScenes()}"
+                  ng-click="$ctrl.selectAllScenes()">
+            <i ng-class="{'icon-plus': !$ctrl.selectAllScenes(),
+                          'icon-cross': $ctrl.selectAllScenes()}"></i>
+          </button>
+        </div>
       </div>
     </div>
   </div>

--- a/app-frontend/src/app/pages/browse/browse.html
+++ b/app-frontend/src/app/pages/browse/browse.html
@@ -66,12 +66,11 @@
             {{$ctrl.selectedScenes.size || 'No'}} scenes selected
           </button>
 
-          <!-- TODO : Developers need to make this function please. -->
           <button class="btn btn-small"
-                  ng-class="{'btn-primary': $ctrl.selectAllScenes()}"
+                  ng-class="{'btn-primary': $ctrl.allSelected}"
                   ng-click="$ctrl.selectAllScenes()">
-            <i ng-class="{'icon-plus': !$ctrl.selectAllScenes(),
-                          'icon-cross': $ctrl.selectAllScenes()}"></i>
+            <i ng-class="{'icon-plus': !$ctrl.allSelected,
+                          'icon-cross': $ctrl.allSelected}"></i>
           </button>
         </div>
       </div>

--- a/app-frontend/src/assets/styles/sass/components/_button.scss
+++ b/app-frontend/src/assets/styles/sass/components/_button.scss
@@ -70,7 +70,7 @@
 
 .btn-default {
   background: $shade-normal;
-  border-color: $shade-normal;
+  border-color: darken($shade-normal, 5%);
   color: #fff;
 
   @include button-states($shade-normal);
@@ -78,7 +78,7 @@
 
 .btn-primary {
   background: $brand-primary;
-  border-color: $brand-primary;
+  border-color: darken($brand-primary, 5%);
   color: #fff;
 
   @include button-states($brand-primary);
@@ -86,7 +86,7 @@
 
 .btn-secondary {
   background: $brand-secondary;
-  border-color: $brand-secondary;
+  border-color: darken($brand-secondary, 5%);
   color: #fff;
 
   @include button-states($brand-secondary);
@@ -108,7 +108,7 @@
 
 .btn-warning {
   background: $warning;
-  border-color: $warning;
+  border-color: darken($warning, 5%);
   color: #fff;
 
   @include button-states($warning);
@@ -116,7 +116,7 @@
 
 .btn-danger {
 	background: $danger;
-  border-color: $danger;
+  border-color: darken($danger, 5%);
   color: #fff;
 
   @include button-states($danger);
@@ -177,7 +177,7 @@
  */
 .btn-toggle {
   background : $shade-dark;
-  border-color: $shade-dark;
+  border-color: darken($shade-dark, 5%);
   color: $text-base;
 
   &:hover, &.hover,
@@ -206,7 +206,7 @@
 
   &.active {
     background: $brand-primary;
-    border-color: $brand-primary;
+    border-color: darken($brand-primary, 5%);
     color: #fff;
     box-shadow: none;
 


### PR DESCRIPTION
## Overview

This PR implements a currently non-functioning select all button in the scene browser. 

I need dev support in making the button work. It should function exactly the same way as the select all button in the editor.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~

### Demo

<img width="394" alt="screen shot 2016-12-28 at 9 42 33 am" src="https://cloud.githubusercontent.com/assets/1928955/21525158/49c95026-cce9-11e6-8349-e76996d7c2d2.png">


### Notes

The button does not yet function. Developer support needed.


## Testing Instructions

 * Go the scene browser
 * Select all button should appear in the footer of the sidebar next to selected scenes button.

Connects #836
