### PR TITLE
Fix Tile Authentication

### DIFF
--- a/app-backend/build.sbt
+++ b/app-backend/build.sbt
@@ -71,15 +71,19 @@ lazy val forkliftDependencies = List(
 lazy val migrationsDependencies =
   dbDependencies ++ forkliftDependencies ++ loggingDependencies
 
-lazy val appDependencies = dbDependencies ++ migrationsDependencies ++ Seq(
+lazy val testDependencies = List(
+    Dependencies.scalatest,
+    Dependencies.akkatestkit
+)
+
+lazy val appDependencies = dbDependencies ++ migrationsDependencies ++
+    testDependencies ++ Seq(
   Dependencies.akka,
   Dependencies.akkahttp,
   Dependencies.akkaHttpCors,
   Dependencies.akkajson,
   Dependencies.akkastream,
-  Dependencies.akkatestkit,
   Dependencies.akkaSlf4j,
-  Dependencies.scalatest,
   Dependencies.authCommon,
   Dependencies.akkaHttpExtensions,
   Dependencies.ammoniteOps,
@@ -151,6 +155,9 @@ lazy val tile = Project("tile", file("tile"))
   .dependsOn(authentication)
   .dependsOn(tool)
   .settings(commonSettings:_*)
+  .settings({
+    libraryDependencies ++= testDependencies
+  })
   .settings(assemblyMergeStrategy in assembly := {
     case "reference.conf" => MergeStrategy.concat
     case "application.conf" => MergeStrategy.concat

--- a/app-backend/tile/src/main/scala/Main.scala
+++ b/app-backend/tile/src/main/scala/Main.scala
@@ -23,14 +23,13 @@ object AkkaSystem {
 }
 
 object Main extends App
-  with TileAuthentication
   with Config
   with AkkaSystem.LoggerExecutor {
 
   import AkkaSystem._
 
   implicit lazy val database = Database.DEFAULT
-  val router = new Router(database)
+  val router = new Router()
 
   Http().bindAndHandle(router.root, httpHost, httpPort)
 }

--- a/app-backend/tile/src/main/scala/Router.scala
+++ b/app-backend/tile/src/main/scala/Router.scala
@@ -24,7 +24,8 @@ import spray.json._
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent._
 
-class Router(db: Database) extends LazyLogging {
+class Router extends LazyLogging with TileAuthentication {
+  implicit lazy val database = Database.DEFAULT
   def exceptionHandler =
     ExceptionHandler {
       case e: ValueNotFoundError =>
@@ -46,10 +47,12 @@ class Router(db: Database) extends LazyLogging {
           }
         }
       } ~
-      SceneRoutes.root ~
-      MosaicRoutes.mosaicProject(db) ~
-      pathPrefix("tools") {
-        ToolRoutes.root(db)
+      tileAuthenticateOption { _ =>
+        SceneRoutes.root ~
+        MosaicRoutes.mosaicProject(database) ~
+        pathPrefix("tools") {
+          ToolRoutes.root(database)
+        }
       }
     }
   }

--- a/app-backend/tile/src/test/scala/auth/AuthSpec.scala
+++ b/app-backend/tile/src/test/scala/auth/AuthSpec.scala
@@ -1,0 +1,32 @@
+package com.azavea.rf.tile
+
+import org.scalatest.{Matchers, WordSpec}
+import akka.http.scaladsl.testkit.{RouteTestTimeout, ScalatestRouteTest}
+import akka.http.scaladsl.model.StatusCodes
+import akka.actor.ActorSystem
+
+import concurrent.duration._
+import akka.http.scaladsl.server.Route
+
+class AuthSpec extends WordSpec
+    with Matchers
+    with ScalatestRouteTest {
+
+  val router = new Router()
+
+  "tile authentication" should {
+    "reject anonymous users" in {
+      Get("/tiles") ~> router.root ~> check {
+        rejection
+      }
+    }
+  }
+
+  "tile authentication" should {
+    "reject invalid tokens" in {
+      Get("/tiles?token=not-valid") ~> router.root ~> check {
+        rejection
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Overview

Brings back authentication to the Tile Server.

### Checklist

- [ ] ~Styleguide updated, if necessary~
- [ ] ~Swagger specification updated, if necessary~

### Notes

I'm looking into adding a test for this.

## Testing Instructions

 * Bring up / restart `./scripts/server`
 * navigate to a page for an ingested dataset (Yosemite works well) that displays tiles (Share, Color Correction, etc.).
 * Use the web inspector to copy a `curl` link for one of the tiles that is loaded.
 * Open a terminal and paste in the copied link; I recommend redirecting to a file (`... > tile.png`) so that you don't get a bunch of binary garbage in your terminal.
 * Edit the `curl` command to remove the `?token=` parameter and confirm that you get an error message about the token parameter being required.
 * Edit the `curl` command to add the `?token=` parameter but with an invalid token and confirm you get an error message about the token being invalid.
 * Open a console to the app-backend container with `./scripts/console app-server sbt`
 * Run `project tile` and then `test`. You should see two successes.
 * If you want, revert this PR's changes to `Router.scala` and rerun tests to confirm they fail.

Closes #992 
