### PR TITLE
Fix tiler deadlocks when interacting with the database

### DIFF
--- a/app-backend/database/src/main/scala/com/azavea/rf/database/Database.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/Database.scala
@@ -20,7 +20,6 @@ class Database(jdbcUrl: String, dbUser: String, dbPassword: String) {
   hikariConfig.setJdbcUrl(jdbcUrl)
   hikariConfig.setUsername(dbUser)
   hikariConfig.setPassword(dbPassword)
-  hikariConfig.setConnectionTimeout(2000)
 
   private val dataSource = new HikariDataSource(hikariConfig)
 
@@ -34,7 +33,7 @@ class Database(jdbcUrl: String, dbUser: String, dbPassword: String) {
   import driver.api._
 
   val db = {
-    val executor = AsyncExecutor("slick", numThreads=64, queueSize=1000)
+    val executor = AsyncExecutor("slick", numThreads=5, queueSize=1000)
     driver.api.Database.forDataSource(dataSource, executor)
   }
 }


### PR DESCRIPTION
## Overview

The connection timeout for our database connection pool was initially set too low, which in conjunction with the number of threads allocated for Slick, caused many of the Slick threads to spin in a parked state while eating up all of the available CPU.

These changes reduce the overall number of threads to 5 ((2 * CPU Cores) + 1) and remove the explicit 2000ms connection timeout in favor of the 30s default.

### Demo

This will hopefully go away:

<img width="813" alt="screen shot 2017-01-19 at 15 00 32" src="https://cloud.githubusercontent.com/assets/43639/22123013/1034a1fa-de58-11e6-9b95-581872a09579.png">

## Testing Instructions

- Login to staging
- Go into the editor of a project with the scenes from Egypt
- Color correct them in any way you like
- Interact with the map tiles (zoom in/out, pan around)
- Note holes in the map or slow load times (with 1 tiler instance, requests can take 3-4 seconds, but they don't hang indefinitely)
