### PR TITLE
WIP: Add diagram node preview and comparison

### DIFF
--- a/app-frontend/package.json
+++ b/app-frontend/package.json
@@ -38,7 +38,7 @@
     "angular-ui-bootstrap": "~2.1.4",
     "angular-ui-router": "~0.3.1",
     "angular-ui-tree": "~2.22.1",
-    "angularjs-slider": "~5.7.0",
+    "angularjs-slider": "~6.0.0",
     "auth0-lock": "~10.4.1",
     "bootstrap-sass": "~3.3.6",
     "d3": "~3.4.4",

--- a/app-frontend/src/app/components/diagramContainer/diagramContainer.component.js
+++ b/app-frontend/src/app/components/diagramContainer/diagramContainer.component.js
@@ -4,9 +4,6 @@ export default {
     templateUrl: diagramContainerTpl,
     controller: 'DiagramContainerController',
     bindings: {
-        shapes: '<?',
-        cellLabel: '<?',
-        onCellClick: '&',
-        onPaperClick: '&'
+        onPreview: '&'
     }
 };

--- a/app-frontend/src/app/components/diagramContainer/diagramContainer.controller.js
+++ b/app-frontend/src/app/components/diagramContainer/diagramContainer.controller.js
@@ -57,7 +57,8 @@ export default class DiagramContainerController {
 
         this.nodes.set(ndviBefore, {
             input: 0,
-            name: 'NDVI - Before'
+            name: 'NDVI - Before',
+            part: 'ndvi0'
         });
 
         let reclassifyBefore = this.createRectangle({
@@ -68,7 +69,8 @@ export default class DiagramContainerController {
 
         this.nodes.set(reclassifyBefore, {
             input: 0,
-            name: 'Reclassify - Before'
+            name: 'Reclassify - Before',
+            part: 'class0'
         });
 
         this.createLink([ndviBefore, 'Output'], [reclassifyBefore, 'Input']);
@@ -81,7 +83,8 @@ export default class DiagramContainerController {
 
         this.nodes.set(ndviAfter, {
             input: 1,
-            name: 'NDVI - After'
+            name: 'NDVI - After',
+            part: 'ndvi1'
         });
 
         let reclassifyAfter = this.createRectangle({
@@ -92,7 +95,8 @@ export default class DiagramContainerController {
 
         this.nodes.set(reclassifyAfter, {
             input: 1,
-            name: 'Reclassify - After'
+            name: 'Reclassify - After',
+            part: 'class1'
         });
 
         this.createLink([ndviAfter, 'Output'], [reclassifyAfter, 'Input']);
@@ -105,7 +109,8 @@ export default class DiagramContainerController {
 
         this.nodes.set(subtract, {
             input: 1,
-            name: 'Subtract'
+            name: 'Subtract',
+            part: 'final'
         });
 
         this.createLink([reclassifyBefore, 'Output'], [subtract, 'First']);
@@ -227,7 +232,7 @@ export default class DiagramContainerController {
                                        this.defaultContextMenu;
 
         this.contextMenuEl = this.$compile(this.contextMenuTpl)(menuScope)[0];
-        this.$element[0].append(this.contextMenuEl);
+        this.$element[0].appendChild(this.contextMenuEl);
         this.contextMenuEl = $(this.contextMenuEl).css({
             top: bounds.y,
             left: bounds.x + bounds.width / 2

--- a/app-frontend/src/app/components/diagramContainer/diagramContainer.controller.js
+++ b/app-frontend/src/app/components/diagramContainer/diagramContainer.controller.js
@@ -2,7 +2,8 @@ const Map = require('es6-map');
 /* global joint, $ */
 
 export default class DiagramContainerController {
-    constructor($element, $scope, $state, $timeout, $compile, mousetipService) {
+    constructor( // eslint-disable-line max-params
+        $element, $scope, $state, $timeout, $compile, mousetipService) {
         'ngInject';
         this.$element = $element;
         this.$scope = $scope;
@@ -174,7 +175,7 @@ export default class DiagramContainerController {
         }];
     }
 
-    onPaperClick(evt) {
+    onPaperClick() {
         this.$scope.$evalAsync(() => {
             if (this.isComparing) {
                 this.cancelComparison();

--- a/app-frontend/src/app/components/diagramContainer/diagramContainer.html
+++ b/app-frontend/src/app/components/diagramContainer/diagramContainer.html
@@ -1,18 +1,1 @@
-<div class="main lab-workspace"></div>
-<div class="lab-contextmenu" ng-show="$ctrl.isShowingContextMenu">
-    <div>
-        <ul>
-            <li ng-repeat="item in $ctrl.currentContextMenu track by $index"
-                ng-click="item.callback()">
-                {{item.label}}
-            </li>
-        </ul>
-    </div>
-</div>
-<div class="lab-contextmenu measuring">
-    <ul>
-        <li ng-repeat="item in $ctrl.currentContextMenu track by $index">
-            {{item.label}}
-        </li>
-    </ul>
-</div>
+<div class="lab-workspace"></div>

--- a/app-frontend/src/app/components/diagramContainer/diagramContainer.scss
+++ b/app-frontend/src/app/components/diagramContainer/diagramContainer.scss
@@ -14,6 +14,7 @@
     margin: 0;
     padding: 0;
     border: 1px solid darken(#465076, 15%);
+    white-space: nowrap;
     li {
       display: inline-block;
       padding: 12px;

--- a/app-frontend/src/app/components/diagramContainer/diagramContainer.scss
+++ b/app-frontend/src/app/components/diagramContainer/diagramContainer.scss
@@ -6,10 +6,9 @@
 .lab-contextmenu {
   position: absolute;
   background: #465076;
-  &.measuring {
-    top: -10000px;
-    left: -10000px;
-  }
+  transform: translateX(-50%) translateY(-100%);
+  // Compensates for pointer
+  margin-top: -8px;
   ul {
     list-style: none;
     margin: 0;
@@ -47,4 +46,15 @@
 	margin-left: -8px;
 }
 
-// @TODO: add rotated sqare div to make pointer;
+.mousetip {
+  position: absolute;
+  top: -10000px;
+  left: -10000px;
+  z-index: 10000;
+  margin-left: 18px;
+  background: #465076;
+  color: #fff;
+  padding: 8px 12px;
+  border-radius: 4px;
+  box-shadow: 4px 4px 4px rgba(0,0,0,0.25);
+}

--- a/app-frontend/src/app/components/mapContainer/leaflet-side-by-side.js
+++ b/app-frontend/src/app/components/mapContainer/leaflet-side-by-side.js
@@ -1,0 +1,255 @@
+/* eslint-disable */
+
+(function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
+(function (global){
+var L = (typeof window !== "undefined" ? window['L'] : typeof global !== "undefined" ? global['L'] : null)
+require('./layout.css')
+require('./range.css')
+
+var mapWasDragEnabled
+var mapWasTapEnabled
+
+// Leaflet v0.7 backwards compatibility
+function on (el, types, fn, context) {
+  types.split(' ').forEach(function (type) {
+    L.DomEvent.on(el, type, fn, context)
+  })
+}
+
+// Leaflet v0.7 backwards compatibility
+function off (el, types, fn, context) {
+  types.split(' ').forEach(function (type) {
+    L.DomEvent.off(el, type, fn, context)
+  })
+}
+
+function getRangeEvent (rangeInput) {
+  return 'oninput' in rangeInput ? 'input' : 'change'
+}
+
+function cancelMapDrag () {
+  mapWasDragEnabled = this._map.dragging.enabled()
+  mapWasTapEnabled = this._map.tap && this._map.tap.enabled()
+  this._map.dragging.disable()
+  this._map.tap && this._map.tap.disable()
+}
+
+function uncancelMapDrag (e) {
+  this._refocusOnMap(e)
+  if (mapWasDragEnabled) {
+    this._map.dragging.enable()
+  }
+  if (mapWasTapEnabled) {
+    this._map.tap.enable()
+  }
+}
+
+// convert arg to an array - returns empty array if arg is undefined
+function asArray (arg) {
+  return (arg === 'undefined') ? [] : Array.isArray(arg) ? arg : [arg]
+}
+
+function noop () {
+  return
+}
+
+L.Control.SideBySide = L.Control.extend({
+  options: {
+    thumbSize: 42,
+    padding: 0
+  },
+
+  initialize: function (leftLayers, rightLayers, options) {
+    this.setLeftLayers(leftLayers)
+    this.setRightLayers(rightLayers)
+    L.setOptions(this, options)
+  },
+
+  getPosition: function () {
+    var rangeValue = this._range.value
+    var offset = (0.5 - rangeValue) * (2 * this.options.padding + this.options.thumbSize)
+    return this._map.getSize().x * rangeValue + offset
+  },
+
+  setPosition: noop,
+
+  includes: L.Mixin.Events,
+
+  addTo: function (map) {
+    this.remove()
+    this._map = map
+
+    var container = this._container = L.DomUtil.create('div', 'leaflet-sbs', map._controlContainer)
+
+    this._divider = L.DomUtil.create('div', 'leaflet-sbs-divider', container)
+    var range = this._range = L.DomUtil.create('input', 'leaflet-sbs-range', container)
+    range.type = 'range'
+    range.min = 0
+    range.max = 1
+    range.step = 'any'
+    range.value = 0.5
+    range.style.paddingLeft = range.style.paddingRight = this.options.padding + 'px'
+    this._addEvents()
+    this._updateLayers()
+    return this
+  },
+
+  remove: function () {
+    if (!this._map) {
+      return this
+    }
+    this._removeEvents()
+    L.DomUtil.remove(this._container)
+
+    this._map = null
+
+    return this
+  },
+
+  setLeftLayers: function (leftLayers) {
+    this._leftLayers = asArray(leftLayers)
+    this._updateLayers()
+    return this
+  },
+
+  setRightLayers: function (rightLayers) {
+    this._rightLayers = asArray(rightLayers)
+    this._updateLayers()
+    return this
+  },
+
+  _updateClip: function () {
+    var map = this._map
+    var nw = map.containerPointToLayerPoint([0, 0])
+    var se = map.containerPointToLayerPoint(map.getSize())
+    var clipX = nw.x + this.getPosition()
+    var dividerX = this.getPosition()
+
+    this._divider.style.left = dividerX + 'px'
+    this.fire('dividermove', {x: dividerX})
+    var clipLeft = 'rect(' + [nw.y, clipX, se.y, nw.x].join('px,') + 'px)'
+    var clipRight = 'rect(' + [nw.y, se.x, se.y, clipX].join('px,') + 'px)'
+    if (this._leftLayer) {
+      this._leftLayer.getContainer().style.clip = clipLeft
+    }
+    if (this._rightLayer) {
+      this._rightLayer.getContainer().style.clip = clipRight
+    }
+  },
+
+  _updateLayers: function () {
+    if (!this._map) {
+      return this
+    }
+    var prevLeft = this._leftLayer
+    var prevRight = this._rightLayer
+    this._leftLayer = this._rightLayer = null
+    this._leftLayers.forEach(function (layer) {
+      if (this._map.hasLayer(layer)) {
+        this._leftLayer = layer
+      }
+    }, this)
+    this._rightLayers.forEach(function (layer) {
+      if (this._map.hasLayer(layer)) {
+        this._rightLayer = layer
+      }
+    }, this)
+    if (prevLeft !== this._leftLayer) {
+      prevLeft && this.fire('leftlayerremove', {layer: prevLeft})
+      this._leftLayer && this.fire('leftlayeradd', {layer: this._leftLayer})
+    }
+    if (prevRight !== this._rightLayer) {
+      prevRight && this.fire('rightlayerremove', {layer: prevRight})
+      this._rightLayer && this.fire('rightlayeradd', {layer: this._rightLayer})
+    }
+    this._updateClip()
+  },
+
+  _addEvents: function () {
+    var range = this._range
+    var map = this._map
+    if (!map || !range) return
+    map.on('move', this._updateClip, this)
+    map.on('layeradd layerremove', this._updateLayers, this)
+    on(range, getRangeEvent(range), this._updateClip, this)
+    on(range, 'mousedown touchstart', cancelMapDrag, this)
+    on(range, 'mouseup touchend', uncancelMapDrag, this)
+  },
+
+  _removeEvents: function () {
+    var range = this._range
+    var map = this._map
+    if (range) {
+      off(range, getRangeEvent(range), this._updateClip, this)
+      off(range, 'mousedown touchstart', cancelMapDrag, this)
+      off(range, 'mouseup touchend', uncancelMapDrag, this)
+    }
+    if (map) {
+      map.off('layeradd layerremove', this._updateLayers, this)
+      map.off('move', this._updateClip, this)
+    }
+  }
+})
+
+L.control.sideBySide = function (leftLayers, rightLayers, options) {
+  return new L.Control.SideBySide(leftLayers, rightLayers, options)
+}
+
+module.exports = L.Control.SideBySide
+
+}).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
+},{"./layout.css":2,"./range.css":4}],2:[function(require,module,exports){
+var css = ".leaflet-sbs-range {\n    position: absolute;\n    top: 50%;\n    width: 100%;\n    z-index: 999;\n}\n.leaflet-sbs-divider {\n    position: absolute;\n    top: 0;\n    bottom: 0;\n    left: 50%;\n    margin-left: -2px;\n    width: 4px;\n    background-color: #fff;\n    pointer-events: none;\n    z-index: 999;\n}\n"; (require("./node_modules/cssify"))(css, undefined, '/Users/gregor/Dev/DdDev/leaflet-side-by-side/layout.css'); module.exports = css;
+},{"./node_modules/cssify":3}],3:[function(require,module,exports){
+function injectStyleTag(document, fileName, cb) {
+  var style = document.getElementById(fileName);
+
+  if (style) {
+    cb(style);
+  } else {
+    var head = document.getElementsByTagName('head')[0];
+
+    style = document.createElement('style');
+    style.id = fileName;
+    cb(style);
+    head.appendChild(style);
+  }
+
+  return style;
+}
+
+module.exports = function (css, customDocument, fileName) {
+  var doc = customDocument || document;
+  if (doc.createStyleSheet) {
+    var sheet = doc.createStyleSheet()
+    sheet.cssText = css;
+    return sheet.ownerNode;
+  } else {
+    return injectStyleTag(doc, fileName, function(style) {
+      if (style.styleSheet) {
+        style.styleSheet.cssText = css;
+      } else {
+        style.innerHTML = css;
+      }
+    });
+  }
+};
+
+module.exports.byUrl = function(url) {
+  if (document.createStyleSheet) {
+    return document.createStyleSheet(url).ownerNode;
+  } else {
+    var head = document.getElementsByTagName('head')[0],
+        link = document.createElement('link');
+
+    link.rel = 'stylesheet';
+    link.href = url;
+
+    head.appendChild(link);
+    return link;
+  }
+};
+
+},{}],4:[function(require,module,exports){
+var css = ".leaflet-sbs-range {\n    -webkit-appearance: none;\n    display: inline-block!important;\n    vertical-align: middle;\n    height: 0;\n    padding: 0;\n    margin: 0;\n    border: 0;\n    background: rgba(0, 0, 0, 0.25);\n    min-width: 100px;\n    cursor: pointer;\n    pointer-events: none;\n    z-index: 999;\n}\n.leaflet-sbs-range::-ms-fill-upper {\n    background: transparent;\n}\n.leaflet-sbs-range::-ms-fill-lower {\n    background: rgba(255, 255, 255, 0.25);\n}\n/* Browser thingies */\n\n.leaflet-sbs-range::-moz-range-track {\n    opacity: 0;\n}\n.leaflet-sbs-range::-ms-track {\n    opacity: 0;\n}\n.leaflet-sbs-range::-ms-tooltip {\n    display: none;\n}\n/* For whatever reason, these need to be defined\n * on their own so dont group them */\n\n.leaflet-sbs-range::-webkit-slider-thumb {\n    -webkit-appearance: none;\n    margin: 0;\n    padding: 0;\n    background: #fff;\n    height: 40px;\n    width: 40px;\n    border-radius: 20px;\n    cursor: ew-resize;\n    pointer-events: auto;\n    border: 1px solid #ddd;\n    background-image: url(\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAFAAAABQCAMAAAC5zwKfAAAABlBMVEV9fX3///+Kct39AAAAAnRSTlP/AOW3MEoAAAA9SURBVFjD7dehDQAwDANBZ/+l2wmKoiqR7pHRcaeaCxAIBAL/g7k9JxAIBAKBQCAQCAQC14H+MhAIBE4CD3fOFvGVBzhZAAAAAElFTkSuQmCC\");\n    background-position: 50% 50%;\n    background-repeat: no-repeat;\n    background-size: 40px 40px;\n}\n.leaflet-sbs-range::-ms-thumb {\n    margin: 0;\n    padding: 0;\n    background: #fff;\n    height: 40px;\n    width: 40px;\n    border-radius: 20px;\n    cursor: ew-resize;\n    pointer-events: auto;\n    border: 1px solid #ddd;\n    background-image: url(\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAFAAAABQCAMAAAC5zwKfAAAABlBMVEV9fX3///+Kct39AAAAAnRSTlP/AOW3MEoAAAA9SURBVFjD7dehDQAwDANBZ/+l2wmKoiqR7pHRcaeaCxAIBAL/g7k9JxAIBAKBQCAQCAQC14H+MhAIBE4CD3fOFvGVBzhZAAAAAElFTkSuQmCC\");\n    background-position: 50% 50%;\n    background-repeat: no-repeat;\n    background-size: 40px 40px;\n}\n.leaflet-sbs-range::-moz-range-thumb {\n    padding: 0;\n    right: 0    ;\n    background: #fff;\n    height: 40px;\n    width: 40px;\n    border-radius: 20px;\n    cursor: ew-resize;\n    pointer-events: auto;\n    border: 1px solid #ddd;\n    background-image: url(\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAFAAAABQCAMAAAC5zwKfAAAABlBMVEV9fX3///+Kct39AAAAAnRSTlP/AOW3MEoAAAA9SURBVFjD7dehDQAwDANBZ/+l2wmKoiqR7pHRcaeaCxAIBAL/g7k9JxAIBAKBQCAQCAQC14H+MhAIBE4CD3fOFvGVBzhZAAAAAElFTkSuQmCC\");\n    background-position: 50% 50%;\n    background-repeat: no-repeat;\n    background-size: 40px 40px;\n}\n.leaflet-sbs-range:disabled::-moz-range-thumb {\n    cursor: default;\n}\n.leaflet-sbs-range:disabled::-ms-thumb {\n    cursor: default;\n}\n.leaflet-sbs-range:disabled::-webkit-slider-thumb {\n    cursor: default;\n}\n.leaflet-sbs-range:disabled {\n    cursor: default;\n}\n.leaflet-sbs-range:focus {\n    outline: none!important;\n}\n.leaflet-sbs-range::-moz-focus-outer {\n    border: 0;\n}\n\n"; (require("./node_modules/cssify"))(css, undefined, '/Users/gregor/Dev/DdDev/leaflet-side-by-side/range.css'); module.exports = css;
+},{"./node_modules/cssify":3}]},{},[1]);

--- a/app-frontend/src/app/components/mapContainer/mapContainer.module.js
+++ b/app-frontend/src/app/components/mapContainer/mapContainer.module.js
@@ -5,6 +5,7 @@ import MapContainerController from './mapContainer.controller.js';
 require('leaflet/dist/leaflet.css');
 require('leaflet-draw/dist/leaflet.draw.css');
 require('leaflet-draw/dist/leaflet.draw.js');
+require('./leaflet-side-by-side.js');
 require('./mapContainer.scss');
 
 const MapContainerModule = angular.module('components.mapContainer', []);

--- a/app-frontend/src/app/components/navBar/navBar.controller.js
+++ b/app-frontend/src/app/components/navBar/navBar.controller.js
@@ -48,7 +48,7 @@ export default class NavBarController {
             });
 
             this.activeModal.result.then(t => {
-                this.$state.go('lab.edit', {toolid: t.id});
+                this.$state.go('lab.run', {toolid: t.id});
             });
         }
 

--- a/app-frontend/src/app/core/core.module.js
+++ b/app-frontend/src/app/core/core.module.js
@@ -11,6 +11,7 @@ require('./services/auth.service')(shared);
 require('./services/token.service')(shared);
 require('./services/layer.service')(shared);
 require('./services/map.service')(shared);
+require('./services/mousetip.service')(shared);
 require('./services/thumbnail.service')(shared);
 require('./services/tool.service')(shared);
 require('./services/toolTag.service')(shared);

--- a/app-frontend/src/app/core/services/mousetip.service.js
+++ b/app-frontend/src/app/core/services/mousetip.service.js
@@ -1,0 +1,91 @@
+/* global $, _ */
+
+export default (app) => {
+    class MousetipService {
+        constructor($compile, $document) {
+            this.$compile = $compile;
+            this.$document = $document;
+            this.throttledReposition = _.throttle(this.setPosition.bind(this), 16, {leading: true});
+        }
+
+        set(content) {
+            if (!this.isRendered || content !== this.content) {
+                this.content = content;
+                this.render();
+            }
+            return this;
+        }
+
+        remove() {
+            this.$el.toggle(false);
+            this.$el.remove();
+            this.$el = null;
+            this.isRendered = false;
+            this.removeListeners();
+            return this;
+        }
+
+        render() {
+            if (this.$el) {
+                this.$el.remove();
+            }
+            this.$el = this.compileTemplate();
+            this.$document.find('body').append(this.$el);
+            this.isRendered = true;
+            this.attachListeners();
+            return this;
+        }
+
+        setPosition(e) {
+            if (e && this.$el && !this.mouseOut) {
+                this.$el.css({
+                    top: e.pageY,
+                    left: e.pageX
+                });
+                this.$el.toggle(true);
+            } else if (this.$el) {
+                this.$el.toggle(false);
+            }
+            return this;
+        }
+
+        onMouseOut(e) {
+            if (!e.toElement) {
+                this.mouseOut = true;
+                if (this.$el) {
+                    this.$el.toggle(false);
+                }
+            }
+            return this;
+        }
+
+        onMouseEnter() {
+            this.mouseOut = false;
+            if (this.$el) {
+                this.$el.toggle(true);
+            }
+            return this;
+        }
+
+        attachListeners() {
+            $(this.$document).on('mousemove', this.throttledReposition);
+            $(this.$document).on('mouseout blur', this.onMouseOut.bind(this));
+            $(this.$document).on('mouseenter focus', this.onMouseEnter.bind(this));
+            return this;
+        }
+
+        removeListeners() {
+            $(this.$document).off('mousemove', this.throttledReposition);
+            $(this.$document).off('mouseout blur', this.onMouseOut.bind(this));
+            $(this.$document).off('mouseenter focus', this.onMouseEnter.bind(this));
+            return this;
+        }
+
+        compileTemplate() {
+            let template = `<div class="mousetip">${this.content}</div>`;
+            return this.$compile(template)(this);
+        }
+    }
+
+    app.service('mousetipService', MousetipService);
+};

--- a/app-frontend/src/app/pages/lab/edit/edit.controller.js
+++ b/app-frontend/src/app/pages/lab/edit/edit.controller.js
@@ -1,80 +1,207 @@
-/* global L */
+const Map = require('es6-map');
 
 export default class LabEditController {
-    constructor($scope, $timeout, $element, $uibModal, mapService, projectService, layerService) {
+    constructor( // eslint-disable-line max-params
+        $scope, $state, $uibModal, mapService, layerService, projectService) {
         'ngInject';
         this.$scope = $scope;
-        this.$timeout = $timeout;
-        this.$element = $element;
+        this.$parent = $scope.$parent.$ctrl;
+        this.$state = $state;
         this.$uibModal = $uibModal;
-        this.getMap = () => mapService.getMap('lab-run-preview');
+        this.mapService = mapService;
+        this.layerService = layerService;
+        this.projectService = projectService;
+        this.inputs = {
+            bands: {
+                nir: '5',
+                red: '4'
+            }
+        };
     }
 
     $onInit() {
-        this.inputs = [false, false];
-        this.inputParameters = [{
-            bands: {
-                nir: '5',
-                red: '4'
-            }
-        }, {
-            bands: {
-                nir: '5',
-                red: '4'
-            }
-        }];
+        this.setTestingTools();
+        this.getMap = () => this.mapService.getMap('lab-run');
+        this.projectId = this.$state.params.projectid;
+        this.sceneLayers = new Map();
+
+        if (this.$parent.toolId && !this.project) {
+            this.ensureProjectSelected();
+        }
     }
 
-    showPreview(data) {
-        this.isShowingPreview = true;
-        this.isComparing = false;
-        this.exitText = 'Close Preview';
-        this.previewData = data;
-
-        if (data.constructor === Array) {
-            // An array was passed, we assume a comparison
-            this.isComparing = true;
-            this.comparison = data;
-            this.exitTest = 'Close Comparison';
-            // @TODO: when endpoints are functioning, this will be handled accordingly
-            // for now, we are just passing in empty layers to display the control
-            this.sideBySideControl = L.control.sideBySide(L.featureGroup(), L.featureGroup());
+    ensureProjectSelected() {
+        if (this.projectId) {
+            this.loadingProject = true;
+            this.projectService.query({id: this.projectId}).then(
+                (project) => {
+                    this.project = project;
+                    this.loadingProject = false;
+                    this.getSceneList();
+                },
+                () => {
+                    this.loadingProject = false;
+                    // @TODO: handle displaying an error message
+                }
+            );
+        } else {
+            this.selectProjectModal();
         }
+    }
 
-        this.getMap().then(m => {
-            if (this.isComparing && !this.sideBySideAdded) {
-                this.sideBySideControl.addTo(m.map);
-                this.sideBySideAdded = true;
-            } else if (!this.isComparing && this.sideBySideAdded){
-                this.sideBySideControl.remove();
-                this.sideBySideAdded = false;
-            }
-            this.$timeout(() => m.map.invalidateSize());
+    fitAllScenes() {
+        if (this.sceneList.length) {
+            this.fitScenes(this.sceneList);
+        }
+    }
+
+    fitScenes(scenes) {
+        this.getMap().then((map) =>{
+            let sceneFootprints = scenes.map((scene) => scene.dataFootprint);
+            map.map.fitBounds(L.geoJSON(sceneFootprints).getBounds());
         });
     }
 
-    closePreview() {
-        this.isShowingPreview = false;
+    getSceneList() {
+        this.sceneRequestState = {loading: true};
+        this.projectService.getAllProjectScenes(
+            {projectId: this.projectId}
+        ).then(
+            (allScenes) => {
+                this.sceneList = allScenes;
+                this.fitAllScenes();
+                this.layersFromScenes();
+            },
+            (error) => {
+                this.sceneRequestState.errorMsg = error;
+            }
+        ).finally(() => {
+            this.sceneRequestState.loading = false;
+        });
     }
 
-    selectProjectModal(src) {
+    layersFromScenes() {
+        // Create scene layers to use for color correction
+        for (const scene of this.sceneList) {
+            let sceneLayer = this.layerService.layerFromScene(scene, this.projectId);
+            this.sceneLayers.set(scene.id, sceneLayer);
+        }
+
+        this.layers = this.sceneLayers.values();
+        this.getMap().then((map) => {
+            map.deleteLayers('scenes');
+            for (let layer of this.layers) {
+                let tiles = layer.getNDVILayer([this.inputs.bands.nir, this.inputs.bands.red]);
+                map.addLayer('scenes', tiles);
+            }
+        });
+    }
+
+    updateInputs() {
+        this.layersFromScenes();
+    }
+
+    selectToolModal() {
         if (this.activeModal) {
             this.activeModal.dismiss();
         }
 
+        const backdrop = this.project ? true : 'static';
+        const keyboard = Boolean(this.project);
+
         this.activeModal = this.$uibModal.open({
             component: 'rfSelectProjectModal',
+            backdrop: backdrop,
+            keyboard: keyboard,
             resolve: {
-                project: () => this.inputs[src],
+                project: () => this.project,
                 content: () => ({
                     title: 'Select a project'
                 })
             }
         });
+    }
 
-        this.activeModal.result.then(p => {
-            this.inputs[src] = p;
-            this.$scope.$evalAsync();
+    selectProjectModal() {
+        if (this.activeModal) {
+            this.activeModal.dismiss();
+        }
+
+        const backdrop = this.project ? true : 'static';
+        const keyboard = Boolean(this.project);
+
+        this.activeModal = this.$uibModal.open({
+            component: 'rfSelectProjectModal',
+            backdrop: backdrop,
+            keyboard: keyboard,
+            resolve: {
+                project: () => this.project,
+                content: () => ({
+                    title: 'Select a project'
+                })
+            }
         });
+    }
+
+    setTestingTools() {
+        this.tools = [
+            {
+                definition: 'ndvi',
+                params: ['red', 'nir'],
+                result: {
+                    apply: '/',
+                    args: [
+                        {
+                            apply: '-',
+                            args: ['red', 'nir']
+                        }, {
+                            apply: '+',
+                            args: ['red', 'nir']
+                        }
+                    ]
+                }
+            }, {
+                definition: 'multiband_ndvi',
+                params: ['LC8'],
+                result: {
+                    apply: '/',
+                    args: [
+                        {
+                            apply: '-',
+                            args: ['LC8[4]', 'LC8[5]']
+                        }, {
+                            apply: '+',
+                            args: ['LC8[4]', 'LC8[5]']
+                        }
+                    ]
+                }
+            }, {
+                definition: 'LC8_ndvi',
+                params: ['LC8'],
+                include: [
+                    {
+                        definition: 'ndvi',
+                        params: ['red', 'nir'],
+                        result: {
+                            apply: '/',
+                            args: [
+                                {
+                                    apply: '-',
+                                    args: ['red', 'nir']
+                                }, {
+                                    apply: '+',
+                                    args: ['red', 'nir']
+                                }
+                            ]
+                        }
+                    }
+                ],
+                result: {
+                    apply: 'ndvi',
+                    args: ['LC8[4]', 'LC8[5]']
+                }
+            }
+        ];
+        this.selectedTool = this.tools[0];
     }
 }

--- a/app-frontend/src/app/pages/lab/edit/edit.controller.js
+++ b/app-frontend/src/app/pages/lab/edit/edit.controller.js
@@ -1,9 +1,13 @@
+/* global L */
+
 export default class LabEditController {
-    constructor($scope, $element, $uibModal) {
+    constructor($scope, $timeout, $element, $uibModal, mapService, projectService, layerService) {
         'ngInject';
         this.$scope = $scope;
+        this.$timeout = $timeout;
         this.$element = $element;
         this.$uibModal = $uibModal;
+        this.getMap = () => mapService.getMap('lab-run-preview');
     }
 
     $onInit() {
@@ -19,6 +23,38 @@ export default class LabEditController {
                 red: '4'
             }
         }];
+    }
+
+    showPreview(data) {
+        this.isShowingPreview = true;
+        this.isComparing = false;
+        this.exitText = 'Close Preview';
+        this.previewData = data;
+
+        if (data.constructor === Array) {
+            // An array was passed, we assume a comparison
+            this.isComparing = true;
+            this.comparison = data;
+            this.exitTest = 'Close Comparison';
+            // @TODO: when endpoints are functioning, this will be handled accordingly
+            // for now, we are just passing in empty layers to display the control
+            this.sideBySideControl = L.control.sideBySide(L.featureGroup(), L.featureGroup());
+        }
+
+        this.getMap().then(m => {
+            if (this.isComparing && !this.sideBySideAdded) {
+                this.sideBySideControl.addTo(m.map);
+                this.sideBySideAdded = true;
+            } else if (!this.isComparing && this.sideBySideAdded){
+                this.sideBySideControl.remove();
+                this.sideBySideAdded = false;
+            }
+            this.$timeout(() => m.map.invalidateSize());
+        });
+    }
+
+    closePreview() {
+        this.isShowingPreview = false;
     }
 
     selectProjectModal(src) {

--- a/app-frontend/src/app/pages/lab/edit/edit.html
+++ b/app-frontend/src/app/pages/lab/edit/edit.html
@@ -142,5 +142,27 @@
       </div>
     </div>
   </div>
-  <rf-diagram-container class="main with-position">
-  </rf-diagram-container>
+  <div class="main with-position">
+    <rf-diagram-container class="with-position"
+                          on-preview="$ctrl.showPreview(data)">
+    </rf-diagram-container>
+    <div style="position: absolute; top:0; bottom: 0; left: 0; right: 0;" ng-show="$ctrl.isShowingPreview">
+      <rf-map-container map-id="lab-run-preview"></rf-map-container>
+      <div class="preview-control-bar">
+          <button class="btn btn-primary" ng-click="$ctrl.closePreview()">{{$ctrl.exitText}}</button>
+      </div>
+      <div class="preview-info-bar" ng-show="$ctrl.isComparing">
+        <div class="split-container">
+          <button class="btn">{{$ctrl.previewData[0].name}}</button>
+        </div>
+        <div class="split-container">
+          <button class="btn">{{$ctrl.previewData[1].name}}</button>
+        </div>
+      </div>
+      <div class="preview-info-bar" ng-show="!$ctrl.isComparing">
+        <div class="split-container">
+          <button class="btn">{{$ctrl.previewData.name}}</button>
+        </div>
+      </div>
+    </div>
+  </div>

--- a/app-frontend/src/app/pages/lab/edit/edit.html
+++ b/app-frontend/src/app/pages/lab/edit/edit.html
@@ -1,168 +1,75 @@
-<!-- Workflow container -->
-<!-- @TODO: figure out how to style this to get desired functionality;
-  doesn't work right without this style rule
--->
-  <div class="sidebar sidebar-scrollable" style="flex: 0 0 auto;">
+<div class="main">
+  <div class="sidebar sidebar-extended sidebar-dark not-offset" ng-show="$ctrl.isShowingParams">
+      Params Sidebar
+  </div>
+  <!-- Workflow container -->
+  <div class="sidebar sidebar-extended sidebar-scrollable">
     <div class="sidebar-content flex-row with-padding with-border">
       <h5 class="sidebar-title">
           Inputs
       </h5>
       <div class="sidebar-actions">
-        <button class="btn btn-secondary">
-          <i class="icon-parameters"></i> Parameters
+        <button class="btn btn-primary">Raster Settings</button>
+      </div>
+    </div>
+    <div class="sidebar-content flex-row with-padding"
+         ng-show="$ctrl.project">
+      <div class="run-project-name">
+          {{$ctrl.project.name || "No project selected"}}
+      </div>
+      <div class="sidebar-actions">
+        <button class="btn btn-small btn-square"
+                ng-click="$ctrl.selectProjectModal(true)">
+          Change Project
         </button>
       </div>
     </div>
-    <div class="sidebar-scrollable">
-      <div class="sidebar-content with-padding with-border">
-        <h5 class="sidebar-title">
-            <div class="btn btn-square really-square">1</div><span>NDVI - Before</span>
-        </h5>
-        <div class="instructions-container" ng-show="!$ctrl.inputs[0]">
-          <p>
-            The NDVI tool requires a source with NIR and Red bands
-          </p>
-          <button class="btn btn-primary"
-                  ng-click="$ctrl.selectProjectModal(0)">
-            Select A Source
-          </button>
+    <div class="sidebar-content with-padding"
+         ng-show="$ctrl.project">
+      <form>
+        <div class="form-group">
+          <label for="formGroupExampleInput">Red Band</label>
+          <select class="form-control" id="red-band-map"  ng-model="$ctrl.inputs.bands.red">
+            <option value="1">Band 1</option>
+            <option value="2">Band 2</option>
+            <option value="3">Band 3</option>
+            <option value="4">Band 4</option>
+            <option value="5">Band 5</option>
+            <option value="6">Band 6</option>
+            <option value="7">Band 7</option>
+            <option value="8">Band 8</option>
+            <option value="9">Band 9</option>
+            <option value="10">Band 10</option>
+            <option value="11">Band 11</option>
+          </select>
         </div>
-        <form class="inset form-horizontal">
-          <div class="form-group" ng-show="$ctrl.inputs[0]">
-            <label for="formGroupExampleInput">Input Source</label>
-            <div class="form-group all-in-one">
-              <input type="text" class="form-control" id="input-0" placeholder="Example input" readonly ng-value="$ctrl.inputs[0].name">
-              <button class="btn btn-link" ng-click="$ctrl.selectProjectModal(0)">
-                Change
-              </button>
-            </div>
-          </div>
-          <div class="form-group" ng-show="$ctrl.inputs[0]">
-            <label for="formGroupExampleInput">Red Band</label>
-            <select class="form-control" id="red-band-map"  ng-model="$ctrl.inputParameters[0].bands.red">
-              <option value="1">Band 1</option>
-              <option value="2">Band 2</option>
-              <option value="3">Band 3</option>
-              <option value="4">Band 4</option>
-              <option value="5">Band 5</option>
-              <option value="6">Band 6</option>
-              <option value="7">Band 7</option>
-              <option value="8">Band 8</option>
-              <option value="9">Band 9</option>
-              <option value="10">Band 10</option>
-              <option value="11">Band 11</option>
-            </select>
-          </div>
-          <div class="form-group" ng-show="$ctrl.inputs[0]">
-            <label for="formGroupExampleInput">NIR Band</label>
-            <select class="form-control" id="nir-band-map" ng-model="$ctrl.inputParameters[0].bands.nir">
-              <option value="1">Band 1</option>
-              <option value="2">Band 2</option>
-              <option value="3">Band 3</option>
-              <option value="4">Band 4</option>
-              <option value="5">Band 5</option>
-              <option value="6">Band 6</option>
-              <option value="7">Band 7</option>
-              <option value="8">Band 8</option>
-              <option value="9">Band 9</option>
-              <option value="10">Band 10</option>
-              <option value="11">Band 11</option>
-            </select>
-          </div>
-        </form>
-      </div>
-      <div class="sidebar-content with-padding with-border">
-        <h5 class="sidebar-title">
-            <div class="btn btn-square really-square">2</div><span>NDVI - After</span>
-        </h5>
-        <div class="instructions-container" ng-show="!$ctrl.inputs[1]">
-          <p>
-            The NDVI tool requires a source with NIR and Red bands
-          </p>
-          <button class="btn btn-primary"
-                  ng-click="$ctrl.selectProjectModal(1)">
-            Select A Source
-          </button>
+        <div class="form-group">
+          <label for="formGroupExampleInput">NIR Band</label>
+          <select class="form-control" id="nir-band-map" ng-model="$ctrl.inputs.bands.nir">
+            <option value="1">Band 1</option>
+            <option value="2">Band 2</option>
+            <option value="3">Band 3</option>
+            <option value="4">Band 4</option>
+            <option value="5">Band 5</option>
+            <option value="6">Band 6</option>
+            <option value="7">Band 7</option>
+            <option value="8">Band 8</option>
+            <option value="9">Band 9</option>
+            <option value="10">Band 10</option>
+            <option value="11">Band 11</option>
+          </select>
         </div>
-        <form class="inset">
-          <div class="form-group" ng-show="$ctrl.inputs[1]">
-            <label for="formGroupExampleInput">Input Source</label>
-            <div class="form-group all-in-one">
-              <input type="text" class="form-control" id="input-1" placeholder="Example input" readonly ng-value="$ctrl.inputs[1].name">
-              <button class="btn btn-link" ng-click="$ctrl.selectProjectModal(1)">
-                Change
-              </button>
-            </div>
-          </div>
-          <div class="form-group" ng-show="$ctrl.inputs[1]">
-            <label for="formGroupExampleInput">Red Band</label>
-            <select class="form-control" id="red-band-map"  ng-model="$ctrl.inputParameters[1].bands.red">
-              <option value="1">Band 1</option>
-              <option value="2">Band 2</option>
-              <option value="3">Band 3</option>
-              <option value="4">Band 4</option>
-              <option value="5">Band 5</option>
-              <option value="6">Band 6</option>
-              <option value="7">Band 7</option>
-              <option value="8">Band 8</option>
-              <option value="9">Band 9</option>
-              <option value="10">Band 10</option>
-              <option value="11">Band 11</option>
-            </select>
-          </div>
-          <div class="form-group" ng-show="$ctrl.inputs[1]">
-            <label for="formGroupExampleInput">NIR Band</label>
-            <select class="form-control" id="nir-band-map" ng-model="$ctrl.inputParameters[1].bands.nir">
-              <option value="1">Band 1</option>
-              <option value="2">Band 2</option>
-              <option value="3">Band 3</option>
-              <option value="4">Band 4</option>
-              <option value="5">Band 5</option>
-              <option value="6">Band 6</option>
-              <option value="7">Band 7</option>
-              <option value="8">Band 8</option>
-              <option value="9">Band 9</option>
-              <option value="10">Band 10</option>
-              <option value="11">Band 11</option>
-            </select>
-          </div>
-        </form>
-      </div>
+      </form>
     </div>
-    <div class="sidebar-content flex-row with-padding with-borders">
+    <div class="sidebar-content flex-row with-padding">
       <div class="form-btn-row">
         <div class="btn-group">
-          <button class="btn">
-            Cancel
-          </button>
-          <button class="btn btn-primary">
-            Save
+          <button class="btn btn-primary" ng-click="$ctrl.updateInputs()">
+            Apply
           </button>
         </div>
       </div>
     </div>
   </div>
-  <div class="main with-position">
-    <rf-diagram-container class="with-position"
-                          on-preview="$ctrl.showPreview(data)">
-    </rf-diagram-container>
-    <div style="position: absolute; top:0; bottom: 0; left: 0; right: 0;" ng-show="$ctrl.isShowingPreview">
-      <rf-map-container map-id="lab-run-preview"></rf-map-container>
-      <div class="preview-control-bar">
-          <button class="btn btn-primary" ng-click="$ctrl.closePreview()">{{$ctrl.exitText}}</button>
-      </div>
-      <div class="preview-info-bar" ng-show="$ctrl.isComparing">
-        <div class="split-container">
-          <button class="btn">{{$ctrl.previewData[0].name}}</button>
-        </div>
-        <div class="split-container">
-          <button class="btn">{{$ctrl.previewData[1].name}}</button>
-        </div>
-      </div>
-      <div class="preview-info-bar" ng-show="!$ctrl.isComparing">
-        <div class="split-container">
-          <button class="btn">{{$ctrl.previewData.name}}</button>
-        </div>
-      </div>
-    </div>
-  </div>
+  <rf-map-container map-id="lab-run"></rf-map-container>
+</div>

--- a/app-frontend/src/app/pages/lab/edit/edit.module.js
+++ b/app-frontend/src/app/pages/lab/edit/edit.module.js
@@ -3,8 +3,8 @@ import angular from 'angular';
 import LabEditController from './edit.controller.js';
 import labEditComponent from './edit.component.js';
 
-require('./edit.scss');
 
+require('./edit.scss');
 const labEditModule = angular.module('pages.lab.edit', []);
 
 labEditModule.component('labEdit', labEditComponent);

--- a/app-frontend/src/app/pages/lab/edit/edit.module.js
+++ b/app-frontend/src/app/pages/lab/edit/edit.module.js
@@ -3,6 +3,8 @@ import angular from 'angular';
 import LabEditController from './edit.controller.js';
 import labEditComponent from './edit.component.js';
 
+require('./edit.scss');
+
 const labEditModule = angular.module('pages.lab.edit', []);
 
 labEditModule.component('labEdit', labEditComponent);

--- a/app-frontend/src/app/pages/lab/edit/edit.scss
+++ b/app-frontend/src/app/pages/lab/edit/edit.scss
@@ -1,33 +1,5 @@
-.preview-control-bar {
-  position: absolute;
-  top: 0;
-  right: 0;
-  left: 0;
-  padding: 16px;
-  pointer-events: false;
-  & > * {
-    pointer-events: true;
-  }
-  text-align: center;
-  z-index: 1100;
-}
-
-.preview-info-bar {
-  position: absolute;
-  bottom: 0;
-  right: 0;
-  left: 0;
-  padding: 16px;
-  pointer-events: false;
-  display: flex;
-  justify-content: center;
-  & > * {
-    pointer-events: true;
-  }
-  text-align: center;
-  z-index: 1100;
-  .split-container {
-    flex: 1;
-    text-align: center;
-  }
+.run-project-name {
+  flex: 1;
+  font-weight: bold;
+  color: #333;
 }

--- a/app-frontend/src/app/pages/lab/edit/edit.scss
+++ b/app-frontend/src/app/pages/lab/edit/edit.scss
@@ -1,0 +1,33 @@
+.preview-control-bar {
+  position: absolute;
+  top: 0;
+  right: 0;
+  left: 0;
+  padding: 16px;
+  pointer-events: false;
+  & > * {
+    pointer-events: true;
+  }
+  text-align: center;
+  z-index: 1100;
+}
+
+.preview-info-bar {
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  left: 0;
+  padding: 16px;
+  pointer-events: false;
+  display: flex;
+  justify-content: center;
+  & > * {
+    pointer-events: true;
+  }
+  text-align: center;
+  z-index: 1100;
+  .split-container {
+    flex: 1;
+    text-align: center;
+  }
+}

--- a/app-frontend/src/app/pages/lab/lab.html
+++ b/app-frontend/src/app/pages/lab/lab.html
@@ -6,17 +6,14 @@
       </nav>
       <span class="navbar-vertical-divider"></span>
       <nav>
-        <a>Properties</a>
+        <a href ui-sref="lab.run" ui-sref-active="active">Run</a>
+        <a href ui-sref="lab.edit" ui-sref-active="active">Build</a>
       </nav>
     </div>
     <div class="navbar-right">
-      <nav>
-        <a href ui-sref="lab.run" ui-sref-active="active">Run</a>
-        <a href ui-sref="lab.edit" ui-sref-active="active">Build</a>
-        <div class="btn-group">
-          <button class="btn btn-primary">Clone Model</button>
-          <button class="btn btn-primary">Publish</button>
-        </div>
+      <nav class="nav-right">
+        <button class="btn">Clone</button>
+        <button class="btn btn-primary">Publish</button>
       </nav>
     </div>
   </div>

--- a/app-frontend/src/app/pages/lab/run/run.controller.js
+++ b/app-frontend/src/app/pages/lab/run/run.controller.js
@@ -1,7 +1,8 @@
 /* global L */
 
 export default class LabRunController {
-    constructor($scope, $timeout, $element, $uibModal, mapService, projectService, layerService) {
+    constructor( // eslint-disable-line max-params
+        $scope, $timeout, $element, $uibModal, mapService) {
         'ngInject';
         this.$scope = $scope;
         this.$timeout = $timeout;
@@ -23,6 +24,25 @@ export default class LabRunController {
                 red: '4'
             }
         }];
+        this.initControls();
+    }
+
+    initControls() {
+        this.reclassifyThreshold = {
+            options: {
+                floor: -1,
+                ceil: 1,
+                step: 0.1,
+                precision: 1,
+                onChange: this.onReclassifyThresholdChange.bind(this)
+            }
+        };
+        this.reclassifyBeforeThresholdValue = 0;
+        this.reclassifyAfterThresholdValue = 0;
+    }
+
+    onReclassifyThresholdChange() {
+        // Placeholder
     }
 
     showPreview(data) {
@@ -45,7 +65,7 @@ export default class LabRunController {
             if (this.isComparing && !this.sideBySideAdded) {
                 this.sideBySideControl.addTo(m.map);
                 this.sideBySideAdded = true;
-            } else if (!this.isComparing && this.sideBySideAdded){
+            } else if (!this.isComparing && this.sideBySideAdded) {
                 this.sideBySideControl.remove();
                 this.sideBySideAdded = false;
             }

--- a/app-frontend/src/app/pages/lab/run/run.html
+++ b/app-frontend/src/app/pages/lab/run/run.html
@@ -16,7 +16,7 @@
     <div class="sidebar-scrollable">
       <div class="sidebar-content with-padding with-border">
         <h5 class="sidebar-title">
-            <div class="btn btn-square really-square">1</div><span>NDVI - Before</span>
+            NDVI - Before
         </h5>
         <div class="instructions-container" ng-show="!$ctrl.inputs[0]">
           <p>
@@ -71,9 +71,10 @@
           </div>
         </form>
       </div>
+
       <div class="sidebar-content with-padding with-border">
         <h5 class="sidebar-title">
-            <div class="btn btn-square really-square">2</div><span>NDVI - After</span>
+            NDVI - After
         </h5>
         <div class="instructions-container" ng-show="!$ctrl.inputs[1]">
           <p>
@@ -125,6 +126,42 @@
               <option value="10">Band 10</option>
               <option value="11">Band 11</option>
             </select>
+          </div>
+        </form>
+      </div>
+      <div class="sidebar-content with-padding with-border">
+        <h5 class="sidebar-title">
+            Reclassify - Before
+        </h5>
+        <form class="inset form-horizontal">
+          <div class="form-group">
+            <label for="formGroupExampleInput">Threshold</label>
+            <div>
+              <rzslider id="reclassify-before-threshold-value"
+                        class="light"
+                        rz-slider-model="$ctrl.reclassifyBeforeThresholdValue"
+                        rz-slider-options="$ctrl.reclassifyThreshold.options"
+                        on-change="$ctrl.onReclassifyBeforeThresholdChange()">
+              </rzslider>
+            </div>
+          </div>
+        </form>
+      </div>
+      <div class="sidebar-content with-padding with-border">
+        <h5 class="sidebar-title">
+            Reclassify - After
+        </h5>
+        <form class="inset form-horizontal">
+          <div class="form-group">
+            <label for="formGroupExampleInput">Threshold</label>
+            <div>
+              <rzslider id="reclassify-after-threshold-value"
+                        class="light"
+                        rz-slider-model="$ctrl.reclassifyAfterThresholdValue"
+                        rz-slider-options="$ctrl.reclassifyThreshold.options"
+                        on-change="$ctrl.onReclassifyAfterThresholdChange()">
+              </rzslider>
+            </div>
           </div>
         </form>
       </div>

--- a/app-frontend/src/app/pages/lab/run/run.html
+++ b/app-frontend/src/app/pages/lab/run/run.html
@@ -139,9 +139,8 @@
             <div>
               <rzslider id="reclassify-before-threshold-value"
                         class="light"
-                        rz-slider-model="$ctrl.reclassifyBeforeThresholdValue"
-                        rz-slider-options="$ctrl.reclassifyThreshold.options"
-                        on-change="$ctrl.onReclassifyBeforeThresholdChange()">
+                        rz-slider-model="$ctrl.thresholds.before"
+                        rz-slider-options="$ctrl.reclassifyBeforeThreshold.options">
               </rzslider>
             </div>
           </div>
@@ -157,9 +156,8 @@
             <div>
               <rzslider id="reclassify-after-threshold-value"
                         class="light"
-                        rz-slider-model="$ctrl.reclassifyAfterThresholdValue"
-                        rz-slider-options="$ctrl.reclassifyThreshold.options"
-                        on-change="$ctrl.onReclassifyAfterThresholdChange()">
+                        rz-slider-model="$ctrl.thresholds.after"
+                        rz-slider-options="$ctrl.reclassifyAfterThreshold.options">
               </rzslider>
             </div>
           </div>
@@ -186,9 +184,10 @@
     <div style="position: absolute; top:0; bottom: 0; left: 0; right: 0;" ng-show="$ctrl.isShowingPreview">
       <rf-map-container map-id="lab-run-preview"></rf-map-container>
       <div class="preview-control-bar">
-          <button class="btn btn-primary" ng-click="$ctrl.closePreview()">{{$ctrl.exitText}}</button>
+          <button ng-if="$ctrl.previewLayers.length > 1" class="btn btn-primary" ng-click="$ctrl.closePreview()">Exit Node Comparison</button>
+          <button ng-if="$ctrl.previewLayers.length == 1" class="btn btn-primary" ng-click="$ctrl.closePreview()">Exit Node Preview</button>
       </div>
-      <div class="preview-info-bar" ng-show="$ctrl.isComparing">
+      <div class="preview-info-bar" ng-show="$ctrl.previewLayers.length > 1">
         <div class="split-container">
           <button class="btn">{{$ctrl.previewData[0].name}}</button>
         </div>
@@ -196,7 +195,7 @@
           <button class="btn">{{$ctrl.previewData[1].name}}</button>
         </div>
       </div>
-      <div class="preview-info-bar" ng-show="!$ctrl.isComparing">
+      <div class="preview-info-bar" ng-show="$ctrl.previewLayers.length == 1">
         <div class="split-container">
           <button class="btn">{{$ctrl.previewData.name}}</button>
         </div>

--- a/app-frontend/src/app/pages/lab/run/run.html
+++ b/app-frontend/src/app/pages/lab/run/run.html
@@ -1,75 +1,168 @@
-<div class="main">
-  <div class="sidebar sidebar-extended sidebar-dark not-offset" ng-show="$ctrl.isShowingParams">
-      Params Sidebar
-  </div>
-  <!-- Workflow container -->
-  <div class="sidebar sidebar-extended sidebar-scrollable">
+<!-- Workflow container -->
+<!-- @TODO: figure out how to style this to get desired functionality;
+  doesn't work right without this style rule
+-->
+  <div class="sidebar sidebar-scrollable" style="flex: 0 0 auto;">
     <div class="sidebar-content flex-row with-padding with-border">
       <h5 class="sidebar-title">
           Inputs
       </h5>
       <div class="sidebar-actions">
-        <button class="btn btn-primary">Raster Settings</button>
-      </div>
-    </div>
-    <div class="sidebar-content flex-row with-padding"
-         ng-show="$ctrl.project">
-      <div class="run-project-name">
-          {{$ctrl.project.name || "No project selected"}}
-      </div>
-      <div class="sidebar-actions">
-        <button class="btn btn-small btn-square"
-                ng-click="$ctrl.selectProjectModal(true)">
-          Change Project
+        <button class="btn btn-secondary">
+          <i class="icon-parameters"></i> Parameters
         </button>
       </div>
     </div>
-    <div class="sidebar-content with-padding"
-         ng-show="$ctrl.project">
-      <form>
-        <div class="form-group">
-          <label for="formGroupExampleInput">Red Band</label>
-          <select class="form-control" id="red-band-map"  ng-model="$ctrl.inputs.bands.red">
-            <option value="1">Band 1</option>
-            <option value="2">Band 2</option>
-            <option value="3">Band 3</option>
-            <option value="4">Band 4</option>
-            <option value="5">Band 5</option>
-            <option value="6">Band 6</option>
-            <option value="7">Band 7</option>
-            <option value="8">Band 8</option>
-            <option value="9">Band 9</option>
-            <option value="10">Band 10</option>
-            <option value="11">Band 11</option>
-          </select>
+    <div class="sidebar-scrollable">
+      <div class="sidebar-content with-padding with-border">
+        <h5 class="sidebar-title">
+            <div class="btn btn-square really-square">1</div><span>NDVI - Before</span>
+        </h5>
+        <div class="instructions-container" ng-show="!$ctrl.inputs[0]">
+          <p>
+            The NDVI tool requires a source with NIR and Red bands
+          </p>
+          <button class="btn btn-primary"
+                  ng-click="$ctrl.selectProjectModal(0)">
+            Select A Source
+          </button>
         </div>
-        <div class="form-group">
-          <label for="formGroupExampleInput">NIR Band</label>
-          <select class="form-control" id="nir-band-map" ng-model="$ctrl.inputs.bands.nir">
-            <option value="1">Band 1</option>
-            <option value="2">Band 2</option>
-            <option value="3">Band 3</option>
-            <option value="4">Band 4</option>
-            <option value="5">Band 5</option>
-            <option value="6">Band 6</option>
-            <option value="7">Band 7</option>
-            <option value="8">Band 8</option>
-            <option value="9">Band 9</option>
-            <option value="10">Band 10</option>
-            <option value="11">Band 11</option>
-          </select>
+        <form class="inset form-horizontal">
+          <div class="form-group" ng-show="$ctrl.inputs[0]">
+            <label for="formGroupExampleInput">Input Source</label>
+            <div class="form-group all-in-one">
+              <input type="text" class="form-control" id="input-0" placeholder="Example input" readonly ng-value="$ctrl.inputs[0].name">
+              <button class="btn btn-link" ng-click="$ctrl.selectProjectModal(0)">
+                Change
+              </button>
+            </div>
+          </div>
+          <div class="form-group" ng-show="$ctrl.inputs[0]">
+            <label for="formGroupExampleInput">Red Band</label>
+            <select class="form-control" id="red-band-map"  ng-model="$ctrl.inputParameters[0].bands.red">
+              <option value="1">Band 1</option>
+              <option value="2">Band 2</option>
+              <option value="3">Band 3</option>
+              <option value="4">Band 4</option>
+              <option value="5">Band 5</option>
+              <option value="6">Band 6</option>
+              <option value="7">Band 7</option>
+              <option value="8">Band 8</option>
+              <option value="9">Band 9</option>
+              <option value="10">Band 10</option>
+              <option value="11">Band 11</option>
+            </select>
+          </div>
+          <div class="form-group" ng-show="$ctrl.inputs[0]">
+            <label for="formGroupExampleInput">NIR Band</label>
+            <select class="form-control" id="nir-band-map" ng-model="$ctrl.inputParameters[0].bands.nir">
+              <option value="1">Band 1</option>
+              <option value="2">Band 2</option>
+              <option value="3">Band 3</option>
+              <option value="4">Band 4</option>
+              <option value="5">Band 5</option>
+              <option value="6">Band 6</option>
+              <option value="7">Band 7</option>
+              <option value="8">Band 8</option>
+              <option value="9">Band 9</option>
+              <option value="10">Band 10</option>
+              <option value="11">Band 11</option>
+            </select>
+          </div>
+        </form>
+      </div>
+      <div class="sidebar-content with-padding with-border">
+        <h5 class="sidebar-title">
+            <div class="btn btn-square really-square">2</div><span>NDVI - After</span>
+        </h5>
+        <div class="instructions-container" ng-show="!$ctrl.inputs[1]">
+          <p>
+            The NDVI tool requires a source with NIR and Red bands
+          </p>
+          <button class="btn btn-primary"
+                  ng-click="$ctrl.selectProjectModal(1)">
+            Select A Source
+          </button>
         </div>
-      </form>
+        <form class="inset">
+          <div class="form-group" ng-show="$ctrl.inputs[1]">
+            <label for="formGroupExampleInput">Input Source</label>
+            <div class="form-group all-in-one">
+              <input type="text" class="form-control" id="input-1" placeholder="Example input" readonly ng-value="$ctrl.inputs[1].name">
+              <button class="btn btn-link" ng-click="$ctrl.selectProjectModal(1)">
+                Change
+              </button>
+            </div>
+          </div>
+          <div class="form-group" ng-show="$ctrl.inputs[1]">
+            <label for="formGroupExampleInput">Red Band</label>
+            <select class="form-control" id="red-band-map"  ng-model="$ctrl.inputParameters[1].bands.red">
+              <option value="1">Band 1</option>
+              <option value="2">Band 2</option>
+              <option value="3">Band 3</option>
+              <option value="4">Band 4</option>
+              <option value="5">Band 5</option>
+              <option value="6">Band 6</option>
+              <option value="7">Band 7</option>
+              <option value="8">Band 8</option>
+              <option value="9">Band 9</option>
+              <option value="10">Band 10</option>
+              <option value="11">Band 11</option>
+            </select>
+          </div>
+          <div class="form-group" ng-show="$ctrl.inputs[1]">
+            <label for="formGroupExampleInput">NIR Band</label>
+            <select class="form-control" id="nir-band-map" ng-model="$ctrl.inputParameters[1].bands.nir">
+              <option value="1">Band 1</option>
+              <option value="2">Band 2</option>
+              <option value="3">Band 3</option>
+              <option value="4">Band 4</option>
+              <option value="5">Band 5</option>
+              <option value="6">Band 6</option>
+              <option value="7">Band 7</option>
+              <option value="8">Band 8</option>
+              <option value="9">Band 9</option>
+              <option value="10">Band 10</option>
+              <option value="11">Band 11</option>
+            </select>
+          </div>
+        </form>
+      </div>
     </div>
-    <div class="sidebar-content flex-row with-padding">
+    <div class="sidebar-content flex-row with-padding with-borders">
       <div class="form-btn-row">
         <div class="btn-group">
-          <button class="btn btn-primary" ng-click="$ctrl.updateInputs()">
-            Apply
+          <button class="btn">
+            Cancel
+          </button>
+          <button class="btn btn-primary">
+            Save
           </button>
         </div>
       </div>
     </div>
   </div>
-  <rf-map-container map-id="lab-run"></rf-map-container>
-</div>
+  <div class="main with-position">
+    <rf-diagram-container class="with-position"
+                          on-preview="$ctrl.showPreview(data)">
+    </rf-diagram-container>
+    <div style="position: absolute; top:0; bottom: 0; left: 0; right: 0;" ng-show="$ctrl.isShowingPreview">
+      <rf-map-container map-id="lab-run-preview"></rf-map-container>
+      <div class="preview-control-bar">
+          <button class="btn btn-primary" ng-click="$ctrl.closePreview()">{{$ctrl.exitText}}</button>
+      </div>
+      <div class="preview-info-bar" ng-show="$ctrl.isComparing">
+        <div class="split-container">
+          <button class="btn">{{$ctrl.previewData[0].name}}</button>
+        </div>
+        <div class="split-container">
+          <button class="btn">{{$ctrl.previewData[1].name}}</button>
+        </div>
+      </div>
+      <div class="preview-info-bar" ng-show="!$ctrl.isComparing">
+        <div class="split-container">
+          <button class="btn">{{$ctrl.previewData.name}}</button>
+        </div>
+      </div>
+    </div>
+  </div>

--- a/app-frontend/src/app/pages/lab/run/run.module.js
+++ b/app-frontend/src/app/pages/lab/run/run.module.js
@@ -3,8 +3,8 @@ import angular from 'angular';
 import LabRunController from './run.controller.js';
 import labRunComponent from './run.component.js';
 
-
 require('./run.scss');
+
 const labRunModule = angular.module('pages.lab.run', []);
 
 labRunModule.component('labRun', labRunComponent);

--- a/app-frontend/src/app/pages/lab/run/run.scss
+++ b/app-frontend/src/app/pages/lab/run/run.scss
@@ -9,7 +9,7 @@
     pointer-events: true;
   }
   text-align: center;
-  z-index: 1100;
+  z-index: 1000;
 }
 
 .preview-info-bar {
@@ -25,7 +25,7 @@
     pointer-events: true;
   }
   text-align: center;
-  z-index: 1100;
+  z-index: 1000;
   .split-container {
     flex: 1;
     text-align: center;

--- a/app-frontend/src/app/pages/lab/run/run.scss
+++ b/app-frontend/src/app/pages/lab/run/run.scss
@@ -1,5 +1,33 @@
-.run-project-name {
-  flex: 1;
-  font-weight: bold;
-  color: #333;
+.preview-control-bar {
+  position: absolute;
+  top: 0;
+  right: 0;
+  left: 0;
+  padding: 16px;
+  pointer-events: false;
+  & > * {
+    pointer-events: true;
+  }
+  text-align: center;
+  z-index: 1100;
+}
+
+.preview-info-bar {
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  left: 0;
+  padding: 16px;
+  pointer-events: false;
+  display: flex;
+  justify-content: center;
+  & > * {
+    pointer-events: true;
+  }
+  text-align: center;
+  z-index: 1100;
+  .split-container {
+    flex: 1;
+    text-align: center;
+  }
 }

--- a/app-frontend/src/app/pages/lab/run/run.scss
+++ b/app-frontend/src/app/pages/lab/run/run.scss
@@ -31,3 +31,15 @@
     text-align: center;
   }
 }
+
+.rzslider.light {
+  .rz-bar {
+    background: #d8e0f3;
+  }
+  .rz-bubble {
+    padding: 0px;
+    bottom: 0px;
+    margin-top: 24px;
+    display: block;
+  }
+}

--- a/app-frontend/yarn.lock
+++ b/app-frontend/yarn.lock
@@ -161,9 +161,9 @@ angular@^1.0.8, angular@^1.x, angular@~1.5.8:
   version "1.5.11"
   resolved "https://registry.yarnpkg.com/angular/-/angular-1.5.11.tgz#8c5ba7386f15965c9acf3429f6881553aada30d6"
 
-angularjs-slider@~5.7.0:
-  version "5.7.0"
-  resolved "https://registry.yarnpkg.com/angularjs-slider/-/angularjs-slider-5.7.0.tgz#2c20cebe0d2e1ee62ec0c9484ec1f8b7d8cd9ac3"
+angularjs-slider@~6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/angularjs-slider/-/angularjs-slider-6.0.0.tgz#c0f430d859d9f4f7c03f092dd289ed2545c582c6"
 
 ansi-escapes@^1.1.0:
   version "1.4.0"
@@ -4500,11 +4500,11 @@ multipipe@^0.1.2:
   dependencies:
     duplexer2 "0.0.2"
 
-mute-stream@0.0.5, mute-stream@~0.0.4:
+mute-stream@0.0.5:
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.5.tgz#8fbfabb0a98a253d3184331f9e8deb7372fac6c0"
 
-mute-stream@0.0.6:
+mute-stream@0.0.6, mute-stream@~0.0.4:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.6.tgz#48962b19e169fd1dfc240b3f1e7317627bbc47db"
 
@@ -5825,13 +5825,13 @@ semver-truncate@^1.0.0:
   dependencies:
     semver "^5.3.0"
 
-"semver@2 || 3 || 4 || 5", "semver@2.x || 3.x || 4 || 5", semver@^4.0.3, semver@~4.3.3:
-  version "4.3.6"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-4.3.6.tgz#300bc6e0e86374f7ba61068b5b1ecd57fc6532da"
-
-semver@^5.1.0, semver@^5.3.0, semver@~5.3.0:
+"semver@2 || 3 || 4 || 5", "semver@2.x || 3.x || 4 || 5", semver@^5.1.0, semver@^5.3.0, semver@~5.3.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"
+
+semver@^4.0.3, semver@~4.3.3:
+  version "4.3.6"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-4.3.6.tgz#300bc6e0e86374f7ba61068b5b1ecd57fc6532da"
 
 send@0.14.1:
   version "0.14.1"


### PR DESCRIPTION
## Overview

This PR does many things:
  - Refactors context menu code to render correctly in spite of angular's attempts to do the opposite
  - Adds the side-by-side leaflet control (see notes)
  - Adds a mousetip (a tooltip but travels with mouse) service
  - Adds a preview map that will show a single node's output or compare two nodes' output

### Demo

<img width="1280" alt="screen shot 2017-01-18 at 12 31 02 pm" src="https://cloud.githubusercontent.com/assets/2442245/22075477/2170379c-dd7a-11e6-9983-3ec0c0faec42.png">
<img width="1278" alt="screen shot 2017-01-18 at 12 31 11 pm" src="https://cloud.githubusercontent.com/assets/2442245/22075476/216f2adc-dd7a-11e6-9985-8038cd7f2e0b.png">
<img width="1278" alt="screen shot 2017-01-18 at 12 31 23 pm" src="https://cloud.githubusercontent.com/assets/2442245/22075478/21725374-dd7a-11e6-92e2-320a0f7202ab.png">
<img width="1276" alt="screen shot 2017-01-18 at 12 31 36 pm" src="https://cloud.githubusercontent.com/assets/2442245/22075480/2173d4e2-dd7a-11e6-8959-cd301e1434d9.png">
<img width="1278" alt="screen shot 2017-01-18 at 12 31 44 pm" src="https://cloud.githubusercontent.com/assets/2442245/22075479/217371be-dd7a-11e6-875f-d263661e6062.png">


### Notes

The leaflet side-by-side control is developed to be used with browserify and attempting to use that within the webpack context blew up leaflet. The only way I managed to get the control to cooperate was to use a special build of the side-by-side control and put it directly into the codebase. It's ugly, but it works.

@designmatty, the preview slider is not styled, but can be if we strip out the stylesheet injected by the `leaflet-side-by-side.js` file. Also, the previewed nodes' names are displayed at the bottom of the map, but the style does not reflect what was in the mocks. The map attribution now has the same style as the mocked-up node names, so I thought we could change it for now and address this issue in a future style clean up.

When in comparison mode, it would probably be best to disable dragging of nodes and have the cursor reflect selection (`cursor: pointer`) when hovering a node.

After clicking the 'Compare to...' option, if the user clicks 'Cancel' or clicks the diagram background, we cancel the comparison process.

Currently, the PR is WIP as we need endpoints to truly compare or preview individual nodes.

## Testing Instructions

 * Go to the lab
 * Select a node, see that the context menu shows up as expected
 * Click 'View Output', see that the map comes up in single display mode
 * Exit the preview, and click 'Compare to...' within the context menu and select a node to compare to, see that the map comes up in comparison mode.
