### PR TITLE
Refactor dead-end modals to lab and editor

### DIFF
--- a/app-frontend/src/app/components/navBar/navBar.controller.js
+++ b/app-frontend/src/app/components/navBar/navBar.controller.js
@@ -1,14 +1,14 @@
 import assetLogo from '../../../assets/images/logo-raster-foundry.png';
 
-// rfNavBar controller class
 export default class NavBarController {
     constructor( // eslint-disable-line max-params
-        $log, $state, store, $scope, APP_CONFIG, authService
+        $log, $state, $uibModal, store, $scope, APP_CONFIG, authService
     ) {
         'ngInject';
 
         this.$log = $log;
         this.$state = $state;
+        this.$uibModal = $uibModal;
         this.store = store;
         this.authService = authService;
 
@@ -18,6 +18,41 @@ export default class NavBarController {
 
         this.optionsOpen = false;
         this.assetLogo = assetLogo;
+    }
+
+    gotoEditor() {
+        if (!this.$state.$current.name.includes('editor')) {
+            if (this.activeModal) {
+                this.activeModal.dismiss();
+            }
+
+            this.activeModal = this.$uibModal.open({
+                component: 'rfSelectProjectModal'
+            });
+
+            this.activeModal.result.then(p => {
+                this.$state.go('editor.project.color.scenes', {projectid: p.id});
+            });
+        }
+        return this.activeModal;
+    }
+
+    gotoLab() {
+        if (!this.$state.$current.name.includes('lab')) {
+            if (this.activeModal) {
+                this.activeModal.dismiss();
+            }
+
+            this.activeModal = this.$uibModal.open({
+                component: 'rfSelectToolModal'
+            });
+
+            this.activeModal.result.then(t => {
+                this.$state.go('lab.edit', {toolid: t.id});
+            });
+        }
+
+        return this.activeModal;
     }
 
     signin() {

--- a/app-frontend/src/app/components/navBar/navBar.html
+++ b/app-frontend/src/app/components/navBar/navBar.html
@@ -7,7 +7,7 @@
     <span class="navbar-vertical-divider"></span>
     <nav>
       <a href ui-sref="browse" ui-sref-active="active">Scene browser</a>
-      <a href ui-sref="editor.project.color.scenes"
+      <a href ng-click="$ctrl.gotoEditor()"
          ng-class="{
                    active: $ctrl.$state.$current.name.includes('editor')
                    }">Editor</a>
@@ -15,7 +15,7 @@
          ng-class="{
                    active: $ctrl.$state.$current.name.includes('market')
                    }">Tool Catalog</a>
-      <a href ui-sref="lab.edit"
+      <a href ng-click="$ctrl.gotoLab()"
          ng-class="{
                    active: $ctrl.$state.$current.name.includes('lab')
                    }">Lab</a>

--- a/app-frontend/src/app/components/selectProjectModal/selectProjectModal.controller.js
+++ b/app-frontend/src/app/components/selectProjectModal/selectProjectModal.controller.js
@@ -34,7 +34,6 @@ export default class SelectProjectModalController {
     }
 
     setSelected(project) {
-        this.dismiss();
-        this.$state.go(this.$state.current, {projectid: project.id});
+        this.close({$value: project});
     }
 }

--- a/app-frontend/src/app/components/selectProjectModal/selectProjectModal.html
+++ b/app-frontend/src/app/components/selectProjectModal/selectProjectModal.html
@@ -1,11 +1,11 @@
 <div class="modal-header">
   <button type="button" class="close" aria-label="Close"
-          ng-click="$ctrl.dismiss()" ng-show="$ctrl.resolve.project">
+          ng-click="$ctrl.dismiss()" ng-show="!$ctrl.resolve.requireSelection">
     <span aria-hidden="true">&times;</span>
   </button>
   <span class="badge"><i class="icon-bucket"></i></span>
   <h4 class="modal-title">
-    {{$ctrl.resolve.content.title}}
+    {{$ctrl.resolve.content.title || 'Select Project'}}
   </h4>
 </div>
 <div class="modal-body">

--- a/app-frontend/src/app/components/selectToolModal/selectToolModal.controller.js
+++ b/app-frontend/src/app/components/selectToolModal/selectToolModal.controller.js
@@ -7,12 +7,12 @@ export default class SelectToolModalController {
     }
 
     fetchToolList() {
-        this.loadingTools = true;
+        this.loading = true;
         this.toolService.query().then(d => {
             this.updatePagination(d);
             this.lastToolResponse = d;
             this.toolList = d.results;
-            this.loadingTools = false;
+            this.loading = false;
         });
     }
 

--- a/app-frontend/src/app/components/selectToolModal/selectToolModal.html
+++ b/app-frontend/src/app/components/selectToolModal/selectToolModal.html
@@ -1,4 +1,8 @@
 <div class="modal-header">
+  <button type="button" class="close" aria-label="Close"
+          ng-click="$ctrl.dismiss()" ng-show="!$ctrl.resolve.requireSelection">
+    <span aria-hidden="true">&times;</span>
+  </button>
   <span class="badge"><i class="icon-bucket"></i></span>
   <h4 class="modal-title">
     {{$ctrl.resolve.content.title || "Select Tool"}}

--- a/app-frontend/src/app/pages/editor/project/projectEdit.controller.js
+++ b/app-frontend/src/app/pages/editor/project/projectEdit.controller.js
@@ -161,8 +161,15 @@ export default class ProjectEditController {
             backdrop: 'static',
             keyboard: false,
             resolve: {
+                requireSelection: () => true
             }
         });
+
+        this.activeModal.results.then(p => {
+            this.$state.go(this.$state.current, {projectid: p.id});
+        });
+
+        return this.activeModal;
     }
 
     publishModal() {

--- a/app-frontend/src/app/pages/lab/lab.controller.js
+++ b/app-frontend/src/app/pages/lab/lab.controller.js
@@ -40,6 +40,7 @@ class labController {
             backdrop: 'static',
             keyboard: false,
             resolve: {
+                requireSelection: () => true
             }
         }).result.then((t) => {
             this.$state.go(this.$state.current, {toolid: t.id});


### PR DESCRIPTION
## Overview

Refactors how transitions to the lab and editor handled getting required user input: selecting the current tool and selecting the current project, respectively. Now, when normally navigating through the app, the modals that get the required input from the user occur on the current page so that the user can exit the modal, which was before un-allowed.

### Notes

These operations might ideally integrated into the UI better (not a modal).

I retained the dead-end functionality if the user _somehow_ gets to a certain route (changing the URL manually) without a required entity being selected. This should almost never occur.


## Testing Instructions

 * Click the `Editor` link and check that you are not forced to select something and can exit the modal
* Click the `Lab` link and check that you are not forced to select something and can exit the modal
