### PR TITLE
Feature/jis/add datasource endpoint

### DIFF
--- a/app-backend/app/src/main/scala/Router.scala
+++ b/app-backend/app/src/main/scala/Router.scala
@@ -16,6 +16,7 @@ import com.azavea.rf.tooltag.ToolTagRoutes
 import com.azavea.rf.token.TokenRoutes
 import com.azavea.rf.toolcategory.ToolCategoryRoutes
 import com.azavea.rf.grid.GridRoutes
+import com.azavea.rf.datasource.DatasourceRoutes
 import com.azavea.rf.utils.Config
 
 /**
@@ -37,6 +38,7 @@ trait Router extends HealthCheckRoutes
     with ConfigRoutes
     with ToolCategoryRoutes
     with GridRoutes
+    with DatasourceRoutes
     with Config {
 
   val corsSettings = CorsSettings.defaultSettings
@@ -55,8 +57,9 @@ trait Router extends HealthCheckRoutes
       pathPrefix("users") { userRoutes } ~
       pathPrefix("tools") { toolRoutes } ~
       pathPrefix("tool-tags") { toolTagRoutes } ~
-      pathPrefix("tool-categories") { toolCategoryRoutes }~
-      pathPrefix("scene-grid") { gridRoutes }
+      pathPrefix("tool-categories") { toolCategoryRoutes } ~
+      pathPrefix("scene-grid") { gridRoutes } ~
+      pathPrefix("datasources") { datasourceRoutes }
     } ~
     pathPrefix("config") {
       configRoutes

--- a/app-backend/app/src/main/scala/datasource/QueryParameters.scala
+++ b/app-backend/app/src/main/scala/datasource/QueryParameters.scala
@@ -1,0 +1,15 @@
+package com.azavea.rf.datasource
+
+import java.util.UUID
+
+import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.server.directives.ParameterDirectives.parameters
+
+import com.azavea.rf.database.query._
+import com.azavea.rf.utils.queryparams._
+
+trait DatasourceQueryParameterDirective extends QueryParametersCommon {
+  val datasourceQueryParams = parameters((
+    'name.as[String].?
+  )).as(DatasourceQueryParameters)
+}

--- a/app-backend/app/src/main/scala/datasource/Routes.scala
+++ b/app-backend/app/src/main/scala/datasource/Routes.scala
@@ -1,0 +1,83 @@
+package com.azavea.rf.datasource
+
+import java.util.UUID
+
+import scala.util.{Success, Failure}
+
+import akka.http.scaladsl.server.Route
+import akka.http.scaladsl.model.StatusCodes
+
+import com.lonelyplanet.akka.http.extensions.{PaginationDirectives, PageRequest}
+
+import com.azavea.rf.common.{Authentication, UserErrorHandler}
+import com.azavea.rf.database.tables.Datasources
+import com.azavea.rf.database.query._
+import com.azavea.rf.database.{Database, ActionRunner}
+import com.azavea.rf.datamodel._
+
+trait DatasourceRoutes extends Authentication
+    with DatasourceQueryParameterDirective
+    with PaginationDirectives
+    with UserErrorHandler
+    with ActionRunner {
+  implicit def database: Database
+
+  val datasourceRoutes: Route = handleExceptions(userExceptionHandler) {
+    pathEndOrSingleSlash {
+      get { listDatasources } ~
+      post { createDatasource }
+    } ~
+    pathPrefix(JavaUUID) { datasourceId =>
+      get { getDatasource(datasourceId) } ~
+      put { updateDatasource(datasourceId) } ~
+      delete { deleteDatasource(datasourceId) }
+    }
+  }
+
+  def listDatasources: Route = authenticate { user =>
+    (withPagination & datasourceQueryParams) {
+      (page: PageRequest, datasourceParams: DatasourceQueryParameters) =>
+      complete {
+        list[Datasource](Datasources.listDatasources(page.offset, page.limit, datasourceParams),
+                         page.offset,
+                         page.limit)
+      }
+    }
+  }
+
+  def getDatasource(datasourceId: UUID): Route = authenticate { user =>
+    get {
+      rejectEmptyResponse {
+        complete {
+          readOne[Datasource](Datasources.getDatasource(datasourceId))
+        }
+      }
+    }
+  }
+
+  def createDatasource: Route = authenticate { user =>
+    entity(as[Datasource.Create]) { newDatasource =>
+      onSuccess(write[Datasource](Datasources.insertDatasource(newDatasource, user))) { datasource =>
+        complete(datasource)
+      }
+    }
+  }
+
+  def updateDatasource(datasourceId: UUID): Route = authenticate { user =>
+    entity(as[Datasource]) { updateDatasource =>
+      onSuccess(update(Datasources.updateDatasource(updateDatasource, datasourceId, user))) { count =>
+        complete(StatusCodes.NoContent)
+      }
+    }
+  }
+
+  def deleteDatasource(datasourceId: UUID): Route = authenticate { user =>
+    onSuccess(drop(Datasources.deleteDatasource(datasourceId))) {
+      case 1 => complete(StatusCodes.NoContent)
+      case 0 => complete(StatusCodes.NotFound)
+      case count => throw new IllegalStateException(
+        s"Error deleting datasource. Delete result expected to be 1, was $count"
+      )
+    }
+  }
+}

--- a/app-backend/app/src/main/scala/datasource/package.scala
+++ b/app-backend/app/src/main/scala/datasource/package.scala
@@ -1,0 +1,12 @@
+
+package com.azavea.rf
+
+import com.azavea.rf.datamodel._
+
+package object datasource extends RfJsonProtocols {
+
+  //implicit val organizationCreateFormat = jsonFormat1(OrganizationCreate)
+  //implicit val userWithRoleCreateFormat = jsonFormat2(UserWithRoleCreate)
+  //implicit val userWithRoleFormat = jsonFormat4(UserWithRole)
+  implicit val paginatedDatasourceFormat = jsonFormat6(PaginatedResponse[Datasource])
+}

--- a/app-backend/app/src/test/scala/datasource/DatasourceSpec.scala
+++ b/app-backend/app/src/test/scala/datasource/DatasourceSpec.scala
@@ -150,7 +150,7 @@ class DatasourceSpec extends WordSpec
     Get(url3).withHeaders(
       List(authHeader)
     ) ~> baseRoutes ~> check {
-      responseAs[PaginatedResponse[Datasource]].count shouldEqual 0
+      responseAs[PaginatedResponse[Datasource]].count shouldEqual 1
     }
   }
 }

--- a/app-backend/app/src/test/scala/datasource/DatasourceSpec.scala
+++ b/app-backend/app/src/test/scala/datasource/DatasourceSpec.scala
@@ -1,0 +1,156 @@
+package com.azavea.rf.datasource
+
+import java.util.UUID
+
+import org.scalatest.{Matchers, WordSpec}
+import akka.http.scaladsl.testkit.{ScalatestRouteTest, RouteTestTimeout}
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.model.{HttpEntity, ContentTypes}
+import akka.http.scaladsl.server.Route
+import akka.actor.ActorSystem
+import concurrent.duration._
+import spray.json._
+
+import com.azavea.rf.datamodel._
+import com.azavea.rf.utils.Config
+import com.azavea.rf.{DBSpec, Router, AuthUtils}
+import java.sql.Timestamp
+import java.time.Instant
+
+
+class DatasourceSpec extends WordSpec
+    with Matchers
+    with ScalatestRouteTest
+    with Config
+    with Router
+    with DBSpec {
+  implicit val ec = system.dispatcher
+
+  implicit def database = db
+  implicit def default(implicit system: ActorSystem) = RouteTestTimeout(DurationInt(20).second)
+
+  val authHeader = AuthUtils.generateAuthHeader("Default")
+  val baseDatasourcePath = "/api/datasources/"
+  val publicOrgId = UUID.fromString("dfac6307-b5ef-43f7-beda-b9f208bb7726")
+  val exColorCorrect = Map[String, Any](
+    "alpha" -> 0,
+    "blueBand" -> 1,
+    "min" -> 0,
+    "max" -> 20000,
+    "redGamma" -> 0,
+    "equalize" -> false,
+    "beta" -> 13,
+    "blueGamma" -> 0,
+    "brightness" -> -6,
+    "greenBand" -> 2,
+    "contrast" -> 9,
+    "redBand" -> 3,
+    "greenGamma" -> 0
+  )
+
+  val datasource1 = Datasource.Create(
+    publicOrgId,
+    "Datasource1",
+    Visibility.Public,
+    exColorCorrect,
+    Map()
+  )
+
+  val datasource2 = Datasource.Create(
+    publicOrgId,
+    "Datasource2",
+    Visibility.Public,
+    exColorCorrect,
+    Map()
+  )
+
+  // A third datasource scoped to a different privacy level
+  val datasource3 = Datasource.Create(
+    publicOrgId,
+    "Datasource3",
+    Visibility.Private,
+    exColorCorrect,
+    Map()
+  )
+
+  // Alias to baseRoutes to be explicit
+  val baseRoutes = routes
+
+  "/api/datasources/" should {
+    "require authentication" in {
+      Get("/api/datasources/") ~> baseRoutes ~> check {
+        reject
+      }
+      Get("/api/datasources/").withHeaders(
+        List(authHeader)
+      ) ~> baseRoutes ~> check {
+        responseAs[PaginatedResponse[Datasource]]
+      }
+    }
+
+    "create an datasource successfully once authenticated" in {
+      Post("/api/datasources/").withHeadersAndEntity(
+        List(authHeader),
+        HttpEntity(
+          ContentTypes.`application/json`,
+          datasource1.toJson.toString()
+        )
+      ) ~> baseRoutes ~> check {
+        responseAs[Datasource]
+      }
+
+      Post("/api/datasources/").withHeadersAndEntity(
+        List(authHeader),
+        HttpEntity(
+          ContentTypes.`application/json`,
+          datasource2.toJson.toString()
+        )
+      ) ~> baseRoutes ~> check {
+        responseAs[Datasource]
+      }
+
+      Post("/api/datasources/").withHeadersAndEntity(
+        List(authHeader),
+        HttpEntity(
+          ContentTypes.`application/json`,
+          datasource3.toJson.toString()
+        )
+      ) ~> baseRoutes ~> check {
+        responseAs[Datasource]
+      }
+    }
+  }
+
+  /** Ignored because there's only one user + org in the db with datasources */
+  "scope to organization and privacy correctly" ignore {
+    Get(s"$baseDatasourcePath?organization=${publicOrgId}").withHeaders(
+      List(authHeader)
+    ) ~> baseRoutes ~> check {
+      // total is 4 because of landsat and sentinel in migration 38
+      responseAs[PaginatedResponse[Datasource]].count shouldEqual 3
+    }
+  }
+
+  "filter by name correctly" in {
+    val url1 = s"$baseDatasourcePath?name=${datasource1.name}"
+    Get(url1).withHeaders(
+      List(authHeader)
+    ) ~> baseRoutes ~> check {
+      responseAs[PaginatedResponse[Datasource]].count shouldEqual 1
+    }
+
+    val url2 = s"$baseDatasourcePath?name=${datasource2.name}"
+    Get(url2).withHeaders(
+      List(authHeader)
+    ) ~> baseRoutes ~> check {
+      responseAs[PaginatedResponse[Datasource]].count shouldEqual 1
+    }
+
+    val url3 = s"$baseDatasourcePath?name=${datasource3.name}"
+    Get(url3).withHeaders(
+      List(authHeader)
+    ) ~> baseRoutes ~> check {
+      responseAs[PaginatedResponse[Datasource]].count shouldEqual 0
+    }
+  }
+}

--- a/app-backend/database/src/main/scala/com/azavea/rf/database/ActionRunner.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/ActionRunner.scala
@@ -1,0 +1,42 @@
+package com.azavea.rf.database
+
+import scala.concurrent.Future
+import scala.concurrent.ExecutionContext.Implicits.global
+
+import slick.lifted.Rep
+import slick.dbio.{DBIO, StreamingDBIO, Streaming}
+
+import com.azavea.rf.datamodel.PaginatedResponse
+import com.azavea.rf.database.{Database => DB}
+import com.azavea.rf.database.ExtendedPostgresDriver.api.TableQuery
+import com.azavea.rf.database.query.ListQueryResult
+
+trait ActionRunner {
+
+  def list[T](a: ListQueryResult[T], offset: Int, limit: Int)
+          (implicit database: DB): Future[PaginatedResponse[T]] = {
+    database.db.run(for {
+      records <- a.records
+      nRecords <- a.nRecords
+    } yield {
+      PaginatedResponse[T](
+        nRecords,
+        offset > 0,
+        (offset + 1) * limit < nRecords,
+        offset,
+        limit,
+        records
+      )
+    })
+
+  }
+
+  def readOne[T](a: DBIO[Option[T]])(implicit database: DB): Future[Option[T]] =
+    database.db.run(a)
+
+  def write[T](a: DBIO[T])(implicit database: DB): Future[T] = database.db.run(a)
+
+  def update(a: DBIO[Int])(implicit database: DB): Future[Int] = database.db.run(a)
+
+  def drop(a: DBIO[Int])(implicit database: DB): Future[Int] = database.db.run(a)
+}

--- a/app-backend/database/src/main/scala/com/azavea/rf/database/QueryParameters.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/QueryParameters.scala
@@ -179,3 +179,7 @@ case class CombinedToolCategoryQueryParams(
   timestampParams: TimestampQueryParameters = TimestampQueryParameters(),
   toolCategoryParams: ToolCategoryQueryParameters = ToolCategoryQueryParameters()
 )
+
+case class DatasourceQueryParameters(
+  name: Option[String] = None
+)

--- a/app-backend/database/src/main/scala/com/azavea/rf/database/QueryResults.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/QueryResults.scala
@@ -1,0 +1,8 @@
+package com.azavea.rf.database.query
+
+import slick.dbio.DBIO
+
+case class ListQueryResult[T](
+  records: DBIO[Seq[T]],
+  nRecords: DBIO[Int]
+)

--- a/app-backend/database/src/main/scala/com/azavea/rf/database/fields/OrgFkVisibleFields.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/fields/OrgFkVisibleFields.scala
@@ -1,0 +1,17 @@
+package com.azavea.rf.database.fields
+
+import com.azavea.rf.database.ExtendedPostgresDriver.api._
+import com.azavea.rf.datamodel.{Organization, Visibility}
+
+trait OrgFkVisibleFields extends OrganizationFkFields with VisibilityField { self: Table[_] => }
+
+object OrgFkVisibleFields {
+  implicit class DefaultQuery[M <: OrgFkVisibleFields, U, C[_]](that: Query[M, U, Seq]) {
+    def filterOrgVisibility(org: Organization) = {
+      that.filter { rec => {
+          rec.visibility === Visibility.fromString("PUBLIC") || rec.organizationId === org.id
+        }
+      }
+    }
+  }
+}

--- a/app-backend/database/src/main/scala/com/azavea/rf/database/fields/UserFkVisibleFields.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/fields/UserFkVisibleFields.scala
@@ -7,10 +7,10 @@ import com.azavea.rf.datamodel.{User, Visibility}
 import slick.lifted.ForeignKeyQuery
 
 
-trait UserFkVisibileFields extends UserFkFields with VisibilityField { self: Table[_] => }
+trait UserFkVisibleFields extends UserFkFields with VisibilityField { self: Table[_] => }
 
-object UserFkVisibileFields {
-  implicit class DefaultQuery[M <: UserFkVisibileFields, U, C[_]](that: Query[M, U, Seq]) {
+object UserFkVisibleFields {
+  implicit class DefaultQuery[M <: UserFkVisibleFields, U, C[_]](that: Query[M, U, Seq]) {
     def filterUserVisibility(user: User) = {
       that.filter { rec => {
         rec.visibility === Visibility.fromString("PUBLIC") || rec.createdBy === user.id

--- a/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Images.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Images.scala
@@ -17,7 +17,7 @@ import com.typesafe.scalalogging.LazyLogging
 class Images(_tableTag: Tag) extends Table[Image](_tableTag, "images")
     with ImageFields
     with OrganizationFkFields
-    with UserFkVisibileFields
+    with UserFkVisibleFields
     with TimestampFields
 {
   def * = (id, createdAt, modifiedAt, organizationId, createdBy, modifiedBy,

--- a/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Projects.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Projects.scala
@@ -22,7 +22,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 class Projects(_tableTag: Tag) extends Table[Project](_tableTag, "projects")
                                       with ProjectFields
                                       with OrganizationFkFields
-                                      with UserFkVisibileFields
+                                      with UserFkVisibleFields
                                       with TimestampFields
 {
   def * = (id, createdAt, modifiedAt, organizationId, createdBy, modifiedBy, name, slugLabel, description, visibility, tags, manualOrder) <> (Project.tupled, Project.unapply)

--- a/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Scenes.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Scenes.scala
@@ -22,7 +22,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 class Scenes(_tableTag: Tag) extends Table[Scene](_tableTag, "scenes")
                                      with SceneFields
                                      with OrganizationFkFields
-                                     with UserFkVisibileFields
+                                     with UserFkVisibleFields
                                      with TimestampFields
 {
   def * = (id, createdAt, createdBy, modifiedAt, modifiedBy, organizationId, ingestSizeBytes, visibility,

--- a/docs/swagger/spec.yml
+++ b/docs/swagger/spec.yml
@@ -268,6 +268,16 @@ paths:
           description: Unexpected error
           schema:
             $ref: '#/definitions/Error'
+  /datasources/:
+    get:
+      summary: Lists paginated datasources that a user has access to
+      description: |
+        Datasources are sensors that share common metadata, like default color corrections. Scenes from
+        a given datasource can be mosaiced and color corrected together.
+      tags:
+        - Datasources
+      parameters:
+        - $ref: '#/parameters/name'
   /scenes/:
     get:
       summary: Lists paginated scenes that a user has access to
@@ -972,6 +982,11 @@ parameters:
         - createdAt,asc
         - modifiedAt,desc
         - modifiedAt,asc
+  name:
+    name: name
+    in: query
+    description: name of a datasource to filter to
+    type: string
   organization:
     name: organization
     in: query


### PR DESCRIPTION
## Overview

This commit adds a datasource endpoint that allows filtering by datasource name
and getting datasources by ID. It also includes the necessary classes and
methods to abstract pagination and action execution out of database table
definitions.

### Checklist

- ~[ ] Styleguide updated, if necessary~
- [x] Swagger specification updated, if necessary

### Notes

~I didn't update the style guide, but think maybe I should to indicate that database table methods should return actions or [`<method>QueryResult` objects](https://github.com/azavea/raster-foundry/blob/582476a418d5a30ce8e891f858e7cff4ac2b15bd/app-backend/database/src/main/scala/com/azavea/rf/database/QueryResults.scala).~

I'll update this in the PR to close #635

The `ActionRunner` trait is what I'm planning to use to address #635, so this would also be a good place to talk about whether this is a good abstraction. An example of the value we'll get out of returning actions instead of futures is in the `list[T]` method in [`ActionRunner`](https://github.com/azavea/raster-foundry/blob/ee032a2170354403f7c11cda7e804fb9429160da/app-backend/database/src/main/scala/com/azavea/rf/database/ActionRunner.scala) file -- we can just throw everything we need into a for comprehension and ask the database to run that

## Testing Instructions

 * Run scala tests

Connects #635 
Closes #978