### PR TITLE
Add context menus and selected cell to diagram

### DIFF
--- a/app-frontend/src/app/components/diagramContainer/diagramContainer.component.js
+++ b/app-frontend/src/app/components/diagramContainer/diagramContainer.component.js
@@ -1,5 +1,7 @@
+import diagramContainerTpl from './diagramContainer.html';
+
 export default {
-    template: '<div class="main lab-workspace"></div>',
+    templateUrl: diagramContainerTpl,
     controller: 'DiagramContainerController',
     bindings: {
         shapes: '<?',

--- a/app-frontend/src/app/components/diagramContainer/diagramContainer.html
+++ b/app-frontend/src/app/components/diagramContainer/diagramContainer.html
@@ -1,0 +1,18 @@
+<div class="main lab-workspace"></div>
+<div class="lab-contextmenu" ng-show="$ctrl.isShowingContextMenu">
+    <div>
+        <ul>
+            <li ng-repeat="item in $ctrl.currentContextMenu track by $index"
+                ng-click="item.callback()">
+                {{item.label}}
+            </li>
+        </ul>
+    </div>
+</div>
+<div class="lab-contextmenu measuring">
+    <ul>
+        <li ng-repeat="item in $ctrl.currentContextMenu track by $index">
+            {{item.label}}
+        </li>
+    </ul>
+</div>

--- a/app-frontend/src/app/components/diagramContainer/diagramContainer.module.js
+++ b/app-frontend/src/app/components/diagramContainer/diagramContainer.module.js
@@ -2,6 +2,8 @@ import angular from 'angular';
 import DiagramContainerComponent from './diagramContainer.component.js';
 import DiagramContainerController from './diagramContainer.controller.js';
 
+require('./diagramContainer.scss');
+
 const DiagramContainerModule = angular.module('components.diagramContainer', []);
 
 DiagramContainerModule.component('rfDiagramContainer', DiagramContainerComponent);

--- a/app-frontend/src/app/components/diagramContainer/diagramContainer.scss
+++ b/app-frontend/src/app/components/diagramContainer/diagramContainer.scss
@@ -1,0 +1,47 @@
+// @TODO: incorporate dropdown styles into app styles
+
+.lab-contextmenu {
+  position: absolute;
+  background: #465076;
+  &.measuring {
+    top: -10000px;
+    left: -10000px;
+  }
+  ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    border: 1px solid darken(#465076, 15%);
+    li {
+      display: inline-block;
+      padding: 12px;
+      color: #fff;
+      border-right: 1px solid rgba(#000, 0.5);
+      transition: all 0.25s;
+      cursor: pointer;
+      &:last-child {
+        border-right: none;
+      }
+      &:hover {
+        background: #738FFC;
+      }
+    }
+  }
+}
+
+.lab-contextmenu div:after {
+	top: 100%;
+	left: 50%;
+	border: solid transparent;
+	content: " ";
+	height: 0;
+	width: 0;
+	position: absolute;
+	pointer-events: none;
+	border-color: rgba(136, 183, 213, 0);
+	border-top-color: darken(#465076, 15%);
+	border-width: 8px;
+	margin-left: -8px;
+}
+
+// @TODO: add rotated sqare div to make pointer;


### PR DESCRIPTION
## Overview

Add context menus to each diagram cell. Context menus can be individually defined for any cell, or can be set to a default context menu. Each context menu item can define a callback. Only one context menu is shown at a time.
 
### Demo

<img width="1266" alt="screen shot 2017-01-13 at 11 41 12 am" src="https://cloud.githubusercontent.com/assets/2442245/21937376/3afb3c5a-d985-11e6-9e92-3bd701ae614b.png">

### Notes

Didn't do anything to handle cases where a cell would not have a context menu. Best way to handle this in the future would be to specifically set the context menu for that cell id to `false` and adjust context menu display to handle the `false` value.

The context menus have been tested to properly execute their callbacks, but for now, the default callbacks are empty.

## Testing Instructions

* Go to the lab and click on diagram nodes, see that the context menu appears when you click a cell.
* Click outside of any cell to deselect it and hide it's context menu.
* Click the 'NDVI - Before' cell and check that it has a unique first context menu item (demonstrating that defining non-default menus works)
