### PR TITLE
Fix browse scene thumbnail persistence

### DIFF
--- a/app-frontend/src/app/components/selectedScenesModal/selectedScenesModal.controller.js
+++ b/app-frontend/src/app/components/selectedScenesModal/selectedScenesModal.controller.js
@@ -2,7 +2,6 @@ export default class SelectedScenesModalController {
     constructor($log, $state) {
         'ngInject';
         this.$state = $state;
-
         this.scenes = [];
         this.selectedScenes = this.resolve.scenes;
         this.selectedScenes.forEach((value) => {
@@ -12,14 +11,6 @@ export default class SelectedScenesModalController {
 
     isSelected(scene) {
         return this.selectedScenes.has(scene.id);
-    }
-
-    setSelected(scene, selected) {
-        if (selected) {
-            this.selectedScenes.set(scene.id, scene);
-        } else {
-            this.selectedScenes.delete(scene.id);
-        }
     }
 
     viewSceneDetail(scene) {

--- a/app-frontend/src/app/components/selectedScenesModal/selectedScenesModal.html
+++ b/app-frontend/src/app/components/selectedScenesModal/selectedScenesModal.html
@@ -22,7 +22,7 @@
           ng-click="$ctrl.viewSceneDetail(scene)"
           scene="scene" selected="$ctrl.isSelected(scene)"
           selectable="true"
-          on-select="$ctrl.setSelected(scene, selected)"
+          on-select="$ctrl.resolve.selectScene(scene, selected)"
           class="selectable"
           ng-repeat="scene in $ctrl.scenes track by scene.id">
       </rf-scene-item>
@@ -47,7 +47,7 @@
       </button>
   	</div>
   	<button type="button" class="btn" data-dismiss="modal"
-            ng-click="$ctrl.selectedScenes.clear()">
+            ng-click="$ctrl.resolve.selectNoScenes()">
       <i class="icon-cross"></i>
       Deselect All
     </button>

--- a/app-frontend/src/app/core/services/map.service.js
+++ b/app-frontend/src/app/core/services/map.service.js
@@ -293,7 +293,7 @@ class MapWrapper {
      * @returns {this} this
      */
     setThumbnail(scene, useSmall, persist) {
-        if (!persist && scene.id in this.persistedThumbnails) {
+        if (this.persistedThumbnails.has(scene.id)) {
             return this;
         }
         let footprintGeojson = Object.assign({
@@ -351,7 +351,7 @@ class MapWrapper {
         if (!scene) {
             this.deleteLayers('thumbnail');
             this.deleteGeojson('thumbnail');
-        } else {
+        } else if (this.persistedThumbnails.has(scene.id)) {
             this.map.removeLayer(this.persistedThumbnails.get(scene.id));
             this.persistedThumbnails.delete(scene.id);
         }

--- a/app-frontend/src/app/pages/browse/browse.controller.js
+++ b/app-frontend/src/app/pages/browse/browse.controller.js
@@ -322,6 +322,7 @@ export default class BrowseController {
 
     selectNoScenes() {
         this.selectedScenes.clear();
+        this.sceneList.forEach(s => this.setSelected(s, false));
     }
 
     toggleSelectAndClosePane() {
@@ -407,7 +408,9 @@ export default class BrowseController {
         this.activeModal = this.$uibModal.open({
             component: 'rfSelectedScenesModal',
             resolve: {
-                scenes: () => this.selectedScenes
+                scenes: () => this.selectedScenes,
+                selectScene: () => this.setSelected.bind(this),
+                selectNoScenes: () => this.selectNoScenes.bind(this)
             }
         });
 


### PR DESCRIPTION
## Overview

This fixes some thumbnail bugs, such as thumbnails remaining on the map after their scene is selected and then the select all button is used, or thumbnails persisting on the map after the respective scene is de-selected from the modal.


## Testing Instructions

 * Hover over scenes on the browse page and ensure thumbnails are displayed
 * Select a scene, ensure its thumbnail is displayed and persisted when the mouse leaves the scene's element
 * Click the select all button, ensure all thumbnails are displayed
 * Click the select all button again, ensure no thumbnails are displayed
 * Select some scenes, then click the selected scene button to open the modal
 * De-select some scenes from there, make sure those changes are persisted to the browse page and the the thumbnails are removed
 * Select more scenes again, open the modal, and then deselect all from the modal. Ensure no thumbnails remain on the map

Connects #888
