### PR TITLE
Implement shallow NDVI tool

### DIFF
--- a/app-frontend/src/app/components/diagramContainer/diagramContainer.component.js
+++ b/app-frontend/src/app/components/diagramContainer/diagramContainer.component.js
@@ -3,6 +3,7 @@ export default {
     controller: 'DiagramContainerController',
     bindings: {
         shapes: '<?',
+        cellLabel: '<?',
         onCellClick: '&',
         onPaperClick: '&'
     }

--- a/app-frontend/src/app/components/diagramContainer/diagramContainer.controller.js
+++ b/app-frontend/src/app/components/diagramContainer/diagramContainer.controller.js
@@ -13,9 +13,10 @@ export default class DiagramContainerController {
     }
 
     $onChanges(changes) {
-        if (this.graph && changes.shapes) {
+        if (this.graph && (changes.shapes || changes.cellLabel)) {
             this.graph.clear();
-            changes.shapes.forEach(s => this.graph.addCell(s));
+            this.initShapes();
+            this.shapes.forEach(s => this.graph.addCell(s));
         }
     }
 
@@ -27,14 +28,18 @@ export default class DiagramContainerController {
                 y: ($(this.workspaceElement).height() - 75) / 2
             },
             size: {
-                width: 225,
+                width: 350,
                 height: 75
             },
             attrs: {
                 rect: {
                     rx: 4,
                     ry: 7,
-                    fill: '#cfcfcf'
+                    fill: '#dfdfdf'
+                },
+                text: {
+                    fill: '#333333',
+                    text: this.cellLabel
                 }
             },
             ports: {

--- a/app-frontend/src/app/components/selectToolModal/selectToolModal.component.js
+++ b/app-frontend/src/app/components/selectToolModal/selectToolModal.component.js
@@ -1,0 +1,14 @@
+import selectToolModalTpl from './selectToolModal.html';
+
+const SelectToolModalComponent = {
+    templateUrl: selectToolModalTpl,
+    bindings: {
+        close: '&',
+        dismiss: '&',
+        modalInstance: '<',
+        resolve: '<'
+    },
+    controller: 'SelectToolModalController'
+};
+
+export default SelectToolModalComponent;

--- a/app-frontend/src/app/components/selectToolModal/selectToolModal.controller.js
+++ b/app-frontend/src/app/components/selectToolModal/selectToolModal.controller.js
@@ -1,0 +1,34 @@
+export default class SelectToolModalController {
+    constructor($log, $state, toolService) {
+        'ngInject';
+        this.$state = $state;
+        this.toolService = toolService;
+        this.fetchToolList();
+    }
+
+    fetchToolList() {
+        this.loadingTools = true;
+        this.toolService.query().then(d => {
+            this.updatePagination(d);
+            this.lastToolResponse = d;
+            this.toolList = d.results;
+            this.loadingTools = false;
+        });
+    }
+
+    updatePagination(data) {
+        this.pagination = {
+            show: data.count > data.pageSize,
+            count: data.count,
+            currentPage: data.page + 1,
+            startingItem: data.page * data.pageSize + 1,
+            endingItem: Math.min((data.page + 1) * data.pageSize, data.count),
+            hasNext: data.hasNext,
+            hasPrevious: data.hasPrevious
+        };
+    }
+
+    selectTool(toolData) {
+        this.close({$value: toolData});
+    }
+}

--- a/app-frontend/src/app/components/selectToolModal/selectToolModal.html
+++ b/app-frontend/src/app/components/selectToolModal/selectToolModal.html
@@ -1,22 +1,16 @@
 <div class="modal-header">
-  <button type="button" class="close" aria-label="Close"
-          ng-click="$ctrl.dismiss()" ng-show="$ctrl.resolve.project">
-    <span aria-hidden="true">&times;</span>
-  </button>
   <span class="badge"><i class="icon-bucket"></i></span>
   <h4 class="modal-title">
-    {{$ctrl.resolve.content.title}}
+    {{$ctrl.resolve.content.title || "Select Tool"}}
   </h4>
 </div>
 <div class="modal-body">
   <div class="list-group">
-    <rf-project-item
-        project="project"
-        selectable
-        selected="$ctrl.resolve.project.id === project.id"
-        on-select="$ctrl.setSelected(project)"
-        ng-repeat="project in $ctrl.projectList track by project.id">
-    </rf-project-item>
+    <rf-tool-item
+        ng-repeat="toolData in $ctrl.toolList"
+        tool-data="toolData"
+        ng-click="$ctrl.selectTool(toolData)"
+    ></rf-tool-item>
   </div>
   <div class="list-group" ng-show="$ctrl.loading">
     <span class="list-placeholder">

--- a/app-frontend/src/app/components/selectToolModal/selectToolModal.module.js
+++ b/app-frontend/src/app/components/selectToolModal/selectToolModal.module.js
@@ -1,0 +1,15 @@
+import angular from 'angular';
+import SelectToolModalComponent from './selectToolModal.component.js';
+import SelectToolModalController from './selectToolModal.controller.js';
+require('../../../assets/font/fontello/css/fontello.css');
+
+const SelectToolModalModule = angular.module('components.selectToolModal', []);
+
+SelectToolModalModule.controller(
+    'SelectToolModalController', SelectToolModalController
+);
+SelectToolModalModule.component(
+    'rfSelectToolModal', SelectToolModalComponent
+);
+
+export default SelectToolModalModule;

--- a/app-frontend/src/app/core/services/gridLayer.service.js
+++ b/app-frontend/src/app/core/services/gridLayer.service.js
@@ -255,7 +255,6 @@ export default (app) => {
 
             return new GridLayer();
         }
-
     }
 
     app.service('gridLayerService', GridLayerService);

--- a/app-frontend/src/app/core/services/layer.service.js
+++ b/app-frontend/src/app/core/services/layer.service.js
@@ -62,6 +62,19 @@ export default (app) => {
             });
         }
 
+        getNDVILayer(bands = [5, 4]) {
+            if (this._tiles) { // eslint-disable-line no-underscore-dangle
+                return this.$q((resolve) => {
+                    resolve(this._tiles); // eslint-disable-line no-underscore-dangle
+                });
+            }
+            // eslint-disable-next-line no-underscore-dangle
+            this._tiles = L.tileLayer(this.getNDVIURL(bands),
+                {bounds: this.bounds, attribution: 'Raster Foundry'}
+            );
+            return this._tiles; // eslint-disable-line no-underscore-dangle
+        }
+
         /**
          * Helper function to return string for a tile layer
          * @returns {string} URL for this tile layer
@@ -74,6 +87,14 @@ export default (app) => {
                 return `/tiles/${organizationId}/` +
                     `${userId}/${this.scene.id}/rgb/{z}/{x}/{y}/?${formattedParams}`;
             });
+        }
+
+        getNDVIURL(bands) {
+            let organizationId = this.scene.organizationId;
+            // TODO: replace this once user IDs are URL safe ISSUE: 766
+            let userId = this.scene.createdBy.replace('|', '_');
+            return `/tiles/${organizationId}/` +
+                `${userId}/${this.scene.id}/ndvi/{z}/{x}/{y}/?bands=${bands[0]},${bands[1]}`;
         }
 
         /**

--- a/app-frontend/src/app/index.components.js
+++ b/app-frontend/src/app/index.components.js
@@ -23,5 +23,7 @@ export default angular.module('index.components', [
     require('./components/refreshTokenModal/refreshTokenModal.module.js').name,
     require('./components/downloadModal/downloadModal.module.js').name,
     require('./components/featureFlagOverrides/featureFlagOverrides.module.js').name,
-    require('./components/selectProjectModal/selectProjectModal.module.js').name
+    require('./components/selectProjectModal/selectProjectModal.module.js').name,
+    require('./components/selectToolModal/selectToolModal.module.js').name
+
 ]);

--- a/app-frontend/src/app/index.routes.js
+++ b/app-frontend/src/app/index.routes.js
@@ -232,7 +232,7 @@ function marketStates($stateProvider) {
 function labStates($stateProvider) {
     $stateProvider
         .state('lab', {
-            url: '/lab',
+            url: '/lab/:toolid',
             templateUrl: labTpl,
             controller: 'LabController',
             controllerAs: '$ctrl',
@@ -245,7 +245,7 @@ function labStates($stateProvider) {
             controllerAs: '$ctrl'
         })
         .state('lab.run', {
-            url: '/run',
+            url: '/run/:projectid?',
             templateUrl: labRunTpl,
             controller: 'LabRunController',
             controllerAs: '$ctrl'

--- a/app-frontend/src/app/pages/lab/edit/edit.controller.js
+++ b/app-frontend/src/app/pages/lab/edit/edit.controller.js
@@ -3,7 +3,16 @@ export default class LabEditController {
         'ngInject';
         this.$scope = $scope;
         this.$element = $element;
+        this.$parent = $scope.$parent.$ctrl;
         this.isShowingParams = false;
+    }
+
+    $onInit() {
+        if (this.$parent.toolRequest) {
+            this.$parent.toolRequest.then(t => {
+                this.cellLabel = t.title;
+            });
+        }
     }
 
     showParams() {

--- a/app-frontend/src/app/pages/lab/edit/edit.html
+++ b/app-frontend/src/app/pages/lab/edit/edit.html
@@ -1,5 +1,6 @@
 <!-- Workflow container -->
 <rf-diagram-container class="main"
+                      cell-label="$ctrl.cellLabel"
                       on-cell-click="$ctrl.showParams()"
                       on-paper-click="$ctrl.hideParams()">
 </rf-diagram-container>

--- a/app-frontend/src/app/pages/lab/lab.controller.js
+++ b/app-frontend/src/app/pages/lab/lab.controller.js
@@ -1,8 +1,51 @@
 class labController {
-    constructor() {
+    constructor($log, $state, $uibModal, toolService) {
         'ngInject';
+        this.$log = $log;
+        this.$state = $state;
+        this.$uibModal = $uibModal;
+        this.toolService = toolService;
+    }
 
-        // This is an abstract view so it's just a container for its children
+    $onInit() {
+        this.toolData = this.$state.params.toolData;
+        this.toolId = this.$state.params.toolid;
+        if (!this.tool) {
+            if (this.toolId) {
+                this.fetchTool();
+            } else {
+                this.selectToolModal();
+            }
+        }
+    }
+
+    fetchTool() {
+        this.loadingTool = true;
+        this.toolRequest = this.toolService.get(this.toolId);
+        this.toolRequest.then(d => {
+            this.tool = d;
+            this.tool.createdAtFormatted = new Date(d.createdAt).toLocaleDateString();
+            this.tool.modifiedAtFormatted = new Date(d.modifiedAt).toLocaleDateString();
+            this.loadingTools = false;
+        });
+    }
+
+    selectToolModal() {
+        if (this.activeModal) {
+            this.activeModal.dismiss();
+        }
+
+        this.activeModal = this.$uibModal.open({
+            component: 'rfSelectToolModal',
+            backdrop: 'static',
+            keyboard: false,
+            resolve: {
+            }
+        }).result.then((t) => {
+            this.$state.go(this.$state.current, {toolid: t.id});
+        });
+
+        return this.activeModal;
     }
 }
 

--- a/app-frontend/src/app/pages/lab/lab.html
+++ b/app-frontend/src/app/pages/lab/lab.html
@@ -2,7 +2,7 @@
   <div class="navbar secondary-navbar">
     <div class="navbar-left">
       <nav>
-        <a class="active">Tool Name</a>
+        <a class="active">{{$ctrl.tool.title}}</a>
       </nav>
       <span class="navbar-vertical-divider"></span>
       <nav>

--- a/app-frontend/src/app/pages/lab/run/run.controller.js
+++ b/app-frontend/src/app/pages/lab/run/run.controller.js
@@ -1,6 +1,207 @@
+const Map = require('es6-map');
+
 export default class LabRunController {
-    constructor($scope) {
+    constructor( // eslint-disable-line max-params
+        $scope, $state, $uibModal, mapService, layerService, projectService) {
         'ngInject';
         this.$scope = $scope;
+        this.$parent = $scope.$parent.$ctrl;
+        this.$state = $state;
+        this.$uibModal = $uibModal;
+        this.mapService = mapService;
+        this.layerService = layerService;
+        this.projectService = projectService;
+        this.inputs = {
+            bands: {
+                nir: '5',
+                red: '4'
+            }
+        };
+    }
+
+    $onInit() {
+        this.setTestingTools();
+        this.getMap = () => this.mapService.getMap('lab-run');
+        this.projectId = this.$state.params.projectid;
+        this.sceneLayers = new Map();
+
+        if (this.$parent.toolId && !this.project) {
+            this.ensureProjectSelected();
+        }
+    }
+
+    ensureProjectSelected() {
+        if (this.projectId) {
+            this.loadingProject = true;
+            this.projectService.query({id: this.projectId}).then(
+                (project) => {
+                    this.project = project;
+                    this.loadingProject = false;
+                    this.getSceneList();
+                },
+                () => {
+                    this.loadingProject = false;
+                    // @TODO: handle displaying an error message
+                }
+            );
+        } else {
+            this.selectProjectModal();
+        }
+    }
+
+    fitAllScenes() {
+        if (this.sceneList.length) {
+            this.fitScenes(this.sceneList);
+        }
+    }
+
+    fitScenes(scenes) {
+        this.getMap().then((map) =>{
+            let sceneFootprints = scenes.map((scene) => scene.dataFootprint);
+            map.map.fitBounds(L.geoJSON(sceneFootprints).getBounds());
+        });
+    }
+
+    getSceneList() {
+        this.sceneRequestState = {loading: true};
+        this.projectService.getAllProjectScenes(
+            {projectId: this.projectId}
+        ).then(
+            (allScenes) => {
+                this.sceneList = allScenes;
+                this.fitAllScenes();
+                this.layersFromScenes();
+            },
+            (error) => {
+                this.sceneRequestState.errorMsg = error;
+            }
+        ).finally(() => {
+            this.sceneRequestState.loading = false;
+        });
+    }
+
+    layersFromScenes() {
+        // Create scene layers to use for color correction
+        for (const scene of this.sceneList) {
+            let sceneLayer = this.layerService.layerFromScene(scene, this.projectId);
+            this.sceneLayers.set(scene.id, sceneLayer);
+        }
+
+        this.layers = this.sceneLayers.values();
+        this.getMap().then((map) => {
+            map.deleteLayers('scenes');
+            for (let layer of this.layers) {
+                let tiles = layer.getNDVILayer([this.inputs.bands.nir, this.inputs.bands.red]);
+                map.addLayer('scenes', tiles);
+            }
+        });
+    }
+
+    updateInputs() {
+        this.layersFromScenes();
+    }
+
+    selectToolModal() {
+        if (this.activeModal) {
+            this.activeModal.dismiss();
+        }
+
+        const backdrop = this.project ? true : 'static';
+        const keyboard = Boolean(this.project);
+
+        this.activeModal = this.$uibModal.open({
+            component: 'rfSelectProjectModal',
+            backdrop: backdrop,
+            keyboard: keyboard,
+            resolve: {
+                project: () => this.project,
+                content: () => ({
+                    title: 'Select a project'
+                })
+            }
+        });
+    }
+
+    selectProjectModal() {
+        if (this.activeModal) {
+            this.activeModal.dismiss();
+        }
+
+        const backdrop = this.project ? true : 'static';
+        const keyboard = Boolean(this.project);
+
+        this.activeModal = this.$uibModal.open({
+            component: 'rfSelectProjectModal',
+            backdrop: backdrop,
+            keyboard: keyboard,
+            resolve: {
+                project: () => this.project,
+                content: () => ({
+                    title: 'Select a project'
+                })
+            }
+        });
+    }
+
+    setTestingTools() {
+        this.tools = [
+            {
+                definition: 'ndvi',
+                params: ['red', 'nir'],
+                result: {
+                    apply: '/',
+                    args: [
+                        {
+                            apply: '-',
+                            args: ['red', 'nir']
+                        }, {
+                            apply: '+',
+                            args: ['red', 'nir']
+                        }
+                    ]
+                }
+            }, {
+                definition: 'multiband_ndvi',
+                params: ['LC8'],
+                result: {
+                    apply: '/',
+                    args: [
+                        {
+                            apply: '-',
+                            args: ['LC8[4]', 'LC8[5]']
+                        }, {
+                            apply: '+',
+                            args: ['LC8[4]', 'LC8[5]']
+                        }
+                    ]
+                }
+            }, {
+                definition: 'LC8_ndvi',
+                params: ['LC8'],
+                include: [
+                    {
+                        definition: 'ndvi',
+                        params: ['red', 'nir'],
+                        result: {
+                            apply: '/',
+                            args: [
+                                {
+                                    apply: '-',
+                                    args: ['red', 'nir']
+                                }, {
+                                    apply: '+',
+                                    args: ['red', 'nir']
+                                }
+                            ]
+                        }
+                    }
+                ],
+                result: {
+                    apply: 'ndvi',
+                    args: ['LC8[4]', 'LC8[5]']
+                }
+            }
+        ];
+        this.selectedTool = this.tools[0];
     }
 }

--- a/app-frontend/src/app/pages/lab/run/run.html
+++ b/app-frontend/src/app/pages/lab/run/run.html
@@ -1,12 +1,75 @@
-<div class="sidebar sidebar-extended sidebar-dark not-offset" ng-show="$ctrl.isShowingParams">
-    Params Sidebar
-    <!-- Sidebar -->
-    <!--
-        @TODO: this sidebar should not occupy the space of the main div
-        as we want to maximize the screen area of the workspace
-    -->
-</div>
-<!-- Workflow container -->
-<div class="main" style="background: #dadada;">
-    Model Running Workspace
+<div class="main">
+  <div class="sidebar sidebar-extended sidebar-dark not-offset" ng-show="$ctrl.isShowingParams">
+      Params Sidebar
+  </div>
+  <!-- Workflow container -->
+  <div class="sidebar sidebar-extended sidebar-scrollable">
+    <div class="sidebar-content flex-row with-padding with-border">
+      <h5 class="sidebar-title">
+          Inputs
+      </h5>
+      <div class="sidebar-actions">
+        <button class="btn btn-primary">Raster Settings</button>
+      </div>
+    </div>
+    <div class="sidebar-content flex-row with-padding"
+         ng-show="$ctrl.project">
+      <div class="run-project-name">
+          {{$ctrl.project.name || "No project selected"}}
+      </div>
+      <div class="sidebar-actions">
+        <button class="btn btn-small btn-square"
+                ng-click="$ctrl.selectProjectModal(true)">
+          Change Project
+        </button>
+      </div>
+    </div>
+    <div class="sidebar-content with-padding"
+         ng-show="$ctrl.project">
+      <form>
+        <div class="form-group">
+          <label for="formGroupExampleInput">Red Band</label>
+          <select class="form-control" id="red-band-map"  ng-model="$ctrl.inputs.bands.red">
+            <option value="1">Band 1</option>
+            <option value="2">Band 2</option>
+            <option value="3">Band 3</option>
+            <option value="4">Band 4</option>
+            <option value="5">Band 5</option>
+            <option value="6">Band 6</option>
+            <option value="7">Band 7</option>
+            <option value="8">Band 8</option>
+            <option value="9">Band 9</option>
+            <option value="10">Band 10</option>
+            <option value="11">Band 11</option>
+          </select>
+        </div>
+        <div class="form-group">
+          <label for="formGroupExampleInput">NIR Band</label>
+          <select class="form-control" id="nir-band-map" ng-model="$ctrl.inputs.bands.nir">
+            <option value="1">Band 1</option>
+            <option value="2">Band 2</option>
+            <option value="3">Band 3</option>
+            <option value="4">Band 4</option>
+            <option value="5">Band 5</option>
+            <option value="6">Band 6</option>
+            <option value="7">Band 7</option>
+            <option value="8">Band 8</option>
+            <option value="9">Band 9</option>
+            <option value="10">Band 10</option>
+            <option value="11">Band 11</option>
+          </select>
+        </div>
+      </form>
+    </div>
+    <div class="sidebar-content flex-row with-padding">
+      <div class="form-btn-row">
+        <div class="btn-group">
+          <button class="btn btn-primary" ng-click="$ctrl.updateInputs()">
+            Apply
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <rf-map-container map-id="lab-run"></rf-map-container>
 </div>

--- a/app-frontend/src/app/pages/lab/run/run.module.js
+++ b/app-frontend/src/app/pages/lab/run/run.module.js
@@ -3,6 +3,8 @@ import angular from 'angular';
 import LabRunController from './run.controller.js';
 import labRunComponent from './run.component.js';
 
+
+require('./run.scss');
 const labRunModule = angular.module('pages.lab.run', []);
 
 labRunModule.component('labRun', labRunComponent);

--- a/app-frontend/src/app/pages/lab/run/run.scss
+++ b/app-frontend/src/app/pages/lab/run/run.scss
@@ -1,0 +1,5 @@
+.run-project-name {
+  flex: 1;
+  font-weight: bold;
+  color: #333;
+}

--- a/app-frontend/src/app/pages/market/tool/tool.html
+++ b/app-frontend/src/app/pages/market/tool/tool.html
@@ -130,7 +130,7 @@
           <div class="panel">
             <div class="panel-body centered">
               <h5>Free to use</h5>
-              <button class="btn btn-primary">Execute Tool</button>
+              <a ui-sref="lab.run({toolid: $ctrl.tool.id})" class="btn btn-primary">Execute Tool</a>
             </div>
           </div>
           <div class="reference-list">


### PR DESCRIPTION
## Overview

This adds a functioning NDVI tool.

### Demo

![screen shot 2017-01-10 at 11 41 35 am](https://cloud.githubusercontent.com/assets/2442245/21815256/fa341a14-d729-11e6-8cc3-02c02f5e407a.png)
![screen shot 2017-01-10 at 11 41 59 am](https://cloud.githubusercontent.com/assets/2442245/21815254/fa3391ac-d729-11e6-9a84-1bdc963cbb7c.png)
![screen shot 2017-01-10 at 11 42 15 am](https://cloud.githubusercontent.com/assets/2442245/21815253/fa338e8c-d729-11e6-9491-cb65f939e95a.png)
![screen shot 2017-01-10 at 11 42 40 am](https://cloud.githubusercontent.com/assets/2442245/21815255/fa340894-d729-11e6-9ec8-0f3d2fa6db0e.png)

### Notes

- This only works on scenes that can also be color corrected as the proper endpoint is not yet ready
- The JointJS diagram is still naively implemented
- Using any band > 6 causes a 400 for the tiles. I don't think it is worth the time to catch the errors and display a message since this is a temporary implementation.
- The returned tiles are transparent, which causes some visual issues when the tiles overlap (very apparent in the screen shots)
- I added an 'Apply' button to the tool controls to reduce load on the tile server.

Developing this made me think that we may want to consider making the active project a top-level concept rather than a parameter of routes further down the route tree. We have several spots where we select and maintain an active project in different ways. This would be a major adjustment, but I think it would improve the clarity of the product and a user could go from adjusting the mosaic ordering of their project and jump over to the lab and simply run a tool on their project in two or three clicks.


## Testing Instructions

- From any route enter the lab, ensure you are prompted to select a tool and cannot navigate through the various lab states without an actively selected tool
- Go to the tool catalog and see that clicking 'Execute Tool` on the NDVI tool page takes you to the `run` section of the lab
- Check that you cannot operate the tool controls within the `run` section without having a project selected
- Ensure you can switch projects and that the NDVI output is changed
- Adjust the input bands and see that the NDVI output is changed
- Check that the project select modal can be dismissed if a project has already been selected

Connects #826, #899
