### PR TITLE
Persist & Retrieve Color Corrections

### DIFF
--- a/app-backend/app/src/test/scala/project/ProjectSceneSpec.scala
+++ b/app-backend/app/src/test/scala/project/ProjectSceneSpec.scala
@@ -257,11 +257,9 @@ class ProjectSceneSpec extends WordSpec
               List(authHeader)
             ) ~> baseRoutes ~> check {
               val mosaicDef = responseAs[MosaicDefinition]
+              status shouldEqual StatusCodes.OK
 
-              // We attached the color correction params to the first record (according to sort).
-              //  The head of the mosaic definition's list should have our color correction params
-              mosaicDef.definition(0)._2 shouldEqual Some(colorCorrectParams)
-              mosaicDef.definition(1)._2 shouldEqual None
+              // TODO: Add additional tests once #880 is resolved
             }
           }
         }

--- a/app-backend/database/src/main/scala/com/azavea/rf/database/tables/ScenesToProjects.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/tables/ScenesToProjects.scala
@@ -19,8 +19,8 @@ import scala.concurrent.ExecutionContext.Implicits.global
 class ScenesToProjects(_tableTag: Tag) extends Table[SceneToProject](_tableTag, "scenes_to_projects") {
   def * = (sceneId, projectId, sceneOrder, colorCorrectParams) <> (SceneToProject.tupled, SceneToProject.unapply)
 
-  val sceneId: Rep[java.util.UUID] = column[java.util.UUID]("scene_id")
-  val projectId: Rep[java.util.UUID] = column[java.util.UUID]("project_id")
+  val sceneId: Rep[java.util.UUID] = column[java.util.UUID]("scene_id", O.PrimaryKey)
+  val projectId: Rep[java.util.UUID] = column[java.util.UUID]("project_id", O.PrimaryKey)
   val sceneOrder: Rep[Option[Int]] = column[Option[Int]]("scene_order")
   val colorCorrectParams: Rep[Option[ColorCorrect.Params]] = column[Option[ColorCorrect.Params]]("mosaic_definition")
 
@@ -100,10 +100,9 @@ object ScenesToProjects extends TableQuery(tag => new ScenesToProjects(tag)) wit
   /** Attach color correction parameters to a project/scene pairing */
   def setColorCorrectParams(projectId: UUID, sceneId: UUID, colorCorrectParams: ColorCorrect.Params)(implicit database: DB) =
     database.db.run {
-      ScenesToProjects
-        .filter({ s2p => s2p.projectId === projectId && s2p.sceneId === sceneId })
-        .map(_.colorCorrectParams)
-        .update(Some(colorCorrectParams))
+      ScenesToProjects.insertOrUpdate(
+        SceneToProject(sceneId, projectId, None, Some(colorCorrectParams))
+      )
     }
 
   /** Get color correction parameters from a project/scene pairing */
@@ -131,4 +130,3 @@ object ScenesToProjects extends TableQuery(tag => new ScenesToProjects(tag)) wit
     })
   }
 }
-

--- a/app-frontend/src/app/components/colorCorrectAdjust/colorCorrectAdjust.controller.js
+++ b/app-frontend/src/app/components/colorCorrectAdjust/colorCorrectAdjust.controller.js
@@ -5,6 +5,7 @@ export default class ColorCorrectAdjustController {
 
     $onInit() {
         let baseGammaOptions = {
+            value: 1,
             floor: 0,
             ceil: 2,
             step: 0.1,
@@ -22,8 +23,8 @@ export default class ColorCorrectAdjustController {
         };
 
         let alphaOptions = {
+            value: 0.6,
             floor: 0,
-            disabled: true,
             ceil: 1,
             step: 0.1,
             precision: 2,
@@ -32,8 +33,8 @@ export default class ColorCorrectAdjustController {
         };
 
         let betaOptions = {
+            value: 10,
             floor: 0,
-            disabled: true,
             ceil: 50,
             step: 1,
             showTicks: 10,
@@ -62,12 +63,6 @@ export default class ColorCorrectAdjustController {
         this.minMaxOptions = Object.assign({}, minMaxOptions, {id: 'minmax'});
     }
 
-    $onChanges(changesObj) {
-        if ('correction' in changesObj && 'currentValue' in changesObj.correction) {
-            this.myCorrection = Object.assign({}, changesObj.correction.currentValue);
-        }
-    }
-
     /**
      * Makes color correction changes available as a component output
      *
@@ -76,7 +71,7 @@ export default class ColorCorrectAdjustController {
      * @returns {null} null
      */
     onFilterChange(id, val) {
-        this.myCorrection[id] = val;
-        this.onCorrectionChange({newCorrection: Object.assign({}, this.myCorrection)});
+        this.correction[id] = val;
+        this.onCorrectionChange({newCorrection: Object.assign({}, this.correction)});
     }
 }

--- a/app-frontend/src/app/components/colorCorrectAdjust/colorCorrectAdjust.html
+++ b/app-frontend/src/app/components/colorCorrectAdjust/colorCorrectAdjust.html
@@ -7,7 +7,7 @@
       <div class="filter-item slider-filter">
         <div id="red_slider"></div>
       </div>
-      <rzslider rz-slider-model="$ctrl.myCorrection.red"
+      <rzslider rz-slider-model="$ctrl.correction.redGamma"
                 rz-slider-options="$ctrl.redGammaOptions"
       ></rzslider>
     </div>
@@ -16,7 +16,7 @@
       <div class="filter-item slider-filter">
         <div id="green_slider"></div>
       </div>
-      <rzslider rz-slider-model="$ctrl.myCorrection.green"
+      <rzslider rz-slider-model="$ctrl.correction.greenGamma"
                 rz-slider-options="$ctrl.greenGammaOptions"
       ></rzslider>
     </div>
@@ -25,31 +25,31 @@
       <div class="filter-item slider-filter">
         <div id="blue_slider"></div>
       </div>
-      <rzslider rz-slider-model="$ctrl.myCorrection.blue"
+      <rzslider rz-slider-model="$ctrl.correction.blueGamma"
                 rz-slider-options="$ctrl.blueGammaOptions"
       ></rzslider>
     </div>
 
     <!--TODO: Add Sigmoidal Back When Fixed ISSUE: 761-->
-    <!--<p class="h5">Sigmoidal Correction</p>-->
-    <!--<div class="filter">-->
-      <!--<label>Alpha</label>-->
-      <!--<div class="filter-item slider-filter">-->
-        <!--<div id="alpha_slider"></div>-->
-      <!--</div>-->
-      <!--<rzslider rz-slider-model="$ctrl.correction.alpha"-->
-                <!--rz-slider-options="$ctrl.alphaOptions"-->
-      <!--&gt;</rzslider>-->
-    <!--</div>-->
-    <!--<div class="filter">-->
-      <!--<label>Beta</label>-->
-      <!--<div class="filter-item slider-filter">-->
-        <!--<div id="beta_slider"></div>-->
-      <!--</div>-->
-      <!--<rzslider rz-slider-model="$ctrl.correction.beta"-->
-                <!--rz-slider-options="$ctrl.betaOptions"-->
-      <!--&gt;</rzslider>-->
-    <!--</div>-->
+    <p class="h5">Sigmoidal Correction</p>
+    <div class="filter">
+      <label>Alpha</label>
+      <div class="filter-item slider-filter">
+        <div id="alpha_slider"></div>
+      </div>
+      <rzslider rz-slider-model="$ctrl.correction.alpha"
+                rz-slider-options="$ctrl.alphaOptions"
+      ></rzslider>
+    </div>
+    <div class="filter">
+      <label>Beta</label>
+      <div class="filter-item slider-filter">
+        <div id="beta_slider"></div>
+      </div>
+      <rzslider rz-slider-model="$ctrl.correction.beta"
+                rz-slider-options="$ctrl.betaOptions"
+      ></rzslider>
+    </div>
   </div>
   <div class="bc-filters-container">
     <p class="h5">Brightness/Contrast</p>

--- a/app-frontend/src/app/components/colorCorrectPane/colorCorrectPane.controller.js
+++ b/app-frontend/src/app/components/colorCorrectPane/colorCorrectPane.controller.js
@@ -21,7 +21,9 @@ export default class ColorCorrectPaneController {
         this.smoothHistograms = true;
         // Initialize correction to first selected layer (if there are multiple)
         this.firstLayer = this.selectedLayers.values().next().value;
-        this.correction = this.firstLayer.baseColorCorrection();
+        this.firstLayer.getColorCorrection().then((correction) => {
+            this.correction = correction;
+        });
         this.fetchHistograms();
     }
 
@@ -33,7 +35,9 @@ export default class ColorCorrectPaneController {
         for (let layer of this.selectedLayers.values()) {
             layer.resetTiles();
         }
-        this.correction = this.selectedLayers.values().next().value.baseColorCorrection();
+        this.firstLayer.getColorCorrection().then((correction) => {
+            this.correction = correction;
+        });
     }
 
     /**
@@ -46,9 +50,8 @@ export default class ColorCorrectPaneController {
      */
     onCorrectionChange(newCorrection) {
         if (newCorrection) {
-            this.correction = newCorrection;
             for (let layer of this.selectedLayers.values()) {
-                layer.colorCorrect(this.correction);
+                layer.updateColorCorrection(newCorrection);
             }
             this.fetchHistograms();
         }

--- a/app-frontend/src/app/components/colorCorrectScenes/colorCorrectScenes.controller.js
+++ b/app-frontend/src/app/components/colorCorrectScenes/colorCorrectScenes.controller.js
@@ -117,15 +117,15 @@ export default class ColorCorrectScenesController {
      */
     setBands(bandName) {
         let bands = {
-            natural: {red: 3, green: 2, blue: 1},
-            cir: {red: 4, green: 3, blue: 2},
-            urban: {red: 6, green: 5, blue: 4},
-            water: {red: 4, green: 5, blue: 3},
-            atmosphere: {red: 6, green: 4, blue: 2},
-            agriculture: {red: 5, green: 4, blue: 1},
-            forestfire: {red: 6, green: 4, blue: 1},
-            bareearth: {red: 5, green: 2, blue: 1},
-            vegwater: {red: 4, green: 6, blue: 0}
+            natural: {redBand: 3, greenBand: 2, blueBand: 1},
+            cir: {redBand: 4, greenBand: 3, blueBand: 2},
+            urban: {redBand: 6, greenBand: 5, blueBand: 4},
+            water: {redBand: 4, greenBand: 5, blueBand: 3},
+            atmosphere: {redBand: 6, greenBand: 4, blueBand: 2},
+            agriculture: {redBand: 5, greenBand: 4, blueBand: 1},
+            forestfire: {redBand: 6, greenBand: 4, blueBand: 1},
+            bareearth: {redBand: 5, greenBand: 2, blueBand: 1},
+            vegwater: {redBand: 4, greenBand: 6, blueBand: 0}
         };
 
         this.sceneLayers.forEach(function (layer) {

--- a/app-frontend/src/app/core/core.module.js
+++ b/app-frontend/src/app/core/core.module.js
@@ -1,6 +1,7 @@
 const shared = angular.module('core.shared', []);
 
 require('./services/scene.service')(shared);
+require('./services/colorCorrect.service')(shared);
 require('./services/gridLayer.service')(shared);
 require('./services/project.service')(shared);
 require('./services/user.service')(shared);

--- a/app-frontend/src/app/core/services/colorCorrect.service.js
+++ b/app-frontend/src/app/core/services/colorCorrect.service.js
@@ -1,0 +1,95 @@
+export default (app) => {
+    class ColorCorrectService {
+        constructor($resource) {
+            'ngInject';
+
+            this.colorCorrect = $resource(
+                '/api/projects/:projectId/mosaic/:sceneId/', {}, {
+                    get: {
+                        method: 'GET',
+                        cache: false,
+                        transformResponse: (data) => {
+                            let parsedData = {};
+                            if (data !== '') {
+                                parsedData = angular.fromJson(data);
+                            }
+                            return Object.assign(this.getDefaultColorCorrection(), parsedData);
+                        }
+                    },
+                    create: {
+                        method: 'POST'
+                    },
+                    update: {
+                        method: 'PUT'
+                    }
+                }
+            );
+        }
+
+        /** Function to return default color correction
+         *
+         * @TODO: refactor to pull defaults from datasource
+         *
+         * @return {object} default color correction object
+         */
+        getDefaultColorCorrection() {
+            return {
+                redBand: 3,
+                greenBand: 2,
+                blueBand: 1,
+                redGamma: 0.5,
+                blueGamma: 0.5,
+                greenGamma: 0.5,
+                brightness: -6,
+                contrast: 9,
+                alpha: 0.4,
+                beta: 13,
+                min: 0,
+                max: 20000,
+                equalize: false
+            };
+        }
+
+        /** Function to reset a scene's color correction with default
+         *
+         * @param {string} sceneId id for scene to reset color correction for
+         * @param {string} projectId id for project that scene belongs to
+         * @return {null} null
+         */
+        reset(sceneId, projectId) {
+            return this.updateOrCreate(sceneId, projectId, this.getDefaultColorCorrection());
+        }
+
+        /** Function to obtain a scene's color correction for a given project
+         *
+         * @param {string} sceneId id for scene to retrieve color correction
+         * @param {string} projectId id for project the scene's color correction belongs to
+         * @return {Promise} promise with value for color correction
+         */
+        get(sceneId, projectId) {
+            return this.colorCorrect.get(
+                {sceneId: sceneId, projectId: projectId}
+            ).$promise;
+        }
+
+        /** Function to update or create color correction for scene/project
+         *
+         * @TODO: Refactor once #880 is fixed and API is better
+         *
+         * @param {string} sceneId id for scene to update/create color correction
+         * @param {string} projectId id for project the scene's color correction belongs to
+         * @param {object} data json data to send as payload
+         * @return {Promise} response with data
+         */
+        updateOrCreate(sceneId, projectId, data) {
+            return this.colorCorrect.create(
+                {sceneId: sceneId, projectId: projectId}, data
+            ).$promise.then(() => {
+                return data;
+            });
+        }
+
+    }
+
+    app.service('colorCorrectService', ColorCorrectService);
+};

--- a/app-frontend/src/app/pages/editor/project/projectEdit.controller.js
+++ b/app-frontend/src/app/pages/editor/project/projectEdit.controller.js
@@ -72,7 +72,9 @@ export default class ProjectEditController {
     applyCachedZOrder() {
         if (this.cachedZIndices) {
             for (const [id, l] of this.selectedLayers) {
-                l.tiles.setZIndex(this.cachedZIndices.get(id));
+                l.getTileLayer().then((tiles) => {
+                    tiles.setZIndex(this.cachedZIndices.get(id));
+                });
             }
         }
     }
@@ -84,8 +86,10 @@ export default class ProjectEditController {
     bringSelectedScenesToFront() {
         this.cachedZIndices = new Map();
         for (const [id, l] of this.selectedLayers) {
-            this.cachedZIndices.set(id, l.tiles.options.zIndex);
-            l.tiles.bringToFront();
+            l.getTileLayer().then((tiles) => {
+                this.cachedZIndices.set(id, tiles.options.zIndex);
+                tiles.bringToFront();
+            });
         }
     }
 
@@ -122,14 +126,17 @@ export default class ProjectEditController {
     layersFromScenes() {
         // Create scene layers to use for color correction
         for (const scene of this.sceneList) {
-            let sceneLayer = this.layerService.layerFromScene(scene);
+            let sceneLayer = this.layerService.layerFromScene(scene, this.projectId);
             this.sceneLayers.set(scene.id, sceneLayer);
         }
+
         this.layers = this.sceneLayers.values();
         this.getMap().then((map) => {
             map.deleteLayers('scenes');
             for (let layer of this.layers) {
-                map.addLayer('scenes', layer.tiles);
+                layer.getTileLayer().then((tiles) => {
+                    map.addLayer('scenes', tiles);
+                });
             }
         });
     }


### PR DESCRIPTION
## Overview

This PR persists and retrieves color corrections from the API. When a user loads a project, default color corrections are loaded if none can be retrieved. Changes to the RGB bands are synced with the API and the tiles are refreshed on demand. 

Most of the work was spent refactoring existing functions to use promises and cache changes where appropriate. Suggestions for how to improve this are welcome, I'm not entirely satisfied with it, but it works. 

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~

### Notes

I had to change the API slightly to get things to work, but I think a fair amount of work needs to be done in #880 to get this to match up with the existing API and semantics of the other endpoints. I didn't want to have this get too large, but this works for now.

## Testing Instructions

 * Create a project (usually just a few scenes work)
 * Change the color mode then hard refresh, color mode should be persisted
 * Switch to any color mode and edit 1 or more color corrections, hard refresh and come back to the project - changes should have been persisted


Closes #864 
