### PR TITLE
Feature/lk/set scene ingest status

### DIFF
--- a/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Projects.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Projects.scala
@@ -252,6 +252,15 @@ object Projects extends TableQuery(tag => new Projects(tag)) with LazyLogging {
       }
     }
 
+    val scenesNotIngestedQuery = for {
+      s <- Scenes if s.id.inSet(sceneIds) && s.ingestStatus.inSet(
+        Set(IngestStatus.NotIngested, IngestStatus.Failed))
+    } yield (s.ingestStatus)
+
+    database.db.run {
+      scenesNotIngestedQuery.update((IngestStatus.ToBeIngested))
+    }
+
     listSelectProjectScenes(projectId, sceneIds)
   }
 


### PR DESCRIPTION
## Overview

Set the ingest status of scenes to be `TOBEINGESTED` when they are added to a project, so airflow can detect which scenes need to be ingested.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~

## Testing Instructions

 * Add a scene to a project
 * Request scenes with an ingestStatus of TOBEINGESTED
 * Verify that the added scene shows up in the list