### PR TITLE
use mosaic tile server

### DIFF
--- a/app-frontend/src/app/components/colorCorrectPane/colorCorrectPane.component.js
+++ b/app-frontend/src/app/components/colorCorrectPane/colorCorrectPane.component.js
@@ -4,7 +4,8 @@ const colorCorrectPane = {
     templateUrl: colorCorrectPaneTpl,
     controller: 'ColorCorrectPaneController',
     bindings: {
-        selectedLayers: '<'
+        selectedLayers: '<',
+        mosaicLayer: '='
     }
 };
 

--- a/app-frontend/src/app/components/colorCorrectScenes/colorCorrectScenes.component.js
+++ b/app-frontend/src/app/components/colorCorrectScenes/colorCorrectScenes.component.js
@@ -4,6 +4,7 @@ const colorCorrectScenes = {
     templateUrl: colorCorrectScenesTpl,
     controller: 'ColorCorrectScenesController',
     bindings: {
+        mosaicLayer: '=',
         selectedScenes: '=',
         selectedLayers: '=',
         sceneList: '<',

--- a/app-frontend/src/app/core/services/layer.service.js
+++ b/app-frontend/src/app/core/services/layer.service.js
@@ -10,55 +10,102 @@ export default (app) => {
          * @param {object} $http injected angular $http service
          * @param {object} $q promise service
          * @param {object} colorCorrectService color correction service
-         * @param {object} scene response from the API
+         * @param {object} projectService project service
+         * @param {object} scene response from the API, optional
          * @param {object} projectId project that layer is in
+         * @param {boolean} projectMosaic flag to enable requesting layers from mosaic tile server
          * @param {boolean} gammaCorrect flag to enable gamma correction
          * @param {boolean} sigmoidCorrect flag to enable sigmoidal correction
          * @param {boolean} colorClipCorrect flag to enable color clipping
          * @param {object} bands keys = band type, values = band number
          */
         constructor( // eslint-disable-line max-params
-            $http, $q, colorCorrectService, scene, projectId, gammaCorrect = true,
-            sigmoidCorrect = true, colorClipCorrect = true, bands = {red: 3, green: 2, blue: 1}
+            $http, $q, colorCorrectService, projectService, scene, projectId,
+            projectMosaic = true, gammaCorrect = true, sigmoidCorrect = true,
+            colorClipCorrect = true, bands = {red: 3, green: 2, blue: 1}
         ) {
             this.$http = $http;
             this.$q = $q;
             this.scene = scene;
+            this.projectMosaic = projectMosaic;
             this.gammaCorrect = gammaCorrect;
             this.sigmoidCorrect = sigmoidCorrect;
             this.colorClipCorrect = colorClipCorrect;
             this.colorCorrectService = colorCorrectService;
+            this.projectService = projectService;
             this.bands = bands;
             this.projectId = projectId;
-            this._tiles = null; // eslint-disable-line no-underscore-dangle
+            this._sceneTiles = null; // eslint-disable-line no-underscore-dangle
+            this._mosaicTiles = null; // eslint-disable-line no-underscore-dangle
             this._correction = null; // eslint-disable-line no-underscore-dangle
-            this.bounds = L.latLngBounds(
-                L.latLng(
-                    scene.sceneMetadata.lowerLeftCornerLatitude,
-                    scene.sceneMetadata.lowerLeftCornerLongitude
-                ),
-                L.latLng(
-                    scene.sceneMetadata.upperRightCornerLatitude,
-                    scene.sceneMetadata.upperRightCornerLongitude
-                )
-            );
+            this.getBounds();
         }
 
-        /** Function to return a promise that resolves into a leaflet tile layer
+        /** Function to return bounds from either the project or the scene
+          *
+          * @return {object} Leaflet latLngBounds
+          */
+        getBounds() {
+            if (this.projectMosaic) {
+                this.projectService.getProjectCorners(this.projectId).then((data) => {
+                    this.bounds = L.latLngBounds(
+                        L.latLng(
+                            data.lowerLeftLat,
+                            data.lowerLeftLon
+                        ),
+                        L.latLng(
+                            data.upperRightLat,
+                            data.upperRightLon
+                        )
+                    );
+                });
+            } else {
+                this.bounds = L.latLngBounds(
+                    L.latLng(
+                        this.scene.sceneMetadata.lowerLeftCornerLatitude,
+                        this.scene.sceneMetadata.lowerLeftCornerLongitude
+                    ),
+                    L.latLng(
+                        this.scene.sceneMetadata.upperRightCornerLatitude,
+                        this.scene.sceneMetadata.upperRightCornerLongitude
+                    )
+                );
+            }
+        }
+
+        /** Function to return a promise that resolves into a leaflet tile layer for scenes
          *
-         * @return {$promise} promise for leaflet tile layer
+         * @return {$promise} promise for leaflet tile layer for scenes
          */
-        getTileLayer() {
-            if (this._tiles) { // eslint-disable-line no-underscore-dangle
+        getSceneTileLayer() {
+            if (this._sceneTiles) { // eslint-disable-line no-underscore-dangle
                 return this.$q((resolve) => {
-                    resolve(this._tiles); // eslint-disable-line no-underscore-dangle
+                    resolve(this._sceneTiles); // eslint-disable-line no-underscore-dangle
                 });
             }
-            return this.getLayerURL().then((url) => {
-                this._tiles = L.tileLayer(url, // eslint-disable-line no-underscore-dangle
+            return this.getSceneLayerURL().then((url) => {
+                this._sceneTiles = L.tileLayer(url, // eslint-disable-line no-underscore-dangle
                     {bounds: this.bounds, attribution: 'Raster Foundry'}
                 );
-                return this._tiles; // eslint-disable-line no-underscore-dangle
+                return this._sceneTiles; // eslint-disable-line no-underscore-dangle
+            });
+        }
+
+        /** Function to return a promise that resolves into a leaflet tile layer for mosaic
+         *
+         * @return {$promise} promise for leaflet tile layer for mosaic
+         */
+        getMosaicTileLayer() {
+            if (this._mosaicTiles) { // eslint-disable-line no-underscore-dangle
+                return this.$q((resolve) => {
+                    resolve(this._mosaicTiles); // eslint-disable-line no-underscore-dangle
+                });
+            }
+            return this.getMosaicLayerURL().then((url) => {
+                this._mosaicTiles = L.tileLayer(url, // eslint-disable-line no-underscore-dangle
+                                                {bounds: this.bounds, attribution: 'Raster Foundry'}
+                                               );
+                return this._mosaicTiles; // eslint-disable-line no-underscore-dangle
             });
         }
 
@@ -79,13 +126,24 @@ export default (app) => {
          * Helper function to return string for a tile layer
          * @returns {string} URL for this tile layer
          */
-        getLayerURL() {
-            let organizationId = this.scene.organizationId;
-            // TODO: replace this once user IDs are URL safe ISSUE: 766
-            let userId = this.scene.createdBy.replace('|', '_');
+        getSceneLayerURL() {
+            let userParams = this.userParamsFromScene(this.scene);
+            let organizationId = userParams.organizationId;
+            let userId = userParams.userId;
             return this.formatColorParams().then((formattedParams) => {
                 return `/tiles/${organizationId}/` +
                     `${userId}/${this.scene.id}/rgb/{z}/{x}/{y}/?${formattedParams}`;
+            });
+        }
+
+        getMosaicLayerURL(params) {
+            let userParams = this.userParamsFromScene(this.scene);
+            let organizationId = userParams.organizationId;
+            let userId = userParams.userId;
+            let formattedParams = L.Util.getParamString(params);
+            return this.$q((resolve) => {
+                resolve(`/tiles/${organizationId}/` +
+                        `${userId}/project/${this.projectId}/{z}/{x}/{y}/${formattedParams}`);
             });
         }
 
@@ -102,10 +160,9 @@ export default (app) => {
          * @returns {string} URL for the histogram
          */
         getHistogramURL() {
-            let organizationId = this.scene.organizationId;
-            // TODO: replace this once user IDs are URL safe ISSUE: 766
-
-            let userId = this.scene.createdBy.replace('|', '_');
+            let userParams = this.userParamsFromScene(this.scene);
+            let organizationId = userParams.organizationId;
+            let userId = userParams.userId;
             return this.formatColorParams().then((formattedParams) => {
                 return `/tiles/${organizationId}/` +
                     `${userId}/${this.scene.id}/rgb/histogram/?${formattedParams}`;
@@ -128,7 +185,7 @@ export default (app) => {
          * @returns {null} null
          */
         updateBands(bands = {redBand: 3, greenBand: 2, blueBand: 1}) {
-            this.getColorCorrection().then((correction) => {
+            return this.getColorCorrection().then((correction) => {
                 this.updateColorCorrection(Object.assign(correction, bands));
             });
         }
@@ -140,7 +197,7 @@ export default (app) => {
         resetTiles() {
             this._correction = this.colorCorrectService // eslint-disable-line no-underscore-dangle
                 .getDefaultColorCorrection();
-            this.colorCorrectService.reset(this.scene.id, this.projectId)
+            return this.colorCorrectService.reset(this.scene.id, this.projectId)
                 .then(() => this.colorCorrect());
         }
 
@@ -177,12 +234,35 @@ export default (app) => {
             });
         }
 
+        /**
+         * Helper function to turn a correction object into usable params
+         *
+         * for some reason  getColorCorrection's returned object includes all
+         * sorts of extra attributes like $promise that we don't want leaflet
+         * to turn into query params, so we have to grab only the parts that
+         * we want to get the request to work.
+         *
+         * @param {object} object containing color correction params
+         * @returns {object} initial object filtered to legal parameters
+         */
+        paramsFromObject(object) {
+            return {
+                redBand: object.redBand,
+                blueBand: object.blueBand,
+                greenBand: object.greenBand,
+                redGamma: object.redGamma,
+                greenGamma: object.greenGamma,
+                blueGamma: object.blueGamma,
+                brightness: object.brightness,
+                contrast: object.contrast,
+                alpha: object.alpha,
+                beta: object.beta,
+                min: object.min,
+                max: object.max
+            };
+        }
+
         getColorCorrection() {
-            if (this._correction) { // eslint-disable-line no-underscore-dangle
-                return this.$q((resolve) => {
-                    resolve(this._correction); // eslint-disable-line no-underscore-dangle
-                });
-            }
             return this.colorCorrectService.get(
                 this.scene.id, this.projectId
             ).then((data) => {
@@ -193,7 +273,7 @@ export default (app) => {
 
         updateColorCorrection(corrections) {
             this._correction = corrections; // eslint-disable-line no-underscore-dangle
-            this.colorCorrectService.updateOrCreate(
+            return this.colorCorrectService.updateOrCreate(
                 this.scene.id, this.projectId, corrections
             ).then(() => this.colorCorrect());
         }
@@ -204,30 +284,49 @@ export default (app) => {
          * @returns {null} null
          */
         colorCorrect() {
-            this.getTileLayer().then((tiles) => {
-                this.getLayerURL().then((url) => {
+            this.getSceneTileLayer().then((tiles) => {
+                this.getSceneLayerURL().then((url) => {
                     return tiles.setUrl(url);
                 });
             });
         }
+
+        /**
+         * Helper function to get user params from scene or list of scenes
+         * @param {object|object[]}scene scene or list of scenes to extract user params from
+         * @returns {object} {userId: url-safe user id, organizationId: url-safe org id}
+         */
+        userParamsFromScene(scene) {
+            // if we have one scene, make it into an array and grab the first element.
+            // if we have several scenes, concat them all to the empty array and take the first
+            let tmp = [].concat(scene)[0];
+            return {
+                // TODO: replace this once user IDs are URL safe ISSUE: 766
+                userId: tmp.createdBy.replace('|', '_'),
+                organizationId: tmp.organizationId
+            };
+        }
     }
 
     class LayerService {
-        constructor($http, $q, colorCorrectService) {
+        constructor($http, $q, colorCorrectService, projectService) {
             'ngInject';
             this.$http = $http;
             this.$q = $q;
             this.colorCorrectService = colorCorrectService;
+            this.projectService = projectService;
         }
 
         /**
          * Constructor for layer via a service
          * @param {object} scene resource returned via API
          * @param {string} projectId id for project scene belongs to
+         * @param {boolean} projectMosaic flag to enable requesting layers from mosaic tile server
          * @returns {Layer} layer created
          */
-        layerFromScene(scene, projectId) {
-            return new Layer(this.$http, this.$q, this.colorCorrectService, scene, projectId);
+        layerFromScene(scene, projectId, projectMosaic = false) {
+            return new Layer(this.$http, this.$q, this.colorCorrectService, this.projectService,
+                             scene, projectId, projectMosaic);
         }
     }
 

--- a/app-frontend/src/app/core/services/project.service.js
+++ b/app-frontend/src/app/core/services/project.service.js
@@ -90,6 +90,37 @@ export default (app) => {
             return this.Project.projectScenes(params).$promise;
         }
 
+        getProjectCorners(projectId) {
+            return this.getAllProjectScenes({projectId: projectId}).then((scenes) => {
+                let corners = {
+                    lowerLeftLon: null,
+                    lowerLeftLat: null,
+                    upperRightLon: null,
+                    upperRightLat: null
+                };
+                scenes.forEach(scene => {
+                    let metadata = scene.sceneMetadata;
+                    if (metadata.lowerLeftCornerLatitude < corners.lowerLeftLat ||
+                        corners.lowerLeftLat === null) {
+                        corners.lowerLeftLat = metadata.lowerLeftCornerLatitude;
+                    }
+                    if (metadata.lowerLeftCornerLongitude < corners.lowerLeftLon ||
+                        corners.lowerLeftLon === null) {
+                        corners.lowerLeftLon = metadata.lowerLeftCornerLongitude;
+                    }
+                    if (metadata.upperRightCornerLatitude < corners.upperRightLat ||
+                        corners.upperRightLat === null) {
+                        corners.upperRightLat = metadata.upperRightCornerLatitude;
+                    }
+                    if (metadata.upperRightCornerLongitude < corners.upperRightLon ||
+                        corners.upperRightLon === null) {
+                        corners.upperRightLon = metadata.upperRightCornerLongitude;
+                    }
+                });
+                return corners;
+            });
+        }
+
         /** Return all scenes in a single collection, making multiple requests if necessary
          *
          * @param {object} params to pass as query params


### PR DESCRIPTION
## Overview

This PR requests a mosaic of all scenes in a project from the tile server instead of requesting each scene individually. As a result we only add one layer to the map for the scenes in a project instead of one per scene.

### Checklist

- ~[ ] Styleguide updated, if necessary~
- ~[ ] Swagger specification updated, if necessary~

### Demo

No gifs because they looked terrible after fuzzing and I didn't want to upload 80mb images

## Testing Instructions

 * Bring up your front- and backends
 * Open dev tools and start recording network activity
 * Go to the editor for a project on the correctable Egypt scenes
 * Select some scenes and then color correct them
 * Verify that the mosaic redraws with color correction changes and that the requests are going to `/tiles/`

Connects #825 
