### PR TITLE
Simplify tiler URLs

### DIFF
--- a/app-backend/build.sbt
+++ b/app-backend/build.sbt
@@ -154,6 +154,7 @@ lazy val tile = Project("tile", file("tile"))
   .dependsOn(database)
   .dependsOn(common)
   .dependsOn(tool)
+  .dependsOn(ingest)
   .settings(commonSettings:_*)
   .settings({
     libraryDependencies ++= testDependencies

--- a/app-backend/tile/src/main/scala/RfLayerId.scala
+++ b/app-backend/tile/src/main/scala/RfLayerId.scala
@@ -1,5 +1,13 @@
 package com.azavea.rf.tile
 
+import com.azavea.rf.datamodel.Scene
+import scala.concurrent.Future
+import scala.concurrent.ExecutionContext.Implicits.global
+
+import com.azavea.rf.ingest.util.S3.S3UrlRx
+import com.azavea.rf.database.Database
+import com.azavea.rf.database.tables.Scenes
+
 import java.util.UUID
 
 import geotrellis.spark.LayerId
@@ -9,8 +17,17 @@ import geotrellis.spark.LayerId
   * Eventually these must be mapped to an S3 prefix.
   * This class encapsulates the relationship and gives a place to modify the mapping
   */
-case class RfLayerId(org: UUID, user: String, scene: UUID) {
-  def prefix: String = s"${org.toString}/$user"
-  def catalogId(zoom: Int) = LayerId(scene.toString, zoom)
-  def layerName: String = scene.toString
+case class RfLayerId(sceneId: UUID) {
+  def prefix(implicit database: Database): Future[Option[String]] = {
+    val sceneQuery = Scenes.getScene(sceneId)
+    sceneQuery.map { sceneOption =>
+      for {
+        scene <- sceneOption
+        ingestLocation <- scene.ingestLocation
+        result <- S3UrlRx.findFirstMatchIn(ingestLocation)
+      } yield result.group("prefix")
+    }
+  }
+  def catalogId(zoom: Int) = LayerId(sceneId.toString, zoom)
+  def layerName: String = sceneId.toString
 }

--- a/app-backend/tile/src/main/scala/Router.scala
+++ b/app-backend/tile/src/main/scala/Router.scala
@@ -28,13 +28,13 @@ import scala.concurrent._
 
 class Router extends LazyLogging
     with TileAuthentication
-    with UserErrorHandler {
+    with TileErrorHandler {
 
   implicit lazy val database = Database.DEFAULT
   implicit val system = AkkaSystem.system
   implicit val materializer = AkkaSystem.materializer
 
-  def root = handleExceptions(userExceptionHandler) {
+  def root = handleExceptions(tileExceptionHandler) {
     pathPrefix("tiles") {
       pathPrefix("healthcheck") {
         pathEndOrSingleSlash {

--- a/app-backend/tile/src/main/scala/directives/TileErrorHandler.scala
+++ b/app-backend/tile/src/main/scala/directives/TileErrorHandler.scala
@@ -1,0 +1,41 @@
+package com.azavea.rf.tile
+
+import geotrellis.spark.io.LayerIOError
+import com.azavea.rf.common.RollbarNotifier
+import com.azavea.rf.common.RfStackTrace
+import akka.http.scaladsl.server.{Route, ExceptionHandler, Directives}
+import akka.http.scaladsl.model.StatusCodes
+import com.typesafe.scalalogging.LazyLogging
+import spray.json.{SerializationException, DeserializationException}
+import com.typesafe.scalalogging.LazyLogging
+
+trait TileErrorHandler extends Directives
+    with RollbarNotifier
+    with LazyLogging {
+  val tileExceptionHandler = ExceptionHandler {
+    case e: IllegalArgumentException =>
+      logger.error(RfStackTrace(e))
+      sendError(e)
+      complete(StatusCodes.ClientError(400)("Bad Argument", e.getMessage))
+    case e: IllegalStateException =>
+      logger.error(RfStackTrace(e))
+      sendError(e)
+      complete(StatusCodes.ClientError(400)("Bad Request", e.getMessage))
+    case e: DeserializationException =>
+      logger.error(RfStackTrace(e))
+      sendError(e)
+      complete(StatusCodes.ClientError(400)("Decoding Error", e.getMessage))
+    case e: SerializationException =>
+      logger.error(RfStackTrace(e))
+      sendError(e)
+      complete(StatusCodes.ServerError(500)("Encoding Error", e.getMessage))
+    case e: LayerIOError =>
+      logger.error(RfStackTrace(e))
+      sendError(e)
+      complete(StatusCodes.ClientError(404)("Scene or Scene tile data not found", e.getMessage))
+    case e: Exception =>
+      sendError(e)
+      complete(StatusCodes.ServerError(500)("An unknown error occurred", ""))
+  }
+}
+

--- a/app-backend/tile/src/main/scala/routes/MosaicRoutes.scala
+++ b/app-backend/tile/src/main/scala/routes/MosaicRoutes.scala
@@ -21,11 +21,11 @@ object MosaicRoutes extends LazyLogging {
     HttpResponse(entity = HttpEntity(ContentType(MediaTypes.`image/png`), png.bytes))
 
   def mosaicProject(implicit db: Database): Route =
-    pathPrefix(JavaUUID / Segment / "project" / JavaUUID/ IntNumber / IntNumber / IntNumber) { (orgId, userId, projectId, zoom, x, y) =>
+    pathPrefix(JavaUUID / IntNumber / IntNumber / IntNumber) { (projectId, zoom, x, y) =>
       parameter("tag".?) { tag =>
         get {
           complete {
-            Mosaic(orgId, userId, projectId, zoom, x, y, tag).map { maybeTile =>
+            Mosaic(projectId, zoom, x, y, tag).map { maybeTile =>
               maybeTile.map { tile => pngAsHttpResponse(tile.renderPng()) }
             }
           }

--- a/app-backend/tile/src/main/scala/routes/SceneRoutes.scala
+++ b/app-backend/tile/src/main/scala/routes/SceneRoutes.scala
@@ -25,7 +25,7 @@ import scala.concurrent._
 object SceneRoutes extends LazyLogging {
 
   def root: Route =
-    pathPrefix(JavaUUID / Segment / JavaUUID).as(RfLayerId) { id =>
+    pathPrefix(JavaUUID).as(RfLayerId) { id =>
       pathPrefix("rgb") {
         layerTileAndHistogram(id) { (futureMaybeTile, futureHist) =>
           imageRoute(futureMaybeTile, futureHist)

--- a/app-backend/tile/src/main/scala/routes/ToolRoutes.scala
+++ b/app-backend/tile/src/main/scala/routes/ToolRoutes.scala
@@ -97,12 +97,11 @@ object ToolRoutes extends LazyLogging {
         )
         { (partId, p0, p1, class0, class1, geotiffOutput, colorMap) =>
           complete {
-            val orgId = UUID.fromString(organizationId)
             val varMap = Map(
               'LC8_0 -> { (z: Int, x: Int, y: Int) =>
-                Mosaic.raw(orgId, userId, UUID.fromString(p0), z, x, y)},
+                Mosaic.raw(UUID.fromString(p0), z, x, y)},
               'LC8_1 -> { (z: Int, x: Int, y: Int) =>
-                Mosaic.raw(orgId, userId, UUID.fromString(p1), z, x, y)})
+                Mosaic.raw(UUID.fromString(p1), z, x, y)})
 
             val model: Op = partId match {
               case Some("ndvi0") => ndvi0

--- a/app-frontend/src/app/core/services/layer.service.js
+++ b/app-frontend/src/app/core/services/layer.service.js
@@ -129,33 +129,21 @@ export default (app) => {
          * @returns {string} URL for this tile layer
          */
         getSceneLayerURL() {
-            let userParams = this.userParamsFromScene(this.scene);
-            let organizationId = userParams.organizationId;
-            let userId = userParams.userId;
             return this.formatColorParams().then((formattedParams) => {
-                return `/tiles/${organizationId}/` +
-                    `${userId}/${this.scene.id}/rgb/{z}/{x}/{y}/?${formattedParams}`;
+                return `/tiles/${this.scene.id}/rgb/{z}/{x}/{y}/?${formattedParams}`;
             });
         }
 
         getMosaicLayerURL(params = {}) {
-            let userParams = this.userParamsFromScene(this.scene);
-            let organizationId = userParams.organizationId;
-            let userId = userParams.userId;
             params.token = this.authService.token();
             let formattedParams = L.Util.getParamString(params);
             return this.$q((resolve) => {
-                resolve(`/tiles/${organizationId}/` +
-                        `${userId}/project/${this.projectId}/{z}/{x}/{y}/${formattedParams}`);
+                resolve(`/tiles/${this.projectId}/{z}/{x}/{y}/${formattedParams}`);
             });
         }
 
         getNDVIURL(bands) {
-            let organizationId = this.scene.organizationId;
-            // TODO: replace this once user IDs are URL safe ISSUE: 766
-            let userId = this.scene.createdBy.replace('|', '_');
-            return `/tiles/${organizationId}/` +
-                `${userId}/${this.scene.id}/ndvi/{z}/{x}/{y}/?bands=${bands[0]},${bands[1]}`;
+            return `/tiles/${this.scene.id}/ndvi/{z}/{x}/{y}/?bands=${bands[0]},${bands[1]}`;
         }
 
         /**
@@ -163,12 +151,8 @@ export default (app) => {
          * @returns {string} URL for the histogram
          */
         getHistogramURL() {
-            let userParams = this.userParamsFromScene(this.scene);
-            let organizationId = userParams.organizationId;
-            let userId = userParams.userId;
             return this.formatColorParams().then((formattedParams) => {
-                return `/tiles/${organizationId}/` +
-                    `${userId}/${this.scene.id}/rgb/histogram/?${formattedParams}`;
+                return `/tiles/${this.scene.id}/rgb/histogram/?${formattedParams}`;
             });
         }
 

--- a/app-frontend/src/app/core/services/project.service.js
+++ b/app-frontend/src/app/core/services/project.service.js
@@ -202,8 +202,6 @@ export default (app) => {
         }
 
         getProjectLayerURL(project, token) {
-            let userId = 'rf_airflow-user';
-
             let params = {
                 tag: new Date().getTime()
             };
@@ -215,8 +213,7 @@ export default (app) => {
             let formattedParams = L.Util.getParamString(params);
 
             return this.getBaseURL() +
-                `/tiles/${project.organizationId}/${userId}` +
-                `/project/${project.id}/{z}/{x}/{y}/${formattedParams}`;
+                `/tiles/${project.id}/{z}/{x}/{y}/${formattedParams}`;
         }
 
         getProjectShareURL(project) {

--- a/app-tasks/Dockerfile
+++ b/app-tasks/Dockerfile
@@ -1,9 +1,6 @@
 FROM python:2.7
 
 ENV AIRFLOW_HOME /usr/local/airflow
-ENV SPARK_VERSION 2.0.1
-ENV HADOOP_VERSION 2.7
-ENV PATH=${PATH}:/usr/lib/spark/sbin:/usr/lib/spark/bin
 
 COPY requirements.txt /tmp/
 COPY rf/ /tmp/rf
@@ -17,25 +14,19 @@ RUN set -ex \
     && buildDeps=' \
        python-dev \
     ' \
-    && sparkDeps=' \
-       openjdk-8-jre \
-    ' \
     && gdal=' \
        gdal-bin \
        libgdal1h \
        libgdal-dev \
     ' \
     && echo "deb http://ftp.debian.org/debian jessie-backports main" > /etc/apt/sources.list.d/backports.list \
-    && apt-get update && apt-get install -y --no-install-recommends ${buildDeps} ${gdal} ${sparkDeps} \
+    && apt-get update && apt-get install -y --no-install-recommends ${buildDeps} ${gdal} \
     && pip install --no-cache-dir \
            numpy==$(grep "numpy" /tmp/requirements.txt | cut -d= -f3) \
     && pip install --no-cache-dir -r /tmp/requirements.txt \
     && (cd /tmp/rf && python setup.py install) \
     && apt-get purge -y --auto-remove ${buildDeps} \
-    && rm -rf /var/lib/apt/lists/* \
-    && mkdir -p /usr/lib/spark \
-    && wget -qO- http://d3kbcqa49mib13.cloudfront.net/spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz \
-    | tar -xzC /usr/lib/spark --strip-components=1
+    && rm -rf /var/lib/apt/lists/*
 
 USER airflow
 WORKDIR ${AIRFLOW_HOME}


### PR DESCRIPTION
## Overview

Formerly, layer data was organized on S3 based on the username and organization of the user owning the layer; the username and organization ID were included in each tile URL in order to allow the tiler to determine the S3 location of the layer data. However, this had several drawbacks, including prohibiting non-URL-safe usernames and potentially causing duplication of layer data ingested by different users. This removes the organization ID and the Username from tile URLs and relies on the `ingestLocation` field on the Scenes object in order to find the location on S3 of the layer data.

### Checklist

- [ ] ~Styleguide updated, if necessary~
- [ ] ~Swagger specification updated, if necessary~

## Testing Instructions

 * Fire up the server and head to color correction for any Project which is ingested (e.g. Yosemite).
 * You should not see any tiles; this is because none of the existing Scenes in the database have values in the `ingestLocation` column.
 * Verify that the tile requests only include a single UUID parameter, rather than two UUIDs and a username.
 * Verify that the tile requests received 404 responses indicating that the Scene or its data could not be found.
 * Open a Postgres shell via `./scripts/psql`
 * Run `update scenes set ingest_location='s3://rasterfoundry-staging-catalogs-us-east-1/dfac6307-b5ef-43f7-beda-b9f208bb7726/rf_airflow-user' where id='535f33b5-7a81-4403-b58a-89f6d71faf4a';` or something similar (substituting the scene ID that you want to display). The Yosemite scenes are IDs `63b15316-2b28-4280-8eb5-c98de4adffab` and `535f33b5-7a81-4403-b58a-89f6d71faf4a`.
 * Restart the server to make sure you clear out any caching that is happening, and revisit the color correction page. You should see tiles as expected.

Closes #1011 
