### PR TITLE
Add project select modal to editor

### DIFF
--- a/app-frontend/src/app/components/navBar/navBar.html
+++ b/app-frontend/src/app/components/navBar/navBar.html
@@ -7,7 +7,7 @@
     <span class="navbar-vertical-divider"></span>
     <nav>
       <a href ui-sref="browse" ui-sref-active="active">Scene browser</a>
-      <a href ui-sref="editor"
+      <a href ui-sref="editor.project.color.scenes"
          ng-class="{
                    active: $ctrl.$state.$current.name.includes('editor')
                    }">Editor</a>

--- a/app-frontend/src/app/components/selectProjectModal/selectProjectModal.component.js
+++ b/app-frontend/src/app/components/selectProjectModal/selectProjectModal.component.js
@@ -1,0 +1,15 @@
+// Component code
+import selectProjectModalTpl from './selectProjectModal.html';
+
+const SelectProjectModalComponent = {
+    templateUrl: selectProjectModalTpl,
+    bindings: {
+        close: '&',
+        dismiss: '&',
+        modalInstance: '<',
+        resolve: '<'
+    },
+    controller: 'SelectProjectModalController'
+};
+
+export default SelectProjectModalComponent;

--- a/app-frontend/src/app/components/selectProjectModal/selectProjectModal.controller.js
+++ b/app-frontend/src/app/components/selectProjectModal/selectProjectModal.controller.js
@@ -1,0 +1,40 @@
+export default class SelectProjectModalController {
+    constructor($log, $state, projectService) {
+        'ngInject';
+        this.$state = $state;
+        this.projectService = projectService;
+        this.populateProjectList(1);
+    }
+
+    populateProjectList(page) {
+        if (this.loading) {
+            return;
+        }
+        delete this.errorMsg;
+        this.loading = true;
+        this.projectService.query(
+            {
+                sort: 'createdAt,desc',
+                pageSize: 5,
+                page: page - 1
+            }
+        ).then((projectResult) => {
+            this.lastProjectResult = projectResult;
+            this.numPaginationButtons = 6 - projectResult.page % 5;
+            if (this.numPaginationButtons < 3) {
+                this.numPaginationButtons = 3;
+            }
+            this.currentPage = projectResult.page + 1;
+            this.projectList = this.lastProjectResult.results;
+            this.loading = false;
+        }, () => {
+            this.errorMsg = 'Server error.';
+            this.loading = false;
+        });
+    }
+
+    setSelected(project) {
+        this.dismiss();
+        this.$state.go(this.$state.current, {projectid: project.id});
+    }
+}

--- a/app-frontend/src/app/components/selectProjectModal/selectProjectModal.html
+++ b/app-frontend/src/app/components/selectProjectModal/selectProjectModal.html
@@ -1,0 +1,41 @@
+<div class="modal-header">
+  <span class="badge"><i class="icon-bucket"></i></span>
+  <h4 class="modal-title">
+    Select a Project to Edit
+  </h4>
+</div>
+<div class="modal-body">
+  <div class="list-group">
+    <rf-project-item
+        project="project"
+        selectable
+        selected="false"
+        on-select="$ctrl.setSelected(project)"
+        ng-repeat="project in $ctrl.projectList track by project.id">
+    </rf-project-item>
+  </div>
+  <div class="list-group" ng-show="$ctrl.loading">
+    <span class="list-placeholder">
+      <i class="icon-load"></i>
+    </span>
+  </div>
+  <div ng-if="!$ctrl.loading && $ctrl.lastProjectResult && $ctrl.lastProjectResult.count === 0"
+        class="list-group">
+    <span class="list-placeholder">
+      You have not created any Projects.
+    </span>
+  </div>
+  <div class="list-group text-center"
+        ng-show="!$ctrl.loading && $ctrl.lastProjectResult && $ctrl.lastProjectResult.count > $ctrl.lastProjectResult.pageSize && !$ctrl.errorMsg">
+    <ul uib-pagination
+        items-per-page="$ctrl.lastProjectResult.pageSize"
+        total-items="$ctrl.lastProjectResult.count"
+        ng-model="$ctrl.currentPage"
+        max-size="4"
+        rotate="true"
+        boundary-link-numbers="true"
+        force-ellipses="true"
+        ng-change="$ctrl.populateProjectList($ctrl.currentPage)">
+    </ul>
+  </div>
+</div>

--- a/app-frontend/src/app/components/selectProjectModal/selectProjectModal.module.js
+++ b/app-frontend/src/app/components/selectProjectModal/selectProjectModal.module.js
@@ -1,0 +1,15 @@
+import angular from 'angular';
+import SelectProjectModalComponent from './selectProjectModal.component.js';
+import SelectProjectModalController from './selectProjectModal.controller.js';
+require('../../../assets/font/fontello/css/fontello.css');
+
+const SelectProjectModalModule = angular.module('components.selectProjectModal', []);
+
+SelectProjectModalModule.controller(
+    'SelectProjectModalController', SelectProjectModalController
+);
+SelectProjectModalModule.component(
+    'rfSelectProjectModal', SelectProjectModalComponent
+);
+
+export default SelectProjectModalModule;

--- a/app-frontend/src/app/index.components.js
+++ b/app-frontend/src/app/index.components.js
@@ -22,5 +22,6 @@ export default angular.module('index.components', [
     require('./components/projectAddModal/projectAddModal.module.js').name,
     require('./components/refreshTokenModal/refreshTokenModal.module.js').name,
     require('./components/downloadModal/downloadModal.module.js').name,
-    require('./components/featureFlagOverrides/featureFlagOverrides.module.js').name
+    require('./components/featureFlagOverrides/featureFlagOverrides.module.js').name,
+    require('./components/selectProjectModal/selectProjectModal.module.js').name
 ]);

--- a/app-frontend/src/app/index.routes.js
+++ b/app-frontend/src/app/index.routes.js
@@ -60,7 +60,7 @@ function editorStates($stateProvider) {
             abstract: true
         })
         .state('editor.project', {
-            url: '/project/:projectid',
+            url: '/project/:projectid?',
             template: '<rf-project-editor class="app-content"></rf-project-editor>',
             abstract: true
         })

--- a/app-frontend/src/app/pages/editor/project/projectEdit.controller.js
+++ b/app-frontend/src/app/pages/editor/project/projectEdit.controller.js
@@ -41,12 +41,19 @@ export default class ProjectEditController {
                         // @TODO: handle displaying an error message
                     }
                 );
+                this.getSceneList();
+            } else {
+                this.selectProjectModal();
             }
         }
 
         this.$scope.$watch('$ctrl.sceneList', this.fitAllScenes.bind(this));
 
-        this.getSceneList();
+        this.$scope.$on('$destroy', () => {
+            if (this.activeModal) {
+                this.activeModal.dismiss();
+            }
+        });
     }
 
     setHoveredScene(scene) {
@@ -144,6 +151,20 @@ export default class ProjectEditController {
         });
     }
 
+    selectProjectModal() {
+        if (this.activeModal) {
+            this.activeModal.dismiss();
+        }
+
+        this.activeModal = this.$uibModal.open({
+            component: 'rfSelectProjectModal',
+            backdrop: 'static',
+            keyboard: false,
+            resolve: {
+            }
+        });
+    }
+
     publishModal() {
         if (this.activeModal) {
             this.activeModal.dismiss();
@@ -151,6 +172,8 @@ export default class ProjectEditController {
 
         this.activeModal = this.$uibModal.open({
             component: 'rfPublishModal',
+            backdrop: 'static',
+            keyboard: false,
             resolve: {
                 project: () => this.project
             }


### PR DESCRIPTION
## Overview

Adds a modal that, when the user enters the editor from the top-level link, allows a user to select a project to edit.

## Demo

<img width="1238" alt="screen shot 2017-01-06 at 2 23 53 pm" src="https://cloud.githubusercontent.com/assets/2442245/21730770/408eed4e-d41f-11e6-88eb-715384104198.png">

## Notes

We may want to consider providing a way for a user to switch projects more intuitively, such as a switch project button within the editor interface. Right now, when in the editor, the user must navigate back to their library, to the projects, view the project, then click edit.

## Testing Instructions

 * Enter the editor from the top-level link and ensure you are prompted to select a project.
 * Ensure the modal does not reappear while actively editing a project

Connects #837
