### PR TITLE
Private thumbnail proxy

### DIFF
--- a/app-backend/app/src/main/resources/application.conf
+++ b/app-backend/app/src/main/resources/application.conf
@@ -43,6 +43,10 @@ auth0 {
   bearer = ${?AUTH0_MANAGEMENT_BEARER}
 }
 
+s3 {
+  thumbnailBucket = ${?THUMBNAIL_BUCKET}
+}
+
 featureFlags {
   features = [
     {

--- a/app-backend/app/src/main/scala/Router.scala
+++ b/app-backend/app/src/main/scala/Router.scala
@@ -60,6 +60,9 @@ trait Router extends HealthCheckRoutes
     } ~
     pathPrefix("config") {
       configRoutes
+    } ~
+    pathPrefix("thumbnails") {
+      thumbnailImageRoutes
     }
   }
 }

--- a/app-backend/app/src/main/scala/thumbnail/Routes.scala
+++ b/app-backend/app/src/main/scala/thumbnail/Routes.scala
@@ -1,24 +1,29 @@
 package com.azavea.rf.thumbnail
 
 import java.util.UUID
-
-import scala.util.{Success, Failure}
+import java.net.URI
+import scala.util.{Success, Failure, Try}
 
 import akka.http.scaladsl.server.Route
-import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.model.{StatusCodes, ContentType, HttpEntity, HttpResponse, MediaType, MediaTypes}
+import akka.http.scaladsl.model.MediaType.Binary
+import org.apache.commons.io.IOUtils
 
 import com.lonelyplanet.akka.http.extensions.PaginationDirectives
 
-import com.azavea.rf.common.{UserErrorHandler, Authentication}
+
+import com.azavea.rf.common.{UserErrorHandler, Authentication, S3}
 import com.azavea.rf.database.tables.Thumbnails
 import com.azavea.rf.database.Database
 import com.azavea.rf.datamodel._
+import com.azavea.rf.utils.Config
 
 
 trait ThumbnailRoutes extends Authentication
     with ThumbnailQueryParameterDirective
     with PaginationDirectives
-    with UserErrorHandler {
+    with UserErrorHandler
+    with Config {
 
   implicit def database: Database
 
@@ -32,6 +37,19 @@ trait ThumbnailRoutes extends Authentication
         get { getThumbnail(thumbnailId) } ~
         put { updateThumbnail(thumbnailId) } ~
         delete { deleteThumbnail(thumbnailId) }
+      }
+    } ~
+    pathPrefix(Segment) { thumbnailPath =>
+      pathEndOrSingleSlash {
+        get { getThumbnailImage(thumbnailPath) }
+      }
+    }
+  }
+
+  val thumbnailImageRoutes: Route = handleExceptions(userExceptionHandler) {
+    pathPrefix(Segment) { thumbnailPath =>
+      pathEndOrSingleSlash {
+        get { getThumbnailImage(thumbnailPath) }
       }
     }
   }
@@ -60,6 +78,20 @@ trait ThumbnailRoutes extends Authentication
         }
       }
     }
+  }
+
+  def getThumbnailImage(thumbnailPath: String): Route = validateTokenParameter { token =>
+    var uriString = s"http://s3.amazonaws.com/${thumbnailBucket}/${thumbnailPath}"
+    val uri = new URI(uriString)
+    val s3Object = S3.getObject(uri)
+    val metaData = S3.getObjectMetadata(s3Object)
+    val s3MediaType = MediaType.parse(metaData.getContentType()) match {
+      case Right(m) => m.asInstanceOf[MediaType.Binary]
+      case Left(_) => MediaTypes.`image/png`
+    }
+    complete(HttpResponse(entity =
+      HttpEntity(ContentType(s3MediaType), S3.getObjectBytes(s3Object))
+    ))
   }
 
   def updateThumbnail(thumbnailId: UUID): Route = authenticate { user =>

--- a/app-backend/app/src/main/scala/utils/Config.scala
+++ b/app-backend/app/src/main/scala/utils/Config.scala
@@ -7,6 +7,7 @@ trait Config {
   private val httpConfig = config.getConfig("http")
   private val auth0Config = config.getConfig("auth0")
   private val featureFlagConfig = config.getConfig("featureFlags")
+  private val s3Config = config.getConfig("s3")
 
   val httpHost = httpConfig.getString("interface")
   val httpPort = httpConfig.getInt("port")
@@ -17,4 +18,6 @@ trait Config {
   val auth0ClientId = auth0Config.getString("clientId")
 
   val featureFlags = featureFlagConfig.getConfigList("features")
+
+  val thumbnailBucket = s3Config.getString("thumbnailBucket")
 }

--- a/app-backend/build.sbt
+++ b/app-backend/build.sbt
@@ -86,8 +86,10 @@ lazy val appDependencies = dbDependencies ++ migrationsDependencies ++
   Dependencies.akkaSlf4j,
   Dependencies.authCommon,
   Dependencies.akkaHttpExtensions,
+  Dependencies.commonsIO,
   Dependencies.ammoniteOps,
-  Dependencies.geotrellisSlick
+  Dependencies.geotrellisSlick,
+  Dependencies.geotrellisS3
 )
 
 lazy val root = Project("root", file("."))
@@ -107,7 +109,9 @@ lazy val common = Project("common", file("common"))
   .settings({libraryDependencies ++= Seq(
     Dependencies.authAkka,
     Dependencies.akka,
-    Dependencies.akkahttp
+    Dependencies.akkahttp,
+    Dependencies.commonsIO,
+    Dependencies.geotrellisS3
   )})
 
 lazy val migrations = Project("migrations", file("migrations"))

--- a/app-backend/common/src/main/scala/S3.scala
+++ b/app-backend/common/src/main/scala/S3.scala
@@ -1,0 +1,37 @@
+package com.azavea.rf.common
+
+import scala.util.{Success, Failure, Try}
+
+import org.apache.commons.io.IOUtils
+
+import com.amazonaws.auth._
+import com.amazonaws.services.s3.{AmazonS3Client, AmazonS3URI}
+import com.amazonaws.services.s3.model.{S3Object, ObjectMetadata}
+
+import java.io._
+import java.net._
+
+package object S3 {
+  def getObject(uri: URI): S3Object = {
+    val client = new AmazonS3Client(new DefaultAWSCredentialsProviderChain)
+    val s3uri = new AmazonS3URI(uri)
+    Try(client.getObject(s3uri.getBucket, s3uri.getKey)) match {
+      case Success(o) => o
+      case Failure(ex) => throw new Exception(ex)
+    }
+  }
+
+  def getObjectMetadata(s3Object: S3Object): ObjectMetadata = {
+    s3Object.getObjectMetadata()
+  }
+
+  def getObjectBytes(s3Object: S3Object): Array[Byte] = {
+    val s3InputStream = s3Object.getObjectContent()
+
+    try {
+      IOUtils.toByteArray(s3InputStream)
+    } finally {
+      s3InputStream.close()
+    }
+  }
+}

--- a/nginx/etc/nginx/conf.d/app.conf
+++ b/nginx/etc/nginx/conf.d/app.conf
@@ -34,6 +34,14 @@ server {
         proxy_pass http://tile-server-upstream;
     }
 
+    location /thumbnails {
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Forwarded-For $remote_addr;
+        proxy_redirect off;
+
+        proxy_pass http://app-server-upstream;
+    }
+
     location = /healthcheck/ {
         proxy_set_header Host $http_host;
         proxy_set_header X-Forwarded-For $remote_addr;
@@ -41,6 +49,7 @@ server {
 
         proxy_pass http://app-server-upstream;
     }
+
 
     # Angular config
     location = /config {


### PR DESCRIPTION
## Overview

This PR does two things:
- ~~adds a `common` subproject (this is the first commit and will be dropped in favor of #1025)~~
- adds an endpoint (`thumbnails`) that, with a proper auth token, will allow users to access thumbnails that are stored on S3

### Notes

~~As mentioned above, once #1025 is merged, the `common` subproject commit will be dropped and this will be rebased.~~

## Testing Instructions

* Retrieve a valid token param (can go to a tiling page, such as the editor, and inspect the requests)
* Make sure you have the latest `.env` and restart your dev environment
* Using something like Postman (so you can see the image instead of binary data), send a request to `/thumbnails/4b46eecb-9dd9-45e3-b0fb-a7b5f1b5f2b5.jpg?token=<token>`. You should get the thumbnail back. (Note: this is a test thumbnail)
* Change a portion of the token and check that the request is denied
* Remove the token parameter completely and check that the request is denied.

Connects #980
