### PR TITLE
Move home directory of Airflow user

### DIFF
--- a/app-tasks/Dockerfile
+++ b/app-tasks/Dockerfile
@@ -8,7 +8,7 @@ COPY rf/ /tmp/rf
 RUN set -ex \
     addgroup --system airflow \
     && adduser --disabled-password --system --group \
-               --uid 1000 --home ${AIRFLOW_HOME} \
+               --uid 1000 --home /var/lib/airflow \
                --shell /usr/sbin/nologin \
                airflow \
     && buildDeps=' \

--- a/docker-compose.airflow.yml
+++ b/docker-compose.airflow.yml
@@ -10,7 +10,7 @@ services:
       - ./app-tasks/dags/:/opt/raster-foundry/app-tasks/dags/
       - ./app-tasks/rf/:/opt/raster-foundry/app-tasks/rf/
       - ./app-tasks/rf/src/rf/:/usr/local/bin/rf/
-      - $HOME/.aws:/usr/local/airflow/.aws:ro
+      - $HOME/.aws:/var/lib/airflow/.aws:ro
     build:
       context: ./app-tasks
       dockerfile: Dockerfile
@@ -66,7 +66,7 @@ services:
       - ./app-tasks/dags/:/opt/raster-foundry/app-tasks/dags/
       - ./app-tasks/rf/:/opt/raster-foundry/app-tasks/rf/
       - ./app-tasks/rf/src/rf/:/usr/local/bin/rf/
-      - $HOME/.aws:/usr/local/airflow/.aws:ro
+      - $HOME/.aws:/var/lib/airflow/.aws:ro
     build:
       context: ./app-tasks
       dockerfile: Dockerfile
@@ -97,7 +97,7 @@ services:
       - ./app-tasks/dags/:/opt/raster-foundry/app-tasks/dags/
       - ./app-tasks/rf/:/opt/raster-foundry/app-tasks/rf/
       - ./app-tasks/rf/src/rf/:/usr/local/bin/rf/
-      - $HOME/.aws:/usr/local/airflow/.aws:ro
+      - $HOME/.aws:/var/lib/airflow/.aws:ro
     build:
       context: ./app-tasks
       dockerfile: Dockerfile
@@ -127,7 +127,7 @@ services:
       - ./app-tasks/dags/:/opt/raster-foundry/app-tasks/dags/
       - ./app-tasks/rf/:/opt/raster-foundry/app-tasks/rf/
       - ./app-tasks/rf/src/rf/:/usr/local/bin/rf/
-      - $HOME/.aws:/usr/local/airflow/.aws:ro
+      - $HOME/.aws:/var/lib/airflow/.aws:ro
     build:
       context: ./app-tasks
       dockerfile: Dockerfile


### PR DESCRIPTION
## Overview

In order to prevent various home directory files from leaking into the local file system, move the `airflow` user's home directory to `/var/lib/airflow`, but keep Airflow's location of `AIRFLOW_HOME` the way it was.

Fixes https://github.com/azavea/raster-foundry/issues/1021

## Testing Instructions

Use the `server` script to launch the default set services, along with the Airflow services, and ensure that none of them blow up with errors indicating that they cannot locate an AWS profile:

```bash
vagrant@vagrant-ubuntu-trusty-64:/opt/raster-foundry$ ./scripts/server --with-airflow
```

Next, use `console` to get into an Airflow worker, launch `ipython`, and ensure that the associated dotfiles are not on the local file system:

```bash
vagrant@vagrant-ubuntu-trusty-64:/opt/raster-foundry$ ./scripts/console airflow-worker bash
airflow@499e59ac9eda:/usr/local/airflow$ ipython
Python 2.7.12 (default, Dec 16 2016, 03:08:23)
Type "copyright", "credits" or "license" for more information.

IPython 5.1.0 -- An enhanced Interactive Python.
?         -> Introduction and overview of IPython's features.
%quickref -> Quick reference.
help      -> Python's own help system.
object?   -> Details about 'object', use 'object??' for extra details.

In [1]: import sys

In [2]: exit
airflow@499e59ac9eda:/usr/local/airflow$ ls -l /var/lib/airflow/.ipython/
total 12
drwxr-xr-x 2 airflow airflow 4096 Feb  6 22:15 extensions
drwxr-xr-x 2 airflow airflow 4096 Feb  6 22:15 nbextensions
drwxr-xr-x 7 airflow airflow 4096 Feb  6 22:15 profile_default
```