### PR TITLE
Add footprint generation from geotiffs

### DIFF
--- a/app-tasks/rf/src/rf/models/scene.py
+++ b/app-tasks/rf/src/rf/models/scene.py
@@ -48,7 +48,7 @@ class Scene(BaseModel):
         self.name = name
         self.thumbnailStatus = thumbnailStatus
         self.boundaryStatus = boundaryStatus
-        self.status = status
+        self.ingestStatus = ingestStatus
         self.metadataFiles = metadataFiles
 
         # Optional - can be None

--- a/app-tasks/rf/src/rf/models/scene.py
+++ b/app-tasks/rf/src/rf/models/scene.py
@@ -12,8 +12,9 @@ class Scene(BaseModel):
 
     def __init__(self, organizationId, ingestSizeBytes, visibility, tags,
                  datasource, sceneMetadata, name, thumbnailStatus, boundaryStatus,
-                 status, metadataFiles, sunAzimuth=None, sunElevation=None, cloudCover=None, acquisitionDate=None,
-                 id=None, thumbnails=None, tileFootprint=None, dataFootprint=None, images=None):
+                 ingestStatus, metadataFiles, sunAzimuth=None, sunElevation=None,
+                 cloudCover=None, acquisitionDate=None, id=None, thumbnails=None,
+                 tileFootprint=None, dataFootprint=None, images=None):
         """Create a new Scene
 
         Args:
@@ -26,7 +27,7 @@ class Scene(BaseModel):
             name (str): name of scene (displayed to users)
             thumbnailStatus (str): status of thumbnail creation
             boundaryStatus (str): status of creating boundaries
-            status (str): overall status of scene creation
+            ingestStatus (str): overall status of scene creation
             sunAzimuth (float): azimuth of sun when scene was created from satellite/uav
             sunElevation (float): elevation of sun when scene was created
             cloudCover (float): percent of scene covered by clouds
@@ -75,19 +76,22 @@ class Scene(BaseModel):
         )
 
     def to_dict(self):
+        filterFields = {}
+        statusFields = dict(thumbnailStatus=self.thumbnailStatus,
+                            boundaryStatus=self.boundaryStatus,
+                            ingestStatus=self.ingestStatus)
         scene_dict = dict(
             organizationId=self.organizationId, ingestSizeBytes=self.ingestSizeBytes, visibility=self.visibility,
-            tags=self.tags, datasource=self.datasource, sceneMetadata=self.sceneMetadata,
-            name=self.name, thumbnailStatus=self.thumbnailStatus, boundaryStatus=self.boundaryStatus,
-            status=self.status, metadataFiles=self.metadataFiles)
+            tags=self.tags, datasource=self.datasource, sceneMetadata=self.sceneMetadata, filterFields=filterFields,
+            name=self.name, statusFields=statusFields, metadataFiles=self.metadataFiles)
         if self.sunAzimuth:
-            scene_dict['sunAzimuth'] = self.sunAzimuth
+            filterFields['sunAzimuth'] = self.sunAzimuth
         if self.sunElevation:
-            scene_dict['sunElevation'] = self.sunElevation
+            filterFields['sunElevation'] = self.sunElevation
         if self.cloudCover is not None:
-            scene_dict['cloudCover'] = self.cloudCover
+            filterFields['cloudCover'] = self.cloudCover
         if self.acquisitionDate:
-            scene_dict['acquisitionDate'] = self.acquisitionDate
+            filterFields['acquisitionDate'] = self.acquisitionDate
         if self.id:
             scene_dict['id'] = self.id
 

--- a/app-tasks/rf/src/rf/uploads/geotiff/__init__.py
+++ b/app-tasks/rf/src/rf/uploads/geotiff/__init__.py
@@ -1,3 +1,4 @@
 from .create_thumbnails import create_thumbnails
 from .create_scenes import create_geotiff_scene, GeoTiffS3SceneFactory
 from .create_images import create_geotiff_image
+from .create_footprints import extract_footprints

--- a/app-tasks/rf/src/rf/uploads/geotiff/create_footprints.py
+++ b/app-tasks/rf/src/rf/uploads/geotiff/create_footprints.py
@@ -1,0 +1,130 @@
+"""Creates a data/tile footprint"""
+import logging
+import tempfile
+import numpy as np
+from pyproj import Proj, transform
+import rasterio
+from rasterio.features import shapes
+
+from rf.models import Footprint
+from rf.uploads.landsat8.io import get_tempdir
+
+logger = logging.getLogger(__name__)
+
+
+def create_tif_mask(temp_dir, local_tif_path):
+    """Uses rasterio to create masks for tile and data
+
+    Note: exploits the fact that 255 in the near infrared band indicates
+    nodata to create the data footprint mask
+
+    Args:
+        temp_dir (str): directory to create masked tif in
+        local_tif_path (str): local tif to use to create mask
+    """
+    _, tile_mask_tif_path = tempfile.mkstemp(suffix='.TIF', dir=temp_dir)
+    _, data_mask_tif_path = tempfile.mkstemp(suffix='.TIF', dir=temp_dir)
+    with rasterio.open(local_tif_path) as src:
+        kwargs = src.meta.copy()
+        kwargs.update({
+            'count': 1,
+            'nodata': 0,
+            'dtype': rasterio.ubyte,
+            'compress': 'lzw'
+        })
+
+        with rasterio.open(data_mask_tif_path, 'w', **kwargs) as dst:
+            for _, window in src.block_windows(1):
+                block = src.read(4, window=window)
+                block[block < 255] = 1
+                block[block == 255] = 0
+                dst.write(block.astype(rasterio.ubyte), window=window, indexes=1)
+
+        with rasterio.open(tile_mask_tif_path, 'w', **kwargs) as dst:
+            for _, window in src.block_windows(1):
+                block = src.read(4, window=window)
+                block[block <= 255] = 1
+                dst.write(block.astype(rasterio.ubyte), window=window, indexes=1)
+
+    return tile_mask_tif_path, data_mask_tif_path
+
+
+def coord_transform(coords, src_crs, target_crs):
+    """Helper function to transform a set of coordinates from src to target
+
+    Args:
+        coords (list):
+        src_crs (pyproj.Proj): projection of source coordinates
+        target_crs (pyproj.Proj): projection to transform to
+
+    Returns:
+        list
+    """
+    src_x, src_y = zip(*coords)
+    reprojected = transform(src_crs, target_crs, src_x, src_y)
+    return zip(*reprojected)
+
+
+def transform_polygon_coordinates(feature, src_crs, target_crs):
+    """Transforms coordinates of a geojson polygon from src to target
+
+    Args:
+        feature (dict): geojson polygon
+        src_crs (pyproj.Proj): projection of original coordinates
+        target_crs (pyproj.Proj): projection to transform coordinates to
+
+    Returns:
+        dict
+    """
+    copied_feature = feature.copy()
+    for index, coords in enumerate(copied_feature['coordinates']):
+        reproj_coords = coord_transform(coords, src_crs, target_crs)
+        feature['coordinates'][index] = reproj_coords
+    return feature
+
+
+def extract_polygon(mask_tif_path):
+    """Extracts polygon to a geojson dict
+
+    Args:
+        mask_tif_path (str): path to tif to extract geojson from
+
+    Returns:
+        str: path to geojson file
+    """
+
+    with rasterio.open(mask_tif_path, 'r') as src:
+        raster = src.read(1)
+        src_crs = Proj(init=src.crs.get('init'))
+        src_affine = src.affine
+
+    mask = np.ma.masked_equal(raster, 0)
+    geoms = shapes(raster, mask=mask, transform=src_affine, connectivity=8)
+
+    footprint, value = geoms.next()
+
+    assert value == 1.0, 'Geometry should be of value 1'
+
+    target_crs = Proj(init='epsg:4326')
+    feature = transform_polygon_coordinates(footprint, src_crs, target_crs)
+    return {'type': 'MultiPolygon', 'coordinates': [feature['coordinates']]}
+
+
+def extract_footprints(organization_id, tif_path):
+    """Performs all actions to extract polygon from a kayak scene
+
+    Args:
+        organization_id (str): organization footprints belong to
+        tif_path (str): path to tif to extract polygons from
+
+    Returns:
+        tuple
+    """
+    logger.info('Beginning process to extract footprint for image:%s', tif_path)
+
+    with get_tempdir() as temp_dir:
+        tile_mask_tif_path, data_mask_tif_path = create_tif_mask(temp_dir, tif_path)
+        data_footprint = extract_polygon(data_mask_tif_path)
+        tile_footprint = extract_polygon(tile_mask_tif_path)
+        return (Footprint(organization_id, tile_footprint),
+                Footprint(organization_id, data_footprint))

--- a/app-tasks/rf/src/rf/uploads/geotiff/extract_footprint.py
+++ b/app-tasks/rf/src/rf/uploads/geotiff/extract_footprint.py
@@ -1,7 +1,0 @@
-import logging
-
-logger = logging.getLogger(__name__)
-
-def extract_footprint(tif_path):
-    logger.info('Extracting footprint for %s', tif_path)
-    return tif_path

--- a/app-tasks/rf/src/rf/uploads/landsat8/create_scenes.py
+++ b/app-tasks/rf/src/rf/uploads/landsat8/create_scenes.py
@@ -5,7 +5,12 @@ import logging
 import uuid
 
 from rf.models import Scene
-from rf.utils.io import JobStatus, Visibility, s3_obj_exists
+from rf.utils.io import (
+    IngestStatus,
+    JobStatus,
+    Visibility,
+    s3_obj_exists
+)
 
 from .create_bands import create_bands
 from .create_images import create_images
@@ -79,7 +84,7 @@ def create_landsat8_scenes(csv_row):
         'L8 {}'.format(landsat_path),  # name
         JobStatus.SUCCESS,
         JobStatus.SUCCESS,
-        JobStatus.QUEUED,
+        IngestStatus.NOTINGESTED,
         id=scene_id,
         acquisitionDate=timestamp,
         cloudCover=cloud_cover,

--- a/app-tasks/rf/src/rf/uploads/sentinel2/create_scenes.py
+++ b/app-tasks/rf/src/rf/uploads/sentinel2/create_scenes.py
@@ -6,7 +6,13 @@ import os
 import uuid
 
 from rf.models import Scene
-from rf.utils.io import JobStatus, Visibility
+from rf.utils.io import (
+    IngestStatus,
+    JobStatus,
+    Visibility,
+    s3_obj_exists
+)
+
 
 from .settings import bucket, s3, organization, datasource_id
 from .create_footprint import create_footprints
@@ -77,7 +83,7 @@ def create_sentinel2_scenes(tile_path):
         'S2 {}'.format(tile_path),  # name
         JobStatus.SUCCESS if thumbnails else JobStatus.FAILURE,
         JobStatus.SUCCESS if dataFootprint else JobStatus.FAILURE,
-        JobStatus.QUEUED,
+        IngestStatus.NOTINGESTED,
         id=scene_id,
         acquisitionDate=tileinfo['timestamp'],
         cloudCover=tileinfo['cloudyPixelPercentage'],

--- a/app-tasks/rf/src/rf/utils/io.py
+++ b/app-tasks/rf/src/rf/utils/io.py
@@ -54,6 +54,12 @@ class JobStatus(object):
     UPLOADING = 'UPLOADING'
     PARTIALFAILURE = 'PARTIALFAILURE'
 
+class IngestStatus(object):
+    NOTINGESTED = 'NOTINGESTED'
+    TOBEINGESTED = 'TOBEINGESTED'
+    INGESTING = 'INGESTING'
+    INGESTED = 'INGESTED'
+    FAILED = 'FAILED'
 
 class Visibility(object):
     PUBLIC = 'PUBLIC'


### PR DESCRIPTION
## Overview

This commit adds support for extracting footprints for both the data and tile of a geotiff.

With this particular initial dataset it is assumed that `nodata` is represented by values of `255` in the near-infrared band. This will likely not hold for future geotiffs, but seems like the best option for this initial set of data received.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~

### Demo

![footprints](https://cloud.githubusercontent.com/assets/898060/22610341/ff116214-ea32-11e6-96fa-01c2d0da6d2b.png)


## Testing Instructions

* Download a kayak geotiff and move it into a mounted or copied directory of the `airflow-worker` (e.g. `app-tasks/rf`)
 * Inside the vagrant machine open bash `./scripts/console airflow-worker bash`
 * CD to wherever you put the test geotiff
 * Open ipython and run the following code (you must set path):
```python
from rf.uploads.geotiff.create_scenes import load_example
import json
scene = create_geotiff_scene(path, 'dummy-org', 'dummy-datasource')
with open('test.json', 'wb') as fh:
    fh.write(json.dumps(scene.to_dict())
```
 * inspect `test.json` for completeness (should have two footprints, you can also copy/paste the geojson into a feature collection)