### PR TITLE
Allow layers to be overwritten on ingest

### DIFF
--- a/app-backend/build.sbt
+++ b/app-backend/build.sbt
@@ -139,7 +139,7 @@ lazy val ingest = Project("ingest", file("ingest"))
   .settings(commonSettings:_*)
   .settings(resolvers += Resolver.bintrayRepo("azavea", "geotrellis"))
   .settings({
-    libraryDependencies ++= Seq(
+    libraryDependencies ++= loggingDependencies ++ Seq(
       Dependencies.geotrellisSpark,
       Dependencies.geotrellisS3,
       Dependencies.geotrellisUtil,

--- a/app-backend/ingest/src/main/scala/com/azavea/rf/ingest/CommandLine.scala
+++ b/app-backend/ingest/src/main/scala/com/azavea/rf/ingest/CommandLine.scala
@@ -20,9 +20,13 @@ object CommandLine {
     opt[Unit]('t', "test").action( (_, conf) =>
       conf.copy(testRun = true) ).text("Run this job as a test - delete output after run")
 
+    opt[Unit]("overwrite").action( (_, conf) =>
+      conf.copy(testRun = true) ).text("Overwrite conflicting layers")
+
     opt[URI]('j',"jobDefinition")
       .action( (jd, conf) => conf.copy(jobDefinition = jd) )
       .text("The location of the json which defines an ingest job")
       .required
+
   }
 }

--- a/app-backend/ingest/src/main/scala/com/azavea/rf/ingest/CommandLine.scala
+++ b/app-backend/ingest/src/main/scala/com/azavea/rf/ingest/CommandLine.scala
@@ -18,7 +18,7 @@ object CommandLine {
     head("raster-foundry-ingest", "0.1")
 
     opt[Unit]('t', "test").action( (_, conf) =>
-      conf.copy(testRun = true) ).text("Run this job as a test - delete output after run")
+      conf.copy(testRun = true) ).text("Run this job as a test - verify output")
 
     opt[Unit]("overwrite").action( (_, conf) =>
       conf.copy(testRun = true) ).text("Overwrite conflicting layers")

--- a/app-backend/ingest/src/main/scala/com/azavea/rf/ingest/util/Testing.scala
+++ b/app-backend/ingest/src/main/scala/com/azavea/rf/ingest/util/Testing.scala
@@ -14,6 +14,7 @@ import geotrellis.raster._
 import geotrellis.raster.io.geotiff.MultibandGeoTiff
 import geotrellis.spark.tiling._
 import geotrellis.proj4.LatLng
+import com.typesafe.scalalogging.LazyLogging
 import spray.json._
 import DefaultJsonProtocol._
 
@@ -22,7 +23,7 @@ import java.util.UUID
 
 import com.azavea.rf.ingest.tool._
 
-object Testing {
+object Testing extends LazyLogging {
 
   /** Check that an ingested layer has a valid s3-based catalog entry for an ingest definition */
   def validateS3CatalogEntry(catalogURI: URI, layerID: UUID): Unit = {
@@ -31,6 +32,7 @@ object Testing {
     val gtLayerID = LayerId(layerID.toString, 0)
     if (! attributeStore.read[Boolean](gtLayerID, "ingestComplete"))
       throw new Exception("Something went wrong during ingest...")
+    else logger.info("Ingest completed successfully")
   }
 
   /** Check that an ingested layer has a valid file-based catalog entry for an ingest definition */
@@ -39,6 +41,7 @@ object Testing {
     val gtLayerID = LayerId(layerID.toString, 0)
     if (! attributeStore.read[Boolean](gtLayerID, "ingestComplete"))
       throw new Exception("Something went wrong during ingest...")
+    else logger.info("Ingest completed successfully")
   }
 
   /** Check that an ingested layer has a valid catalog entry for an ingest definition */


### PR DESCRIPTION
## Overview

Layer deletion prior to ingest is a desirable feature in cases where prior ingests may have been incorrectly specified. This PR adds the `--overwrite` flag to the ingest subproject's command line arguments and wires said flag into the ingest process so that layer deletion is carried out when it is provided.

## Testing Instructions

See the `docs` directory for instructions on trying out an ingest. Simply add the `--overwrite` flag to exhibit layer deletion behavior.

Connects #1036
