### PR TITLE
Use tag for caching mosaicDefinition, default to none

### DIFF
--- a/app-backend/tile/src/main/scala/image/Mosaic.scala
+++ b/app-backend/tile/src/main/scala/image/Mosaic.scala
@@ -35,8 +35,7 @@ object Mosaic {
   }
 
   /** Cache the result of mosaic definition, use tag to control cache rollover */
-  def mosaicDefinition(projectId: UUID, tagttl: Option[TagWithTTL])
-                      (implicit db: Database) = {
+  def mosaicDefinition(projectId: UUID, tagttl: Option[TagWithTTL])(implicit db: Database) = {
     tagttl match {
       case Some(t) =>
         cachingWithTTL(s"mosaic-definition-$projectId-${t.tag}")(t.ttl) {

--- a/app-frontend/src/app/core/services/layer.service.js
+++ b/app-frontend/src/app/core/services/layer.service.js
@@ -236,7 +236,8 @@ export default (app) => {
                 alpha: object.alpha,
                 beta: object.beta,
                 min: object.min,
-                max: object.max
+                max: object.max,
+                tag: object.tag ? object.tag : (new Date()).getTime()
             };
         }
 


### PR DESCRIPTION
## Overview

Tile server wasn't using tags correctly to determine whether to cache

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~

### Notes

Mosaic.raw no longer caches by default - this code will be ripped out at some point anyways later on.

Currently, the frontend will use the time that the color correction settings were last changed in the cache key. This can be changed to something else, like a publish key if needed.

## Testing Instructions

* Go to the project editor using a project with ingested scenes.
* Edit the color correction settings
* wait for about half of the tiles to load
* change the settings
* Previously, it would start loading the new settings alongside the old tiles, then refresh and cause some inconsistencies.  With the new caching behaviour, it should instead continue loading with the old settings, then refresh the layer and load using the new settings.

Closes #958
