### PR TITLE
Use memcached in tile server

### DIFF
--- a/app-backend/build.sbt
+++ b/app-backend/build.sbt
@@ -149,7 +149,10 @@ lazy val tile = Project("tile", file("tile"))
       Dependencies.spark,
       Dependencies.geotrellisSpark,
       Dependencies.geotrellisS3,
-      Dependencies.scaffeine,
+      Dependencies.caffeine,
+      Dependencies.elasticacheClient,
+      Dependencies.scalacacheCaffeine,
+      Dependencies.scalacacheMemcache,
       Dependencies.akkajson
     )
   })

--- a/app-backend/build.sbt
+++ b/app-backend/build.sbt
@@ -152,7 +152,7 @@ lazy val tile = Project("tile", file("tile"))
       Dependencies.caffeine,
       Dependencies.elasticacheClient,
       Dependencies.scalacacheCaffeine,
-      Dependencies.scalacacheMemcache,
+      Dependencies.scalacacheMemcache.exclude("net.spy", "spymemcached"),
       Dependencies.akkajson
     )
   })

--- a/app-backend/project/Dependencies.scala
+++ b/app-backend/project/Dependencies.scala
@@ -30,7 +30,10 @@ object Dependencies {
   val akkaHttpExtensions = "com.lonelyplanet"            %% "akka-http-extensions"              % Version.akkaHttpExtensions
   val akkaHttpCors       = "ch.megard"                   %% "akka-http-cors"                    % Version.akkaHttpCors
   val ammoniteOps        = "com.lihaoyi"                 %% "ammonite-ops"                      % Version.ammoniteOps
-  val scaffeine          = "com.github.blemale"          %% "scaffeine"                         % Version.scaffeine
   val commonsIO          = "commons-io"                   % "commons-io"                        % Version.commonsIO
   val scopt              = "com.github.scopt"            %% "scopt"                             % Version.scopt
+  val caffeine           = "com.github.ben-manes.caffeine" % "caffeine"                         % Version.caffeine
+  val scalacacheMemcache = "com.github.cb372"            %% "scalacache-memcached"              % Version.scalacache
+  val scalacacheCaffeine = "com.github.cb372"            %% "scalacache-caffeine"               % Version.scalacache
+  val elasticacheClient  = "com.amazonaws"                % "elasticache-java-cluster-client"   % Version.elasticacheClient
 }

--- a/app-backend/project/Version.scala
+++ b/app-backend/project/Version.scala
@@ -22,4 +22,7 @@ object Version {
   val scaffeine          = "1.3.0"
   val commonsIO          = "2.5"
   val scopt              = "3.5.0"
+  val scalacache         = "0.9.3"
+  val elasticacheClient  = "1.1.1"
+  val caffeine           = "2.3.5"
 }

--- a/app-backend/project/plugins.sbt
+++ b/app-backend/project/plugins.sbt
@@ -16,3 +16,5 @@ addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.3")
 addSbtPlugin("io.spray" % "sbt-revolver" % "0.8.0")
 
 addSbtPlugin("com.sksamuel.scapegoat" %% "sbt-scapegoat" % "1.0.4")
+
+addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.8.2")

--- a/app-backend/tile/src/main/resources/application.conf
+++ b/app-backend/tile/src/main/resources/application.conf
@@ -3,12 +3,19 @@ http {
   port = 9900
 }
 
+memcached {
+  host = "tile-cache.service.rasterfoundry.internal"
+  host = ${?MEMCACHED_HOST}
+  port = 11211
+  port = ${?MEMCACHED_PORT}
+}
 
-tile-server {
+tile-server { 
   cache {
     size = ${?TILE_SERVER_CACHE_SIZE}
     expiration = ${?TILE_SERVER_CACHE_EXPIRATION}
   }
 
+  bucket = "rasterfoundry-staging-catalogs-us-east-1"
   bucket = ${?TILE_SERVER_BUCKET}
 }

--- a/app-backend/tile/src/main/scala/Config.scala
+++ b/app-backend/tile/src/main/scala/Config.scala
@@ -25,4 +25,8 @@ trait Config {
 
   lazy val defaultBucket:String =
     tileserverConfig.getString("bucket")
+
+  private lazy val memcached = config.getConfig("memcached")
+  lazy val memcachedHost: String = memcached.getString("host")
+  lazy val memcachedPort: Int = memcached.getInt("port")
 }

--- a/app-backend/tile/src/main/scala/LayerCache.scala
+++ b/app-backend/tile/src/main/scala/LayerCache.scala
@@ -1,5 +1,6 @@
 package com.azavea.rf.tile
 
+import com.github.benmanes.caffeine.cache.Caffeine
 import geotrellis.raster._
 import geotrellis.raster.histogram.Histogram
 import geotrellis.spark._
@@ -7,11 +8,18 @@ import geotrellis.raster.io._
 import geotrellis.spark.io._
 import geotrellis.spark.io.s3.{S3AttributeStore, S3ValueReader}
 import scala.concurrent._
-import java.util.concurrent.Executors
+import java.util.concurrent.{Executors, TimeUnit}
+
 import scala.util._
-import com.github.blemale.scaffeine.{ AsyncLoadingCache, Scaffeine, LoadingCache }
 import scala.concurrent.ExecutionContext.Implicits.global
 import spray.json.DefaultJsonProtocol._
+import scalacache._
+
+import scalacache.caffeine.CaffeineCache
+import scalacache.memcached.MemcachedCache
+import com.github.benmanes.caffeine.cache._
+
+import scalacache.serialization.InMemoryRepr
 
 /**
   * ValueReaders need to read layer metadata in order to know how to decode (x/y) queries into resource reads.
@@ -23,62 +31,50 @@ import spray.json.DefaultJsonProtocol._
   * things that require time to generate, usually a network fetch, use AsyncLoadingCache
   */
 object LayerCache extends Config {
-  /** Cache AttributeStores.
-    * This is not Async cache as per usual because constructing S3AttributeStore is cheap.
-    * However it maintains an internal cache of layer attributes that are reused when reading tiles.
-    */
-  val cacheAttributeStore: LoadingCache[(String, String), S3AttributeStore] =
-    Scaffeine()
-      .recordStats()
-      .expireAfterWrite(cacheExpiration)
-      .maximumSize(cacheSize)
-      .build { case (bucket: String, prefix: String) => S3AttributeStore(bucket, prefix) }
-
-  val cacheHistogram: AsyncLoadingCache[(RfLayerId, Int), Array[Histogram[Double]]] =
-    Scaffeine()
-      .recordStats()
-      .expireAfterWrite(cacheExpiration)
-      .maximumSize(cacheSize)
-      .buildAsyncFuture { case (id, zoom: Int) =>
-        Future { S3AttributeStore(defaultBucket, id.prefix).read[Array[Histogram[Double]]](id.catalogId(zoom), "histogram") }
-      }
-
-  val cacheReaders: LoadingCache[(RfLayerId, Int), Reader[SpatialKey, MultibandTile]] =
-    Scaffeine()
-      .expireAfterWrite(cacheExpiration)
-      .maximumSize(cacheSize)
-      .build { case (id, zoom) =>
-        new S3ValueReader(attributeStore(defaultBucket, id.prefix)).reader[SpatialKey, MultibandTile](id.catalogId(zoom))
-      }
-
   val blockingExecutionContext =
     ExecutionContext.fromExecutor(Executors.newFixedThreadPool(64))
 
-  def attributeStore(bucket: String, prefix: String): S3AttributeStore =
-    cacheAttributeStore.get((bucket, prefix))
+  implicit val memoryCache: ScalaCache[InMemoryRepr] = {
+    val underlyingCaffeineCache =
+      Caffeine.newBuilder()
+        .maximumSize(cacheSize)
+        .expireAfterAccess(cacheExpiration.toMillis, TimeUnit.MILLISECONDS)
+        .build[String, Object]
+    ScalaCache(CaffeineCache(underlyingCaffeineCache))
+  }
 
-  def attributeStore(prefix: String): S3AttributeStore =
-    attributeStore(defaultBucket, prefix)
+  // TODO: Make a scalacache Codec using on Kryo
+  implicit val memcached: ScalaCache[Array[Byte]] = {
+    import net.spy.memcached._
+    import java.net.InetSocketAddress
+    val client = new MemcachedClient(new InetSocketAddress(memcachedHost, memcachedPort))
+    ScalaCache(MemcachedCache(client))
+  }
 
-  val cacheMaybeTile: AsyncLoadingCache[(RfLayerId, Int, SpatialKey), Option[MultibandTile]] =
-    Scaffeine()
-      .recordStats()
-      .expireAfterWrite(cacheExpiration)
-      .maximumSize(cacheSize)
-      .buildAsyncFuture { case (id: RfLayerId, zoom, key: SpatialKey) =>
-        Future {
-          Try(cacheReaders.get((id, zoom)).read(key))  match {
-            // Only cache failures through failed query
-            case Success(tile) => Some(tile)
-            case Failure(e: TileNotFoundError) => None
-            case Failure(e) => throw e
-          }
-        }(blockingExecutionContext)
+  def attributeStore(bucket: String, prefix: String): Future[S3AttributeStore] =
+    caching[S3AttributeStore, InMemoryRepr](s"store-$bucket-$prefix"){
+      Future.successful(S3AttributeStore(bucket, prefix))
     }
 
+  def attributeStore(prefix: String): Future[S3AttributeStore] =
+    attributeStore(defaultBucket, prefix)
+
   def maybeTile(id: RfLayerId, zoom: Int, key: SpatialKey): Future[Option[MultibandTile]] =
-    cacheMaybeTile.get((id, zoom, key))
+    caching[Option[MultibandTile], Array[Byte]](s"tile-$id-$zoom-$key") {
+      for (store <- attributeStore(defaultBucket, id.prefix)) yield {
+        val reader = new S3ValueReader(store).reader[SpatialKey, MultibandTile](id.catalogId(zoom))
+        Try(reader.read(key)) match {
+          // Only cache failures through failed query
+          case Success(tile) => Some(tile)
+          case Failure(e: TileNotFoundError) => None
+          case Failure(e) => throw e
+        }
+      }
+    }
 
   def bandHistogram(id: RfLayerId, zoom: Int): Future[Array[Histogram[Double]]] =
-    cacheHistogram.get((id, 0))
+    caching[Array[Histogram[Double]], Array[Byte]]("histogram", id, zoom) {
+      for (store <- attributeStore(defaultBucket, id.prefix)) yield
+        store.read[Array[Histogram[Double]]](id.catalogId(0), "histogram")
+    }
 }


### PR DESCRIPTION
## Overview

This introduces the use of memcached in the tile server. This requires a switch from scaffine caching library to scalacache. We bring in the elasticache aware memcache client: https://github.com/awslabs/aws-elasticache-cluster-client-memcached-for-java

Introduces new environment variables:
 - `MEMCACHED_HOST`: default to `tile-cache.service.rasterfoundry.internal`
 - `MEMCACHED_PORT`: default to `11211`

We still require caffine, which is now used through scalacache in order to perform in-memory caching for the tile readers and attribute stores. The story with attribute stores is a little strange because they maintain internal cache for the layer metadata attributes. This can be made less strange by writing a GeoTrellis AttributeStore mixin that does the caching in memcached.

The default behavior is in memcached is to use Java serialization to encode the values (tiles). This is OK, but can be made better by using Kryo instead.

At this point this PR should be OK to be tested.

### Checklist
- [x] Use memcached through scalacache for tiles
- [x] Add configuration and env vars for memcached
- [x] Test single scene endpoint
- [x] Test mosaic endpoint
- [ ] AttributeStore caching based on memcached
- [ ] More efficient compression `Codec` for memcached

Connects #763 
