### PR TITLE
Fix production build styling

### DIFF
--- a/app-frontend/config/webpack/global.js
+++ b/app-frontend/config/webpack/global.js
@@ -89,11 +89,9 @@ module.exports = function (_path) {
                 }
             }, {
                 test: /\.css$/,
-                loaders: [
-                    'style-loader',
-                    'css-loader?sourceMap',
-                    'postcss-loader'
-                ]
+                loader: DEVELOPMENT ? 'style-loader!css-loader?sourceMap!postcss-loader'
+                    : ExtractTextPlugin.extract('style-loader',
+                                                'css-loader!postcss-loader')
             }, {
                 test: /\.(scss|sass)$/,
                 loader: DEVELOPMENT ? 'style-loader!' + stylesLoader


### PR DESCRIPTION
## Overview

This commit fixes the production build styling by switching to the
extract text plugin for styles during production builds. There may be a
small performance penalty, but this solves the styling issue by ensuring
that all the styling is concatenated together into a single file. The
project's styles are applied last (the next sass style loader) so our
overrides will be preserved.

The problem was caused because the CSS styles for vendor assets were
being inlined and/or loaded via javascript based on our loader usage.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~

### Demo

Development style assets maintained (inlined/called by javascript):

![dev-styles](https://cloud.githubusercontent.com/assets/898060/21545010/025c5e36-cda2-11e6-91e6-9565b0e7baba.png)

Production style assets:
![prod-css](https://cloud.githubusercontent.com/assets/898060/21545013/08e5fa3c-cda2-11e6-89e0-a8713f5e09de.png)

## Testing Instructions

 * Start VM
 * Run: `./scripts/console app-frontend "npm run build"`
 * Start server: `./scripts/server`
 * Browse to `localhost:9100` and the production assets should be loaded via nginx and filters should not be broken

Closes #571 
