### PR TITLE
Update datasource filter and references

### DIFF
--- a/app-frontend/src/app/components/filterPane/filterPane.html
+++ b/app-frontend/src/app/components/filterPane/filterPane.html
@@ -116,14 +116,18 @@
          ng-mouseup="$ctrl.toggleDrag.toggle = false">
       <label>Imagery sources</label>
       <div class="filter-item tag-filter">
-        <button type="button"
-                class="btn btn-toggle btn-small"
-                autocomplete="off"
-                ng-mousedown="$ctrl.onSourceFilterMousedown(filter, filterAttrs)"
-                ng-mouseover="$ctrl.onSourceFilterMouseover(filter)"
-                ng-class="{'active': filterAttrs.enabled}"
-                ng-repeat="(filter, filterAttrs) in $ctrl.sourceFilters track by filter">
-          {{filterAttrs.label}}
+        <button class="btn btn-toggle btn-small"
+                ng-click="$ctrl.toggleSourceFilter(id)"
+                ng-class="{'active': filter.enabled}"
+                ng-repeat="(id, filter) in $ctrl.staticSourceFilters track by id"
+                disabled>
+          {{filter.datasource.name}}
+        </button>
+        <button class="btn btn-toggle btn-small"
+                ng-click="$ctrl.toggleSourceFilter(id)"
+                ng-class="{'active': filter.enabled}"
+                ng-repeat="(id, filter) in $ctrl.dynamicSourceFilters track by id">
+          {{filter.datasource.name}}
         </button>
       </div>
     </div>

--- a/app-frontend/src/app/components/sceneDetail/sceneDetail.component.js
+++ b/app-frontend/src/app/components/sceneDetail/sceneDetail.component.js
@@ -4,7 +4,10 @@ const rfSceneDetail = {
     templateUrl: sceneDetailTpl,
     bindings: {
         scene: '<',
-        showThumbnail: '<'
+        showThumbnail: '<',
+        isSelected: '<',
+        onCloseClick: '&',
+        onSelectClick: '&'
     },
     replace: true,
     controller: 'SceneDetailComponentController'

--- a/app-frontend/src/app/components/sceneDetail/sceneDetail.controller.js
+++ b/app-frontend/src/app/components/sceneDetail/sceneDetail.controller.js
@@ -1,6 +1,15 @@
 export default class SceneDetailComponentController {
-    constructor(thumbnailService) {
+    constructor(thumbnailService, datasourceService) {
         'ngInject';
         this.thumbnailService = thumbnailService;
+        this.datasourceService = datasourceService;
+    }
+
+    $onInit() {
+        this.datasourceLoaded = false;
+        this.datasourceService.get(this.scene.datasource).then(d => {
+            this.datasourceLoaded = true;
+            this.datasource = d;
+        });
     }
 }

--- a/app-frontend/src/app/components/sceneDetail/sceneDetail.html
+++ b/app-frontend/src/app/components/sceneDetail/sceneDetail.html
@@ -1,30 +1,57 @@
-<div class="content">
-  <img ng-if="$ctrl.scene.thumbnails.length && $ctrl.showThumbnail"
-       ng-attr-src="{{$ctrl.thumbnailService.getBestFit($ctrl.scene.thumbnails, 275).url}}"
-       class="center-img rounded-img detail-img">
-  <img ng-if="!$ctrl.scene.thumbnails.length && $ctrl.showThumbnail"
-       src="https://placehold.it/275x275"
-       class="center-img rounded-img detail-img">
-  <h5 class="color-dark">Scene properties</h5>
-  <dl class="meta-list">
-    <dt ng-if-start="$ctrl.scene.cloudCover">Cloud Cover</dt>
-    <dd ng-if-end>{{$ctrl.scene.cloudCover | number}} %</dd>
-    <dt ng-if-start="$ctrl.scene.acquisitionDate">Aquisition Date</dt>
-    <dd ng-if-end>{{$ctrl.scene.acquisitionDate | date}}</dd>
-    <dt ng-if-start="$ctrl.scene.createdAt">Created Date</dt>
-    <dd ng-if-end>{{$ctrl.scene.createdAt | date}}</dd>
-    <dt ng-if-start="$ctrl.scene.modifiedAt">Modified Date</dt>
-    <dd ng-if-end>{{$ctrl.scene.modifiedAt | date}}</dd>
-    <dt ng-if-start="$ctrl.scene.datasource">Datasource</dt>
-    <dd ng-if-end>{{$ctrl.scene.datasource}}</dd>
-    <dt>Visiblity</dt>
-    <dd>{{$ctrl.scene.visibility}}</dd>
-  </dl>
-  <h5 class="color-dark">Scene metadata</h5>
-  <dl class="meta-list">
-    <dt ng-repeat-start="(metaKey, metaVal) in $ctrl.scene.sceneMetadata">
-      {{metaKey}}
-    </dt>
-    <dd ng-repeat-end>{{metaVal}}</dd>
-  </dl>
+<div class="sidebar-static">
+  <p>
+    <strong class="color-dark">{{$ctrl.scene.name}}</strong><br>
+    {{$ctrl.datasourceLoaded ? $ctrl.datasource.name : 'Loading datasource'}}
+  </p>
+  <div class="sidebar-actions">
+    <button class="btn btn-square" ng-click="$ctrl.onCloseClick()">
+      <i class="icon-cross"></i>
+    </button>
+  </div>
+</div>
+<div class="sidebar-scrollable">
+  <div class="content">
+    <img ng-if="$ctrl.scene.thumbnails.length && $ctrl.showThumbnail"
+        ng-attr-src="{{$ctrl.thumbnailService.getBestFit($ctrl.scene.thumbnails, 275).url}}"
+        class="center-img rounded-img detail-img">
+    <img ng-if="!$ctrl.scene.thumbnails.length && $ctrl.showThumbnail"
+        src="https://placehold.it/275x275"
+        class="center-img rounded-img detail-img">
+    <h5 class="color-dark">Scene properties</h5>
+    <dl class="meta-list">
+      <dt ng-if-start="$ctrl.scene.cloudCover">Cloud Cover</dt>
+      <dd ng-if-end>{{$ctrl.scene.cloudCover | number}} %</dd>
+      <dt ng-if-start="$ctrl.scene.acquisitionDate">Aquisition Date</dt>
+      <dd ng-if-end>{{$ctrl.scene.acquisitionDate | date}}</dd>
+      <dt ng-if-start="$ctrl.scene.createdAt">Created Date</dt>
+      <dd ng-if-end>{{$ctrl.scene.createdAt | date}}</dd>
+      <dt ng-if-start="$ctrl.scene.modifiedAt">Modified Date</dt>
+      <dd ng-if-end>{{$ctrl.scene.modifiedAt | date}}</dd>
+      <dt ng-if-start="$ctrl.scene.datasource">Datasource</dt>
+      <dd ng-if-end>{{$ctrl.datasourceLoaded ? $ctrl.datasource.name : 'Loading datasource'}}</dd>
+      <dt>Visiblity</dt>
+      <dd>{{$ctrl.scene.visibility}}</dd>
+    </dl>
+    <h5 class="color-dark">Scene metadata</h5>
+    <dl class="meta-list">
+      <dt ng-repeat-start="(metaKey, metaVal) in $ctrl.scene.sceneMetadata">
+        {{metaKey}}
+      </dt>
+      <dd ng-repeat-end>{{metaVal}}</dd>
+    </dl>
+  </div>
+</div>
+<div class="sidebar-static">
+  <div class="sidebar-actions">
+    <button class="btn btn-square"
+            ng-class="$ctrl.isSelected ? 'btn-secondary' : ''"
+            ng-click="$ctrl.onSelectClick()">
+      <span ng-if="!$ctrl.isSelected">
+        Select Scene
+      </span>
+      <span ng-if="$ctrl.isSelected">
+        Deselect
+      </span>
+    </button>
+  </div>
 </div>

--- a/app-frontend/src/app/components/sceneItem/sceneItem.controller.js
+++ b/app-frontend/src/app/components/sceneItem/sceneItem.controller.js
@@ -1,10 +1,23 @@
 export default class SceneItemController {
-    constructor($scope, $attrs, thumbnailService, mapService) {
+    constructor($scope, $attrs, thumbnailService, mapService, datasourceService) {
         'ngInject';
         this.thumbnailService = thumbnailService;
+        this.mapService = mapService;
         this.isSelectable = $attrs.hasOwnProperty('selectable');
         this.isDraggable = $attrs.hasOwnProperty('draggable');
-        $scope.$watch(
+        this.datasourceService = datasourceService;
+        this.$scope = $scope;
+    }
+
+    $onInit() {
+        this.datasourceLoaded = false;
+
+        this.datasourceService.get(this.scene.datasource).then(d => {
+            this.datasourceLoaded = true;
+            this.datasource = d;
+        });
+
+        this.$scope.$watch(
             () => this.selected({scene: this.scene}),
             (selected) => {
                 this.selectedStatus = selected;
@@ -12,12 +25,12 @@ export default class SceneItemController {
         );
 
         if (this.isDraggable) {
-            Object.assign($scope.$parent.$treeScope.$callbacks, {
+            Object.assign(this.$scope.$parent.$treeScope.$callbacks, {
                 dragStart: function () {
-                    mapService.disableFootprints = true;
+                    this.mapService.disableFootprints = true;
                 },
                 dragStop: function () {
-                    mapService.disableFootprints = false;
+                    this.mapService.disableFootprints = false;
                 }
             });
         }

--- a/app-frontend/src/app/components/sceneItem/sceneItem.html
+++ b/app-frontend/src/app/components/sceneItem/sceneItem.html
@@ -13,7 +13,7 @@
       <strong class="color-dark">{{$ctrl.scene.name}}</strong>
     </span>
     <br>
-    <span title="{{$ctrl.scene.datasource}}">{{$ctrl.scene.datasource}}</span>
+    <span title="{{$ctrl.datasource.name}}">{{$ctrl.datasourceLoaded ? $ctrl.datasource.name : 'Loading datasource'}}</span>
   </div>
   <div class="list-group-right">
     <button class="btn btn-square"

--- a/app-frontend/src/app/core/core.module.js
+++ b/app-frontend/src/app/core/core.module.js
@@ -1,21 +1,22 @@
 const shared = angular.module('core.shared', []);
 
-require('./services/scene.service')(shared);
+require('./services/auth.service')(shared);
 require('./services/colorCorrect.service')(shared);
+require('./services/config.provider')(shared);
+require('./services/datasource.service')(shared);
 require('./services/gridLayer.service')(shared);
 require('./services/imageOverlay.service')(shared);
-require('./services/project.service')(shared);
-require('./services/user.service')(shared);
-require('./services/config.provider')(shared);
-require('./services/auth.service')(shared);
-require('./services/token.service')(shared);
 require('./services/layer.service')(shared);
 require('./services/map.service')(shared);
 require('./services/mousetip.service')(shared);
+require('./services/project.service')(shared);
+require('./services/scene.service')(shared);
 require('./services/thumbnail.service')(shared);
+require('./services/token.service')(shared);
 require('./services/tool.service')(shared);
-require('./services/toolTag.service')(shared);
 require('./services/toolCategory.service')(shared);
+require('./services/toolTag.service')(shared);
+require('./services/user.service')(shared);
 
 require('./services/featureFlagOverrides.service')(shared);
 require('./services/featureFlags.provider')(shared);

--- a/app-frontend/src/app/core/services/datasource.service.js
+++ b/app-frontend/src/app/core/services/datasource.service.js
@@ -1,0 +1,32 @@
+export default (app) => {
+    class DatasourceService {
+        constructor($resource) {
+            'ngInject';
+
+            this.Datasource = $resource(
+                '/api/datasources/:id/', {
+                    id: '@properties.id'
+                }, {
+                    query: {
+                        method: 'GET',
+                        cache: false
+                    },
+                    get: {
+                        method: 'GET',
+                        cache: true
+                    }
+                }
+            );
+        }
+
+        query(params = {}) {
+            return this.Datasource.query(params).$promise;
+        }
+
+        get(id) {
+            return this.Datasource.get({id}).$promise;
+        }
+    }
+
+    app.service('datasourceService', DatasourceService);
+};

--- a/app-frontend/src/app/pages/browse/browse.html
+++ b/app-frontend/src/app/pages/browse/browse.html
@@ -25,16 +25,16 @@
           infinite-scroll-immediate-check=false
           class="list-group">
         <rf-scene-item
-            ng-click="$ctrl.openDetailPane(scene)"
-            scene="scene"
-            selectable
-            selected="$ctrl.isSelected(scene)"
-            on-select="$ctrl.setSelected(scene, selected)"
-            class="selectable"
-            ng-repeat="scene in $ctrl.sceneList track by scene.id"
-            ng-mouseover="$ctrl.setHoveredScene(scene)"
-            ng-mouseleave="$ctrl.removeHoveredScene()"
-            >
+          ng-click="$ctrl.openDetailPane(scene)"
+          scene="scene"
+          selectable
+          selected="$ctrl.isSelected(scene)"
+          on-select="$ctrl.setSelected(scene, selected)"
+          class="selectable"
+          ng-repeat="scene in $ctrl.sceneList track by scene.id"
+          ng-mouseover="$ctrl.setHoveredScene(scene)"
+          ng-mouseleave="$ctrl.removeHoveredScene()"
+        >
         </rf-scene-item>
       </div>
       <div class="list-group" ng-show="$ctrl.loadingScenes">
@@ -83,37 +83,13 @@
   <!-- Scene detail view -->
   <div class="scene-detail-map" ng-if="$ctrl.activeScene">
     <div class="container column-stretch container-not-scrollable">
-      <div class="sidebar">
-        <div class="sidebar-static">
-          <p>
-            <strong class="color-dark">{{$ctrl.activeScene.name}}</strong><br>
-            {{$ctrl.activeScene.datasource}}
-          </p>
-          <div class="sidebar-actions">
-            <button class="btn btn-square" ng-click="$ctrl.closeDetailPane()">
-              <i class="icon-cross"></i>
-            </button>
-          </div>
-        </div>
-        <rf-scene-detail class="sidebar-scrollable"
-                         scene="$ctrl.activeScene"
-                         show-thumbnail="true"
-        ></rf-scene-detail>
-        <div class="sidebar-static">
-          <div class="sidebar-actions">
-            <button class="btn btn-square"
-                    ng-class="$ctrl.isSelected($ctrl.activeScene) ? 'btn-secondary' : ''"
-                    ng-click="$ctrl.toggleSelectAndClosePane()">
-              <span ng-if="!$ctrl.isSelected($ctrl.activeScene)">
-                Select Scene
-              </span>
-              <span ng-if="$ctrl.isSelected($ctrl.activeScene)">
-                Deselect
-              </span>
-            </button>
-          </div>
-        </div>
-      </div>
+      <rf-scene-detail class="sidebar"
+                       scene="$ctrl.activeScene"
+                       show-thumbnail="true"
+                       on-close-click="$ctrl.closeDetailPane()"
+                       on-select-click="$ctrl.toggleSelectAndClosePane()"
+                       is-selected="$ctrl.isSelected($ctrl.activeScene)"
+      ></rf-scene-detail>
       <div class="main">
         <rf-map-container map-id="detail"
                           initial-center="$ctrl.center"


### PR DESCRIPTION
## Overview

This PR adjusts the front-end to better match the addition of a separate datasource model.

More specifically, this PR:
- adds a datasource service
- changes the datasource filter on the browse page to be dynamically built from existing datasource models
- queries for the relevant datasource when necessary in various areas (attributions, detail pages, etc)

The datasource filter currently is composed of two sets of filters: static and dynamic.

The static filters are intended to allow the users to filter down to datasources that match a set of criteria (i.e. owned by the user & private).

The dynamic filters are populated straight from the database.

### Notes

The datasource endpoint does not currently filter on attributes such as visibility or ownership. As a result, the static filters do not work yet.

The datasource endpoint is paged to prepare for a growing number of datasources. This code extracts the content of the first page only, which works fine for now, but will break down in the future. We'll need to have some ideas for how we would handle filtering when we have a large number of datasources.

In addition, when datasources begin to proliferate, we may want to consider returning datasource information with a scene, so that we don't have to query the DB for each one. On a related note, I set the datasource resource to cache the results with the understanding the datasources do not change often, to avoid hammering the db when browsing scenes.

## Testing Instructions

 * On the browse page, check the filtering for specific datasources works
 * In various locations, wherever a scene's datasource is displayed, check that the name of the datasource is shown, rather than the UUID

Connects #979
