### PR TITLE
Split Swagger services out into their own Docker Compose config

### DIFF
--- a/docker-compose.swagger.yml
+++ b/docker-compose.swagger.yml
@@ -1,0 +1,13 @@
+version: '2'
+services:
+  swagger-editor:
+    image: swaggerapi/swagger-editor:latest
+    ports:
+      - "8888:8080"
+
+  swagger-ui:
+    image: nginx:1.10
+    volumes:
+      - ./docs/swagger/:/usr/share/nginx/html:ro
+    ports:
+      - "9999:80"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,15 +76,3 @@ services:
       - $HOME/.aws:/root/.aws:ro
     working_dir: /opt/raster-foundry/app-backend/
     command: ./sbt tile/run
-
-  swagger-editor:
-    image: swaggerapi/swagger-editor:latest
-    ports:
-      - "8888:8080"
-
-  swagger-ui:
-    image: nginx:1.10.1-alpine
-    volumes:
-      - ./docs/swagger/:/usr/share/nginx/html:ro
-    ports:
-      - "9999:80"

--- a/scripts/console
+++ b/scripts/console
@@ -5,7 +5,7 @@ DIR="$(dirname "$0")"
 
 function usage() {
     echo -n \
-"Usage: $(basename "$0") [--with-airflow ] SERVICE COMMAND[S]
+"Usage: $(basename "$0") SERVICE COMMAND[S]
 
 Use docker compose to run a command for a service or drop into a console
 
@@ -20,10 +20,11 @@ then
     then
         usage
     else
-    	docker-compose -f "${DIR}/../docker-compose.yml" \
+        docker-compose -f "${DIR}/../docker-compose.yml" \
+                       -f "${DIR}/../docker-compose.swagger.yml" \
                        -f "${DIR}/../docker-compose.airflow.yml" \
-        			   run --rm --service-ports --entrypoint \
-        			   "/bin/bash -c" "$1" "${@:2}"
+                       run --rm --service-ports --entrypoint \
+                       "/bin/bash -c" "$1" "${@:2}"
     fi
     exit
 fi

--- a/scripts/server
+++ b/scripts/server
@@ -6,7 +6,7 @@ DIR="$(dirname "$0")"
 
 function usage() {
     echo -n \
-"Usage: $(basename "$0")
+"Usage: $(basename "$0") [--with-airflow] [--with-swagger]
 
 Starts servers using docker-compose
 "
@@ -21,6 +21,10 @@ then
     then
         docker-compose -f "${DIR}/../docker-compose.yml" \
                        -f "${DIR}/../docker-compose.airflow.yml" up
+    elif [ "${1:-}" = "--with-swagger" ]
+    then
+        docker-compose -f "${DIR}/../docker-compose.yml" \
+                       -f "${DIR}/../docker-compose.swagger.yml" up
     else
         docker-compose -f "${DIR}/../docker-compose.yml" up
     fi


### PR DESCRIPTION
## Overview

Move the `swagger-editor` and `swagger-ui` services into their own Docker Compose configuration file. In addition, update the `console` and `server` scripts to work with those changes.

Resolves #964

## Testing Instructions

Within one SSH session into the virtual machine, run `server` with no arguments:

```bash
vagrant@vagrant-ubuntu-trusty-64:/opt/raster-foundry$ ./scripts/server
```

In another session, run `docker ps` to confirm that the Swagger services are not running:

```bash
vagrant@vagrant-ubuntu-trusty-64:/opt/raster-foundry$ docker ps --format 'table {{.Names}}'
NAMES
rasterfoundry_nginx_1
rasterfoundry_tile-server_1
rasterfoundry_app-server_1
rasterfoundry_app-frontend_1
rasterfoundry_memcached_1
rasterfoundry_postgres_1
```

Go through the same process again, except this time append the `--with-swagger` option to `server`:

```bash
vagrant@vagrant-ubuntu-trusty-64:/opt/raster-foundry$ ./scripts/server --with-swagger
```

In another session, run `docker ps` to confirm that the Swagger services are running:

```bash
vagrant@vagrant-ubuntu-trusty-64:/opt/raster-foundry$ docker ps --format 'table {{.Names}}'
NAMES
rasterfoundry_nginx_1
rasterfoundry_tile-server_1
rasterfoundry_app-server_1
rasterfoundry_app-frontend_1
rasterfoundry_swagger-ui_1
rasterfoundry_memcached_1
rasterfoundry_swagger-editor_1
rasterfoundry_postgres_1
```