### PR TITLE
Retain bbox query parameter and tiny fixes

### DIFF
--- a/app-frontend/src/app/components/colorCorrectScenes/colorCorrectScenes.controller.js
+++ b/app-frontend/src/app/components/colorCorrectScenes/colorCorrectScenes.controller.js
@@ -2,6 +2,7 @@
 * From a lng coordinate and a zoom level, determine the x-coordinate of
 * the tile in falls within
 * @param {numeric} lng lng coordinate
+* @param {numeric} zoom integer zoom level
 *
 * @returns {numeric} x-coordinate of tile
 */
@@ -13,6 +14,7 @@ let lng2Tile = function (lng, zoom) {
 * From a lat coordinate and a zoom level, determine the y-coordinate of
 * the tile in falls within
 * @param {numeric} lat lat coordinate
+* @param {numeric} zoom integer zoom level
 *
 * @returns {numeric} y-coordinate of tile
 */
@@ -26,6 +28,7 @@ let lat2Tile = function (lat, zoom) {
 * From a tile coordinate and zoom level, determine the lng coordinate of
 * the corresponding tile's NE corner
 * @param {numeric} x x-coordinate of tile
+* @param {numeric} zoom integer zoom level
 *
 * @returns {numeric} lng point of tile NE corner
 */
@@ -37,6 +40,7 @@ let tile2Lng = function (x, zoom) {
 * From a tile coordinate and zoom level, determine the lat coordinate of
 * the corresponding tile's NE corner
 * @param {numeric} y y-coordinate of tile
+* @param {numeric} zoom integer zoom level
 *
 * @returns {numeric} lat point of tile NE corner
 */

--- a/app-frontend/src/app/components/filterPane/filterPane.component.js
+++ b/app-frontend/src/app/components/filterPane/filterPane.component.js
@@ -4,7 +4,8 @@ const rfFilterPane = {
     templateUrl: filterTpl,
     controller: 'FilterPaneController',
     bindings: {
-        filters: '='
+        filters: '=',
+        onCloseClick: '&'
     }
 };
 

--- a/app-frontend/src/app/components/filterPane/filterPane.controller.js
+++ b/app-frontend/src/app/components/filterPane/filterPane.controller.js
@@ -7,6 +7,10 @@ export default class FilterPaneController {
         this.initFilters();
     }
 
+    close() {
+        this.onCloseClick();
+    }
+
     onYearFiltersChange(id, minModel, maxModel) {
         if (minModel === this.yearRange.min) {
             delete this.filters.minAcquisitionDatetime;

--- a/app-frontend/src/app/components/filterPane/filterPane.html
+++ b/app-frontend/src/app/components/filterPane/filterPane.html
@@ -1,7 +1,7 @@
 <div class="sidebar-static" >
   <h5>Filters</h5>
   <div class="sidebar-actions">
-    <button class="btn btn-default btn-small" ng-click="$ctrl.closeFilterPane()">
+    <button class="btn btn-default btn-small" ng-click="$ctrl.close()">
       Close
     </button>
   </div>

--- a/app-frontend/src/app/pages/browse/browse.controller.js
+++ b/app-frontend/src/app/pages/browse/browse.controller.js
@@ -34,7 +34,7 @@ export default class BrowseController {
             return val;
         });
 
-        this.gridLayer = gridLayerService.createNewGridLayer(this.queryParams);
+        this.gridLayer = gridLayerService.createNewGridLayer(Object.assign({}, this.queryParams));
         // 100 is just a placeholder "big" number to leave plenty of space for basemaps
         this.gridLayer.setZIndex(100);
 

--- a/app-frontend/src/app/pages/browse/browse.html
+++ b/app-frontend/src/app/pages/browse/browse.html
@@ -126,7 +126,7 @@
 
   <div class="sidebar sidebar-extended map-filters"
        ng-show="$ctrl.showFilterPane && !$ctrl.activeScene">
-    <rf-filter-pane filters="$ctrl.filters"></rf-filter-pane>
+    <rf-filter-pane on-close-click="$ctrl.toggleFilterPane()" filters="$ctrl.filters"></rf-filter-pane>
   </div>
 
   <div class="main">


### PR DESCRIPTION
## Overview

Fixes bbox not being retained between reloads. Also makes the filter pane 'close' button work and fixes some missed JSDoc params.

## Testing Instructions

 * Zoom into a spot on the browse map, reload, and ensure you are returned to the same spot
 * Open the filter pane and ensure it can now close via the 'close' button.

Connects #912
