### PR TITLE
Add feature flag for 'make source histogram' in color correction

### DIFF
--- a/app-backend/app/src/main/resources/application.conf
+++ b/app-backend/app/src/main/resources/application.conf
@@ -66,5 +66,11 @@ featureFlags {
       name = "Profile Organization Edit",
       description = "Join / Create / Edit / Leave / Delete organizations in user profile settings"
     }
+    {
+      key = "make-source-histogram"
+      active = false
+      name = "Make source histogram"
+      description = "Show or hide the 'make source histogram' link in color correction"
+    }
   ]
 }

--- a/app-frontend/src/app/components/colorCorrectPane/colorCorrectPane.html
+++ b/app-frontend/src/app/components/colorCorrectPane/colorCorrectPane.html
@@ -7,7 +7,7 @@
   </div>
   <div ng-show="!$ctrl.errorLoadingHistogram" class="sidebar-static histogram">
     <rf-channel-histogram data="$ctrl.data"></rf-channel-histogram>
-    <a ng-click="" class="btn btn-link btn-block">Make source histogram</a>
+    <a feature-flag="make-source-histogram" ng-click="" class="btn btn-link btn-block">Make source histogram</a>
   </div>
   <div ng-show="$ctrl.errorLoadingHistogram" class="sidebar-static">
     Error loading histogram


### PR DESCRIPTION
## Overview

Uses a feature flag to hide the 'make source histogram' link within the color correction (just below the histogram). Defaults to hidden.

## Testing Instructions

 * Go to color correct and ensure the 'make source histogram' link is hidden (would be visible below the histogram).
 * Go to the user accounts settings (`settings/account`) page and switch the feature flag for 'Show make source histogram link' to 'on'.
 * Go back to color correction and ensure the link is now visible.

Resolves #827
