### PR TITLE
Add day-of-month range filter

### DIFF
--- a/app-frontend/src/app/components/filterPane/filterPane.controller.js
+++ b/app-frontend/src/app/components/filterPane/filterPane.controller.js
@@ -29,6 +29,20 @@ export default class FilterPaneController {
         }
     }
 
+    onDayOfMonthFiltersChange(id, minModel, maxModel) {
+        if (minModel === this.dayOfMonthRange.min) {
+            delete this.filters.minDayOfMonth;
+        } else {
+            this.filters.minDayOfMonth = minModel;
+        }
+
+        if (maxModel === this.dayOfMonthRange.max) {
+            delete this.filters.maxDayOfMonth;
+        } else {
+            this.filters.maxDayOfMonth = maxModel;
+        }
+    }
+
     onCloudCoverFiltersChange(id, minModel, maxModel) {
         if (minModel === this.cloudCoverRange.min) {
             delete this.filters.minCloudCover;
@@ -95,6 +109,27 @@ export default class FilterPaneController {
         };
 
         this.initMonthFilters();
+
+        this.dayOfMonthRange = {min: 1, max: 31};
+        let minDayOfMonth = this.filters.minDayOfMonth ||
+            this.dayOfMonthRange.min;
+        let maxDayOfMonth = this.filters.maxDayOfMonth ||
+            this.dayOfMonthRange.max;
+        this.dayOfMonthFilters = {
+            minModel: minDayOfMonth,
+            maxModel: maxDayOfMonth,
+            options: {
+                floor: this.dayOfMonthRange.min,
+                ceil: this.dayOfMonthRange.max,
+                minRange: 1,
+                showTicks: 2,
+                step: 1,
+                showTicksValues: true,
+                pushRange: true,
+                draggableRange: true,
+                onEnd: this.onDayOfMonthFiltersChange.bind(this)
+            }
+        };
 
         this.cloudCoverRange = {min: 0, max: 100};
         let minCloudCover = parseInt(this.filters.minCloudCover, 10) ||

--- a/app-frontend/src/app/components/filterPane/filterPane.html
+++ b/app-frontend/src/app/components/filterPane/filterPane.html
@@ -38,6 +38,12 @@
       </div>
     </div>
     <div class="filter">
+      <label>Day of Month</label>
+      <rzslider rz-slider-model="$ctrl.dayOfMonthFilters.minModel"
+                rz-slider-high="$ctrl.dayOfMonthFilters.maxModel"
+                rz-slider-options="$ctrl.dayOfMonthFilters.options"></rzslider>
+    </div>
+    <div class="filter">
       <label>Cloud cover</label>
       <rzslider rz-slider-model="$ctrl.cloudCoverFilters.minModel"
                 rz-slider-high="$ctrl.cloudCoverFilters.maxModel"

--- a/app-frontend/src/app/index.routes.js
+++ b/app-frontend/src/app/index.routes.js
@@ -186,6 +186,8 @@ function browseStates($stateProvider) {
         'maxAcquisitionDatetime',
         'datasource',
         'month',
+        'minDayOfMonth',
+        'maxDayOfMonth',
         'maxSunAzimuth',
         'minSunAzimuth',
         'maxSunElevation',


### PR DESCRIPTION
## Overview

Adds a day-of-month range filter to the front-end.

### Demo

<img width="816" alt="screen shot 2017-01-18 at 1 57 37 pm" src="https://cloud.githubusercontent.com/assets/2442245/22078649/bc127380-dd86-11e6-8f62-0523ec1d3d72.png">
<img width="820" alt="screen shot 2017-01-18 at 1 58 06 pm" src="https://cloud.githubusercontent.com/assets/2442245/22078650/bc19fd9e-dd86-11e6-9007-f6f4de273d83.png">

![screen shot 2017-01-18 at 2 01 30 pm](https://cloud.githubusercontent.com/assets/2442245/22078795/538fd75c-dd87-11e6-8750-e12b46d247d4.png)


### Notes

This does not add the backend code to actually get a set of scenes within the range, this only sends and persists the query params.

## Testing Instructions

 * Open the filter pane on the browse page
 * Adjust the day-of-month filter
 * Verify that the params have been added to the url
