### PR TITLE
Show selected false color composite in dropdown

### DIFF
--- a/app-frontend/src/app/components/colorCorrectScenes/colorCorrectScenes.html
+++ b/app-frontend/src/app/components/colorCorrectScenes/colorCorrectScenes.html
@@ -6,15 +6,14 @@
           Color mode <i class="icon-caret-down"></i>
         </a>
         <ul class="dropdown-menu dropdown-menu-light" uib-dropdown-menu role="menu">
-          <li role="menuitem"><a href ng-click="$ctrl.setBands('natural')">Natural color</a></li>
-          <li role="menuitem"><a href ng-click="$ctrl.setBands('cir')">Color infrared</a></li>
-          <li role="menuitem"><a href ng-click="$ctrl.setBands('urban')">Urban</a></li>
-          <li role="menuitem"><a href ng-click="$ctrl.setBands('water')">Water</a></li>
-          <li role="menuitem"><a href ng-click="$ctrl.setBands('atmosphere')">Atmosphere penetration</a></li>
-          <li role="menuitem"><a href ng-click="$ctrl.setBands('agriculture')">Agriculture</a></li>
-          <li role="menuitem"><a href ng-click="$ctrl.setBands('forestfire')">Forest fire</a></li>
-          <li role="menuitem"><a href ng-click="$ctrl.setBands('bareearth')">Bare Earth change detection</a></li>
-          <li role="menuitem"><a href ng-click="$ctrl.setBands('vegwater')">Vegetation & water</a></li>
+          <li role="menuitem">
+            <a href
+               ng-class="{'active': $ctrl.isActiveColorMode(key)}"
+               ng-click="$ctrl.setBands(key)"
+               ng-repeat="(key, band) in $ctrl.bands track by $index">
+              {{band.label}}
+            </a>
+          </li>
         </ul>
       </div>
       <div class="sidebar-actions">

--- a/app-frontend/src/app/core/services/layer.service.js
+++ b/app-frontend/src/app/core/services/layer.service.js
@@ -250,6 +250,10 @@ export default (app) => {
             });
         }
 
+        getCachedColorCorrection() {
+            return this._correction; // eslint-disable-line no-underscore-dangle
+        }
+
         updateColorCorrection(corrections) {
             this._correction = corrections; // eslint-disable-line no-underscore-dangle
             return this.colorCorrectService.updateOrCreate(

--- a/app-frontend/src/app/pages/editor/project/projectEdit.controller.js
+++ b/app-frontend/src/app/pages/editor/project/projectEdit.controller.js
@@ -127,6 +127,8 @@ export default class ProjectEditController {
                 this.sceneList = allScenes;
                 for (const scene of this.sceneList) {
                     let scenelayer = this.layerService.layerFromScene(scene, this.projectId);
+                    // Init color correction data
+                    scenelayer.getColorCorrection();
                     this.sceneLayers.set(scene.id, scenelayer);
                 }
                 this.layerFromProject();

--- a/app-frontend/src/assets/styles/sass/components/_dropdown.scss
+++ b/app-frontend/src/assets/styles/sass/components/_dropdown.scss
@@ -209,6 +209,11 @@
       padding: 5px 10px;
       font-size: 13px;
       font-weight: 400;
+
+      &.active {
+        background-color: $brand-primary;
+        color: #fff;
+      }
     }
   }
 }


### PR DESCRIPTION
## Overview

Show which false color composite is in use

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~

### Demo
![image](https://cloud.githubusercontent.com/assets/4392704/22303780/d1cb0ae4-e302-11e6-9851-717147ad4d6e.png)

![image](https://cloud.githubusercontent.com/assets/4392704/22303832/ffd44e82-e302-11e6-9aa6-649b3919f520.png)

### Notes

The selection does not update until the layer has switched to the new one - it reflects what's on the map
@designmatty I added a `.active` class selector in `app-frontend/src/assets/styles/sass/components/_dropdown.scss` for selected menu items

## Testing Instructions

 * Go to the the color correction page
* Click the dropdown menu and verify that it initializes to the correct one (may need to wait for layer to load)
* Click another composite, and wait for the map to update. The highlighted menu item should be changed as soon as the new tiles start to load.

Closes #973 
