### PR TITLE
Bump Terraform version to 0.8.2

### DIFF
--- a/deployment/ansible/group_vars/jenkins
+++ b/deployment/ansible/group_vars/jenkins
@@ -2,5 +2,7 @@
 docker_users:
   - "{{ ansible_user }}"
   - "{{ jenkins_name }}"
-terraform_version: "0.7.13"
+
+terraform_version: "0.8.2"
+
 java_version: "7u121*"


### PR DESCRIPTION
## Overview

Ensure that we're at the most current version before attempting to update the VPC address range.

See: https://www.terraform.io/upgrade-guides/0-8.html

## Testing Instructions

Review the output of [this](http://jenkins.staging.rasterfoundry.com/job/raster-foundry/job/raster-foundry/job/develop/138/) Jenkins job to ensure that is completed successfully.

Also, you can SSH into the Jenkins box and inspect the Terraform version:

```bash
$ ssh -l ubuntu jenkins.staging.rasterfoundry.com
ubuntu@ip-172-31-52-80:~$ terraform -v
Terraform v0.8.2
```

Connects:

- #799 
- #798 
