### PR TITLE
Add rollbar to app-server

### DIFF
--- a/app-backend/app/build.sbt
+++ b/app-backend/app/build.sbt
@@ -15,6 +15,7 @@ initialCommands in console := """
   |val publicOrgId = UUID.fromString("dfac6307-b5ef-43f7-beda-b9f208bb7726")
   |import geotrellis.vector.{MultiPolygon, Polygon, Point, Geometry}
   |import geotrellis.slick.Projected
+  |object Rollbar extends utils.RollbarNotifier
   |object Main extends Config { implicit val database = Database.DEFAULT }
   |import Main._
 """.trim.stripMargin

--- a/app-backend/app/src/main/scala/utils/Rollbar.scala
+++ b/app-backend/app/src/main/scala/utils/Rollbar.scala
@@ -1,0 +1,55 @@
+package com.azavea.rf.utils
+
+import scala.concurrent._
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.util.{Success, Failure}
+
+import akka.http.scaladsl.Http
+import akka.http.scaladsl.model._
+import spray.json._
+import DefaultJsonProtocol._
+
+import com.azavea.rf.AkkaSystem
+
+trait RollbarNotifier {
+
+  import AkkaSystem.{system, materializer}
+
+  val rollbarApiToken = sys.env.get("ROLLBAR_API_TOKEN") match {
+    case Some(t) => t
+    case _ =>
+      throw new RuntimeException("Rollbar API token must be present to notify rollbar")
+  }
+
+  val url = "https://api.rollbar.com/api/1/item/"
+
+  val environment = sys.env.get("ENVIRONMENT") match {
+    case Some(env) => env
+    case _ => "staging"
+  }
+
+  def buildRollbarPayload(e: Exception): JsObject = JsObject(
+    "access_token" -> this.rollbarApiToken.toJson,
+    "data" -> JsObject(
+      "environment" -> this.environment.toJson,
+      "body" -> JsObject(
+        "message" -> JsObject(
+          "body" -> e.getMessage.toJson,
+          "stackTrace" -> (e.getStackTrace map { x: StackTraceElement => x.toString })
+            .mkString("\n")
+            .toJson
+        )
+      )
+    )
+  )
+
+  def sendError(e: Exception): Unit = {
+    val payload = this.buildRollbarPayload(e)
+    Http().singleRequest(
+      HttpRequest(HttpMethod("POST", false, false, RequestEntityAcceptance.Expected),
+                  uri = this.url,
+                  entity = HttpEntity(ContentTypes.`application/json`,
+                                      payload.toString))
+    )
+  }
+}

--- a/app-backend/app/src/main/scala/utils/UserErrorHandler.scala
+++ b/app-backend/app/src/main/scala/utils/UserErrorHandler.scala
@@ -5,19 +5,28 @@ import akka.http.scaladsl.model.StatusCodes
 import com.typesafe.scalalogging.LazyLogging
 import spray.json.{SerializationException, DeserializationException}
 
-trait UserErrorHandler extends Directives with LazyLogging {
+trait UserErrorHandler extends Directives
+    with RollbarNotifier
+    with LazyLogging {
   val userExceptionHandler = ExceptionHandler {
     case e: IllegalArgumentException =>
       logger.error(RfStackTrace(e))
+      sendError(e)
       complete(StatusCodes.ClientError(400)("Bad Argument", e.getMessage))
     case e: IllegalStateException =>
       logger.error(RfStackTrace(e))
+      sendError(e)
       complete(StatusCodes.ClientError(400)("Bad Request", e.getMessage))
     case e: DeserializationException =>
       logger.error(RfStackTrace(e))
+      sendError(e)
       complete(StatusCodes.ClientError(400)("Decoding Error", e.getMessage))
     case e: SerializationException =>
       logger.error(RfStackTrace(e))
+      sendError(e)
       complete(StatusCodes.ServerError(500)("Encoding Error", e.getMessage))
+    case e: Exception =>
+      sendError(e)
+      complete(StatusCodes.ServerError(501)("An unknown error occurred", ""))
   }
 }


### PR DESCRIPTION
## Overview

This PR adds rollbar support to the app server so we can see errors that occur in staging while we're not paying attention to them

### Checklist

- ~[ ] Styleguide updated, if necessary~
- ~[ ] Swagger specification updated, if necessary~

### Demo

### Notes

This is sort of minimal for now but is designed to be extensible when we want more. We may want routing-aware `Exception` classes that know different things about the contexts in which they occur than what the base exception classes know (like the URL endpoints where they occur, for example

## Testing Instructions

#### Testing path 1

 * Get the development `.env` file from S3
 * Go to `healthCheckRoutes` and throw an error on purpose, e.g., replace `healthCheckRoutes = ...` with
```scala
val healthCheckRoutes = handleExceptions(healthCheckExceptionHandler) {
  pathEndOrSingleSlash {
    get {
      throw new Exception("words words words")
      complete {
        HealthCheckService.healthCheck
      }
    }
  }
}
```
  * verify in rollbar that your exception was logged

#### Testing path 2

 * Get the development `.env` file from S3
 * `./scripts/console app-server ./sbt`, then `app/console`
 * `Rollbar.sendError(new Exception("really bad news here bud"))`
 * verify in rollbar that your exception was logged

Connects #691 
