### PR TITLE
Project Mosaic Tiler

### DIFF
--- a/app-backend/app/build.sbt
+++ b/app-backend/app/build.sbt
@@ -15,6 +15,6 @@ initialCommands in console := """
   |val publicOrgId = UUID.fromString("dfac6307-b5ef-43f7-beda-b9f208bb7726")
   |import geotrellis.vector.{MultiPolygon, Polygon, Point, Geometry}
   |import geotrellis.slick.Projected
-  |object Main extends Config { implicit val database = new Database(jdbcUrl, dbUser, dbPassword)}
+  |object Main extends Config { implicit val database = Database.DEFAULT }
   |import Main._
 """.trim.stripMargin

--- a/app-backend/app/src/main/resources/application.conf
+++ b/app-backend/app/src/main/resources/application.conf
@@ -30,21 +30,6 @@ http {
   port = 9000
 }
 
-slick {
-  driver = "slick.driver.PostgresDriver$"
-  db {
-    driver = org.postgresql.Driver
-    url = "jdbc:postgresql://database.service.rasterfoundry.internal/"
-    url = ${?POSTGRES_URL}
-    name = "rasterfoundry"
-    name = ${?POSTGRES_NAME}
-    user = "rasterfoundry"
-    user = ${?POSTGRES_USER}
-    password = "rasterfoundry"
-    password = ${?POSTGRES_PASSWORD}
-  }
-}
-
 auth0 {
   clientId = ""
   clientId = ${?AUTH0_CLIENT_ID}

--- a/app-backend/app/src/main/scala/Main.scala
+++ b/app-backend/app/src/main/scala/Main.scala
@@ -21,7 +21,7 @@ object Main extends App with Config with Router with AkkaSystem.LoggerExecutor {
 
   import AkkaSystem._
 
-  implicit val database = new Database(jdbcUrl, dbUser, dbPassword)
+  implicit val database = Database.DEFAULT
 
   Http().bindAndHandle(routes, httpHost, httpPort)
 

--- a/app-backend/app/src/main/scala/utils/Config.scala
+++ b/app-backend/app/src/main/scala/utils/Config.scala
@@ -2,22 +2,14 @@ package com.azavea.rf.utils
 
 import com.typesafe.config.ConfigFactory
 
-
 trait Config {
   val config = ConfigFactory.load()
   private val httpConfig = config.getConfig("http")
-  private val databaseConfig = config.getConfig("slick.db")
   private val auth0Config = config.getConfig("auth0")
   private val featureFlagConfig = config.getConfig("featureFlags")
 
   val httpHost = httpConfig.getString("interface")
   val httpPort = httpConfig.getInt("port")
-
-  val jdbcNoDBUrl = databaseConfig.getString("url")
-  val jdbcDBName = databaseConfig.getString("name")
-  val jdbcUrl = jdbcNoDBUrl + jdbcDBName
-  val dbUser = databaseConfig.getString("user")
-  val dbPassword = databaseConfig.getString("password")
 
   val auth0Domain = auth0Config.getString("domain")
   val auth0Bearer = auth0Config.getString("bearer")

--- a/app-backend/app/src/test/scala/DBSpec.scala
+++ b/app-backend/app/src/test/scala/DBSpec.scala
@@ -1,7 +1,7 @@
 package com.azavea.rf
 
 import ammonite.ops._
-import com.azavea.rf.database.Database
+import com.azavea.rf.database.{ Database, Config => DatabaseConfig }
 import org.scalatest._
 
 import com.azavea.rf.utils._
@@ -13,7 +13,7 @@ import com.azavea.rf.utils._
   * Extend each Spec class that accesses the database with this trait in
   * order to make use of this behavior.
   */
-trait DBSpec extends Suite with BeforeAndAfterAll with Config {
+trait DBSpec extends Suite with BeforeAndAfterAll with DatabaseConfig {
   // This triggers the one-time-only DB setup task for initializing the the test template DB
   InitializeDB
   private val driver = "org.postgresql.Driver"
@@ -50,7 +50,7 @@ trait DBSpec extends Suite with BeforeAndAfterAll with Config {
   * This object is referenced at the head of `DBSpec` - its purpose is to carry out
   *  any one-time-only setup required for DBSpec tests.
   */
-object InitializeDB extends Config {
+object InitializeDB extends DatabaseConfig {
   // Working directory, needed for running %sbt commands
   implicit val wd = cwd
 

--- a/app-backend/app/src/test/scala/utils/PGUtilsSpec.scala
+++ b/app-backend/app/src/test/scala/utils/PGUtilsSpec.scala
@@ -14,7 +14,6 @@ import com.azavea.rf._
 final class PGUtilsSpec extends WordSpec
     with Matchers
     with ScalatestRouteTest
-    with Config
     with Router
     with DBSpec {
 

--- a/app-backend/build.sbt
+++ b/app-backend/build.sbt
@@ -138,6 +138,7 @@ lazy val ingest = Project("ingest", file("ingest"))
 
 lazy val tile = Project("tile", file("tile"))
   .dependsOn(datamodel)
+  .dependsOn(database)
   .settings(commonSettings:_*)
   .settings(assemblyJarName in assembly := "rf-tile-server.jar")
   .settings(resolvers += Resolver.bintrayRepo("azavea", "geotrellis"))

--- a/app-backend/database/src/main/resources/reference.conf
+++ b/app-backend/database/src/main/resources/reference.conf
@@ -1,0 +1,14 @@
+slick {
+  driver = "slick.driver.PostgresDriver$"
+  db {
+    driver = org.postgresql.Driver
+    url = "jdbc:postgresql://database.service.rasterfoundry.internal/"
+    url = ${?POSTGRES_URL}
+    name = "rasterfoundry"
+    name = ${?POSTGRES_NAME}
+    user = "rasterfoundry"
+    user = ${?POSTGRES_USER}
+    password = "rasterfoundry"
+    password = ${?POSTGRES_PASSWORD}
+  }
+}

--- a/app-backend/database/src/main/scala/com/azavea/rf/database/Config.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/Config.scala
@@ -1,0 +1,13 @@
+package com.azavea.rf.database
+
+import com.typesafe.config.ConfigFactory
+
+trait Config {
+  val config = ConfigFactory.load()
+  private val databaseConfig = config.getConfig("slick.db")
+  val jdbcNoDBUrl = databaseConfig.getString("url")
+  val jdbcDBName = databaseConfig.getString("name")
+  val jdbcUrl = jdbcNoDBUrl + jdbcDBName
+  val dbUser = databaseConfig.getString("user")
+  val dbPassword = databaseConfig.getString("password")
+}

--- a/app-backend/database/src/main/scala/com/azavea/rf/database/Config.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/Config.scala
@@ -3,7 +3,7 @@ package com.azavea.rf.database
 import com.typesafe.config.ConfigFactory
 
 trait Config {
-  val config = ConfigFactory.load()
+  private val config = ConfigFactory.load()
   private val databaseConfig = config.getConfig("slick.db")
   val jdbcNoDBUrl = databaseConfig.getString("url")
   val jdbcDBName = databaseConfig.getString("name")

--- a/app-backend/database/src/main/scala/com/azavea/rf/database/Database.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/Database.scala
@@ -27,7 +27,7 @@ class Database(jdbcUrl: String, dbUser: String, dbPassword: String) {
   /**
     * Utility function for closing the underlying DB connection pool
     */
-  def closeConnectionPool() = dataSource.close
+  def closeConnectionPool() = dataSource.close()
 
   // Custom driver to handle postgres column types
   val driver = ExtendedPostgresDriver
@@ -35,6 +35,10 @@ class Database(jdbcUrl: String, dbUser: String, dbPassword: String) {
 
   val db = {
     val executor = AsyncExecutor("slick", numThreads=64, queueSize=1000)
-    Database.forDataSource(dataSource, executor)
+    driver.api.Database.forDataSource(dataSource, executor)
   }
+}
+
+object Database extends Config {
+  def DEFAULT = new Database(jdbcUrl, dbUser, dbPassword)
 }

--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/ColorCorrect.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/ColorCorrect.scala
@@ -22,6 +22,11 @@ object ColorCorrect {
   ) {
     def reorderBands(tile: MultibandTile, hist: Seq[Histogram[Double]]): (MultibandTile, Array[Histogram[Double]]) =
       (tile.subsetBands(redBand, greenBand, blueBand), Array(hist(redBand), hist(greenBand), hist(blueBand)))
+
+    def colorCorrect(tile: MultibandTile, hist: Seq[Histogram[Double]]): MultibandTile = {
+      val (rgbTile, rgbHist) = reorderBands(tile, hist)
+      ColorCorrect(rgbTile, rgbHist, this)
+    }
   }
 
   object Params {

--- a/app-backend/migrations/src/main/resources/application.conf
+++ b/app-backend/migrations/src/main/resources/application.conf
@@ -2,5 +2,5 @@ migrations {
   unhandled_location = "./migrations/src_migrations/main/scala"
   handled_location = "./migrations/src/main/scala/migrations"
   migration_object = "RFMigrations"
-  include file("./app/src/main/resources/application.conf")
+  include file("./database/src/main/resources/reference.conf")
 }

--- a/app-backend/tile/src/main/scala/Main.scala
+++ b/app-backend/tile/src/main/scala/Main.scala
@@ -1,12 +1,14 @@
 package com.azavea.rf.tile
 
+import com.azavea.rf.database.Database
+
 import akka.actor.ActorSystem
 import akka.event.Logging
 import akka.http.scaladsl.Http
 import akka.stream.ActorMaterializer
 import akka.http.scaladsl.server._
 import akka.http.scaladsl.server.Directives._
-import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.model.{HttpResponse, StatusCodes}
 import geotrellis.spark.io._
 
 object AkkaSystem {
@@ -21,7 +23,9 @@ object AkkaSystem {
 object Main extends App with Config with AkkaSystem.LoggerExecutor {
   import AkkaSystem._
 
-  def exceptionHandler  =
+  val database = Database.DEFAULT
+
+  def exceptionHandler =
     ExceptionHandler {
       case e: TileNotFoundError =>
         complete(StatusCodes.NotFound)
@@ -32,7 +36,19 @@ object Main extends App with Config with AkkaSystem.LoggerExecutor {
     }
 
   def rootRoute = handleExceptions(exceptionHandler) {
-    pathPrefix("tiles") { Routes.singleLayer ~ Routes.mosaicLayer }
+    pathPrefix("tiles") {
+      Routes.singleLayer ~ pathPrefix("healthcheck") {
+        pathEndOrSingleSlash {
+          get {
+            complete {
+              HttpResponse(StatusCodes.OK)
+            }
+          }
+        }
+      } ~
+      Routes.singleLayer ~
+      Routes.mosaicProject(database)
+    }
   }
 
   Http().bindAndHandle(rootRoute, httpHost, httpPort)

--- a/app-backend/tile/src/main/scala/Routes.scala
+++ b/app-backend/tile/src/main/scala/Routes.scala
@@ -1,5 +1,6 @@
 package com.azavea.rf.tile
 
+import com.azavea.rf.database.Database
 import com.azavea.rf.tile.image._
 import com.azavea.rf.tile.tool._
 import com.azavea.rf.tile.tool.ToolParams._
@@ -151,16 +152,13 @@ trait Routes extends LazyLogging {
     }
   }
 
-  def mosaicLayer: Route =
-    pathPrefix(JavaUUID / Segment / "mosaic" / IntNumber / IntNumber / IntNumber) { (orgId, userId, zoom, x, y) =>
-      colorCorrectParams { params =>
-        parameters('scene.*) { scenes =>
-          get {
-            complete {
-              val ids = scenes.map(id => RfLayerId(orgId, userId, UUID.fromString(id)))
-              Mosaic(params, ids, zoom, x, y).map { maybeTile =>
-                maybeTile.map { tile => pngAsHttpResponse(tile.renderPng())}
-              }
+  def mosaicProject(implicit db: Database): Route =
+    pathPrefix(JavaUUID / Segment / "project" / JavaUUID/ IntNumber / IntNumber / IntNumber) { (orgId, userId, projectId, zoom, x, y) =>
+      parameter("tag".?) { tag =>
+        get {
+          complete {
+            Mosaic(orgId, userId, projectId, zoom, x, y, tag).map { maybeTile =>
+              maybeTile.map { tile => pngAsHttpResponse(tile.renderPng()) }
             }
           }
         }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,6 +63,7 @@ services:
   tile-server:
     image: quay.io/azavea/scala:2.11.8
     links:
+      - postgres:database.service.rasterfoundry.internal
       - memcached:tile-cache.service.rasterfoundry.internal
     env_file: .env
     ports:


### PR DESCRIPTION
## Overview

Replaces the prototype multi-layer tiler with project mosaic tiler that pulls the `MosaicDefinition` from the DB.

Because database configurations are now used by `tiler` and `app` projects the slick related configurations have been moved to `database` project and one may now get a database instance using `Database.DEFAULT`.

Since we need to hit the DB, which is a semi-precious resource we must cache `ProjectId => MosaicDefinition` lookups, but they also may change rapidly based on user input. To handle this there is an optional `tag` URL parameter to mosaic endpoint that will be included in the cache lookup. This `tag` should be changed after the UI changes and the database is updated to force a cache refresh. Having some mechanism to trigger this refresh allows the cache to stay live for relatively long 5 minutes, covering multiple map refreshes.

If the `tag` parameter is not provided we default to quick cache expiry of 5 seconds. Alternative would be to be punitive and impose a long cache expiry time.

### Demo
![image](https://cloud.githubusercontent.com/assets/1158084/21700555/084ccc9a-d36f-11e6-98a6-414aca15928b.png)

URL: `http://localhost:9900/tiles/dfac6307-b5ef-43f7-beda-b9f208bb7726/rf_airflow-user/project/5df9baab-9b52-4c07-b721-8963ecc3a76c/6/38/26`
Template: `/tiles/{orgId}/{userId}/project/{projectId}/{z}/{x}/{y}`

Connects https://github.com/azavea/raster-foundry/issues/703
