### PR TITLE
Add initial filter values and single year filter mode

### DIFF
--- a/app-frontend/src/app/components/filterPane/filterPane.html
+++ b/app-frontend/src/app/components/filterPane/filterPane.html
@@ -16,10 +16,30 @@
       <div class="filter-item">
         <div id="year_slider"></div>
       </div>
-      <rzslider rz-slider-model="$ctrl.yearFilters.minModel"
-                rz-slider-high="$ctrl.yearFilters.maxModel"
-                rz-slider-options="$ctrl.yearFilters.options"
-      ></rzslider>
+      <div class="btn-group">
+        <button type="button"
+                class="btn btn-toggle btn-small"
+                ng-class="{'active': $ctrl.yearFilterMode === 'range'}"
+                ng-click="$ctrl.setYearFilterMode('range')">
+          Year Range
+        </button>
+        <button type="button"
+                class="btn btn-toggle btn-small"
+                ng-class="{'active': $ctrl.yearFilterMode === 'single'}"
+                ng-click="$ctrl.setYearFilterMode('single')">
+          Single year
+        </button>
+      </div>
+      <br/>
+        <rzslider rz-slider-model="$ctrl.yearRangeFilters.minModel"
+                  rz-slider-high="$ctrl.yearRangeFilters.maxModel"
+                  rz-slider-options="$ctrl.yearRangeFilters.options"
+                  ng-show="$ctrl.yearFilterMode === 'range'"
+        ></rzslider>
+        <rzslider rz-slider-model="$ctrl.singleYearFilter.value"
+                  rz-slider-options="$ctrl.singleYearFilter.options"
+                  ng-show="$ctrl.yearFilterMode === 'single'"
+        ></rzslider>
     </div>
     <div class="filter"
          ng-mouseup="$ctrl.toggleDrag.toggle = false"


### PR DESCRIPTION
## Overview

This PR first adds a single year filtering mode to the browse page. 

As shown in the demos below, this introduces a concept of year filtering modes, starting with 'single' and 'range'. Only one mode can be active at a time.  I've attempted to create an intuitive flow from range to single. The switching flow is:

Switching from 'range' to 'single':
- The range's minimum value is cached
- The range's maximum year is set as the single active filtering year

Switching from 'single' to 'range':
- If there is a minimum value cached, we bring it back as the range min
- The current single year value is used as the max

There are edge cases that don't follow these rules, but I think they are handled logically:
- When the single year is set at the minimum allowable
- When the single year is set as what was once the previous range min
- etc..

This PR also initializes the filters with reasonable (in theory) values:
- Cloud cover <= 10%
- Only previous 2 months

In practice we are able to achieve:
- Cloud cover <= 10%
- Only previous 60-90 days and then some

### Demo

<img width="333" alt="screen shot 2017-01-25 at 10 38 34 am" src="https://cloud.githubusercontent.com/assets/2442245/22319410/7c4e7292-e350-11e6-872d-74ded73ba944.png">
<img width="326" alt="screen shot 2017-01-25 at 10 38 52 am" src="https://cloud.githubusercontent.com/assets/2442245/22319411/7c4f11b6-e350-11e6-8e78-541d77fe6b70.png">
<img width="332" alt="screen shot 2017-01-25 at 10 38 44 am" src="https://cloud.githubusercontent.com/assets/2442245/22319412/7c50a864-e350-11e6-8ab8-ec7475ab4cb4.png">


### Notes

The back-end has enough filtering granularity to accomplish what we'd like, but the front-end filter design does not. For example, we have `minAcquisitionDatetime` and `maxAcquisitionDatetime` but are only using these parameters with with beginning and end of year values.


## Testing Instructions

 * Go to the browse page, clear filters, and reload
 * Ensure that filters are initialized to match expectations
 * Adjust the year filter and ensure that: the url and slider match, transitions from range to single and vice versa seem to make sense

Connects #959, #960
