### PR TITLE
Approximately Clip Thumbnails to Data Footprint

### DIFF
--- a/app-backend/tile/src/main/resources/logback.xml
+++ b/app-backend/tile/src/main/resources/logback.xml
@@ -5,6 +5,8 @@
         </encoder>
     </appender>
 
+    <logger name="scalacache" level="${APP_SERVER_LOG_LEVEL:-info}" />
+
     <root level="${APP_SERVER_LOG_LEVEL:-info}">
         <appender-ref ref="stdout"/>
     </root>

--- a/app-frontend/src/app/components/filterPane/filterPane.html
+++ b/app-frontend/src/app/components/filterPane/filterPane.html
@@ -29,8 +29,7 @@
         <button type="button"
                 class="btn btn-toggle btn-small"
                 autocomplete="off"
-                ng-class="{'active': monthAttrs.enabled,
-                           'disabled': !$ctrl.filters.month}"
+                ng-class="{'active': monthAttrs.enabled}"
                 ng-mousedown="$ctrl.onMonthFilterMousedown(month, monthAttrs)"
                 ng-mouseover="$ctrl.onMonthFilterMouseover(month)"
                 ng-repeat="(month, monthAttrs) in $ctrl.monthFilters track by month">
@@ -69,8 +68,7 @@
                 autocomplete="off"
                 ng-mousedown="$ctrl.onSourceFilterMousedown(filter, filterAttrs)"
                 ng-mouseover="$ctrl.onSourceFilterMouseover(filter)"
-                ng-class="{'active': filterAttrs.enabled,
-                          'disabled': !$ctrl.filters.datasource}"
+                ng-class="{'active': filterAttrs.enabled}"
                 ng-repeat="(filter, filterAttrs) in $ctrl.sourceFilters track by filter">
           {{filterAttrs.label}}
         </button>

--- a/app-frontend/src/app/core/core.module.js
+++ b/app-frontend/src/app/core/core.module.js
@@ -3,6 +3,7 @@ const shared = angular.module('core.shared', []);
 require('./services/scene.service')(shared);
 require('./services/colorCorrect.service')(shared);
 require('./services/gridLayer.service')(shared);
+require('./services/imageOverlay.service')(shared);
 require('./services/project.service')(shared);
 require('./services/user.service')(shared);
 require('./services/config.provider')(shared);

--- a/app-frontend/src/app/core/services/imageOverlay.service.js
+++ b/app-frontend/src/app/core/services/imageOverlay.service.js
@@ -1,0 +1,105 @@
+import _ from 'lodash';
+import Konva from 'konva';
+
+/* eslint no-underscore-dangle: ["error", {"allowAfterThis": true}] */
+/* eslint no-unused-vars: 0 */
+/* eslint spaced-comment: 0 */
+
+export default (app) => {
+    class ImageOverlayService {
+
+        /** Returns a new Image overlay layer that clips to a datamask
+         *
+         * @param {string} url location to request tiles from
+         * @param {L.Bounds} bounds leaflet bounds for image
+         * @param {Object} options additional parameters to create image overlay
+         *
+         * @returns {L.Layer} image layer to put on map for thumbnails
+         */
+        createNewImageOverlay(url, bounds, options) {
+            let ImageOverlayLayer = L.ImageOverlay.extend({
+                options: {
+                    opacity: 1,
+                    alt: '',
+                    interactive: false,
+                    crossOrigin: false,
+                    dataMask: {},
+                    thumbnail: ''
+                },
+
+                _initImage: function () {
+                    this._image = L.DomUtil.create('div', 'leaflet-image-layer ' +
+                        (this._zoomAnimated ? 'leaflet-zoom-animated' : ''));
+                },
+
+                _reset: function () {
+                    let tile = this._image;
+                    let tileBounds = new L.Bounds(
+                        this._map.latLngToLayerPoint(this._bounds.getNorthWest()),
+                        this._map.latLngToLayerPoint(this._bounds.getSouthEast())
+                        );
+                    let size = this.size = tileBounds.getSize();
+
+                    L.DomUtil.setPosition(tile, tileBounds.min);
+
+                    tile.style.width = size.x + 'px';
+                    tile.style.height = size.y + 'px';
+
+                    let dataMask = this.options.dataMask;
+
+                    let result = dataMask.coordinates[0][0].map((lngLat) => {
+                        let point = this._map.latLngToLayerPoint([lngLat[1], lngLat[0]],
+                            this._map.getZoom()
+                        );
+                        return [point.x - tileBounds.min.x, point.y - tileBounds.min.y];
+                    });
+
+                    let points = _.flatten(result);
+
+
+                    let stage = new Konva.Stage({
+                        container: tile,
+                        width: size.x,
+                        height: size.y
+                    });
+
+                    let layer = this.layer = new Konva.Layer();
+
+                    let img = this.img = L.DomUtil.create('img');
+                    img.src = this.options.thumbnail.url;
+
+                    let lineConfig = {
+                        points: points,
+                        width: size.x,
+                        height: size.y,
+                        fillPriority: 'pattern',
+                        fillPatternImage: img,
+                        fillPatternRepeat: 'no-repeat',
+                        fillPatternX: 0,
+                        fillPatternY: 0,
+                        closed: true
+                    };
+
+                    this.lineImage = new Konva.Line(lineConfig);
+
+                    // @TODO: Replace once #897 is closed
+                    img.onload = () => {
+                        let scale = {
+                            x: this.size.x / this.img.naturalWidth,
+                            y: this.size.y / this.img.naturalHeight
+                        };
+                        this.lineImage.fillPatternScale(scale);
+                        this.layer.add(this.lineImage);
+                        this.layer.draw();
+                    };
+                    stage.add(layer);
+                }
+
+            });
+
+            return new ImageOverlayLayer(url, bounds, options);
+        }
+    }
+
+    app.service('imageOverlayService', ImageOverlayService);
+};


### PR DESCRIPTION
## Overview

This PR includes functionality to clip thumbnails to nearly include _just_ the data and exclude no data areas for thumbnails based on the geometry of the data footprint.

This is done by extending the existing [Leaflet Image Overlay] layer and replacing the tile drawing functions with a custom one. This custom layer uses canvas to draw a shape using the data footprint geometry and then uses the thumbnail as a fill image for the drawn canvas polygon. Almost all the areas that are no data should be excluded as a result.

Also fixes styling for filters when none are clicked.

### Checklist

~~- [ ] Styleguide updated, if necessary~~
~~- [ ] Swagger specification updated, if necessary~~

### Demo

Selected scenes on this branch:
![demo](https://cloud.githubusercontent.com/assets/898060/21849782/83349a2c-d7d5-11e6-9def-eeefb685ce07.png)


### Notes

Clipping nodata from thumbnails does not quite line up and the  problem appears to get worse at higher latitude. After extensive testing of transforming the data footprint to pixels on the map I believe the problem likely lies with some combination of (1) generating the thumbnail with native projection and (2) rounding in leaflet.

There may be little that we can do to solve this problem in the short term. I think the next feasible, low effort fix we can do is use a [library] to shring the data footprint polygon such that the smaller footprint eliminates any edge effects. This smaller thumbnail would likely not be noticeable to users since there is regularly significant overlap.

Another issue encountered is that the thumbnails themselves do not have the correct dimensions stored with them. This is solved for now by using a callback to check the `natural width/height` and use those numbres for the scaling factor in canvas.

## Testing Instructions

 * Go to scene browser
 * Hover over scenes

Closes #845, #876
