### PR TITLE
Add share page

### DIFF
--- a/app-frontend/src/app/components/filterPane/filterPane.controller.js
+++ b/app-frontend/src/app/components/filterPane/filterPane.controller.js
@@ -150,6 +150,15 @@ export default class FilterPaneController {
         let minCloudCover = parseInt(this.filters.minCloudCover, 10) ||
             this.cloudCoverRange.min;
         let maxCloudCover = parseInt(this.filters.maxCloudCover, 10) || 10;
+
+        if (!this.filters.minCloudCover && minCloudCover !== this.cloudCoverRange.min) {
+            this.filters.minCloudCover = minCloudCover;
+        }
+
+        if (!this.filters.maxCloudCover && maxCloudCover !== this.cloudCoverRange.max) {
+            this.filters.maxCloudCover = maxCloudCover;
+        }
+
         this.cloudCoverFilters = {
             minModel: minCloudCover,
             maxModel: maxCloudCover,

--- a/app-frontend/src/app/components/navBar/navBar.html
+++ b/app-frontend/src/app/components/navBar/navBar.html
@@ -1,4 +1,4 @@
-<div class="navbar primary-navbar" ng-show="!$ctrl.loadError">
+<div class="navbar primary-navbar" ng-show="!$ctrl.loadError"  ng-if="!$ctrl.$state.$current.name.includes('share')">
   <!-- Nav Left -->
   <div class="navbar-left">
     <a href="#" class="brand">

--- a/app-frontend/src/app/components/publishModal/publishModal.controller.js
+++ b/app-frontend/src/app/components/publishModal/publishModal.controller.js
@@ -1,5 +1,4 @@
 export default class PublishModalController {
     constructor() {
-        'ngInject';
     }
 }

--- a/app-frontend/src/app/components/publishModal/publishModal.html
+++ b/app-frontend/src/app/components/publishModal/publishModal.html
@@ -6,25 +6,53 @@
     <h4 class="modal-title">
       Publish Project - {{$ctrl.resolve.project.name}}
     </h4>
-    <p>Get the XYZ resource link for use in other products</p>
+    <p>Publish or export your project</p>
   </div>
   <div class="modal-body">
     <div class="content">
-      <label>XYZ resource link</label>
-      <div class="form-group all-in-one">
-        <label for="tile-link" class="sr-only">URI Link</label>
-        <input id="tile-link" type="text" class="form-control"
-                value="{{$ctrl.resolve.tileTemplateUrl}}" readonly>
-         <!--
-           @TODO: the copy button is intended to copy the url for the user which
-           is not currently implemented
-         -->
-        <button class="btn btn-link">
-          Copy
-        </button>
+      <h4>Publishing</h4>
+      <div class="form-group">
+        <div>
+          <a class="btn btn-primary" ui-sref="share({projectid: $ctrl.resolve.project.id})">
+            Preview Your Published Project
+          </a>
+        </div>
       </div>
       <div class="form-group">
-        <label>Or download an image of your project</label>
+        <label>Published page URL</label>
+        <div class="form-group all-in-one">
+          <label for="tile-link" class="sr-only">URL</label>
+          <input id="tile-link" type="text" class="form-control"
+                  value="{{$ctrl.resolve.shareUrl}}" readonly>
+          <!--
+            @TODO: the copy button is intended to copy the url for the user which
+            is not currently implemented
+          -->
+          <button class="btn btn-link">
+            Copy
+          </button>
+        </div>
+      </div>
+    </div>
+    <div class="content">
+      <h4>Exporting</h4>
+      <div class="form-group">
+        <label>XYZ resource link</label>
+        <div class="form-group all-in-one">
+          <label for="tile-link" class="sr-only">URI Link</label>
+          <input id="tile-link" type="text" class="form-control"
+                  value="{{$ctrl.resolve.tileUrl}}" readonly>
+          <!--
+            @TODO: the copy button is intended to copy the url for the user which
+            is not currently implemented
+          -->
+          <button class="btn btn-link">
+            Copy
+          </button>
+        </div>
+      </div>
+      <div class="form-group">
+        <label>Download an image of your project</label>
         <div>
           <a class="btn btn-primary" href="">
             Download .png

--- a/app-frontend/src/app/core/services/project.service.js
+++ b/app-frontend/src/app/core/services/project.service.js
@@ -1,9 +1,12 @@
+/* global L */
+
 export default (app) => {
     class ProjectService {
-        constructor($resource, userService, $http, $q) {
+        constructor($resource, $location, userService, $http, $q) {
             'ngInject';
             this.userService = userService;
             this.$http = $http;
+            this.$location = $location;
             this.$q = $q;
 
             this.Project = $resource(
@@ -188,6 +191,36 @@ export default (app) => {
 
         updateProject(params) {
             return this.Project.updateProject(params).$promise;
+        }
+
+        getBaseURL() {
+            let host = this.$location.host();
+            let protocol = this.$location.protocol();
+            let port = this.$location.port();
+            let formattedPort = port !== 80 && port !== 443 ? ':' + port : '';
+            return `${protocol}://${host}${formattedPort}`;
+        }
+
+        getProjectLayerURL(project, token) {
+            let userId = 'rf_airflow-user';
+
+            let params = {
+                tag: new Date().getTime()
+            };
+
+            if (token) {
+                params.token = token;
+            }
+
+            let formattedParams = L.Util.getParamString(params);
+
+            return this.getBaseURL() +
+                `/tiles/${project.organizationId}/${userId}` +
+                `/project/${project.id}/{z}/{x}/{y}/${formattedParams}`;
+        }
+
+        getProjectShareURL(project) {
+            return `${this.getBaseURL()}/#/share/${project.id}`;
         }
     }
 

--- a/app-frontend/src/app/index.module.js
+++ b/app-frontend/src/app/index.module.js
@@ -54,6 +54,7 @@ const App = angular.module(
         require('./pages/library/projects/detail/scene/scene.module.js').name,
         require('./pages/library/projects/detail/projectScenes/projectScenes.module.js').name,
         require('./pages/settings/settings.module.js').name,
+        require('./pages/share/share.module.js').name,
         require('./pages/settings/profile/profile.module.js').name,
         require('./pages/settings/account/account.module.js').name,
         require('./pages/settings/tokens/tokens.module.js').name,

--- a/app-frontend/src/app/index.routes.js
+++ b/app-frontend/src/app/index.routes.js
@@ -25,6 +25,7 @@ import profileTpl from './pages/settings/profile/profile.html';
 import accountTpl from './pages/settings/account/account.html';
 import tokensTpl from './pages/settings/tokens/tokens.html';
 import errorTpl from './pages/error/error.html';
+import shareTpl from './pages/share/share.html';
 
 function librarySceneStates($stateProvider) {
     $stateProvider
@@ -255,6 +256,16 @@ function labStates($stateProvider) {
         });
 }
 
+function shareStates($stateProvider) {
+    $stateProvider
+        .state('share', {
+            url: '/share/:projectid',
+            templateUrl: shareTpl,
+            controller: 'ShareController',
+            controllerAs: '$ctrl'
+        });
+}
+
 function routeConfig($urlRouterProvider, $stateProvider) {
     'ngInject';
 
@@ -265,6 +276,7 @@ function routeConfig($urlRouterProvider, $stateProvider) {
     libraryProjectStates($stateProvider);
     settingsStates($stateProvider);
     labStates($stateProvider);
+    shareStates($stateProvider);
 
     $stateProvider
         .state('error', {

--- a/app-frontend/src/app/pages/editor/project/projectEdit.controller.js
+++ b/app-frontend/src/app/pages/editor/project/projectEdit.controller.js
@@ -179,24 +179,13 @@ export default class ProjectEditController {
 
         this.activeModal = this.$uibModal.open({
             component: 'rfPublishModal',
-            backdrop: 'static',
-            keyboard: false,
             resolve: {
                 project: () => this.project,
-                tileTemplateUrl: () => {
-                    let host = this.$location.host();
-                    let protocol = this.$location.protocol();
-
-                    let port = this.$location.port();
-                    let formattedPort = port !== 80 && port !== 443 ? ':' + port : '';
-                    let tag = (new Date()).getTime();
-                    return `${protocol}://${host}${formattedPort}` +
-                        `/tiles/${this.project.organizationId}` +
-                        '/rf_airflow-user' +
-                        `/project/${this.project.id}/{z}/{x}/{y}/` +
-                        `?tag=${tag}`;
-                }
+                tileUrl: () => this.projectService.getProjectLayerURL(this.project),
+                shareUrl: () => this.projectService.getProjectShareURL(this.project)
             }
         });
+
+        return this.activeModal;
     }
 }

--- a/app-frontend/src/app/pages/lab/run/run.scss
+++ b/app-frontend/src/app/pages/lab/run/run.scss
@@ -18,11 +18,11 @@
   right: 0;
   left: 0;
   padding: 16px;
-  pointer-events: false;
+  pointer-events: none;
   display: flex;
   justify-content: center;
   & > * {
-    pointer-events: true;
+    pointer-events: all;
   }
   text-align: center;
   z-index: 1000;

--- a/app-frontend/src/app/pages/library/projects/detail/projectScenes/projectScenes.controller.js
+++ b/app-frontend/src/app/pages/library/projects/detail/projectScenes/projectScenes.controller.js
@@ -10,7 +10,10 @@ export default class ProjectScenesController {
         this.projectService = projectService;
         this.$parent = $scope.$parent.$ctrl;
         this.$uibModal = $uibModal;
+        this.$scope = $scope;
+    }
 
+    $onInit() {
         this.project = this.$state.params.project;
         this.projectId = this.$state.params.projectid;
 
@@ -25,7 +28,7 @@ export default class ProjectScenesController {
                     (project) => {
                         this.project = project;
                         this.loading = false;
-                        this.populateSceneList($state.params.page || 1);
+                        this.populateSceneList(this.$state.params.page || 1);
                     },
                     () => {
                         this.$state.go('^.^.list');
@@ -35,8 +38,14 @@ export default class ProjectScenesController {
                 this.$state.go('^.^.list');
             }
         } else {
-            this.populateSceneList($state.params.page || 1);
+            this.populateSceneList(this.$state.params.page || 1);
         }
+
+        this.$scope.$on('$destroy', () => {
+            if (this.activeModal) {
+                this.activeModal.dismiss();
+            }
+        });
     }
 
     populateSceneList(page) {
@@ -178,21 +187,12 @@ export default class ProjectScenesController {
             component: 'rfPublishModal',
             resolve: {
                 project: () => this.project,
-                tileTemplateUrl: () => {
-                    let host = this.$location.host();
-                    let protocol = this.$location.protocol();
-
-                    let port = this.$location.port();
-                    let formattedPort = port !== 80 && port !== 443 ? ':' + port : '';
-                    let tag = (new Date()).getTime();
-                    return `${protocol}://${host}${formattedPort}` +
-                        `/tiles/${this.project.organizationId}` +
-                        '/rf_airflow-user' +
-                        `/project/${this.project.id}/{z}/{x}/{y}/` +
-                        `?tag=${tag}`;
-                }
+                tileUrl: () => this.projectService.getProjectLayerURL(this.project),
+                shareUrl: () => this.projectService.getProjectShareURL(this.project)
             }
         });
+
+        return this.activeModal;
     }
 
     shouldShowPagination() {

--- a/app-frontend/src/app/pages/share/share.controller.js
+++ b/app-frontend/src/app/pages/share/share.controller.js
@@ -1,0 +1,74 @@
+import logoAsset from '../../../assets/images/logo-raster-foundry.png';
+/* global L */
+
+export default class ShareController {
+    constructor(
+        $log, $state, authService, projectService, mapService
+    ) {
+        'ngInject';
+        this.$log = $log;
+        this.$state = $state;
+        this.logoAsset = logoAsset;
+        this.authService = authService;
+        this.projectService = projectService;
+        this.getMap = () => mapService.getMap('share-map');
+    }
+
+    $onInit() {
+        this.projectId = this.$state.params.projectid;
+        this.testNoAuth = false;
+        this.sceneList = [];
+
+        if (this.projectId) {
+            this.loadingProject = true;
+            this.projectService.query({id: this.projectId}).then(
+                p => {
+                    this.project = p;
+                    this.loadingProject = false;
+                    this.addProjectLayer();
+                },
+                () => {
+                    this.loadingProject = false;
+                    // @TODO: handle displaying an error message
+                }
+            );
+            this.fitSceneList();
+        }
+    }
+
+    addProjectLayer() {
+        let url = this.projectService.getProjectLayerURL(
+            this.project,
+            this.authService.token()
+        );
+        let layer = L.tileLayer(url);
+
+        this.getMap().then(m => {
+            m.addLayer('share-layer', layer);
+        });
+    }
+
+    fitSceneList() {
+        this.sceneRequestState = {loading: true};
+        this.projectService.getAllProjectScenes(
+            {projectId: this.projectId}
+        ).then(
+            (allScenes) => {
+                this.sceneList = allScenes;
+                this.fitScenes(this.sceneList);
+            },
+            (error) => {
+                this.sceneRequestState.errorMsg = error;
+            }
+        ).finally(() => {
+            this.sceneRequestState.loading = false;
+        });
+    }
+
+    fitScenes(scenes) {
+        this.getMap().then((map) =>{
+            let sceneFootprints = scenes.map((scene) => scene.dataFootprint);
+            map.map.fitBounds(L.geoJSON(sceneFootprints).getBounds());
+        });
+    }
+}

--- a/app-frontend/src/app/pages/share/share.html
+++ b/app-frontend/src/app/pages/share/share.html
@@ -1,0 +1,48 @@
+<div class="navbar primary-navbar">
+  <div class="navbar-left">
+    <a href="#" class="brand">
+      <img ng-attr-src="{{$ctrl.logoAsset}}">
+    </a>
+    <nav>
+      <a class="active">{{$ctrl.project.name}}</a>
+    </nav>
+  </div>
+
+  <div class="navbar-right">
+    <nav ng-if="!$ctrl.testNoAuth">
+      <a href class="icon-link" title="Help">
+        <i class="icon-help"></i>
+      </a>
+      <a href class="icon-link" title="Processing">
+        <i class="icon-processing"></i>
+      </a>
+    </nav>
+    <span class="navbar-vertical-divider" ng-if="!$ctrl.testNoAuth"></span>
+    <nav>
+      <div ng-if="!$ctrl.authService.isLoggedIn || $ctrl.testNoAuth">
+        <button class="btn btn-primary">
+          Sign Up or Sign In
+        </button>
+      </div>
+      <div ng-if="$ctrl.authService.isLoggedIn && !$ctrl.testNoAuth" uib-dropdown class="dropdown-my-account" on-toggle="toggled($ctrl.optionsOpen)">
+        <a href uib-dropdown-toggle>
+          <img ng-if="$ctrl.authService.profile().picture" class="avatar" ng-src="{{$ctrl.authService.profile().picture}}">
+          <img ng-if="! $ctrl.authService.profile().picture" class="avatar" src="https://placehold.it/25x25">
+          <span class="username">{{$ctrl.authService.profile().nickname}}</span>
+          <i class="icon-caret-down"></i>
+        </a>
+        <ul class="dropdown-menu" aria-labelledby="dLabel">
+          <li><a href ui-sref="library.scenes.list">My library</a></li>
+          <li><a href ui-sref="settings.profile">Settings</a></li>
+          <li role="separator" class="divider"></li>
+          <li><a href ng-click="$ctrl.logout()">Sign out</a></li>
+        </ul>
+      </div>
+    </nav>
+  </div>
+</div>
+<div class="container column-stretch container-not-scrollable">
+  <div class="main">
+    <rf-map-container map-id="share-map"></rf-map-container>
+  </div>
+</div>

--- a/app-frontend/src/app/pages/share/share.module.js
+++ b/app-frontend/src/app/pages/share/share.module.js
@@ -1,0 +1,8 @@
+import angular from 'angular';
+import ShareController from './share.controller.js';
+
+const ShareModule = angular.module('pages.share', []);
+
+ShareModule.controller('ShareController', ShareController);
+
+export default ShareModule;


### PR DESCRIPTION
## Overview

This PR adds a share page that will display the most recent output of a project. It also updates the publish modal to provide links to the share page.

This PR also wraps a small CSS adjustment to make sure the zoom control buttons work on the lab run map.

### Demo

<img width="826" alt="screen shot 2017-01-26 at 3 04 02 pm" src="https://cloud.githubusercontent.com/assets/2442245/22348190/c51f2fa6-e3d8-11e6-876d-47e89e694317.png">
<img width="1276" alt="screen shot 2017-01-26 at 3 04 19 pm" src="https://cloud.githubusercontent.com/assets/2442245/22348189/c51e87b8-e3d8-11e6-8204-827128c25009.png">

## Notes

In order to better simulate what the share page looks like non-registered users, there is a flag called `testNoAuth` within the share page controller.

## Testing Instructions

 * Ensure you have a project containing ingested scenes (the yosemite scenes work well)
 * From the project editor, with your ingested scene project active, click the 'Publish' button
 * Check that the modal appears, and has the correct URLs
 * Click the 'Preview Your Published Project' button, and ensure you are taken to the share page
 * Access the project through the library, and click the 'Publish' link on the right side
 * Ensure the modal is properly displayed
 * Check that clicking the preview button takes you to the share page
 * You can also adjust the color correction of the project and check that the changes are shown within the share page
 * You can change the `testNoAuth` flag within the`share.controller.js` to true and test that the user credentials are removed

Connects #989 

Edit: Also included a fix to the filter pane to properly initialize the cloud cover filters. To test this:
 * Clear the current filters on browse
 * Reload
 * Ensure that maxCloudCover in the URL now matches the cloud cover slider (should be 10)
