### PR TITLE
Create scene filter for ingestStatus

### DIFF
--- a/app-backend/app/src/main/scala/scene/QueryParameters.scala
+++ b/app-backend/app/src/main/scala/scene/QueryParameters.scala
@@ -30,8 +30,7 @@ trait SceneQueryParameterDirective extends QueryParametersCommon
     'point.as[String].?,
     'project.as[UUID].?,
     'ingested.as[Boolean].?,
-    'minIngestStatus.as[Int].?,
-    'maxIngestStatus.as[Int].?
+    'ingestStatus.as[String].*
   )).as(SceneQueryParameters)
 
   val sceneQueryParameters = (orgQueryParams &

--- a/app-backend/app/src/test/scala/scene/SceneSpec.scala
+++ b/app-backend/app/src/test/scala/scene/SceneSpec.scala
@@ -232,6 +232,20 @@ class SceneSpec extends WordSpec
       }
     }
 
+    "filter by ingested status correctly" in {
+      val url = s"$baseScene?ingestStatus=INGESTED"
+      Get(url).withHeaders(List(authHeader)) ~> baseRoutes ~> check {
+        responseAs[PaginatedResponse[Scene.WithRelated]].count shouldEqual 1
+      }
+    }
+
+    "filter by multiple ingested status correctly" in {
+      val url = s"$baseScene?ingestStatus=INGESTED&ingestStatus=NOTINGESTED"
+      Get(url).withHeaders(List(authHeader)) ~> baseRoutes ~> check {
+        responseAs[PaginatedResponse[Scene.WithRelated]].count shouldEqual 2
+      }
+    }
+
     "filter scenes by bounding box" in {
       Get("/api/scenes/?bbox=0,0,0.00001,0.00001").withHeaders(
         List(authHeader)

--- a/app-backend/database/src/main/scala/com/azavea/rf/database/QueryParameters.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/QueryParameters.scala
@@ -48,8 +48,7 @@ case class SceneQueryParameters(
   point: Option[String] = None,
   project: Option[UUID] = None,
   ingested: Option[Boolean] = None,
-  minIngestStatus: Option[Int] = None,
-  maxIngestStatus: Option[Int] = None
+  ingestStatus: Iterable[String] = Seq[String]()
 ) {
   val bboxPolygon: Option[Seq[Projected[Polygon]]] = try {
     bbox match {

--- a/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Scenes.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Scenes.scala
@@ -462,6 +462,11 @@ class ScenesTableQuery[M, U, C[_]](scenes: Scenes.TableQuery) extends LazyLoggin
         .map(scene.ingestLocation.isDefined === _)
         .reduceLeftOption(_ || _)
         .getOrElse(true: Rep[Boolean])
+    }.filter { scene =>
+      sceneParams.ingestStatus.map(IngestStatus.fromString(_))
+        .map(scene.ingestStatus === _)
+        .reduceLeftOption(_ || _)
+        .getOrElse(true: Rep[Boolean])
     }
 
     sceneParams.project match {

--- a/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Scenes.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Scenes.scala
@@ -463,8 +463,17 @@ class ScenesTableQuery[M, U, C[_]](scenes: Scenes.TableQuery) extends LazyLoggin
         .reduceLeftOption(_ || _)
         .getOrElse(true: Rep[Boolean])
     }.filter { scene =>
-      sceneParams.ingestStatus.map(IngestStatus.fromString(_))
-        .map(scene.ingestStatus === _)
+      sceneParams.ingestStatus
+        .map( status =>
+          try {
+            scene.ingestStatus === IngestStatus.fromString(status)
+          } catch {
+            case e : Exception =>
+              throw new IllegalArgumentException(
+                s"Invalid Ingest Status: $status"
+              )
+          }
+        )
         .reduceLeftOption(_ || _)
         .getOrElse(true: Rep[Boolean])
     }

--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/IngestStatus.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/IngestStatus.scala
@@ -35,7 +35,7 @@ object IngestStatus {
     case "INGESTING" => Ingesting
     case "INGESTED" => Ingested
     case "FAILED" => Failed
-    case _ => throw new Exception(s"Invalid string: $s")
+    case _ => throw new DeserializationException(s"Invalid IngestStatus: $s")
   }
 
   implicit object DefaultIngestStatusJsonFormat extends RootJsonFormat[IngestStatus] {

--- a/docs/swagger/spec.yml
+++ b/docs/swagger/spec.yml
@@ -302,6 +302,7 @@ paths:
         - $ref: '#/parameters/bbox'
         - $ref: '#/parameters/project'
         - $ref: '#/parameters/ingested'
+        - $ref: '#/parameters/ingestStatus'
       responses:
         200:
           description: Paginated list of scenes
@@ -524,6 +525,7 @@ paths:
         - $ref: '#/parameters/maxResolution'
         - $ref: '#/parameters/tags'
         - $ref: '#/parameters/ingested'
+        - $ref: '#/parameters/ingestStatus'
       responses:
         200:
           description: Paginated list of scenes associated with this project
@@ -1241,6 +1243,12 @@ parameters:
     in: query
     type: boolean
     required: false
+  ingestStatus:
+    name: ingestStatus
+    description: Filter by specific ingest status
+    in: query
+    type: string
+    required: false
 definitions:
   BaseModel:
     type: object
@@ -1476,9 +1484,6 @@ definitions:
               - PUBLIC
               - ORGANIZATION
               - OWNERONLY
-          resolutionMeters:
-            type: number
-            description: Size of pixel in meters
           tags:
             type: array
             description: Tags associated with image
@@ -1496,14 +1501,6 @@ definitions:
             type: string
             format: uuid
             description: Data source scene originated from
-          cloudCover:
-            type: number
-            format: float32
-            description: Proportion of cloud coverage for scene
-          acqusitionDate:
-            type: string
-            format: datetime
-            description: Date scene was acquired from instrument (e.g. satellite, drone)
           dataFootprint:
             type: geojson
             description: polygon for which this scene has data
@@ -1524,34 +1521,64 @@ definitions:
               images in a scene (e.g. relevant .mtl files or .xml)
             items:
               - type: string
-          thumbnailStatus:
-            type: string
-            description: status of thumbnail generation
-            enum:
-              - SUCCESS
-              - FAILURE
-              - PARTIALFAILURE
-              - QUEUED
-              - PROCESSING
-          footprintStatus:
-            type: string
-            description: status of footprint generation
-            enum:
-              - SUCCESS
-              - FAILURE
-              - PARTIALFAILURE
-              - QUEUED
-              - PROCESSING
-          status:
-            type: string
-            description: overall status of scene
-            enum:
-              - UPLOADING
-              - SUCCESS
-              - FAILURE
-              - PARTIALFAILURE
-              - QUEUED
-              - PROCESSING
+          filterFields:
+            type: object
+            $ref: '#/definitions/FilterFields'
+          statusFields:
+            type: object
+            $ref: '#/definitions/StatusFields'
+
+  FilterFields:
+    type: object
+    properties:
+      cloudCover:
+        type: number
+        format: float32
+        description: Proportion of cloud coverage for scene
+      acquisitionDate:
+        type: string
+        format: datetime
+        description: Date scene was acquired from instrument (e.g. satellite, drone)
+      sunAzimuth:
+        type: number
+        format: float32
+        description: Azimuth of the sun
+      sunElevation:
+        type: number
+        format: float32
+        description: Elevation of the sun
+      
+  StatusFields:
+    type: object
+    properties:
+      thumbnailStatus:
+        type: string
+        description: status of thumbnail generation
+        enum:
+          - SUCCESS
+          - FAILURE
+          - PARTIALFAILURE
+          - QUEUED
+          - PROCESSING
+      footprintStatus:
+        type: string
+        description: status of footprint generation
+        enum:
+          - SUCCESS
+          - FAILURE
+          - PARTIALFAILURE
+          - QUEUED
+          - PROCESSING
+      ingestStatus:
+        type: string
+        description: status of ingest
+        enum:
+          - NOTINGESTED
+          - TOBEINGESTED
+          - INGESTING
+          - INGESTED
+          - FAILED
+
   SceneGrid:
     type: array
     items:
@@ -1602,6 +1629,9 @@ definitions:
           fileName:
             type: string
             description: Name of the image file
+          resolutionMeters:
+            type: number
+            description: Size of pixel in meters
           sourceURI:
             type: string
             description: URI to original source. This should include a protocol-like prefix to identify where it is located http://, s3://, etc.
@@ -1620,6 +1650,11 @@ definitions:
           image_metadata:
             type: object
             description: Metadata about this image
+          metadataFiles:
+            type: array
+            description: |
+              Metadata files that should be present for processing all
+              images in a scene (e.g. relevant .mtl files or .xml)
         required:
           - fileName
           - sourceURI


### PR DESCRIPTION
## Overview

Allow filtering scenes on one or multiple ingest statuses

### Checklist

~- [ ] Styleguide updated, if necessary~
- [x] Swagger specification updated, if necessary

## Testing Instructions

 * Run `./scripts/test` and verify that the filter on ingests tests run and pass
 * Run `./scripts/psql` and set the ingest status of a couple scenes like this: `update scenes set (ingest_status) = ('INGESTED') where id = {uuid};` so you have something to filter on
 * Make a request to the scenes endpoint with a `ingestStatus=INGESTED` query param defined and verify that the scenes you've changed are returned

Closes #983