### PR TITLE
Increase RouteTestTimeout to 5s for all specs

### DIFF
--- a/app-backend/app/src/test/scala/auth/AuthSpec.scala
+++ b/app-backend/app/src/test/scala/auth/AuthSpec.scala
@@ -21,7 +21,7 @@ class AuthSpec extends WordSpec
     with DBSpec {
   implicit val ec = system.dispatcher
   implicit def database = db
-  implicit def default(implicit system: ActorSystem) = RouteTestTimeout(DurationInt(3).second)
+  implicit def default(implicit system: ActorSystem) = RouteTestTimeout(DurationInt(5).second)
   val newUserId = "NewUser"
 
   val token = AuthUtils.generateToken(newUserId)

--- a/app-backend/app/src/test/scala/datasource/DatasourceSpec.scala
+++ b/app-backend/app/src/test/scala/datasource/DatasourceSpec.scala
@@ -27,7 +27,7 @@ class DatasourceSpec extends WordSpec
   implicit val ec = system.dispatcher
 
   implicit def database = db
-  implicit def default(implicit system: ActorSystem) = RouteTestTimeout(DurationInt(3).second)
+  implicit def default(implicit system: ActorSystem) = RouteTestTimeout(DurationInt(5).second)
 
   val authHeader = AuthUtils.generateAuthHeader("Default")
   val baseDatasourcePath = "/api/datasources/"

--- a/app-backend/app/src/test/scala/healthcheck/HealthCheckSpec.scala
+++ b/app-backend/app/src/test/scala/healthcheck/HealthCheckSpec.scala
@@ -18,7 +18,7 @@ class HealthCheckSpec extends WordSpec
 
   implicit val ec = system.dispatcher
   implicit def database = db
-  implicit def default(implicit system: ActorSystem) = RouteTestTimeout(DurationInt(3).second)
+  implicit def default(implicit system: ActorSystem) = RouteTestTimeout(DurationInt(5).second)
 
   // Alias to baseRoutes to be explicit
   val baseRoutes = routes

--- a/app-backend/app/src/test/scala/image/ImageSpec.scala
+++ b/app-backend/app/src/test/scala/image/ImageSpec.scala
@@ -28,7 +28,7 @@ class ImageSpec extends WordSpec
   implicit val ec = system.dispatcher
 
   implicit def database = db
-  implicit def default(implicit system: ActorSystem) = RouteTestTimeout(DurationInt(3).second)
+  implicit def default(implicit system: ActorSystem) = RouteTestTimeout(DurationInt(5).second)
 
   val authHeader = AuthUtils.generateAuthHeader("Default")
   val baseImagePath = "/api/images/"

--- a/app-backend/app/src/test/scala/organization/OrganizationSpec.scala
+++ b/app-backend/app/src/test/scala/organization/OrganizationSpec.scala
@@ -23,7 +23,7 @@ class OrganizationSpec extends WordSpec
     with DBSpec {
   implicit val ec = system.dispatcher
   implicit def database = db
-  implicit def default(implicit system: ActorSystem) = RouteTestTimeout(DurationInt(3).second)
+  implicit def default(implicit system: ActorSystem) = RouteTestTimeout(DurationInt(5).second)
 
   // Alias to baseRoutes to be explicit
   val baseRoutes = routes

--- a/app-backend/app/src/test/scala/project/ProjectSceneSpec.scala
+++ b/app-backend/app/src/test/scala/project/ProjectSceneSpec.scala
@@ -26,7 +26,7 @@ class ProjectSceneSpec extends WordSpec
   implicit val ec = system.dispatcher
 
   implicit def database = db
-  implicit def default(implicit system: ActorSystem) = RouteTestTimeout(DurationInt(3).second)
+  implicit def default(implicit system: ActorSystem) = RouteTestTimeout(DurationInt(5).second)
 
   // Alias to baseRoutes to be explicit
   val baseRoutes = routes

--- a/app-backend/app/src/test/scala/project/ProjectSpec.scala
+++ b/app-backend/app/src/test/scala/project/ProjectSpec.scala
@@ -24,7 +24,7 @@ class ProjectSpec extends WordSpec
   implicit val ec = system.dispatcher
 
   implicit def database = db
-  implicit def default(implicit system: ActorSystem) = RouteTestTimeout(DurationInt(3).second)
+  implicit def default(implicit system: ActorSystem) = RouteTestTimeout(DurationInt(5).second)
 
   // Alias to baseRoutes to be explicit
   val baseRoutes = routes

--- a/app-backend/app/src/test/scala/scene/SceneSpec.scala
+++ b/app-backend/app/src/test/scala/scene/SceneSpec.scala
@@ -30,7 +30,7 @@ class SceneSpec extends WordSpec
   implicit val ec = system.dispatcher
 
   implicit def database = db
-  implicit def default(implicit system: ActorSystem) = RouteTestTimeout(DurationInt(3).second)
+  implicit def default(implicit system: ActorSystem) = RouteTestTimeout(DurationInt(5).second)
 
   val authHeader = AuthUtils.generateAuthHeader("Default")
   val baseScene = "/api/scenes/"

--- a/app-backend/app/src/test/scala/tags/ToolTagSpec.scala
+++ b/app-backend/app/src/test/scala/tags/ToolTagSpec.scala
@@ -24,7 +24,7 @@ class ToolTagSpec extends WordSpec
 
   implicit val ec = system.dispatcher
   implicit def database = db
-  implicit def default(implicit system: ActorSystem) = RouteTestTimeout(DurationInt(3).second)
+  implicit def default(implicit system: ActorSystem) = RouteTestTimeout(DurationInt(5).second)
 
   val authHeader = AuthUtils.generateAuthHeader("Default")
   val publicOrgId = UUID.fromString("dfac6307-b5ef-43f7-beda-b9f208bb7726")

--- a/app-backend/app/src/test/scala/thumbnail/ThumbnailSpec.scala
+++ b/app-backend/app/src/test/scala/thumbnail/ThumbnailSpec.scala
@@ -32,7 +32,7 @@ class ThumbnailSpec extends WordSpec
 
   implicit val ec = system.dispatcher
   implicit def database = db
-  implicit def default(implicit system: ActorSystem) = RouteTestTimeout(DurationInt(3).second)
+  implicit def default(implicit system: ActorSystem) = RouteTestTimeout(DurationInt(5).second)
 
   val uuid = new UUID(123456789, 123456789)
   val baseThumbnailRow = Thumbnail(

--- a/app-backend/app/src/test/scala/tools/ToolSpec.scala
+++ b/app-backend/app/src/test/scala/tools/ToolSpec.scala
@@ -22,7 +22,7 @@ class ToolSpec extends WordSpec
 
   implicit val ec = system.dispatcher
   implicit def database = db
-  implicit def default(implicit system: ActorSystem) = RouteTestTimeout(DurationInt(3).second)
+  implicit def default(implicit system: ActorSystem) = RouteTestTimeout(DurationInt(5).second)
 
   val authorization = AuthUtils.generateAuthHeader("Default")
   val publicOrgId = UUID.fromString("dfac6307-b5ef-43f7-beda-b9f208bb7726")

--- a/app-backend/app/src/test/scala/user/UserSpec.scala
+++ b/app-backend/app/src/test/scala/user/UserSpec.scala
@@ -18,7 +18,7 @@ class UserSpec extends WordSpec
     with DBSpec {
   implicit val ec = system.dispatcher
   implicit def database = db
-  implicit def default(implicit system: ActorSystem) = RouteTestTimeout(DurationInt(3).second)
+  implicit def default(implicit system: ActorSystem) = RouteTestTimeout(DurationInt(5).second)
 
   val authHeader = AuthUtils.generateAuthHeader("Default")
 


### PR DESCRIPTION
## Overview

Taking the timeouts from 3s to 5s.

## Testing Instructions

Watch the build output for this pull request. Ensure that none of the tests fail with:

> Request was neither completed nor rejected within N seconds

See: http://jenkins.staging.rasterfoundry.com/blue/organizations/jenkins/raster-foundry%2Fraster-foundry/detail/PR-1056/1/pipeline