### PR TITLE
Add stubbed DAG for ingesting Scenes

### DIFF
--- a/app-tasks/dags/ingest/ingest_project_scenes.py
+++ b/app-tasks/dags/ingest/ingest_project_scenes.py
@@ -1,0 +1,112 @@
+import datetime
+import logging
+import os
+
+from airflow.operators.python_operator import PythonOperator
+from airflow.models import DAG
+
+rf_logger = logging.getLogger('rf')
+ch = logging.StreamHandler()
+ch.setLevel(logging.INFO)
+formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+ch.setFormatter(formatter)
+rf_logger.addHandler(ch)
+
+logger = logging.getLogger(__name__)
+
+default_args = {
+    'owner': 'raster-foundry',
+    'start_date': datetime.datetime(2017, 1, 1)
+}
+
+dag = DAG(
+    dag_id='ingest_project_scenes',
+    default_args=default_args,
+    schedule_interval=None,
+    concurrency=int(os.getenv('AIRFLOW_DAG_CONCURRENCY', 24))
+)
+
+
+################################
+# Utility functions            #
+################################
+def get_uningested_project_scenes():
+    logger.info('Querying for scenes which need to be ingested...')
+    return []
+
+
+def create_ingest_definition(scenes_to_ingest):
+    logger.info('Creating ingest definition...')
+    return str(scenes_to_ingest)
+
+
+def store_ingest_definition(ingest_definition_str):
+    # Possibly use Airflow's builtin S3Hook here
+    logger.info('Uploading ingest definition to S3')
+
+
+################################
+# Callables for PythonOperators#
+################################
+def create_ingest_definition_op():
+    logger.info('Beginning to create ingest definition...')
+    scenes_to_ingest = get_uningested_project_scenes()
+    ingest_definition = create_ingest_definition(scenes_to_ingest)
+    # TODO: Depending on whether the ingest definition provides us with enough
+    # info to update the Scenes' ingested status when the ingest task succeeds
+    # / fails, we may also need to create and upload a list of Scene IDs at
+    # this stage.
+    logger.info('Uploading ingest definition...')
+    store_ingest_definition(ingest_definition)
+    logger.info('Finished creating ingest definition.')
+
+
+def launch_spark_ingest_job_op():
+    logger.info('Launching Spark ingest job...')
+    logger.info('Finished launching Spark ingest job.')
+
+
+def set_ingest_status_success_op():
+    logger.info("Setting scenes' ingested status to success...")
+    logger.info("Finished setting scenes' ingested status.")
+
+
+def set_ingest_status_failure_op():
+    logger.info("Setting scenes' ingested status to failure...")
+    logger.info("Finished setting scenes' ingested status.")
+
+################################
+# Tasks                        #
+################################
+create_ingest_definition_task = PythonOperator(
+    task_id='create_ingest_definition',
+    python_callable=create_ingest_definition_op,
+    dag=dag
+)
+
+launch_spark_ingest_task = PythonOperator(
+    task_id='launch_spark_ingest',
+    python_callable=launch_spark_ingest_job_op,
+    dag=dag
+)
+
+set_ingest_status_success_task = PythonOperator(
+    task_id='set_ingest_status_success',
+    python_callable=set_ingest_status_success_op,
+    trigger_rule='all_success',
+    dag=dag
+)
+
+set_ingest_status_failure_task = PythonOperator(
+    task_id='set_ingest_status_failure',
+    python_callable=set_ingest_status_failure_op,
+    trigger_rule='all_failed',
+    dag=dag
+)
+
+################################
+# DAG Structure Specification  #
+################################
+set_ingest_status_success_task.set_upstream(launch_spark_ingest_task)
+set_ingest_status_failure_task.set_upstream(launch_spark_ingest_task)
+launch_spark_ingest_task.set_upstream(create_ingest_definition_task)

--- a/docker-compose.airflow.yml
+++ b/docker-compose.airflow.yml
@@ -17,6 +17,7 @@ services:
     env_file: .env
     external_links:
       - postgres:database.service.rasterfoundry.internal
+    links:
       - redis:cache.service.rasterfoundry.internal
     environment:
       - AIRFLOW_HOME=/usr/local/airflow
@@ -40,6 +41,7 @@ services:
       dockerfile: Dockerfile
     external_links:
       - postgres:database.service.rasterfoundry.internal
+    links:
       - redis:cache.service.rasterfoundry.internal
     env_file: .env
     environment:
@@ -71,6 +73,7 @@ services:
     restart: always
     external_links:
       - postgres:database.service.rasterfoundry.internal
+    links:
       - redis:cache.service.rasterfoundry.internal
     env_file: .env
     environment:
@@ -100,8 +103,9 @@ services:
       dockerfile: Dockerfile
     external_links:
       - postgres:database.service.rasterfoundry.internal
-      - redis:cache.service.rasterfoundry.internal
       - app-server:rasterfoundry.com
+    links:
+      - redis:cache.service.rasterfoundry.internal
     env_file: .env
     environment:
       - AIRFLOW_HOME=/usr/local/airflow
@@ -129,8 +133,9 @@ services:
       dockerfile: Dockerfile
     external_links:
       - postgres:database.service.rasterfoundry.internal
-      - redis:cache.service.rasterfoundry.internal
       - app-server:rasterfoundry.com
+    links:
+      - redis:cache.service.rasterfoundry.internal
     env_file: .env
     environment:
       - AIRFLOW_HOME=/usr/local/airflow


### PR DESCRIPTION
## Overview

This is a stubbed out Airflow DAG for ingesting Scenes that have been added to Projects.

### Checklist

- [ ] ~Styleguide updated, if necessary~
- [ ] ~Swagger specification updated, if necessary~

### Demo

Successful run:
![ingestsuccess](https://cloud.githubusercontent.com/assets/447977/22564550/ef0122a0-e952-11e6-8a6a-f82f83acc0a1.png)
Failed run:
![ingestfailure](https://cloud.githubusercontent.com/assets/447977/22564768/ad8f5764-e953-11e6-9b81-dcb52aea0c2e.png)


### Notes
This is structured as a single DAG that submits a single Spark job to ingest all necessary Scenes. That seemed to fit my understanding of how ingests work, but if I misunderstood something or if things change, then it might be better to use a structure more like the Sentinel2 import, which has one DAG to discover Sentinel2 data that in turn kicks off a series of DAGs to do the actual importing.

I had to make some changes to the `docker-compose.yml` files in order to get Airflow working because the Redis server isn't currently being treated as a hard dependency of anything and therefore wasn't launching with `./scripts/server`.

## Testing Instructions

 * Launch the Airflow stack with `./scripts/server --with-airflow | grep airflow-worker` so you can see what's going on.
 * Disable all the other Airflow DAGs, otherwise they'll start scheduling a bunch of backfill jobs and any test jobs you kick off won't be able to find an executor. You can either do this by logging into the Airflow interface, or editing the DAG definitions so that their schedule is `None`. 
![disableddags](https://cloud.githubusercontent.com/assets/447977/22567678/ed052e4a-e95e-11e6-864c-ec1bd3d0ceab.png)
 * Open a shell into the Airflow scheduler with `./scripts/console airflow-scheduler bash`
 * Run `airflow trigger_dag ingest_project_scenes`
 * You should see activity in the airflow-worker terminal, and you should be able to see the triggered DAG run in the Airflow UI. You should see something like the successful run above.
 * Edit one of the `*_op()` functions in `app-tasks/dags/ingest/ingest_project_scenes.py` to throw an exception
 * Re-trigger the DAG and you should see a status like the Failed run above; you should also see your exception logged to the console.

Closes #984 
