### PR TITLE
Make color correction selection grid finer

### DIFF
--- a/app-frontend/src/app/components/colorCorrectScenes/colorCorrectScenes.html
+++ b/app-frontend/src/app/components/colorCorrectScenes/colorCorrectScenes.html
@@ -23,7 +23,7 @@
             Action <i class="icon-caret-down"></i>
           </a>
           <ul class="dropdown-menu dropdown-menu-light" uib-dropdown-menu role="menu">
-            <li role="menuitem"><a ng-disabled="$ctrl.selectedScenes.size === 0" ng-click="$ctrl.$state.go('editor.project.color.adjust')">Color correct</a></li>
+            <li role="menuitem"><a ng-disabled="$ctrl.selectedScenes.size === 0" ng-click="$ctrl.goColorCorrect()">Color correct</a></li>
             <li role="menuitem"><a href><i class="icon-load"></i> Sync histogram</a></li>
             <li role="menuitem"><a href><i class="icon-arrows-cw"></i> Reset changes</a></li>
             <li role="menuitem"><a href class="color-danger"><i class="icon-trash"></i> Delete</a></li>

--- a/app-frontend/src/app/components/colorCorrectScenes/colorCorrectScenes.scss
+++ b/app-frontend/src/app/components/colorCorrectScenes/colorCorrectScenes.scss
@@ -1,3 +1,7 @@
-rf-project-editor .leaflet-tile {
-  border: 1px solid black;
+// @TODO: these styles ensure the selection grid is visible
+// and need to be incorporated into the app styles
+
+rf-project-editor .grid-select .leaflet-tile {
+  border-bottom: 1px solid rgba(#999, 0.5);
+  border-right: 1px solid rgba(#999, 0.5);
 }


### PR DESCRIPTION
## Overview

Utilized an `L.gridLayer` to achieve a finer selection resolution (16x).
Also implements multiple grid selection to match browse scene grid filter.

### Demo

<img width="1277" alt="screen shot 2017-01-10 at 4 04 24 pm" src="https://cloud.githubusercontent.com/assets/2442245/21824679/7f3bbb62-d74e-11e6-838e-c0102f109594.png">

## Notes

Scenes cannot be selected until the scene tiles have finished loading (parallel request limit) as we depend on server-side filtering of scenes by bbox.

## Testing Instructions

 * Select a project of 'Egypt' scenes
 * Go to the editor
 * Check that you can select one grid cell
 * Check that by holding `ctrl` you can select multiple grid cells
 * Check that clicking an already selected grid cell will deselect the grid cell
 * Check that when you enter color-correction adjustment, the selection polygons are removed from the map

Connects #849, #851, #852
