### PR TITLE
Instruct Webpack to halt and report failures as soon as they occur

### DIFF
--- a/app-frontend/package.json
+++ b/app-frontend/package.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/azavea/raster-foundry.git"
   },
   "scripts": {
-    "build": "yarn run clean && cross-env NODE_ENV=production webpack --progress --colors",
+    "build": "yarn run clean && cross-env NODE_ENV=production webpack --bail --colors",
     "clean": "rimraf dist/*",
     "build-nginx": "rimraf ../nginx/srv/dist/* && yarn run build && cp -R dist/* ../nginx/srv/dist/",
     "dev": "cross-env NODE_ENV=development webpack-dev-server",


### PR DESCRIPTION
## Overview

Add `--bail` option to the `webpack` command executed within `cibuild` so that the first failure it encounters causes the entire build process to fail.

In addition, remove the `--progress` flag because it leads to too much noise in the build output.

Resolves #967 

## Testing Instructions

Use `console` to strategically remove a directory (the same from the Jenkins build failure logs) from within the `node_modules` directory and then attempt a static bundle build. Ensure that the exist status returned is not zero.

```bash
vagrant@vagrant-ubuntu-trusty-64:/opt/raster-foundry$ ./scripts/console app-frontend /bin/bash
root@dd016d8ac87d:/opt/raster-foundry/app-frontend# rm -rf /opt/raster-foundry/app-frontend/node_modules/node-sass/vendor/
root@dd016d8ac87d:/opt/raster-foundry/app-frontend# exit
vagrant@vagrant-ubuntu-trusty-64:/opt/raster-foundry$ ./scripts/console app-frontend 'yarn run build'

...

error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
vagrant@vagrant-ubuntu-trusty-64:/opt/raster-foundry$ echo $?
1
```

To get you setup back in order, use `console` again blow away `node_modules` and execute `yarn install`:

```bash
vagrant@vagrant-ubuntu-trusty-64:/opt/raster-foundry$ rm -rf .node_modules/
vagrant@vagrant-ubuntu-trusty-64:/opt/raster-foundry$ ./scripts/console app-frontend 'yarn install'
```