### PR TITLE
Fix duplicated image links by adding "distinct" to query

### DIFF
--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/Scene.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/Scene.scala
@@ -181,7 +181,7 @@ object Scene extends GeoJsonSupport {
         val (seqImages, seqThumbnails) = groupedScenes(scene).map {
           case (_, image, _, thumbnail) => (image, thumbnail)
         }.unzip
-        val imagesWithComponents: Seq[Image.WithRelated] = seqImages.flatten.map {
+        val imagesWithComponents: Seq[Image.WithRelated] = seqImages.flatten.distinct.map {
           image => image.withRelatedFromComponents(groupedBands.getOrElse(image.id, Seq[Band]()))
         }
         scene.withRelatedFromComponents(imagesWithComponents, seqThumbnails.flatten.distinct)


### PR DESCRIPTION
## Overview

Join was causing image links to be duplicated

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~

### Demo

![image](https://cloud.githubusercontent.com/assets/4392704/22267447/cb4b9cda-e251-11e6-9aa9-a73b942d501b.png)


## Testing Instructions

* Start server
* Open a landsat scene and verify that it only has 11 images, instead of 22

Connects #957
