### PR TITLE
Hide pagination on adding scenes to project modal

### DIFF
--- a/app-frontend/src/app/components/projectAddModal/projectAddModal.html
+++ b/app-frontend/src/app/components/projectAddModal/projectAddModal.html
@@ -59,7 +59,7 @@
       </span>
     </div>
     <div class="list-group text-center"
-         ng-show="!$ctrl.loading && $ctrl.lastProjectResult && $ctrl.lastProjectResult.count !== 0 && !$ctrl.errorMsg">
+         ng-show="!$ctrl.loading && $ctrl.lastProjectResult && $ctrl.lastProjectResult.count > $ctrl.lastProjectResult.pageSize && !$ctrl.errorMsg">
       <ul uib-pagination
           items-per-page="$ctrl.lastProjectResult.pageSize"
           total-items="$ctrl.lastProjectResult.count"


### PR DESCRIPTION
## Overview

On the modal that allows a user to add selected scenes to a project, show the pagination only when appropriate (item count > page size).

## Testing Instructions

 * Ensure the pagination controls are not present with project item count below the page threshold

Connects #832 
