### PR TITLE
Add grid filter to scene browse

### DIFF
--- a/app-backend/app/src/test/scala/scene/SceneSpec.scala
+++ b/app-backend/app/src/test/scala/scene/SceneSpec.scala
@@ -224,7 +224,7 @@ class SceneSpec extends WordSpec
         val res = responseAs[PaginatedResponse[Scene.WithRelated]]
         res.count shouldEqual 1
       }
-      Get("/api/scenes/?bbox=0,0,0.001,0.001;1000.001,1000.001,1000,1000").withHeaders(
+      Get("/api/scenes/?bbox=0,0,0.001,0.001;1,1,1.001,1.001").withHeaders(
         List(authHeader)
       ) ~> baseRoutes ~> check {
         val res = responseAs[PaginatedResponse[Scene.WithRelated]]

--- a/app-backend/app/src/test/scala/scene/SceneSpec.scala
+++ b/app-backend/app/src/test/scala/scene/SceneSpec.scala
@@ -218,6 +218,12 @@ class SceneSpec extends WordSpec
         val res = responseAs[PaginatedResponse[Scene.WithRelated]]
         res.count shouldEqual 1
       }
+      Get("/api/scenes/?bbox=0,0,0.00001,0.00001;0,0,0.001,0.001").withHeaders(
+        List(authHeader)
+      ) ~> baseRoutes ~> check {
+        val res = responseAs[PaginatedResponse[Scene.WithRelated]]
+        res.count shouldEqual 1
+      }
     }
 
     "filter scenes by point" in {

--- a/app-backend/app/src/test/scala/scene/SceneSpec.scala
+++ b/app-backend/app/src/test/scala/scene/SceneSpec.scala
@@ -224,6 +224,12 @@ class SceneSpec extends WordSpec
         val res = responseAs[PaginatedResponse[Scene.WithRelated]]
         res.count shouldEqual 1
       }
+      Get("/api/scenes/?bbox=0,0,0.001,0.001;1000.001,1000.001,1000,1000").withHeaders(
+        List(authHeader)
+      ) ~> baseRoutes ~> check {
+        val res = responseAs[PaginatedResponse[Scene.WithRelated]]
+        res.count shouldEqual 1
+      }
     }
 
     "filter scenes by point" in {

--- a/app-backend/database/src/main/scala/com/azavea/rf/database/QueryParameters.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/QueryParameters.scala
@@ -46,12 +46,17 @@ case class SceneQueryParameters(
   point: Option[String] = None,
   project: Option[UUID] = None
 ) {
-  val bboxPolygon: Option[Projected[Polygon]] = try {
-    bbox
-      .map(Extent.fromString)
-      .map(_.toPolygon)
-      .map(Projected(_, 4326))
-      .map(_.reproject(LatLng, WebMercator)(3857))
+  val bboxPolygon: Option[Seq[Projected[Polygon]]] = try {
+    bbox match {
+      case Some(b) => Option[Seq[Projected[Polygon]]](
+        b.split(";")
+        .map(Extent.fromString)
+        .map(_.toPolygon)
+        .map(Projected(_, 4326))
+        .map(_.reproject(LatLng, WebMercator)(3857))
+      )
+      case _ => None
+    }
   } catch {
     case e: Exception => throw new IllegalArgumentException(
       "Four comma separated coordinates must be given for bbox"

--- a/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Scenes.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Scenes.scala
@@ -322,7 +322,6 @@ class ScenesTableQuery[M, U, C[_]](scenes: Scenes.TableQuery) extends LazyLoggin
         sceneParams.maxSunAzimuth.map(scene.sunAzimuth < _),
         sceneParams.minSunElevation.map(scene.sunElevation > _),
         sceneParams.maxSunElevation.map(scene.sunElevation < _),
-        sceneParams.bboxPolygon.map(scene.dataFootprint.intersects(_)),
         sceneParams.pointGeom.map(scene.dataFootprint.intersects(_))
       )
       sceneFilterConditions
@@ -339,6 +338,13 @@ class ScenesTableQuery[M, U, C[_]](scenes: Scenes.TableQuery) extends LazyLoggin
         .map(scene.datasource === _)
         .reduceLeftOption(_ || _)
         .getOrElse(true: Rep[Boolean])
+    }.filter { scene =>
+      sceneParams.bboxPolygon match {
+        case Some(b) => b.map(scene.dataFootprint.intersects(_))
+          .reduceLeftOption(_ || _)
+          .getOrElse(Some(true): Rep[Option[Boolean]])
+        case _ => Some(true): Rep[Option[Boolean]]
+      }
     }
 
     sceneParams.project match {

--- a/app-frontend/src/app/core/services/gridLayer.service.js
+++ b/app-frontend/src/app/core/services/gridLayer.service.js
@@ -1,7 +1,6 @@
 import Konva from 'konva';
-
+/* eslint no-underscore-dangle: "off" */
 export default (app) => {
-
     /** Service to create a Leaflet grid layer for scenes
      */
     class GridLayerService {
@@ -67,6 +66,46 @@ export default (app) => {
                         return 'rgba(53,60,88,.60)';
                     }
                     return 'rgba(53,60,88,.70)';
+                },
+
+                /** Function to retrieve bounds of a specific sub-tile of a tile
+                 *
+                 * @param {L.Point} coords xyz coords of parent tile
+                 * @param {number} rectIndex integer subtile index
+                 * @returns {L.LatLngBounds} Bounds of specified sub-tile
+                 */
+                getRectBounds: function (coords, rectIndex) {
+                    // eslint-disable-next-line no-underscore-dangle
+                    switch (rectIndex) {
+                    case 0:
+                        let subCoords0 = new L.Point(coords.x * 2, coords.y * 2);
+                        subCoords0.z = coords.z + 1;
+                        return this._tileCoordsToBounds(subCoords0);
+                    case 1:
+                        let subCoords1 = new L.Point(coords.x * 2 + 1, coords.y * 2);
+                        subCoords1.z = coords.z + 1;
+                        return this._tileCoordsToBounds(subCoords1);
+                    case 2:
+                        let subCoords2 = new L.Point(coords.x * 2 + 1, coords.y * 2 + 1);
+                        subCoords2.z = coords.z + 1;
+                        return this._tileCoordsToBounds(subCoords2);
+                    case 3:
+                        let subCoords3 = new L.Point(coords.x * 2, coords.y * 2 + 1);
+                        subCoords3.z = coords.z + 1;
+                        return this._tileCoordsToBounds(subCoords3);
+                    default:
+                        return null;
+                    }
+                },
+
+                /** Callback function that will return bounds of a clicked sub-tile
+                 *  Intended to be re-implmented by consumer
+                 *
+                 * @param {L.LatLngBounds} bounds bounds passed in by click sub-tile
+                 * @return {L.LatLngBounds} passed bounds
+                 */
+                onClick: function (bounds) {
+                    return bounds;
                 },
 
                 /** Function used to create tile for custom grid layer
@@ -139,6 +178,10 @@ export default (app) => {
 
                     this.requestGrid(coords, this.params).then((result) => {
                         let data = result.data;
+                        topLeft.on('click', (e) => {
+                            const bounds = this.getRectBounds(coords, 0);
+                            this.onClick(e, bounds);
+                        });
                         topLeft.on('mouseover', function () {
                             writeMessage(data[0], 64, 64);
                         });
@@ -147,6 +190,10 @@ export default (app) => {
                         });
                         topLeft.fill(this.getColor(data[0]));
 
+                        topRight.on('click', (e) => {
+                            const bounds = this.getRectBounds(coords, 1);
+                            this.onClick(e, bounds);
+                        });
                         topRight.on('mouseover', function () {
                             writeMessage(data[1], 192, 64);
                         });
@@ -155,6 +202,10 @@ export default (app) => {
                         });
                         topRight.fill(this.getColor(data[1]));
 
+                        bottomLeft.on('click', (e) => {
+                            const bounds = this.getRectBounds(coords, 3);
+                            this.onClick(e, bounds);
+                        });
                         bottomLeft.on('mouseover', function () {
                             writeMessage(data[3], 64, 192);
                         });
@@ -163,6 +214,10 @@ export default (app) => {
                         });
                         bottomLeft.fill(this.getColor(data[3]));
 
+                        bottomRight.on('click', (e) => {
+                            const bounds = this.getRectBounds(coords, 2);
+                            this.onClick(e, bounds);
+                        });
                         bottomRight.on('mouseover', function () {
                             writeMessage(data[2], 192, 192);
                         });

--- a/docs/swagger/spec.yml
+++ b/docs/swagger/spec.yml
@@ -1205,7 +1205,7 @@ parameters:
     required: true
   bbox:
     name: bbox
-    description: Bounding box. eg "bbox=southwest_lng,southwest_lat,northeast_lng,northeast_lat"
+    description: Bounding box. eg "bbox=southwest_lng,southwest_lat,northeast_lng,northeast_lat". Delimit multiple with semicolon.
     in: query
     type: string
     required: false


### PR DESCRIPTION
## Overview
This adds a click interaction to the scene grid cells. When the user clicks an unselected grid cell, it is selected asthe active bbox filter. If the user holds `ctrl`, multiple grid cells can be selected.
### Checklist

- [x] Swagger specification updated, if necessary

### Demo

<img width="1280" alt="screen shot 2017-01-06 at 11 53 22 am" src="https://cloud.githubusercontent.com/assets/2442245/21726251/f323d930-d409-11e6-962d-fb9076be281e.png">

<img width="1280" alt="screen shot 2017-01-06 at 11 53 46 am" src="https://cloud.githubusercontent.com/assets/2442245/21726254/f7c2ab56-d409-11e6-8b87-6955e5f69650.png">

### Notes

We are beginning to have many use-cases for drawing polygons on the map. It may be time to start changing their color from the default leaflet blue into more meaningful colors depending on the context.

## Testing Instructions

 * Go the to scene browse page
 * Click a scene grid cell and see that the scene list is updated
 * Hold `ctrl` and click another cell, see that both cells are now selected and that the scene list is refetched. Repeat a few times.
 * While still holding `ctrl`, click an already selected cell, see that it is deselected while maintaining the other selections and that the scene list is update
 * Release `ctrl` and see that clicking one of any selected cells now deselects all cells and that the scene list is updated
* Try some combinations of this while zooming in and out and see that interactions are intuitive

Connects #872
