### PR TITLE
Rename to 'Tool Catalog' and 'Lab'

### DIFF
--- a/app-backend/database/src/main/scala/com/azavea/rf/database/tables/ToolCategories.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/tables/ToolCategories.scala
@@ -17,7 +17,7 @@ import scala.concurrent.Future
 
 import com.lonelyplanet.akka.http.extensions.PageRequest
 
-/** Table that represents categories for tools in model lab
+/** Table that represents categories for tools in the lab
   *
   * These are user generated categories for tools to help users
   * track and search for them. For instance, users may decide to

--- a/app-backend/database/src/main/scala/com/azavea/rf/database/tables/ToolCategories.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/tables/ToolCategories.scala
@@ -17,7 +17,7 @@ import scala.concurrent.Future
 
 import com.lonelyplanet.akka.http.extensions.PageRequest
 
-/** Table that represents categories for tools in the lab
+/** Table that represents categories for tools in the Raster Foundry lab
   *
   * These are user generated categories for tools to help users
   * track and search for them. For instance, users may decide to

--- a/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Tools.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Tools.scala
@@ -16,7 +16,7 @@ import com.lonelyplanet.akka.http.extensions.{PageRequest, Order}
 import com.typesafe.scalalogging.LazyLogging
 import scala.concurrent.Future
 
-/** Table that represents tools in model lab
+/** Table that represents tools in the Raster Foundry lab
   *
   * These are user generated tools that will eventually
   * contain a set of operations to be applied.

--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/ToolCategory.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/ToolCategory.scala
@@ -4,7 +4,7 @@ import spray.json.DefaultJsonProtocol._
 import java.util.UUID
 import java.sql.Timestamp
 
-/** A user generate category to track tools in model lab
+/** A user generate category to track tools in the Raster Foundry lab
   *
   * @param id UUID Unique identifier for Tool Category
   * @param createdAt Timestamp Creation time for category

--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/ToolTag.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/ToolTag.scala
@@ -4,7 +4,7 @@ import spray.json.DefaultJsonProtocol._
 import java.util.UUID
 import java.sql.Timestamp
 
-/** A user generate tag to track tools in model lab
+/** A user generate tag to track tools in the Raster Foundry lab
   *
   * @param id UUID Unique identifier for Tool Tag
   * @param createdAt Timestamp Creation time for tag

--- a/app-frontend/src/app/components/navBar/navBar.html
+++ b/app-frontend/src/app/components/navBar/navBar.html
@@ -7,14 +7,18 @@
     <span class="navbar-vertical-divider"></span>
     <nav>
       <a href ui-sref="browse" ui-sref-active="active">Scene browser</a>
+      <a href ui-sref="editor"
+         ng-class="{
+                   active: $ctrl.$state.$current.name.includes('editor')
+                   }">Editor</a>
       <a href ui-sref="market.search"
          ng-class="{
                    active: $ctrl.$state.$current.name.includes('market')
-                   }">Model market</a>
+                   }">Tool Catalog</a>
       <a href ui-sref="lab.edit"
          ng-class="{
                    active: $ctrl.$state.$current.name.includes('lab')
-                   }">Model lab</a>
+                   }">Lab</a>
     </nav>
     <span class="navbar-vertical-divider"></span>
   </div>

--- a/app-frontend/src/app/pages/market/tool/tool.html
+++ b/app-frontend/src/app/pages/market/tool/tool.html
@@ -95,7 +95,7 @@
             <h5>Usage License</h5>
             <p>
               No license information was provided. If this work was prepared by
-              Raster Foundry as part of the official Tool marketplace, it is
+              Raster Foundry as part of the official Tool Catalog, it is
               considered a Raster Foundry work and usage should follow the general
               <a>terms of use</a>
             </p>

--- a/docs/swagger/spec.yml
+++ b/docs/swagger/spec.yml
@@ -24,7 +24,7 @@ tags:
     description: Resources to obtain, use, and delete API tokens
   - name: Imagery
     description: Interact with imagery
-  - name: Model Lab
+  - name: Lab
     description: Geospatial processing discovery and endpoints
   - name: Statistics
     description: Statistical metadata about geospatial data
@@ -740,7 +740,7 @@ paths:
     get:
       summary: Lists tools that perform a set of geoprocessing/map algebra functions
       tags:
-        - Model Lab
+        - Lab
       parameters:
         - $ref: '#/parameters/orderingBase'
         - $ref: '#/parameters/pageSize'
@@ -762,7 +762,7 @@ paths:
     post:
       summary: Create a new geoprocessing tool
       tags:
-        - Model Lab
+        - Lab
       responses:
         201:
           description: Create a new geoprocessing tool
@@ -774,7 +774,7 @@ paths:
     get:
       summary: Retrieve details for a single geoprocessing tool
       tags:
-        - Model Lab
+        - Lab
       parameters:
         - $ref: '#/parameters/uuid'
       responses:
@@ -787,7 +787,7 @@ paths:
     delete:
       summary: Delete a tool
       tags:
-        - Model Lab
+        - Lab
       parameters:
         - $ref: '#/parameters/uuid'
       responses:
@@ -798,7 +798,7 @@ paths:
     put:
       summary: Update a geoprocessing tool
       tags:
-        - Model Lab
+        - Lab
       parameters:
         - $ref: '#/parameters/uuid'
       responses:
@@ -810,7 +810,7 @@ paths:
     get:
       summary: List tool tags
       tags:
-        - Model Lab
+        - Lab
       parameters:
         - $ref: '#/parameters/search'
       responses:
@@ -823,7 +823,7 @@ paths:
     post:
       summary: Create a tool tag
       tags:
-        - Model Lab
+        - Lab
       responses:
         201:
           description: Successfully created a new tag for tools
@@ -835,7 +835,7 @@ paths:
     get:
       summary: Get detail of a tool tag
       tags:
-        - Model Lab
+        - Lab
       parameters:
         - $ref: '#/parameters/uuid'
       responses:
@@ -848,7 +848,7 @@ paths:
     delete:
       summary: Delete a given tag
       tags:
-        - Model Lab
+        - Lab
       parameters:
         - $ref: '#/parameters/uuid'
       responses:
@@ -859,7 +859,7 @@ paths:
     put:
       summary: Update a given tool tag
       tags:
-        - Model Lab
+        - Lab
       parameters:
         - $ref: '#/parameters/uuid'
       responses:
@@ -873,7 +873,7 @@ paths:
       parameters:
         - $ref: '#/parameters/search'
       tags:
-        - Model Lab
+        - Lab
       responses:
         200:
           description: Paginated list of tool categories
@@ -882,7 +882,7 @@ paths:
     post:
       summary: Create a new tool category
       tags:
-        - Model Lab
+        - Lab
       responses:
         201:
           description: Successfully created a new tool category
@@ -892,7 +892,7 @@ paths:
     get:
       summary: Retrieve details of a tool category
       tags:
-        - Model Lab
+        - Lab
       parameters:
         - $ref: '#/parameters/slugLabel'
       responses:
@@ -903,7 +903,7 @@ paths:
     put:
       summary: Update a tool category
       tags:
-        - Model Lab
+        - Lab
       responses:
         204:
           description: Successfully updated a tool category
@@ -912,7 +912,7 @@ paths:
     delete:
       summary: Delete a tool category
       tags:
-        - Model Lab
+        - Lab
       parameters:
         - $ref: '#/parameters/slugLabel'
       responses:
@@ -1508,7 +1508,7 @@ definitions:
                   properties:
                     type:
                       type: string
-                      description: Polygon 
+                      description: Polygon
                     coordinates:
                       type: array
                       description: list of polygon coordinate rings


### PR DESCRIPTION
## Overview

Renames 'Model Lab' to 'Lab and 'Model Market' to 'Tool Catalog'.
Also adds a nav-bar link to 'Editor'.

### Notes

The resulting order of the navigation links is:

- Scene Browser
- Editor
- Tool Catalog
- Lab

The `/editor` route is currently abstract. Clicking the link will take the user to the browse page. This would be addressed with #837.

## Testing Instructions

 * Ensure the updated nav links are as expected

Resolves #833
