### PR TITLE
Add light vs dark basemap control to map

### DIFF
--- a/app-frontend/src/app/components/mapContainer/mapContainer.controller.js
+++ b/app-frontend/src/app/components/mapContainer/mapContainer.controller.js
@@ -43,15 +43,6 @@ export default class MapContainerController {
         );
 
 
-        let cartoPositron = L.tileLayer(
-            'https://cartodb-basemaps-{s}.global.ssl.fastly.net/light_all/{z}/{x}/{y}.png', {
-                attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">' +
-                    'OpenStreetMap</a> &copy;<a href="http://cartodb.com/attributions">CartoDB</a>',
-                maxZoom: 19
-            }
-        );
-        cartoPositron.addTo(this.map);
-
         this.$timeout(() => {
             this.map.invalidateSize();
             this.mapService.registerMap(this.map, this.mapId, this.options);

--- a/app-frontend/src/app/core/services/map.service.js
+++ b/app-frontend/src/app/core/services/map.service.js
@@ -64,14 +64,19 @@ class MapWrapper {
                 option.enable();
             });
 
+            // Add zoom control to map's controls
             let zoomControl = L.control.zoom({position: 'topright'});
             this._controls.addTo(this.map);
-            let baseMapControl = L.control.layers({
+            // Add basemap controls to map's controls
+            let baseMaps = {
                 Light: this.getBaseMapLayer('light_all'),
                 Dark: this.getBaseMapLayer('dark_all')
-            }, {});
+            };
+            baseMaps.Light.addTo(this.map);
+            let baseMapControl = L.control.layers(baseMaps, {});
             baseMapControl.addTo(this.map);
             zoomControl.addTo(this.map);
+
             let mapContainer = $(this.map._container); // eslint-disable-line no-underscore-dangle
             let $zoom = mapContainer.find('.leaflet-control-zoom');
             let $mpc = mapContainer.find('.map-control-panel');

--- a/app-frontend/src/app/core/services/map.service.js
+++ b/app-frontend/src/app/core/services/map.service.js
@@ -35,6 +35,16 @@ class MapWrapper {
         this.changeOptions(options);
     }
 
+    getBaseMapLayer(layerName) {
+        let url = `https://cartodb-basemaps-{s}.global.ssl.fastly.net/${layerName}/{z}/{x}/{y}.png`;
+        let properties = {
+            attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">' +
+                'OpenStreetMap</a> &copy;<a href="http://cartodb.com/attributions">CartoDB</a>',
+            maxZoom: 19
+        };
+        return L.tileLayer(url, properties);
+    }
+
     changeOptions(options) {
         let mapInteractionOptions = [
             this.map.scrollWheelZoom,
@@ -54,9 +64,14 @@ class MapWrapper {
                 option.enable();
             });
 
-            let zoom = L.control.zoom({position: 'topright'});
+            let zoomControl = L.control.zoom({position: 'topright'});
             this._controls.addTo(this.map);
-            zoom.addTo(this.map);
+            let baseMapControl = L.control.layers({
+                Light: this.getBaseMapLayer('light_all'),
+                Dark: this.getBaseMapLayer('dark_all')
+            }, {});
+            baseMapControl.addTo(this.map);
+            zoomControl.addTo(this.map);
             let mapContainer = $(this.map._container); // eslint-disable-line no-underscore-dangle
             let $zoom = mapContainer.find('.leaflet-control-zoom');
             let $mpc = mapContainer.find('.map-control-panel');

--- a/app-frontend/src/app/pages/browse/browse.controller.js
+++ b/app-frontend/src/app/pages/browse/browse.controller.js
@@ -34,7 +34,8 @@ export default class BrowseController {
         });
 
         this.gridLayer = gridLayerService.createNewGridLayer(this.queryParams);
-
+        // 100 is just a placeholder "big" number to leave plenty of space for basemaps
+        this.gridLayer.setZIndex(100);
 
         if ($state.params.id) {
             this.sceneService.query({id: $state.params.id}).then(


### PR DESCRIPTION
## Overview

Per #824, we need the option for dark basemaps so users with light image overlays can have nice looking labels

### Checklist

- ~[ ] Styleguide updated, if necessary~
- ~[ ] Swagger specification updated, if necessary~

### Demo

![optimised5](https://cloud.githubusercontent.com/assets/5702984/21730444/c389f538-d41d-11e6-86e8-31a283f9ecbc.gif)

### Notes

This doesn't do anything to style the control. I'm assuming @designmatty will work his magic on the basemap controls similar to what he did with the zoom controls, since this was added in the same pattern.

Also it turned out this is pretty easy, but that we've implemented a custom version in other places for style purposes.

## Testing Instructions

 * Bring up your front- and backends
 * Switch basemaps a few times
 * Add some scenes to the map and switch basemaps a few more times

Connects #824 