### PR TITLE
Add loading indicator to color correct histogram

### DIFF
--- a/app-frontend/src/app/components/colorCorrectPane/colorCorrectPane.controller.js
+++ b/app-frontend/src/app/components/colorCorrectPane/colorCorrectPane.controller.js
@@ -54,13 +54,16 @@ export default class ColorCorrectPaneController {
     }
 
     updateHistogram() {
+        this.loadingHistogram = true;
         this.firstLayer.fetchHistogramData().then(
             (resp) => {
                 this.errorLoadingHistogram = false;
+                this.loadingHistogram = false;
                 this.data = this.generateHistogramData(resp.data);
             }
         ).catch(() => {
             this.errorLoadingHistogram = true;
+            this.loadingHistogram = false;
         });
     }
 

--- a/app-frontend/src/app/components/colorCorrectPane/colorCorrectPane.controller.js
+++ b/app-frontend/src/app/components/colorCorrectPane/colorCorrectPane.controller.js
@@ -54,10 +54,10 @@ export default class ColorCorrectPaneController {
     }
 
     updateHistogram() {
+        this.errorLoadingHistogram = false;
         this.loadingHistogram = true;
         this.firstLayer.fetchHistogramData().then(
             (resp) => {
-                this.errorLoadingHistogram = false;
                 this.loadingHistogram = false;
                 this.data = this.generateHistogramData(resp.data);
             }

--- a/app-frontend/src/app/components/colorCorrectPane/colorCorrectPane.controller.js
+++ b/app-frontend/src/app/components/colorCorrectPane/colorCorrectPane.controller.js
@@ -55,15 +55,28 @@ export default class ColorCorrectPaneController {
 
     updateHistogram() {
         this.errorLoadingHistogram = false;
+        if (this.loadingHistogram) {
+            this.queuedHistogramRequest = true;
+            return;
+        }
         this.loadingHistogram = true;
         this.firstLayer.fetchHistogramData().then(
             (resp) => {
                 this.loadingHistogram = false;
+                this.errorLoadingHistogram = false;
                 this.data = this.generateHistogramData(resp.data);
+                if (this.queuedHistogramRequest) {
+                    this.queuedHistogramRequest = false;
+                    this.updateHistogram();
+                }
             }
         ).catch(() => {
             this.errorLoadingHistogram = true;
             this.loadingHistogram = false;
+            if (this.queuedHistogramRequest) {
+                this.queuedHistogramRequest = false;
+                this.updateHistogram();
+            }
         });
     }
 

--- a/app-frontend/src/app/components/colorCorrectPane/colorCorrectPane.html
+++ b/app-frontend/src/app/components/colorCorrectPane/colorCorrectPane.html
@@ -5,16 +5,21 @@
       <a href class="btn btn-default btn-small" ng-click="$ctrl.$state.go('^.scenes')">Back</a>
     </div>
   </div>
-  <div ng-show="!$ctrl.errorLoadingHistogram" class="sidebar-static histogram">
-    <div class="histogram-loading-indicator" ng-show="$ctrl.loadingHistogram">
-      <i class="icon-load"></i>
+
+  <div class="sidebar-static histogram">
+    <div class="histogram-loading-indicator" ng-show="$ctrl.errorLoadingHistogram || $ctrl.loadingHistogram">
+      <!--Histogram is loading-->
+      <i ng-show="$ctrl.loadingHistogram" class="icon-load animated"></i>
+      <!--Histogram failed to load-->
+      <span ng-show="$ctrl.errorLoadingHistogram && !$ctrl.loadingHistogram">Error loading histogram</span>
     </div>
-    <rf-channel-histogram ng-show="!$ctrl.loadingHistogram" data="$ctrl.data"></rf-channel-histogram>
+
+    <!--Histogram loaded successfully-->
+    <rf-channel-histogram ng-show="!$ctrl.loadingHistogram && !$ctrl.errorLoadingHistogram" data="$ctrl.data"></rf-channel-histogram>
+
     <a feature-flag="make-source-histogram" ng-click="" class="btn btn-link btn-block">Make source histogram</a>
   </div>
-  <div ng-show="$ctrl.errorLoadingHistogram" class="sidebar-static">
-    Error loading histogram
-  </div>
+
   <div class="sidebar-scrollable">
     <rf-color-correct-adjust
         correction="$ctrl.correction"

--- a/app-frontend/src/app/components/colorCorrectPane/colorCorrectPane.html
+++ b/app-frontend/src/app/components/colorCorrectPane/colorCorrectPane.html
@@ -6,7 +6,10 @@
     </div>
   </div>
   <div ng-show="!$ctrl.errorLoadingHistogram" class="sidebar-static histogram">
-    <rf-channel-histogram data="$ctrl.data"></rf-channel-histogram>
+    <div class="histogram-loading-indicator" ng-show="$ctrl.loadingHistogram">
+      <i class="icon-load"></i>
+    </div>
+    <rf-channel-histogram ng-show="!$ctrl.loadingHistogram" data="$ctrl.data"></rf-channel-histogram>
     <a feature-flag="make-source-histogram" ng-click="" class="btn btn-link btn-block">Make source histogram</a>
   </div>
   <div ng-show="$ctrl.errorLoadingHistogram" class="sidebar-static">

--- a/app-frontend/src/app/components/colorCorrectPane/colorCorrectPane.html
+++ b/app-frontend/src/app/components/colorCorrectPane/colorCorrectPane.html
@@ -9,9 +9,9 @@
   <div class="sidebar-static histogram">
     <div class="histogram-loading-indicator" ng-show="$ctrl.errorLoadingHistogram || $ctrl.loadingHistogram">
       <!--Histogram is loading-->
-      <i ng-show="$ctrl.loadingHistogram" class="icon-load animated"></i>
+      <i ng-show="$ctrl.loadingHistogram && !$ctrl.errorLoadingHistogram" class="icon-load animated"></i>
       <!--Histogram failed to load-->
-      <span ng-show="$ctrl.errorLoadingHistogram && !$ctrl.loadingHistogram">Error loading histogram</span>
+      <span ng-show="!$ctrl.loadingHistogram && $ctrl.errorLoadingHistogram">Error loading histogram</span>
     </div>
 
     <!--Histogram loaded successfully-->

--- a/app-frontend/src/app/components/colorCorrectPane/colorCorrectPane.module.js
+++ b/app-frontend/src/app/components/colorCorrectPane/colorCorrectPane.module.js
@@ -3,6 +3,8 @@ import angular from 'angular';
 import ColorCorrectPane from './colorCorrectPane.component.js';
 import ColorCorrectPaneController from './colorCorrectPane.controller.js';
 
+require('./colorCorrectPane.scss');
+
 const ColorCorrectPaneModule = angular.module('components.colorCorrectPane', []);
 
 ColorCorrectPaneModule.component('rfColorCorrectPane', ColorCorrectPane);

--- a/app-frontend/src/app/components/colorCorrectPane/colorCorrectPane.scss
+++ b/app-frontend/src/app/components/colorCorrectPane/colorCorrectPane.scss
@@ -1,0 +1,7 @@
+// @TODO: add class to enforce min-height and minimize UI jank
+.histogram-loading-indicator {
+    min-height: 100px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}

--- a/app-frontend/src/app/components/colorCorrectPane/colorCorrectPane.scss
+++ b/app-frontend/src/app/components/colorCorrectPane/colorCorrectPane.scss
@@ -1,7 +1,14 @@
 // @TODO: add class to enforce min-height and minimize UI jank
+
 .histogram-loading-indicator {
     min-height: 100px;
     display: flex;
+    flex: 1;
     align-items: center;
     justify-content: center;
+    text-align: center;
+}
+
+.icon-load.animated {
+    animation: 2s linear 0s normal none infinite spin;
 }


### PR DESCRIPTION
## Overview

Adds a loading indicator to the histogram container.
Maintains height of histogram container to minimize UI impact.

## Testing Instructions

 * Switch on dev tools network throttling if desired
 * Enter color correction mode and ensure a loading indicator is shown before the histogram is displayed

Connects #829
