### PR TITLE
Persist Scene footprints when selected for color correction

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ The workflow for creating a new migration is:
 
 To do frontend development you will want to install [`nvm`](https://github.com/creationix/nvm#install-script) and use at least version 6.8.1. Once using `nvm`, install [yarn](https://yarnpkg.com/) with `npm install -g yarn`. After following the directions above for starting the VM, start the API server and other backend services by running `./scripts/server`.
 
-Then _outside_ the VM, while the server is still running, run `yarn run start` while inside the `app-frontend/` directory. This will start a `webpack-dev-server` on port 9090 that will auto-reload after javascript and styling changes.
+Then _outside_ the VM, while the server is still running, run `yarn run start` while inside the `app-frontend/` directory. This will start a `webpack-dev-server` on port 9091 that will auto-reload after javascript and styling changes.
 
 There are three options to rebuild the static assets served by nginx:
  - run `yarn run build` outside the VM

--- a/app-frontend/src/app/components/colorCorrectPane/colorCorrectPane.component.js
+++ b/app-frontend/src/app/components/colorCorrectPane/colorCorrectPane.component.js
@@ -5,6 +5,7 @@ const colorCorrectPane = {
     controller: 'ColorCorrectPaneController',
     bindings: {
         selectedLayers: '<',
+        selectedScenes: '<',
         mosaicLayer: '='
     }
 };

--- a/app-frontend/src/app/components/colorCorrectPane/colorCorrectPane.controller.js
+++ b/app-frontend/src/app/components/colorCorrectPane/colorCorrectPane.controller.js
@@ -1,13 +1,15 @@
 export default class ColorCorrectPaneController {
     constructor( // eslint-disable-line max-params
-        $log, $scope, $q, projectService, $state, featureFlags
+        $log, $scope, $q, projectService, $state, featureFlags, sceneService, mapService
     ) {
         'ngInject';
         this.$parent = $scope.$parent.$ctrl;
         this.projectService = projectService;
+        this.sceneService = sceneService;
         this.featureFlags = featureFlags;
         this.$state = $state;
         this.$q = $q;
+        this.getMap = () => mapService.getMap('project');
     }
 
     $onInit() {
@@ -29,10 +31,18 @@ export default class ColorCorrectPaneController {
         if (this.featureFlags.isOn('display-histogram')) {
             this.fetchHistograms();
         }
+        this.getMap().then((map) => {
+            this.selectedScenes.forEach((scene) => {
+                map.setGeojson(scene.id, this.sceneService.getStyledFootprint(scene));
+            });
+        });
     }
 
     $onDestroy() {
         this.$parent.fitAllScenes();
+        this.getMap().then((map) => {
+            this.selectedScenes.forEach((scene) => map.deleteGeojson(scene.id));
+        });
     }
 
     resetCorrection() {

--- a/app-frontend/src/app/components/colorCorrectPane/colorCorrectPane.state.html
+++ b/app-frontend/src/app/components/colorCorrectPane/colorCorrectPane.state.html
@@ -1,2 +1,4 @@
-<rf-color-correct-pane class="flex-column sidebar-dark" selected-layers="$ctrl.selectedLayers">
+<rf-color-correct-pane class="flex-column sidebar-dark"
+  selected-layers="$ctrl.selectedLayers"
+  selected-scenes="$ctrl.selectedScenes">
 </rf-color-correct-pane>

--- a/app-frontend/src/app/core/services/scene.service.js
+++ b/app-frontend/src/app/core/services/scene.service.js
@@ -32,6 +32,25 @@ export default (app) => {
             boundsGeoJson.addData(scene.dataFootprint);
             return boundsGeoJson.getBounds();
         }
+
+        /**
+        * Generate a styled GeoJSON footprint, suitable for placing on a map.
+        * @param {Scene} scene For which to generate a GeoJSON footprint
+        *
+        * @returns {Object} GeoJSON footprint of scene.
+        */
+        getStyledFootprint(scene) {
+            let styledGeojson = Object.assign({}, scene.dataFootprint, {
+                properties: {
+                    options: {
+                        weight: 2,
+                        fillOpacity: 0
+                    }
+                }
+            });
+            return styledGeojson;
+        }
+
     }
 
     app.service('sceneService', SceneService);


### PR DESCRIPTION
## Overview
Our belief that the color-correction's "zoom to selected" functionality was broken seems to have stemmed from UX; because the whole scene list doesn't fit on the screen at the same time, it was easy to unwittingly select multiple scenes using the grid-select functionality, which would then give the impression that the map wasn't zoomed in enough, or zoomed out too far. This adds functionality to persist the footprints of any selected scenes on the map so that the area covered by the selected scenes is clearer.

### Checklist

- [ ] ~Styleguide updated, if necessary~
- [ ] ~Swagger specification updated, if necessary~

### Demo

![footprints1](https://cloud.githubusercontent.com/assets/447977/21997883/ac46dd0c-dbff-11e6-9ddd-85f9caf25984.png)
![footprints2](https://cloud.githubusercontent.com/assets/447977/21997887/af9b995c-dbff-11e6-8d8c-5ca67fd46b1d.png)

### Notes

- ~WIP because I still need to remove the footprints when switching to the Mosaic pane.~

## Testing Instructions
* Start up `yarn run start` and `./scripts/server`
* Navigate to the color correction interface for the Egypt scenes
* Select and deselect scenes through various methods (grid select, select-all button, scene list select buttons) and note that this causes the scenes' footprints to appear on / disappear from the map depending on whether they are selected.
* Confirm that switching to the color-correction interface correctly zooms to the bounds of the selected scenes.
