### PR TITLE
Replace union with or filter for user visibility

### DIFF
--- a/app-backend/database/src/main/scala/com/azavea/rf/database/fields/UserFkFields.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/fields/UserFkFields.scala
@@ -3,7 +3,7 @@ package com.azavea.rf.database.fields
 import com.azavea.rf.database.ExtendedPostgresDriver.api._
 import com.azavea.rf.database.query.UserQueryParameters
 import com.azavea.rf.database.tables.Users
-import com.azavea.rf.datamodel.User
+import com.azavea.rf.datamodel.{User, Visibility}
 import slick.lifted.ForeignKeyQuery
 
 trait UserFkFields { self: Table[_] =>

--- a/app-backend/database/src/main/scala/com/azavea/rf/database/fields/UserFkVisibleFields.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/fields/UserFkVisibleFields.scala
@@ -1,0 +1,21 @@
+package com.azavea.rf.database.fields
+
+import com.azavea.rf.database.ExtendedPostgresDriver.api._
+import com.azavea.rf.database.query.UserQueryParameters
+import com.azavea.rf.database.tables.Users
+import com.azavea.rf.datamodel.{User, Visibility}
+import slick.lifted.ForeignKeyQuery
+
+
+trait UserFkVisibileFields extends UserFkFields with VisibilityField { self: Table[_] => }
+
+object UserFkVisibileFields {
+  implicit class DefaultQuery[M <: UserFkVisibileFields, U, C[_]](that: Query[M, U, Seq]) {
+    def filterUserVisibility(user: User) = {
+      that.filter { rec => {
+        rec.visibility === Visibility.fromString("PUBLIC") || rec.createdBy === user.id
+      }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Overview

This commit replaces the previous implementation of using a union of two
select statements with a filter that uses an OR condition to filter
records according to if the record is labeled as `PUBLIC` or is created by
the user making the API request.

A new trait is added that combines the user foreign key trait with the visibility one that
can be used for tables that have both a visibility field and foreign key for users.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~

### Demo
Using the following request:
```
time curl 'http://localhost:9091/api/scenes?bbox=-127.26562500000001,-46.195042108660154,37.35351562500001,61.56457388515458&maxCloudCover=10&maxCreateDatetime=2017-01-06T03:57:28.361Z&minCloudCover=0&pageSize=20&sort=createdAt,desc' -H 'Authorization: Bearer <TOKEN>' --compressed > /dev/null
```

Timing on develop:
```
real    0m4.402s
user    0m0.008s
sys     0m0.004s
```
Request timing on this branch:
```
real    0m0.479s
user    0m0.004s
sys     0m0.000s
```

### Notes

In conjunction with this PR I have updated the database dump in S3 that gets loaded when `./scripts/load_development_data` is run. This dump has 100K+ scenes and is about 200 mb. It should be a more realistic development experience without being unnecessarily large. Additionally, it should prevent requiring running background task to seed the database.

## Testing Instructions

 * Run `./scripts/load_development_data`
 * Start development server and frontend
 * Load application and observe load times for sidebar. It will initially seem a little slow, but that's because the browser is limiting the number of requests to localhost and the scene grid is making many requests. This will not be a problem when it is deployed because of `http/2`.
 * Slide map to left or right once everything loads - this is a more realistic assessment of load times.
 * Browse to projects page to verify only projects created by your user are loaded (will be none unless you have loaded projects). 

Closes #873 
