### PR TITLE
Memcached attribute store

### DIFF
--- a/app-backend/tile/src/main/scala/LayerCache.scala
+++ b/app-backend/tile/src/main/scala/LayerCache.scala
@@ -42,7 +42,7 @@ object LayerCache extends Config {
     ScalaCache(CaffeineCache(underlyingCaffeineCache))
   }
 
-  // TODO: Make a scalacache Codec using on Kryo
+  // TODO: Make a scalacache Codec using Kryo
   implicit val memcached: ScalaCache[Array[Byte]] = {
     import net.spy.memcached._
     import java.net.InetSocketAddress
@@ -53,12 +53,7 @@ object LayerCache extends Config {
   def attributeStore(bucket: String, prefix: String): Future[S3AttributeStore] =
     caching[S3AttributeStore, InMemoryRepr](s"store-$bucket-$prefix"){
       Future.successful(new S3AttributeStore(bucket, prefix) with MemcachedAttributeStore {
-        implicit val cache: ScalaCache[Array[Byte]] = {
-          import net.spy.memcached._
-          import java.net.InetSocketAddress
-          val client = new MemcachedClient(new InetSocketAddress(memcachedHost, memcachedPort))
-          ScalaCache(MemcachedCache(client))
-        }
+        implicit val cache: ScalaCache[Array[Byte]] = memcached
       })
     }
 

--- a/app-backend/tile/src/main/scala/MemcachedAttributeStore.scala
+++ b/app-backend/tile/src/main/scala/MemcachedAttributeStore.scala
@@ -1,0 +1,87 @@
+package com.azavea.rf.tile
+
+import geotrellis.spark._
+import geotrellis.spark.io._
+
+import spray.json._
+import scalacache._
+
+import scala.concurrent._
+import scala.concurrent.duration._
+import scala.concurrent.ExecutionContext.Implicits.global
+import scalacache.caffeine.CaffeineCache
+import scalacache.memcached.MemcachedCache
+import com.github.benmanes.caffeine.cache._
+import com.typesafe.scalalogging.LazyLogging
+
+/** Stores attributes in memcached as strings
+  *
+  * @usecase The standard GeoTrellis [[AttributeStore]]s don't allow easy modification
+  *           of caching mechanism. This mixin trait overwrites appropriate fields
+  *           to provide caching backed by Memcached.
+  * @note    Certain calls (e.g. to list layerIds) which are not cached by default in a
+  *           GeoTrellis [[AttributeStore]] won't be cached with this trait. Further
+  *           changes will be necessary for this behaior.
+  */
+trait MemcachedAttributeStore extends AttributeStore with LazyLogging {
+  /** Implicit necessary for scalacache writing/reading - must be provided when mixed in */
+  implicit val cache: ScalaCache[Array[Byte]]
+
+  // Configuration Flags (modify when mixing in)
+
+  /** Whether or not to cache all layer attributes  */
+  def cacheAll = true
+
+  /** Time to live for cached elements */
+  def cacheTTL = Some(10.minutes)
+
+  /** Timeout on future for cache retrieval */
+  def timeout = 30.seconds
+
+  // End Configuration Flags
+
+  def memcachedRead[T: JsonFormat](layerId: LayerId, attributeName: String): T = {
+    val futureJson = get[String, Array[Byte]](s"$layerId-$attributeName")
+      .map { _.getOrElse(super.read[T](layerId, attributeName).toJson.compactPrint) }
+    val json = Await.result(futureJson, timeout)
+    logger.debug(s"Memcached read of $layerId-$attributeName")
+    json.parseJson.convertTo[T]
+  }
+
+  def memcachedWrite[T: JsonFormat](layerId: LayerId, attributeName: String, value: T): Unit = {
+    logger.debug(s"Memcached write of $layerId-$attributeName")
+    put[String, Array[Byte]](s"$layerId-$attributeName")(value.toJson.compactPrint, ttl = cacheTTL)
+  }
+
+  abstract override def write[T: JsonFormat](layerId: LayerId, attributeName: String, value: T): Unit = {
+    super.write[T](layerId, attributeName, value)
+    if (cacheAll) memcachedWrite(layerId, attributeName, value)
+  }
+
+  abstract override def read[T: JsonFormat](layerId: LayerId, attributeName: String): T = {
+    if (cacheAll) {
+      memcachedRead[T](layerId, attributeName)
+    } else {
+      super.read[T](layerId, attributeName)
+    }
+  }
+
+  override def cacheRead[T: JsonFormat](layerId: LayerId, attributeName: String): T = {
+    memcachedRead[T](layerId, attributeName)
+  }
+
+  override def cacheWrite[T: JsonFormat](layerId: LayerId, attributeName: String, value: T): Unit = {
+    super.write[T](layerId, attributeName, value)
+    memcachedWrite(layerId, attributeName, value)
+  }
+
+  override def clearCache(): Unit =
+    removeAll()
+
+  override def clearCache(id: LayerId): Unit =
+    removeAll()
+
+  override def clearCache(layerId: LayerId, attributeName: String): Unit =
+    remove(s"$layerId-$attributeName")
+}
+


### PR DESCRIPTION
## Overview

Brief description of what this PR does, and why it is needed.

### Checklist

- [x] Use memcached for attribute store caching
- [x] Manually test storage of attributes on memcached

## Testing Instructions

Testing is a bit involved. As of now, there are a couple of logging statements which will fire under `debug` conditions assuming the appropriate caching behavior is in place. 

To manually test the use of memcached with attributes, telnetting from the tile server to the memcached instance and performing a `stats cachedump` call to ensure that histograms are stored is sufficient. An example output from such a cachedump: `histogram:RfLayerId(dfac6307-b5ef-43f7-beda-b9f208bb7726,rf_airflow-user,7aaf4e29-8f68-4b9a-bf6a-c78e025bb8c6):7 [39311 b; 0 s]`. [A handy reference for talking to memcached](http://lzone.de/cheat-sheet/memcached)
