### PR TITLE
Add thumbnail creation to geotiff processing

### DIFF
--- a/app-tasks/rf/src/rf/uploads/geotiff/__init__.py
+++ b/app-tasks/rf/src/rf/uploads/geotiff/__init__.py
@@ -1,3 +1,3 @@
-from .create_thumbnail import create_thumbnail
+from .create_thumbnails import create_thumbnails
 from .create_scenes import create_geotiff_scene, GeoTiffS3SceneFactory
 from .create_images import create_geotiff_image

--- a/app-tasks/rf/src/rf/uploads/geotiff/create_scenes.py
+++ b/app-tasks/rf/src/rf/uploads/geotiff/create_scenes.py
@@ -8,6 +8,7 @@ from rf.models import Scene
 from rf.utils.io import Visibility, JobStatus
 
 from .create_images import create_geotiff_image
+from .create_thumbnails import create_thumbnails
 from .io import get_geotiff_metadata, get_geotiff_name, s3_url
 
 logger = logging.getLogger(__name__)
@@ -72,8 +73,9 @@ class GeoTiffS3SceneFactory(object):
                 scene = self.create_geotiff_scene(local_tif.name, os.path.splitext(filename)[0])
                 image = self.create_geotiff_image(local_tif.name, s3_url(bucket.name, s3_tif.key),
                                                   scene, filename)
-                # TODO: May want to create thumbnails, footprints here while we have the image
-                # downloaded locally.
+
+
+                scene.thumbnails = create_thumbnails(local_tif.name, scene.id, self.organizationId)
                 scene.images = [image]
             finally:
                 os.remove(local_tif.name)

--- a/app-tasks/rf/src/rf/uploads/geotiff/create_thumbnail.py
+++ b/app-tasks/rf/src/rf/uploads/geotiff/create_thumbnail.py
@@ -1,7 +1,0 @@
-import logging
-
-logger = logging.getLogger(__name__)
-
-def create_thumbnail(tif_path):
-    logger.info('Creating Thumbnail for %s', tif_path)
-    return tif_path

--- a/app-tasks/rf/src/rf/uploads/geotiff/create_thumbnails.py
+++ b/app-tasks/rf/src/rf/uploads/geotiff/create_thumbnails.py
@@ -1,0 +1,142 @@
+"""Creates thumbnails for geotiff imagery
+
+Depends on having geotiff file already downloaded
+"""
+import os
+import subprocess
+
+import boto3
+
+from rf.models import Thumbnail
+
+from .io import get_geotiff_dimensions
+
+def create_thumbnails(tif_path, scene_id, organization_id):
+    """Creates thumbnails based on a geotiff path and scene
+
+    Args:
+        tif_path (str): path of local tiff file
+        scene_id (str): uuid of the scene
+
+    Returns:
+        List[Thumbnail]
+    """
+
+    r_tif_path = os.path.join(
+        os.path.dirname(tif_path),
+        'resampled_{}'.format(os.path.basename(tif_path))
+    )
+    rp_tif_path = os.path.join(
+        os.path.dirname(tif_path),
+        'reprojected_{}'.format(os.path.basename(tif_path))
+    )
+
+    dim = get_geotiff_dimensions(tif_path)
+    max_dim = float(max(get_geotiff_dimensions(tif_path)))
+
+    size_large = 1024
+    size_small = 256
+
+    scale_large = size_large / max_dim
+    scale_small = size_small / max_dim
+
+    dim_large = (dim[0] * scale_large, dim[1] * scale_large)
+    dim_small = (dim[0] * scale_small, dim[1] * scale_small)
+
+    # Create paths for each size thumb
+    path_large = '{}-LARGE.png'.format(scene_id)
+    path_small = '{}-SMALL.png'.format(scene_id)
+
+    # Create urls for each size Thumbnail
+    url_large = '/thumbnails/{}'.format(path_large)
+    url_small = '/thumbnails/{}'.format(path_small)
+
+    try_to_remove_files([r_tif_path, rp_tif_path, path_large, path_small])
+
+    if os.path.isfile(tif_path):
+        try:
+            # Resample tif
+            subprocess.check_call([
+                'gdalwarp', tif_path, r_tif_path,
+                '-ts', str(dim_large[0]), str(dim_large[1]),
+                '-q'
+            ])
+
+            # Reproject tif
+            subprocess.check_call([
+                'gdalwarp', r_tif_path, rp_tif_path,
+                '-t_srs', 'EPSG:3857',
+                '-q'
+            ])
+
+            # Create a temporary env object
+            mod_env = os.environ.copy()
+            # Add variable to avoid sidecar files
+            mod_env['GDAL_PAM_ENABLED'] = 'NO'
+
+            # Convert tif to pngs (large)
+            subprocess.check_call([
+                'gdal_translate', rp_tif_path, path_large,
+                '-b', '1',
+                '-b', '2',
+                '-b', '3',
+                '-outsize', str(dim_large[0]), str(dim_large[1]),
+                '-of', 'PNG',
+                '-q'
+            ], env=mod_env)
+
+            # Convert tif to pngs (small)
+            subprocess.check_call([
+                'gdal_translate', rp_tif_path, path_small,
+                '-b', '1',
+                '-b', '2',
+                '-b', '3',
+                '-outsize', str(dim_small[0]), str(dim_small[1]),
+                '-of', 'PNG',
+                '-q',
+            ], env=mod_env)
+        except:
+            # If any subprocess calls fail, we need to clean up before exiting
+            try_to_remove_files([r_tif_path, rp_tif_path, path_large, path_small])
+            raise
+
+        if os.path.isfile(path_large) and os.path.isfile(path_small):
+            s3_bucket_name = os.getenv('THUMBNAIL_BUCKET')
+            s3_bucket = boto3.resource('s3').Bucket(s3_bucket_name)
+            s3_bucket.upload_file(path_large, path_large, {'ContentType': 'image/png'})
+            s3_bucket.upload_file(path_small, path_small, {'ContentType': 'image/png'})
+
+        try_to_remove_files([r_tif_path, rp_tif_path, path_large, path_small])
+
+    else:
+        return
+
+    # Return List[Thumbnail]
+    return [
+        Thumbnail(
+            organization_id,
+            dim_small[0],
+            dim_small[1],
+            'SMALL',
+            url_small,
+            sceneId=scene_id
+        ),
+        Thumbnail(
+            organization_id,
+            dim_large[0],
+            dim_large[1],
+            'LARGE',
+            url_large,
+            sceneId=scene_id
+        )
+    ]
+
+def try_to_remove_files(files):
+    for f in files:
+        try_to_remove(f)
+
+def try_to_remove(path):
+    try:
+        os.remove(path)
+    except OSError:
+        pass

--- a/app-tasks/rf/src/rf/uploads/geotiff/io.py
+++ b/app-tasks/rf/src/rf/uploads/geotiff/io.py
@@ -55,3 +55,16 @@ def get_geotiff_size_bytes(tif_path):
 
 def s3_url(bucket, key):
     return 's3://{bucket}/{key}'.format(bucket=bucket, key=key)
+
+
+def get_geotiff_dimensions(tif_path):
+    """Reads image dimensions in pixels from GeoTIFF at tif_path
+
+    Args:
+        tif_path (str): Path to local GeoTIFF file
+
+    Returns:
+        Size of the GeoTIFF file in pixels (width, height)
+    """
+    with rasterio.open(tif_path) as src:
+        return (src.width, src.height)


### PR DESCRIPTION
## Overview

Adds thumbnail creation and upload to S3 when creating scene objects from geotiffs.

## Testing Instructions
 * Ensure that your `.env` has a `THUMBNAIL_BUCKET` defined. You can set it to a test bucket if it is not defined
 * Download a kayak geotiff and move it into a mounted or copied directory of the `airflow-worker` (`app-tasks/rf` worked well for me)
 * Inside the vagrant machine open bash `./scripts/console airflow-worker bash`
 * CD to wherever you put the test geotiff
 * Open ipython
 * `from rf.uploads.geotiff.create_thumbnails import create_thumbnails`
 * `create_thumbnails(<path_to_geotiff>, '1234', 'abcd')`
 * Check that thumbnails are uploaded to the S3 bucket

Connects #944
