### PR TITLE
Bump versions of Docker Engine and Compose

### DIFF
--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -1,8 +1,8 @@
 ---
 aws_cli_version: "1.10.47"
 
-docker_version: "1.11.*"
-docker_compose_version: "1.7.1"
+docker_version: "1.12.*"
+docker_compose_version: "1.9.0"
 
 shellcheck_version: "0.3.*"
 

--- a/deployment/ansible/roles.yml
+++ b/deployment/ansible/roles.yml
@@ -1,5 +1,5 @@
 - src: azavea.docker
-  version: 2.0.1
+  version: 2.2.0
 
 - src: azavea.pip
   version: 0.1.1


### PR DESCRIPTION
## Overview

The newest Amazon ECS AMI adds support for Docker 1.12 and these changes are to keep our development environment inline.

In addition, Docker Compose has been upgraded to version 1.9.0, which shouldn't impact the way we use Compose. However, it does open up the possibility of upgrading our `docker-compose.yml` spec to version 2.1, which would opt us in to newer functionality.

## Testing Instructions

Provision the Vagrant virtual machine using this branch and ensure that new versions of Docker and Docker Compose are installed. Also, ensure that all of the services still come up properly:

```bash
$ vagrant up --provision
$ vagrant ssh
vagrant@vagrant-ubuntu-trusty-64:/opt/raster-foundry$ docker --version
Docker version 1.12.6, build 78d1802
vagrant@vagrant-ubuntu-trusty-64:/opt/raster-foundry$ docker-compose --version
docker-compose version 1.9.0, build 2585387
vagrant@vagrant-ubuntu-trusty-64:/opt/raster-foundry$ docker-compose ps
             Name                           Command               State               Ports
-------------------------------------------------------------------------------------------------------
rasterfoundry_app-frontend_1     yarn run start                   Up
rasterfoundry_app-server_1       ./sbt app/run                    Up      0.0.0.0:9000->9000/tcp
rasterfoundry_memcached_1        docker-entrypoint.sh memcached   Up      11211/tcp
rasterfoundry_nginx_1            nginx -g daemon off;             Up      0.0.0.0:9100->443/tcp, 80/tcp
rasterfoundry_postgres_1         /docker-entrypoint.sh postgres   Up      5432/tcp
rasterfoundry_swagger-editor_1   http-server --cors -p8080  ...   Up      0.0.0.0:8888->8080/tcp
rasterfoundry_swagger-ui_1       nginx -g daemon off;             Up      443/tcp, 0.0.0.0:9999->80/tcp
rasterfoundry_tile-server_1      ./sbt tile/run                   Up      0.0.0.0:9900->9900/tcp
```
