### PR TITLE
Remove unused links in library

### DIFF
--- a/app-frontend/src/app/pages/library/library.html
+++ b/app-frontend/src/app/pages/library/library.html
@@ -7,7 +7,7 @@
            ng-class="{
                      'active': $ctrl.$state.$current.name.includes('library.scenes')
                      }">
-          My Scenes
+          Scenes
         </a>
         <a ui-sref="library.projects.list"
         ng-class="{
@@ -15,9 +15,7 @@
                   }">
           Projects
         </a>
-        <a ui-sref="library.mosaics" ui-sref-active="active">Mosaics</a>
         <a ui-sref="library.tools" ui-sref-active="active">Tools</a>
-        <a ui-sref="library.tooloutputs" ui-sref-active="active">Tool Outputs</a>
       </nav>
     </div>
   </div>


### PR DESCRIPTION
## Overview

Removes the 'mosaics' and the 'tool outputs' links from the library menu. Also renames 'My Scenes' to 'Scenes' to match the rest of the interface verbiage.

## Demo

Before:
<img width="489" alt="screen shot 2017-01-12 at 2 45 34 pm" src="https://cloud.githubusercontent.com/assets/2442245/21905557/d7ff0e60-d8d5-11e6-89f9-6c52f8b50ad2.png">

After:
<img width="495" alt="screen shot 2017-01-12 at 2 45 18 pm" src="https://cloud.githubusercontent.com/assets/2442245/21905561/dc71a0ac-d8d5-11e6-9445-1d8bc50c7ad7.png">

## Testing Instructions

 * Look at the library...
