### PR TITLE
Feature/cmb/disable hist wireup publish

### DIFF
--- a/app-backend/app/src/main/resources/application.conf
+++ b/app-backend/app/src/main/resources/application.conf
@@ -63,5 +63,12 @@ featureFlags {
       name = "Market Search"
       description = "Allow the market search feature to be visible"
     }
+    {
+      key = "display-histogram"
+      active = false
+      name = "Display Histogram"
+      description = "Display and fetch histograms for color correction"
+    }
+
   ]
 }

--- a/app-frontend/src/app/components/colorCorrectPane/colorCorrectPane.controller.js
+++ b/app-frontend/src/app/components/colorCorrectPane/colorCorrectPane.controller.js
@@ -1,10 +1,11 @@
 export default class ColorCorrectPaneController {
     constructor( // eslint-disable-line max-params
-        $log, $scope, $q, projectService, $state
+        $log, $scope, $q, projectService, $state, featureFlags
     ) {
         'ngInject';
         this.$parent = $scope.$parent.$ctrl;
         this.projectService = projectService;
+        this.featureFlags = featureFlags;
         this.$state = $state;
         this.$q = $q;
     }
@@ -24,7 +25,10 @@ export default class ColorCorrectPaneController {
         this.firstLayer.getColorCorrection().then((correction) => {
             this.correction = correction;
         });
-        this.fetchHistograms();
+
+        if (this.featureFlags.isOn('display-histogram')) {
+            this.fetchHistograms();
+        }
     }
 
     $onDestroy() {
@@ -53,7 +57,10 @@ export default class ColorCorrectPaneController {
             for (let layer of this.selectedLayers.values()) {
                 layer.updateColorCorrection(newCorrection);
             }
-            this.fetchHistograms();
+
+            if (this.featureFlags.isOn('display-histogram')) {
+                this.fetchHistograms();
+            }
         }
     }
 

--- a/app-frontend/src/app/components/colorCorrectPane/colorCorrectPane.html
+++ b/app-frontend/src/app/components/colorCorrectPane/colorCorrectPane.html
@@ -6,7 +6,7 @@
     </div>
   </div>
 
-  <div class="sidebar-static histogram">
+  <div feature-flag="display-histogram" class="sidebar-static histogram">
     <div class="histogram-loading-indicator" ng-show="$ctrl.errorLoadingHistogram || $ctrl.loadingHistogram">
       <!--Histogram is loading-->
       <i ng-show="$ctrl.loadingHistogram && !$ctrl.errorLoadingHistogram" class="icon-load animated"></i>

--- a/app-frontend/src/app/components/publishModal/publishModal.html
+++ b/app-frontend/src/app/components/publishModal/publishModal.html
@@ -14,7 +14,7 @@
       <div class="form-group all-in-one">
         <label for="tile-link" class="sr-only">URI Link</label>
         <input id="tile-link" type="text" class="form-control"
-                value="/tiles/projects/{{$ctrl.resolve.project.id}}" readonly>
+                value="{{$ctrl.resolve.tileTemplateUrl}}" readonly>
          <!--
            @TODO: the copy button is intended to copy the url for the user which
            is not currently implemented

--- a/app-frontend/src/app/pages/editor/project/projectEdit.controller.js
+++ b/app-frontend/src/app/pages/editor/project/projectEdit.controller.js
@@ -2,11 +2,12 @@ const Map = require('es6-map');
 
 export default class ProjectEditController {
     constructor( // eslint-disable-line max-params
-        $scope, $rootScope, $state, mapService, projectService, layerService, $uibModal
+        $scope, $rootScope, $location, $state, mapService, projectService, layerService, $uibModal
     ) {
         'ngInject';
         this.$state = $state;
         this.$scope = $scope;
+        this.$location = $location;
         this.$rootScope = $rootScope;
         this.projectService = projectService;
         this.layerService = layerService;
@@ -175,7 +176,20 @@ export default class ProjectEditController {
             backdrop: 'static',
             keyboard: false,
             resolve: {
-                project: () => this.project
+                project: () => this.project,
+                tileTemplateUrl: () => {
+                    let host = this.$location.host();
+                    let protocol = this.$location.protocol();
+
+                    let port = this.$location.port();
+                    let formattedPort = port !== 80 || port !== 443 ? ':' + port : '';
+                    let tag = (new Date()).getTime();
+                    return `${protocol}://${host}${formattedPort}` +
+                        `/tiles/${this.project.organizationId}` +
+                        '/rf_airflow-user' +
+                        `/project/${this.project.id}/{z}/{x}/{y}/` +
+                        `?tag=${tag}`;
+                }
             }
         });
     }

--- a/app-frontend/src/app/pages/library/projects/detail/projectScenes/projectScenes.controller.js
+++ b/app-frontend/src/app/pages/library/projects/detail/projectScenes/projectScenes.controller.js
@@ -1,11 +1,12 @@
 export default class ProjectScenesController {
     constructor( // eslint-disable-line max-params
-        $log, $state, projectService, $scope, $uibModal
+        $log, $state, $location, projectService, $scope, $uibModal
     ) {
         'ngInject';
 
         this.$log = $log;
         this.$state = $state;
+        this.$location = $location;
         this.projectService = projectService;
         this.$parent = $scope.$parent.$ctrl;
         this.$uibModal = $uibModal;
@@ -176,7 +177,20 @@ export default class ProjectScenesController {
         this.activeModal = this.$uibModal.open({
             component: 'rfPublishModal',
             resolve: {
-                project: () => this.project
+                project: () => this.project,
+                tileTemplateUrl: () => {
+                    let host = this.$location.host();
+                    let protocol = this.$location.protocol();
+
+                    let port = this.$location.port();
+                    let formattedPort = port !== 80 || port !== 443 ? ':' + port : '';
+                    let tag = (new Date()).getTime();
+                    return `${protocol}://${host}${formattedPort}` +
+                        `/tiles/${this.project.organizationId}` +
+                        '/rf_airflow-user' +
+                        `/project/${this.project.id}/{z}/{x}/{y}/` +
+                        `?tag=${tag}`;
+                }
             }
         });
     }


### PR DESCRIPTION
## Overview

This makes two changes:

 1. Puts histogram fetching and display behind a feature flag
 2. Uses correct publish URL in publish modal

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~

### Demo

![correct-tileurl](https://cloud.githubusercontent.com/assets/898060/21891789/59ee6300-d8a2-11e6-9878-84a06a08159c.png)
![no-hist](https://cloud.githubusercontent.com/assets/898060/21891788/59ed5370-d8a2-11e6-9724-d16d4bc724f7.png)


### Notes

I am creating an issue because the tile server requires the user that generated the scenes, but this will quickly not be the case.

## Testing Instructions

 * Load the editor and start color correcting, verify that the histogram does not display or make requests
 * Use the publish modal in both the editor and library, use that URL in geojson.io to verify tiles load
