### PR TITLE
Feature/js/clean up thumbnail drawing logic

### DIFF
--- a/app-frontend/src/app/components/mosaicScenes/mosaicScenes.controller.js
+++ b/app-frontend/src/app/components/mosaicScenes/mosaicScenes.controller.js
@@ -2,7 +2,7 @@ const Map = require('es6-map');
 
 export default class MosaicScenesController {
     constructor( // eslint-disable-line max-params
-        $log, $scope, $q, $state, projectService, layerService
+        $log, $scope, $q, $state, projectService, layerService, mapService
     ) {
         'ngInject';
         this.projectService = projectService;
@@ -10,6 +10,7 @@ export default class MosaicScenesController {
         this.$state = $state;
         this.$q = $q;
         this.$log = $log;
+        this.mapService = mapService;
     }
 
     $onInit() {
@@ -31,7 +32,8 @@ export default class MosaicScenesController {
     }
 
     setHoveredScene(scene) {
-        this.onSceneMouseover({scene: scene});
+        let toHover = this.mapService.disableFootprints ? null : scene;
+        this.onSceneMouseover({scene: toHover});
     }
 
     removeHoveredScene() {

--- a/app-frontend/src/app/components/sceneItem/sceneItem.controller.js
+++ b/app-frontend/src/app/components/sceneItem/sceneItem.controller.js
@@ -1,5 +1,5 @@
 export default class SceneItemController {
-    constructor($scope, $attrs, thumbnailService) {
+    constructor($scope, $attrs, thumbnailService, mapService) {
         'ngInject';
         this.thumbnailService = thumbnailService;
         this.isSelectable = $attrs.hasOwnProperty('selectable');
@@ -10,6 +10,17 @@ export default class SceneItemController {
                 this.selectedStatus = selected;
             }
         );
+
+        if (this.isDraggable) {
+            Object.assign($scope.$parent.$treeScope.$callbacks, {
+                dragStart: function () {
+                    mapService.disableFootprints = true;
+                },
+                dragStop: function () {
+                    mapService.disableFootprints = false;
+                }
+            });
+        }
     }
 
     toggleSelected(event) {

--- a/app-frontend/src/app/core/services/map.service.js
+++ b/app-frontend/src/app/core/services/map.service.js
@@ -19,6 +19,7 @@ class MapWrapper {
         this._layerMap = new Map();
         this._layerGroup = L.layerGroup().addTo(this.map);
         this.persistedThumbnails = new Map();
+        this.disableFootprints = false;
 
         this._controls = L.control({position: 'topright'});
         this._controls.onAdd = function () {

--- a/app-frontend/src/app/pages/browse/browse.controller.js
+++ b/app-frontend/src/app/pages/browse/browse.controller.js
@@ -301,8 +301,14 @@ export default class BrowseController {
     setSelected(scene, selected) {
         if (selected) {
             this.selectedScenes.set(scene.id, scene);
+            this.getBrowseMap().then((map) => {
+                map.setThumbnail(scene, false, true);
+            });
         } else {
             this.selectedScenes.delete(scene.id);
+            this.getBrowseMap().then((map) => {
+                map.deleteThumbnail(scene);
+            });
         }
     }
 

--- a/app-frontend/src/app/pages/editor/project/projectEdit.controller.js
+++ b/app-frontend/src/app/pages/editor/project/projectEdit.controller.js
@@ -34,6 +34,9 @@ export default class ProjectEditController {
     }
 
     setHoveredScene(scene) {
+        if (!scene) {
+            return;
+        }
         let styledGeojson = Object.assign({}, scene.dataFootprint, {
             properties: {
                 options: {


### PR DESCRIPTION
## Overview

This PR changes logic for drawing footprints in two places:

- in the browse view, when you select a scene, its footprint now persists on the map until it's unselected (#848)
- in the manual mosaicking view, footprints now don't draw when scenes are dragged over each other (#850)

### Checklist

- ~[ ] Styleguide updated, if necessary~
- ~[ ] Swagger specification updated, if necessary~

### Demo

Persisting thumbnails on the map:

![optimised5](https://cloud.githubusercontent.com/assets/5702984/21572672/bdeb78e6-cea9-11e6-96db-24cc285b5072.gif)

Not highlighting when dragging over scenes in mosaic view:
![optimised5](https://cloud.githubusercontent.com/assets/5702984/21572753/d0891aca-ceaa-11e6-8a40-6c001efc4944.gif)

### Notes

Something weird is going on in the mosaic page -- after reordering, the `scene-item`s sometimes no longer have the same footprints they did before. That's pretty bad! I'm not sure what's going on there yet. It's visible in the gif. Check out the starting and ending footprint locations for the scene I dragged.

This problem appears to be transient to some extent -- if you drag a scene around really fast, it usually shows up, while if you reorder scenes at a more reasonable pace, it usually doesn't.

## Testing Instructions

 * start up your server and frontend
 * go to the scene browser, zoom in so you can see some specific scenes (I like the Caribbean because it's cold outside right now, but the choice is yours), and select some scenes
 * drag your mouse somewhere else to verify that their thumbnails persist on the map
 * unselect those scenes and verify that the thumbnails vanish
 * open a project and navigate to mosaicking
 * drag a scene around and verify that footprints for other scenes don't appear on the map when you hover over them

Closes #848
Closes #850