### PR TITLE
Add project select modal in editor

### DIFF
--- a/app-frontend/src/app/pages/editor/project/projectEdit.controller.js
+++ b/app-frontend/src/app/pages/editor/project/projectEdit.controller.js
@@ -156,16 +156,19 @@ export default class ProjectEditController {
             this.activeModal.dismiss();
         }
 
+        const backdrop = this.project ? true : 'static';
+
         this.activeModal = this.$uibModal.open({
             component: 'rfSelectProjectModal',
-            backdrop: 'static',
-            keyboard: false,
+            backdrop: backdrop,
+            keyboard: Boolean(this.project),
             resolve: {
-                requireSelection: () => true
+                project: () => this.project,
+                requireSelection: () => !Boolean(this.project)
             }
         });
 
-        this.activeModal.results.then(p => {
+        this.activeModal.result.then(p => {
             this.$state.go(this.$state.current, {projectid: p.id});
         });
 

--- a/app-frontend/src/app/pages/editor/project/projectEdit.html
+++ b/app-frontend/src/app/pages/editor/project/projectEdit.html
@@ -7,7 +7,7 @@
           <i class="icon-caret-down color-white"></i>
         </a>
         <ul class="dropdown-menu" aria-labelledby="dLabel">
-          <li><a ng-click="$ctrl.gotoEditor()">Open Project</a></li>
+          <li><a ng-click="$ctrl.selectProjectModal()">Open Project</a></li>
         </ul>
       </div>
       <span class="navbar-vertical-divider"></span>


### PR DESCRIPTION
## Overview

This PR adds a functioning project select modal to the project dropdown.

## Notes

It feels like the wording should be 'Switch Project' instead of 'Open Project'. Open made me think 
it might be intended to open the project details page.

## Testing Instructions

 * Go to the editor
 * Open the dropdown by clicking on the current project name
 * Ensure you can change project after clicking 'Open Project'
 * Check that the current project appears selected


