### PR TITLE
Add toggles to disable color correction filters by group

### DIFF
--- a/app-frontend/src/app/components/colorCorrectAdjust/colorCorrectAdjust.controller.js
+++ b/app-frontend/src/app/components/colorCorrectAdjust/colorCorrectAdjust.controller.js
@@ -55,12 +55,16 @@ export default class ColorCorrectAdjustController {
         this.greenGammaOptions = Object.assign({}, baseGammaOptions, {id: 'green'});
         this.blueGammaOptions = Object.assign({}, baseGammaOptions, {id: 'blue'});
 
-        this.brightnessOptions = Object.assign({}, baseFilterOptions, {id: 'brightness'});
-        this.contrastOptions = Object.assign({}, baseFilterOptions, {id: 'contrast'});
-
         this.alphaOptions = Object.assign({}, alphaOptions, {id: 'alpha'});
         this.betaOptions = Object.assign({}, betaOptions, {id: 'beta'});
+
+        this.brightnessOptions = Object.assign({}, baseFilterOptions, {id: 'brightness'});
+        this.contrastOptions = Object.assign({}, baseFilterOptions, {id: 'contrast'});
         this.minMaxOptions = Object.assign({}, minMaxOptions, {id: 'minmax'});
+
+        this.gammaToggle = {value: true};
+        this.sigToggle = {value: true};
+        this.bcToggle = {value: true};
     }
 
     /**
@@ -71,7 +75,38 @@ export default class ColorCorrectAdjustController {
      * @returns {null} null
      */
     onFilterChange(id, val) {
-        this.correction[id] = val;
+        if (id) {
+            this.correction[id] = val;
+        }
         this.onCorrectionChange({newCorrection: Object.assign({}, this.correction)});
+    }
+
+    gammaToggled(value) {
+        this.redGammaOptions.disabled = !value;
+        this.greenGammaOptions.disabled = !value;
+        this.blueGammaOptions.disabled = !value;
+        ['red', 'green', 'blue'].forEach((id) => {
+            this.correction[id] = null;
+        });
+        this.onFilterChange();
+    }
+
+    sigToggled(value) {
+        this.alphaOptions.disabled = !value;
+        this.betaOptions.disabled = !value;
+        ['alpha', 'beta'].forEach((id) => {
+            this.correction[id] = null;
+        });
+        this.onFilterChange();
+    }
+
+    bcToggled(value) {
+        this.brightnessOptions.disabled = !value;
+        this.contrastOptions.disabled = !value;
+        this.minMaxOptions.disabled = !value;
+        ['brightness', 'contrast', 'min', 'max'].forEach((id) => {
+            this.correction[id] = null;
+        });
+        this.onFilterChange();
     }
 }

--- a/app-frontend/src/app/components/colorCorrectAdjust/colorCorrectAdjust.html
+++ b/app-frontend/src/app/components/colorCorrectAdjust/colorCorrectAdjust.html
@@ -1,80 +1,102 @@
 <div class="content histogram-filters">
   <div class="color-filters-container">
     <!-- Color correction -->
-    <p class="h5">Gamma Correction</p>
-    <div class="filter">
-      <label>Red</label>
-      <div class="filter-item slider-filter">
-        <div id="red_slider"></div>
+    <div class="filter-group">
+      <div class="filter-group-header">
+        <p class="h5">Gamma Correction</p>
+        <rf-toggle data-model="$ctrl.gammaToggle"
+                   on-change="$ctrl.gammaToggled(value)">
+        </rf-toggle>
       </div>
-      <rzslider rz-slider-model="$ctrl.correction.redGamma"
-                rz-slider-options="$ctrl.redGammaOptions"
-      ></rzslider>
-    </div>
-    <div class="filter">
-      <label>Green</label>
-      <div class="filter-item slider-filter">
-        <div id="green_slider"></div>
+      <div class="filter-group-body">
+        <div class="filter">
+          <label>Red</label>
+          <div class="filter-item slider-filter">
+            <div id="red_slider"></div>
+          </div>
+          <rzslider rz-slider-model="$ctrl.correction.redGamma"
+                    rz-slider-options="$ctrl.redGammaOptions"
+          ></rzslider>
+        </div>
+        <div class="filter">
+          <label>Green</label>
+          <div class="filter-item slider-filter">
+            <div id="green_slider"></div>
+          </div>
+          <rzslider rz-slider-model="$ctrl.correction.greenGamma"
+                    rz-slider-options="$ctrl.greenGammaOptions"
+          ></rzslider>
+        </div>
+        <div class="filter">
+          <label>Blue</label>
+          <div class="filter-item slider-filter">
+            <div id="blue_slider"></div>
+          </div>
+          <rzslider rz-slider-model="$ctrl.correction.blueGamma"
+                    rz-slider-options="$ctrl.blueGammaOptions"
+          ></rzslider>
+        </div>
       </div>
-      <rzslider rz-slider-model="$ctrl.correction.greenGamma"
-                rz-slider-options="$ctrl.greenGammaOptions"
-      ></rzslider>
-    </div>
-    <div class="filter">
-      <label>Blue</label>
-      <div class="filter-item slider-filter">
-        <div id="blue_slider"></div>
-      </div>
-      <rzslider rz-slider-model="$ctrl.correction.blueGamma"
-                rz-slider-options="$ctrl.blueGammaOptions"
-      ></rzslider>
     </div>
 
-    <!--TODO: Add Sigmoidal Back When Fixed ISSUE: 761-->
-    <p class="h5">Sigmoidal Correction</p>
-    <div class="filter">
-      <label>Alpha</label>
-      <div class="filter-item slider-filter">
-        <div id="alpha_slider"></div>
+    <div class="filter-group">
+      <div class="filter-group-header">
+        <p class="h5">Sigmoidal Correction</p>
+        <rf-toggle data-model="$ctrl.sigToggle"
+                   on-change="$ctrl.sigToggled(value)"></rf-toggle>
       </div>
-      <rzslider rz-slider-model="$ctrl.correction.alpha"
-                rz-slider-options="$ctrl.alphaOptions"
-      ></rzslider>
-    </div>
-    <div class="filter">
-      <label>Beta</label>
-      <div class="filter-item slider-filter">
-        <div id="beta_slider"></div>
+      <div class="filter-group-body">
+        <div class="filter">
+          <label>Alpha</label>
+          <div class="filter-item slider-filter">
+            <div id="alpha_slider"></div>
+          </div>
+          <rzslider rz-slider-model="$ctrl.correction.alpha"
+                    rz-slider-options="$ctrl.alphaOptions"
+          ></rzslider>
+        </div>
+        <div class="filter">
+          <label>Beta</label>
+          <div class="filter-item slider-filter">
+            <div id="beta_slider"></div>
+          </div>
+          <rzslider rz-slider-model="$ctrl.correction.beta"
+                    rz-slider-options="$ctrl.betaOptions"
+          ></rzslider>
+        </div>
       </div>
-      <rzslider rz-slider-model="$ctrl.correction.beta"
-                rz-slider-options="$ctrl.betaOptions"
-      ></rzslider>
     </div>
-  </div>
-  <div class="bc-filters-container">
-    <p class="h5">Brightness/Contrast</p>
-    <div class="filter">
-      <label>Brightness</label>
-      <rzslider rz-slider-model="$ctrl.correction.brightness"
-                rz-slider-options="$ctrl.brightnessOptions"></rzslider>
-    </div>
-    <div class="filter">
-      <label>Contrast</label>
-      <div class="filter-item slider-filter">
-        <div id="contrast"></div>
+
+    <div class="filter-group">
+      <div class="filter-group-header">
+        <p class="h5">Brightness/Contrast</p>
+        <rf-toggle data-model="$ctrl.bcToggle"
+                   on-change="$ctrl.bcToggled(value)"></rf-toggle>
       </div>
-      <rzslider rz-slider-model="$ctrl.correction.contrast"
-                rz-slider-options="$ctrl.contrastOptions"></rzslider>
-    </div>
-    <div class="filter">
-      <label>Min/Max Clipping</label>
-      <div class="filter-item slider-filter">
-        <div id="minmax"></div>
+      <div class="filter-group-body">
+        <div class="filter">
+          <label>Brightness</label>
+          <rzslider rz-slider-model="$ctrl.correction.brightness"
+                    rz-slider-options="$ctrl.brightnessOptions"></rzslider>
+        </div>
+        <div class="filter">
+          <label>Contrast</label>
+          <div class="filter-item slider-filter">
+            <div id="contrast"></div>
+          </div>
+          <rzslider rz-slider-model="$ctrl.correction.contrast"
+                    rz-slider-options="$ctrl.contrastOptions"></rzslider>
+        </div>
+        <div class="filter">
+          <label>Min/Max Clipping</label>
+          <div class="filter-item slider-filter">
+            <div id="minmax"></div>
+          </div>
+          <rzslider rz-slider-model="$ctrl.correction.min"
+                    rz-slider-high="$ctrl.correction.max"
+                    rz-slider-options="$ctrl.minMaxOptions"
+          ></rzslider>
+        </div>
       </div>
-      <rzslider rz-slider-model="$ctrl.correction.min"
-                rz-slider-high="$ctrl.correction.max"
-                rz-slider-options="$ctrl.minMaxOptions"
-      ></rzslider>
     </div>
-  </div>
 </div>

--- a/app-frontend/src/app/components/colorCorrectAdjust/colorCorrectAdjust.module.js
+++ b/app-frontend/src/app/components/colorCorrectAdjust/colorCorrectAdjust.module.js
@@ -4,6 +4,8 @@ import slider from 'angularjs-slider';
 import ColorCorrectAdjust from './colorCorrectAdjust.component.js';
 import ColorCorrectAdjustController from './colorCorrectAdjust.controller.js';
 
+require('./colorCorrectAdjust.scss');
+
 const ColorCorrectAdjustModule = angular.module('components.colorCorrectAdjust', [slider]);
 
 ColorCorrectAdjustModule.component('rfColorCorrectAdjust', ColorCorrectAdjust);

--- a/app-frontend/src/app/components/colorCorrectAdjust/colorCorrectAdjust.scss
+++ b/app-frontend/src/app/components/colorCorrectAdjust/colorCorrectAdjust.scss
@@ -1,0 +1,8 @@
+.filter-group {
+}
+.filter-group-header {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: flex-end;
+}

--- a/app-frontend/src/app/components/colorCorrectAdjust/colorCorrectAdjust.scss
+++ b/app-frontend/src/app/components/colorCorrectAdjust/colorCorrectAdjust.scss
@@ -1,5 +1,4 @@
-.filter-group {
-}
+// @todo @designmatty style this
 .filter-group-header {
   display: flex;
   flex-direction: row;

--- a/app-frontend/src/app/components/toggle/toggle.component.js
+++ b/app-frontend/src/app/components/toggle/toggle.component.js
@@ -1,0 +1,12 @@
+import toggleTpl from './toggle.html';
+const rfToggle = {
+    templateUrl: toggleTpl,
+    controller: 'ToggleController',
+    bindings: {
+        model: '=',
+        onChange: '&'
+    },
+    controllerAs: '$ctrl'
+};
+
+export default rfToggle;

--- a/app-frontend/src/app/components/toggle/toggle.controller.js
+++ b/app-frontend/src/app/components/toggle/toggle.controller.js
@@ -1,0 +1,17 @@
+export default class ToggleController {
+    constructor() {
+        'ngInject';
+    }
+    $onInit() {
+        if (!this.model) {
+            this.model = {
+                value: false
+            };
+        }
+    }
+    $onChanges(changes) {
+        if ('model' in changes && changes.dataModel.currentValue) {
+            this.model = changes.dataModel.currentValue;
+        }
+    }
+}

--- a/app-frontend/src/app/components/toggle/toggle.html
+++ b/app-frontend/src/app/components/toggle/toggle.html
@@ -1,0 +1,6 @@
+<label class="switch">
+  <input type="checkbox"
+         ng-model="$ctrl.model.value"
+         ng-change="$ctrl.onChange({value: $ctrl.model.value})">
+  <div class="slider round"></div>
+</label>

--- a/app-frontend/src/app/components/toggle/toggle.module.js
+++ b/app-frontend/src/app/components/toggle/toggle.module.js
@@ -1,0 +1,12 @@
+import angular from 'angular';
+import ToggleComponent from './toggle.component.js';
+import ToggleController from './toggle.controller.js';
+
+const ToggleModule = angular.module('components.toggle', []);
+
+require('./toggle.scss');
+
+ToggleModule.component('rfToggle', ToggleComponent);
+ToggleModule.controller('ToggleController', ToggleController);
+
+export default ToggleModule;

--- a/app-frontend/src/app/components/toggle/toggle.scss
+++ b/app-frontend/src/app/components/toggle/toggle.scss
@@ -1,0 +1,59 @@
+@import "../../../assets/styles/sass/utils/variables";
+/* The switch - the box around the slider */
+.switch {
+  position: relative;
+  display: inline-block;
+  width: 4em;
+  height: 2em;
+}
+
+/* Hide default HTML checkbox */
+.switch input {display:none;}
+
+/* The slider */
+.slider {
+  position: absolute;
+  cursor: pointer;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: lighten($shade-dark, 5%);
+  -webkit-transition: .4s;
+  transition: .4s;
+}
+
+.slider:before {
+  position: absolute;
+  content: "";
+  height: 1.5em;
+  width: 1.5em;
+  left: 4px;
+  bottom: 4px;
+  background-color: $brand-primary;
+  -webkit-transition: .4s;
+  transition: .4s;
+}
+
+input:checked + .slider {
+  background-color: $shade-dark;
+}
+
+/* input:focus + .slider { */
+/*   box-shadow: 0 0 1px #2196F3; */
+/* } */
+
+input:checked + .slider:before {
+  -webkit-transform: translateX(26px);
+  -ms-transform: translateX(26px);
+  transform: translateX(26px);
+}
+
+/* Rounded sliders */
+.slider.round {
+  border-radius: 34px;
+}
+
+.slider.round:before {
+  border-radius: 50%;
+}

--- a/app-frontend/src/app/components/toggle/toggle.scss
+++ b/app-frontend/src/app/components/toggle/toggle.scss
@@ -1,3 +1,4 @@
+// @todo @designmatty style this
 @import "../../../assets/styles/sass/utils/variables";
 /* The switch - the box around the slider */
 .switch {

--- a/app-frontend/src/app/index.components.js
+++ b/app-frontend/src/app/index.components.js
@@ -24,6 +24,6 @@ export default angular.module('index.components', [
     require('./components/downloadModal/downloadModal.module.js').name,
     require('./components/featureFlagOverrides/featureFlagOverrides.module.js').name,
     require('./components/selectProjectModal/selectProjectModal.module.js').name,
-    require('./components/selectToolModal/selectToolModal.module.js').name
-
+    require('./components/selectToolModal/selectToolModal.module.js').name,
+    require('./components/toggle/toggle.module.js').name
 ]);


### PR DESCRIPTION
## Overview
Add toggles to color correction to enable/disable types of filters

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~

### Demo
![image](https://cloud.githubusercontent.com/assets/4392704/22112006/7b2da566-de2f-11e6-99e7-8c538fe45791.png)
![image](https://cloud.githubusercontent.com/assets/4392704/22112215/20f418b8-de30-11e6-93b7-0c7f5ed34667.png)


### Notes

Some styling is needed
@designmatty I added `src/components/colorCorrectAdjust/colorCorrectAdjust.scss` to position the toggles, and `src/components/toggle/toggle.scss` for the toggle styling.
I think that it will be a lot more clear when things are toggled off once the sliders change color correctly

## Testing Instructions

 * Select some scene and go to the color correct page
 * Open the network tab of your browser's dev tools
 * Toggle a section
 * Verify that the post request sent for each scene has the correct values set to null