### PR TITLE
Prevent duplication of effort on expensive cache misses

### DIFF
--- a/app-backend/build.sbt
+++ b/app-backend/build.sbt
@@ -178,6 +178,7 @@ lazy val tile = Project("tile", file("tile"))
       Dependencies.geotrellisSpark,
       Dependencies.geotrellisS3,
       Dependencies.caffeine,
+      Dependencies.scaffeine,
       Dependencies.elasticacheClient,
       Dependencies.scalacacheCaffeine,
       Dependencies.scalacacheMemcache.exclude("net.spy", "spymemcached"),

--- a/app-backend/database/src/main/scala/com/azavea/rf/database/tables/ScenesToProjects.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/tables/ScenesToProjects.scala
@@ -116,7 +116,7 @@ object ScenesToProjects extends TableQuery(tag => new ScenesToProjects(tag)) wit
   }
 
   /** Get the complete mosaic definition for a giving project */
-  def getMosaicDefinition(projectId: UUID)(implicit database: DB) = {
+  def getMosaicDefinition(projectId: UUID)(implicit database: DB): Future[Option[MosaicDefinition]] = {
     database.db.run {
       ScenesToProjects
         .filter(_.projectId === projectId)

--- a/app-backend/project/Dependencies.scala
+++ b/app-backend/project/Dependencies.scala
@@ -33,6 +33,7 @@ object Dependencies {
   val commonsIO          = "commons-io"                   % "commons-io"                        % Version.commonsIO
   val scopt              = "com.github.scopt"            %% "scopt"                             % Version.scopt
   val caffeine           = "com.github.ben-manes.caffeine" % "caffeine"                         % Version.caffeine
+  val scaffeine          = "com.github.blemale"          %% "scaffeine"                         % "2.0.0"
   val scalacacheMemcache = "com.github.cb372"            %% "scalacache-memcached"              % Version.scalacache
   val scalacacheCaffeine = "com.github.cb372"            %% "scalacache-caffeine"               % Version.scalacache
   val elasticacheClient  = "com.amazonaws"                % "elasticache-java-cluster-client"   % Version.elasticacheClient

--- a/app-backend/tile/src/main/resources/application.conf
+++ b/app-backend/tile/src/main/resources/application.conf
@@ -10,7 +10,7 @@ memcached {
   port = ${?MEMCACHED_PORT}
 }
 
-tile-server { 
+tile-server {
   cache {
     size = ${?TILE_SERVER_CACHE_SIZE}
     expiration = ${?TILE_SERVER_CACHE_EXPIRATION}

--- a/app-backend/tile/src/main/scala/LayerCache.scala
+++ b/app-backend/tile/src/main/scala/LayerCache.scala
@@ -44,6 +44,11 @@ object LayerCache extends Config {
   val memcachedClient =
     new MemcachedClient(new InetSocketAddress(memcachedHost, memcachedPort))
 
+  // TODO: Make a scalacache Codec using Kryo
+  implicit val memcached: ScalaCache[Array[Byte]] = {
+    ScalaCache(MemcachedCache(memcachedClient))
+  }
+
   implicit val memoryCache: ScalaCache[InMemoryRepr] = {
     val underlyingCaffeineCache =
       Caffeine.newBuilder()
@@ -51,12 +56,6 @@ object LayerCache extends Config {
         .expireAfterAccess(cacheExpiration.toMillis, TimeUnit.MILLISECONDS)
         .build[String, Object]
     ScalaCache(CaffeineCache(underlyingCaffeineCache))
-  }
-
-  // TODO: Make a scalacache Codec using Kryo
-  implicit val memcached: ScalaCache[Array[Byte]] = {
-    val client = new MemcachedClient(new InetSocketAddress(memcachedHost, memcachedPort))
-    ScalaCache(MemcachedCache(client))
   }
 
   def attributeStore(bucket: String, prefix: Option[String]): Future[S3AttributeStore] =
@@ -74,7 +73,7 @@ object LayerCache extends Config {
   val futureTiles: ScaffCache[String, Future[Option[MultibandTile]]] =
     Scaffeine()
       .recordStats()
-      .expireAfterWrite(20.minute)
+      .expireAfterWrite(30.second)
       .maximumSize(500)
       .build[String, Future[Option[MultibandTile]]]()
 
@@ -95,7 +94,7 @@ object LayerCache extends Config {
         }
       }
 
-    def fetchTile(cKey: String) = {
+    def fetchRemote(cKey: String) = {
       memcachedClient
         .asyncGet(cKey)
         .asFuture[MultibandTile]
@@ -108,14 +107,14 @@ object LayerCache extends Config {
               for {
                 mbTile <- futureMaybeTile
                 tile <- mbTile
-              } { memcachedClient.set(cKey, 10000, tile) }
+              } { memcachedClient.set(cKey, 30, tile) }
               futureMaybeTile
           }
         })
     }
 
     val cacheKey = s"tile-$id-$zoom-$key"
-    val futureMaybeTile = futureTiles.get(cacheKey, fetchTile)
+    val futureMaybeTile = futureTiles.get(cacheKey, fetchRemote)
     futureTiles.put(cacheKey, futureMaybeTile)
     futureMaybeTile
   }
@@ -124,13 +123,13 @@ object LayerCache extends Config {
   val futureHistograms: ScaffCache[String, Future[Array[Histogram[Double]]]] =
     Scaffeine()
       .recordStats()
-      .expireAfterWrite(20.minute)
+      .expireAfterWrite(30.second)
       .maximumSize(500)
       .build[String, Future[Array[Histogram[Double]]]]()
 
 
   def bandHistogram(id: RfLayerId, zoom: Int): Future[Array[Histogram[Double]]] = {
-    def fetchHistograms(cKey: String) = {
+    def fetchRemote(cKey: String) = {
       memcachedClient
         .asyncGet(cKey)
         .asFuture[Array[Histogram[Double]]]
@@ -145,14 +144,14 @@ object LayerCache extends Config {
               } yield store.read[Array[Histogram[Double]]](id.catalogId(0), "histogram")
               for (
                 histograms <- futureHistograms
-              ) { memcachedClient.set(cKey, 10000, histograms) }
+              ) { memcachedClient.set(cKey, 30, histograms) }
               futureHistograms
           }
         })
     }
 
     val cacheKey = s"histogram-$id-$zoom"
-    val futHistograms = futureHistograms.get(cacheKey, fetchHistograms)
+    val futHistograms = futureHistograms.get(cacheKey, fetchRemote)
     futureHistograms.put(cacheKey, futHistograms)
     futHistograms
   }

--- a/app-backend/tile/src/main/scala/package.scala
+++ b/app-backend/tile/src/main/scala/package.scala
@@ -1,0 +1,29 @@
+package com.azavea.rf
+
+import net.spy.memcached.internal.GetFuture
+
+import scala.concurrent._
+import scala.concurrent.duration._
+import scala.util._
+import scala.concurrent.ExecutionContext.Implicits.global
+import java.util.concurrent.{Executors, TimeUnit}
+
+package object tile {
+
+  trait isFuture[A] {
+    def asFuture[T]: Future[T]
+  }
+
+  implicit class memcachedFutureIsFuture[B <: AnyRef](fut: GetFuture[B]) extends isFuture[GetFuture[B]] {
+    def asFuture[T]: Future[T] = {
+      val promise = Promise[Object]()
+      new Thread(new Runnable {
+        def run() {
+          promise.complete(Try{ fut.get })
+        }
+      }).start
+      promise.future.map({ obj => obj.asInstanceOf[T] })
+    }
+  }
+
+}

--- a/app-backend/tile/src/main/scala/routes/ToolRoutes.scala
+++ b/app-backend/tile/src/main/scala/routes/ToolRoutes.scala
@@ -63,7 +63,7 @@ object ToolRoutes extends LazyLogging {
       case Some(s) if s.contains(':') =>
         ColorMap.fromStringDouble(s).get
       case None =>
-        val colorRamp = ColorRamp(Vector(0xD51D26FF, 0xF8F2B2FF, 0x349E4BFF))
+        val colorRamp = ColorRamp(Vector(0xD51D26FF, 0xDD5249FF, 0xE6876CFF, 0xEFBC8FFF, 0xF8F2B2FF, 0xC7DD98FF, 0x96C87EFF, 0x65B364FF, 0x349E4BFF))
         val breaks = Array[Double](0.05, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 1.0)
         ColorMap(breaks, colorRamp)
       case Some(_) =>


### PR DESCRIPTION
## Overview

At the moment, n-simultaneous requests to memcached which miss will kick off the expensive fallback logic n-times. Instead, we should keep a weak reference to the futures produced in such requests and check that prior to querying memcached. This PR makes single-machine memcached requests atomic for `MosaicDefinition`s, `MultibandTile`s, and `Histogram`s.

A more permanent solution is in the pipeline, but this PR should improve performance on some of the most sluggish parts of the application while we solve this problem in a DRYer way.

Connects #961
