### PR TITLE
Set leakDetectionThreshold

### DIFF
--- a/app-backend/database/src/main/scala/com/azavea/rf/database/Database.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/Database.scala
@@ -20,6 +20,7 @@ class Database(jdbcUrl: String, dbUser: String, dbPassword: String) {
   hikariConfig.setJdbcUrl(jdbcUrl)
   hikariConfig.setUsername(dbUser)
   hikariConfig.setPassword(dbPassword)
+  hikariConfig.setLeakDetectionThreshold(3000L)
 
   private val dataSource = new HikariDataSource(hikariConfig)
 


### PR DESCRIPTION
## Overview

Brief description of what this PR does, and why it is needed.
Sets a `leakDetectionThreshold` for the database connection pool. This will alert us to any potential connection leaks as they happen.

## Testing Instructions
- Add this line to `Database.scala`
```diff
diff --git a/app-backend/database/src/main/scala/com/azavea/rf/database/Database.scala b/app-backend/database/src/main/scala/com/azavea/rf/database/Database.scala
index eeaaab2..d1d73ce 100644
--- a/app-backend/database/src/main/scala/com/azavea/rf/database/Database.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/Database.scala
@@ -41,4 +41,5 @@ class Database(jdbcUrl: String, dbUser: String, dbPassword: String) {
 
 object Database extends Config {
   def DEFAULT = new Database(jdbcUrl, dbUser, dbPassword)
+  DEFAULT.dataSource.getConnection()
 }
```
- Compile this code, then run `scripts/server` from inside of your VM
- Once the services are completely up, sign in to Raster Foundry
- Monitor the console: you should see stack traces from the `tile-server` and the `app-server`. The exception from `tile-server` should show up about 3 seconds after the pool starts, and the exception from the `app-server` should appear 3 seconds after logging in:

```bash
tile-server_1     | [info] Running com.azavea.rf.tile.Main 
tile-server_1     | 22:20:40.053 [run-main-0] INFO  com.zaxxer.hikari.HikariDataSource - HikariCP pool HikariPool-0 is starting.
tile-server_1     | 22:20:41.807 [run-main-0] INFO  c.a.r.d.ExtendedPostgresDriver -  >>> binding uuid -> java.util.UUID 
tile-server_1     | 22:20:41.808 [run-main-0] INFO  c.a.r.d.ExtendedPostgresDriver -  >>> binding text -> java.lang.String 
tile-server_1     | 22:20:41.809 [run-main-0] INFO  c.a.r.d.ExtendedPostgresDriver -  >>> binding bool -> Boolean 
tile-server_1     | 22:20:42.408 [run-main-0] INFO  com.zaxxer.hikari.HikariDataSource - HikariCP pool HikariPool-1 is starting.
tile-server_1     | 22:20:45.428 [Hikari Housekeeping Timer (pool HikariPool-0)] WARN  com.zaxxer.hikari.pool.LeakTask - Connection leak detection triggered for connection org.postgresql.jdbc4.Jdbc4Connection@553b310, stack trace follows
tile-server_1     | java.lang.Exception: Apparent connection leak detected
tile-server_1     | 	at com.azavea.rf.database.Database$.<init>(Database.scala:44)
tile-server_1     | 	at com.azavea.rf.database.Database$.<clinit>(Database.scala)
tile-server_1     | 	at com.azavea.rf.tile.Main$.database$lzycompute(Main.scala:32)
tile-server_1     | 	at com.azavea.rf.tile.Main$.database(Main.scala:32)
tile-server_1     | 	at com.azavea.rf.tile.Main$.delayedEndpoint$com$azavea$rf$tile$Main$1(Main.scala:33)
tile-server_1     | 	at com.azavea.rf.tile.Main$delayedInit$body.apply(Main.scala:25)
tile-server_1     | 	at scala.Function0$class.apply$mcV$sp(Function0.scala:34)
```

```bash
app-server_1      | [info] Running com.azavea.rf.Main 
app-server_1      | [info] 22:20:39.486 [rf-system-akka.actor.default-dispatcher-3] INFO  akka.event.slf4j.Slf4jLogger - Slf4jLogger started
app-server_1      | [info] 22:23:48.178 [rf-system-akka.actor.default-dispatcher-19] INFO  com.zaxxer.hikari.HikariDataSource - HikariCP pool HikariPool-0 is starting.
app-server_1      | [info] 22:23:49.483 [rf-system-akka.actor.default-dispatcher-19] INFO  c.a.r.d.ExtendedPostgresDriver -  >>> binding uuid -> java.util.UUID 
app-server_1      | [info] 22:23:49.483 [rf-system-akka.actor.default-dispatcher-19] INFO  c.a.r.d.ExtendedPostgresDriver -  >>> binding text -> java.lang.String 
app-server_1      | [info] 22:23:49.483 [rf-system-akka.actor.default-dispatcher-19] INFO  c.a.r.d.ExtendedPostgresDriver -  >>> binding bool -> Boolean 
app-server_1      | [info] 22:23:49.746 [rf-system-akka.actor.default-dispatcher-19] INFO  com.zaxxer.hikari.HikariDataSource - HikariCP pool HikariPool-1 is starting.
app-server_1      | [info] 22:23:52.767 [Hikari Housekeeping Timer (pool HikariPool-0)] WARN  com.zaxxer.hikari.pool.LeakTask - Connection leak detection triggered for connection org.postgresql.jdbc4.Jdbc4Connection@65a0421e, stack trace follows
app-server_1      | [info] java.lang.Exception: Apparent connection leak detected
app-server_1      | [info] 	at com.azavea.rf.database.Database$.<init>(Database.scala:44)
app-server_1      | [info] 	at com.azavea.rf.database.Database$.<clinit>(Database.scala)
app-server_1      | [info] 	at com.azavea.rf.Main$.database$lzycompute(Main.scala:24)
app-server_1      | [info] 	at com.azavea.rf.Main$.database(Main.scala:24)
app-server_1      | [info] 	at com.azavea.rf.authentication.Authentication$$anonfun$authenticate$1$$anonfun$apply$1.apply(Authentication.scala:36)
app-server_1      | [info] 	at com.azavea.rf.authentication.Authentication$$anonfun$authenticate$1$$anonfun$apply$1.apply(Authentication.scala:36)
```
Connects #918 
