### PR TITLE
Exclude transitive postgresql dependency

### DIFF
--- a/app-backend/build.sbt
+++ b/app-backend/build.sbt
@@ -56,6 +56,7 @@ lazy val slickDependencies = List(
   Dependencies.slickPG,
   Dependencies.slickPGSpray,
   Dependencies.geotrellisSlick
+    .exclude("postgresql", "postgresql")
 )
 
 lazy val dbDependencies = List(


### PR DESCRIPTION
## Overview

GeoTrellis includes an old version of postgresql for its slick
extensions. Raster Foundry uses a newer version and when the two are
combined an assembly fails due to conflicts.

I favored this over a merge strategy solution because it allows ensuring
a more specific exclusion.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~

### Notes


## Testing Instructions

 * Enter an `sbt` shell (`./scripts/console app-server bash`) and run assembly
