### PR TITLE
Add publish modal to project details and editor

### DIFF
--- a/app-frontend/src/app/components/publishModal/publishModal.component.js
+++ b/app-frontend/src/app/components/publishModal/publishModal.component.js
@@ -1,0 +1,13 @@
+import publishModalTpl from './publishModal.html';
+
+const rfPublishModal = {
+    templateUrl: publishModalTpl,
+    bindings: {
+        close: '&',
+        dismiss: '&',
+        modalInstance: '<',
+        resolve: '<'
+    }
+};
+
+export default rfPublishModal;

--- a/app-frontend/src/app/components/publishModal/publishModal.controller.js
+++ b/app-frontend/src/app/components/publishModal/publishModal.controller.js
@@ -1,0 +1,5 @@
+export default class PublishModalController {
+    constructor() {
+        'ngInject';
+    }
+}

--- a/app-frontend/src/app/components/publishModal/publishModal.html
+++ b/app-frontend/src/app/components/publishModal/publishModal.html
@@ -1,0 +1,40 @@
+<div class="modal-header">
+  <button type="button" class="close" aria-label="Close" ng-click="$ctrl.dismiss()">
+    <span aria-hidden="true">&times;</span>
+  </button>
+  <span class="badge"><i class="icon-download"></i></span>
+  <h4 class="modal-title">
+    Publish Project - {{$ctrl.resolve.project.name}}
+  </h4>
+</div>
+<div class="modal-body">
+  <div class="centered-text">
+    Get the XYZ resource link for use in other products
+  </div>
+  <div class="form-group all-in-one">
+    <label for="tile-link"><i class="icon-bucket"></i></label>
+    <input id="tile-link" type="text" class="form-control"
+            value="/tiles/projects/{{$ctrl.resolve.project.id}}" readonly>
+     <!--
+       @TODO: the copy button is intended to copy the url for the user which
+       is not currently implemented
+     -->
+    <button class="btn btn-link">
+      Copy
+    </button>
+  </div>
+  <div class="centered-text">
+    Or download an image of your project
+  </div>
+  <div class="form-group centered">
+    <a class="btn btn-primary" href="">
+      Download .png
+    </a>
+  </div>
+</div>
+<div class="modal-footer">
+<button type="button" class="btn"
+        ng-click="$ctrl.dismiss()">
+  Done
+</button>
+</div>

--- a/app-frontend/src/app/components/publishModal/publishModal.module.js
+++ b/app-frontend/src/app/components/publishModal/publishModal.module.js
@@ -1,0 +1,16 @@
+import angular from 'angular';
+import PublishModalComponent from './publishModal.component.js';
+import PublishModalController from './publishModal.controller.js';
+require('../../../assets/font/fontello/css/fontello.css');
+require('./publishModal.scss');
+
+const PublishModalModule = angular.module('components.publishModal', []);
+
+PublishModalModule.controller(
+    'PublishModalController', PublishModalController
+);
+PublishModalModule.component(
+    'rfPublishModal', PublishModalComponent
+);
+
+export default PublishModalModule;

--- a/app-frontend/src/app/components/publishModal/publishModal.scss
+++ b/app-frontend/src/app/components/publishModal/publishModal.scss
@@ -1,0 +1,10 @@
+.modal-body .centered-text {
+  padding: 1.5rem;
+  display: flex;
+  position: relative;
+  justify-content: center;
+}
+
+.modal-body .form-group.centered {
+  text-align: center;
+}

--- a/app-frontend/src/app/index.components.js
+++ b/app-frontend/src/app/index.components.js
@@ -16,6 +16,7 @@ export default angular.module('index.components', [
     require('./components/sceneItem/sceneItem.module.js').name,
     require('./components/sceneDetail/sceneDetail.module.js').name,
     require('./components/projectItem/projectItem.module.js').name,
+    require('./components/publishModal/publishModal.module.js').name,
     require('./components/selectedScenesModal/selectedScenesModal.module.js').name,
     require('./components/confirmationModal/confirmationModal.module.js').name,
     require('./components/projectAddModal/projectAddModal.module.js').name,

--- a/app-frontend/src/app/pages/editor/project/projectEdit.html
+++ b/app-frontend/src/app/pages/editor/project/projectEdit.html
@@ -4,6 +4,12 @@
     <a href ui-sref=".mosaic.scenes" ui-sref-active="active"><i class="icon-mosaic"></i> Mosaic</a>
   </nav>
   <span class="navbar-vertical-divider"></span>
+  <div class="navbar-right">
+      <nav>
+        <button class="btn">Save</button>
+        <button class="btn btn-primary" ng-click="$ctrl.publishModal()" ng-disabled="$ctrl.loadingProject || !$ctrl.project">Publish</button>
+      </nav>
+    </div>
 </div>
 <div class="container column-stretch container-not-scrollable with-header">
   <!-- Sidebar (container is in parent view) -->

--- a/app-frontend/src/app/pages/library/projects/detail/projectScenes/projectScenes.controller.js
+++ b/app-frontend/src/app/pages/library/projects/detail/projectScenes/projectScenes.controller.js
@@ -168,6 +168,19 @@ export default class ProjectScenesController {
         }
     }
 
+    publishModal() {
+        if (this.activeModal) {
+            this.activeModal.dismiss();
+        }
+
+        this.activeModal = this.$uibModal.open({
+            component: 'rfPublishModal',
+            resolve: {
+                project: () => this.project
+            }
+        });
+    }
+
     shouldShowPagination() {
         return !this.loading &&
             this.lastSceneResult &&

--- a/app-frontend/src/app/pages/library/projects/detail/projectScenes/projectScenes.html
+++ b/app-frontend/src/app/pages/library/projects/detail/projectScenes/projectScenes.html
@@ -102,6 +102,7 @@
     <div class="content">
       <nav>
         <a href ng-click="$ctrl.$state.go('editor.project.color.scenes', {projectid: $ctrl.projectId})"><i class="icon-mosaic"></i> Editor</a>
+        <a href ng-click="$ctrl.publishModal()"><i class="icon-dropbox"></i> Publish</a>
         <hr>
         <a href class="color-danger"
            ng-click="$ctrl.deleteProject()">


### PR DESCRIPTION
## Overview
Adds the publish modal and links to access it from both the project details page and the project edit page.
Does not actually implement any project publishing, just UI

### Demo

<img width="471" alt="screen shot 2017-01-04 at 1 28 59 pm" src="https://cloud.githubusercontent.com/assets/2442245/21654078/01902b38-d282-11e6-864f-5c30b3efc338.png">

<img width="377" alt="screen shot 2017-01-04 at 1 31 13 pm" src="https://cloud.githubusercontent.com/assets/2442245/21654139/3cc5825c-d282-11e6-9dbc-52ef59369dc9.png">

<img width="901" alt="screen shot 2017-01-04 at 1 29 08 pm" src="https://cloud.githubusercontent.com/assets/2442245/21654085/06101420-d282-11e6-8b47-912f549a8638.png">

### Notes

- Some styling fixes are needed to provide vertically centered buttons within the editor nav-bar (as seen in the second screen shot)
- We may need a new icon for publish (if there is one, I didn't see it)
- I added a publish link to project details as that seems like a logical place for it as well
- @designmatty I added a stylesheet with some small fixes to improve the look and feel of the modal a bit (over mis-using current styles)
- We have to now load the project on the editor page, which we were not currently doing. There is no error feedback if this fails (the error message service will come into play) but the publish button is disabled in this case

## Testing Instructions

 * Navigate to the project details page, click 'Publish' and ensure project name and id are being pulled into the modal template
* Navigate to the project edit page, do the same there

Connects #831
