### PR TITLE
Remove redundant boolean check in editor

### DIFF
--- a/app-frontend/src/app/pages/editor/project/projectEdit.controller.js
+++ b/app-frontend/src/app/pages/editor/project/projectEdit.controller.js
@@ -164,7 +164,7 @@ export default class ProjectEditController {
             keyboard: Boolean(this.project),
             resolve: {
                 project: () => this.project,
-                requireSelection: () => !Boolean(this.project)
+                requireSelection: () => !this.project
             }
         });
 


### PR DESCRIPTION
## Overview

Fixes a linting error that prevented the build from completing successfully

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~

## Testing Instructions

 * Verify that project switching works correctly in editor and webpack does not complain about boolean checking

