### PR TITLE
Add heap to app-frontend

### DIFF
--- a/app-frontend/config/webpack/global.js
+++ b/app-frontend/config/webpack/global.js
@@ -193,7 +193,8 @@ module.exports = function (_path) {
             ),
             new HtmlWebpackPlugin({
                 filename: 'index.html',
-                template: path.join(_path, 'src', 'tpl-index.html')
+                template: path.join(_path, 'src', 'tpl-index.html'),
+                heapLoad: DEVELOPMENT ? '2743344218' : '3505855839'
             })
         ]
     };

--- a/app-frontend/src/app/core/services/auth.service.js
+++ b/app-frontend/src/app/core/services/auth.service.js
@@ -33,6 +33,12 @@ export default (app) => {
                     return;
                 }
 
+                /* eslint-disable no-undef */
+                if (typeof heap !== 'undefined' && typeof heap.identify === 'function') {
+                    heap.identify(profile.email);
+                }
+                /* eslint-enable no-undef */
+
                 this.store.set('profile', profile);
                 this.featureFlagOverrides.setUser(profile.user_id);
                 let userFlags = profile.user_metadata && profile.user_metadata.featureFlags ?

--- a/app-frontend/src/tpl-index.html
+++ b/app-frontend/src/tpl-index.html
@@ -13,6 +13,11 @@
     {% for (var chunk in o.htmlWebpackPlugin.files.chunks) { %}
     <script src="{%=o.htmlWebpackPlugin.files.chunks[chunk].entry %}" defer></script>
     {% } %}
+
+    <script type="text/javascript">
+     window.heap=window.heap||[],heap.load=function(e,t){window.heap.appid=e,window.heap.config=t=t||{};var r=t.forceSSL||"https:"===document.location.protocol,a=document.createElement("script");a.type="text/javascript",a.async=!0,a.src=(r?"https:":"http:")+"//cdn.heapanalytics.com/js/heap-"+e+".js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(a,n);for(var o=function(e){return function(){heap.push([e].concat(Array.prototype.slice.call(arguments,0)))}},p=["addEventProperties","addUserProperties","clearEventProperties","identify","removeEventProperty","setEventProperties","track","unsetEventProperty"],c=0;c<p.length;c++)heap[p[c]]=o(p[c])};
+     heap.load("{%=o.htmlWebpackPlugin.options.heapLoad %}");
+    </script>
 </head>
 <body>
     <!--[if lt IE 10]>


### PR DESCRIPTION
## Overview

This change adds a heap loading string to the application's <HEAD> tag that
connects the app either to the production or dev heap event tracking dashboard.

What it does: add heap

Why we need it: creepily specific tracking data about our users

### Checklist

- ~[ ] Styleguide updated, if necessary~
- ~[ ] Swagger specification updated, if necessary~

### Notes

~I tried adding a `heap.identify` call to the `auth-service` so we'd have nicer user IDs, but there's something about webpack + es6 + asynchronous library loads maybe that made that not work, at least if it's like this [Raygun issue](https://raygun.com/forums/thread/56624) in IE11 (??).~

Just kidding it totally works I don't know why webpack kept complaining

## Testing Instructions

 * Get the heap user/pass info from me
 * Start up your front- and backends
 * Log in and do some stuff
 * Go to the heap list view, click RUN QUERY, and check out your session
