### PR TITLE
Move app-frontend service to test Docker Compose config

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ The workflow for creating a new migration is:
 
 #### Frontend Development
 
-To do frontend development you will want to install [`nvm`](https://github.com/creationix/nvm#install-script) and use at least version 6.8.1. Once using `nvm`, install [yarn](https://yarnpkg.com/) with `npm install -g yarn`. After following the directions above for starting the VM, start the API server and other backend services by running `./scripts/server`.
+To do frontend development you will want to install [`nvm`](https://github.com/creationix/nvm#install-script) and use at least version 6.9+ (`lts/boron`). Once using `nvm`, install [yarn](https://yarnpkg.com/) with `npm install -g yarn`. After following the directions above for starting the VM, start the API server and other backend services by running `./scripts/server`.
 
 Then _outside_ the VM, while the server is still running, run `yarn run start` while inside the `app-frontend/` directory. This will start a `webpack-dev-server` on port 9091 that will auto-reload after javascript and styling changes.
 

--- a/docker-compose.airflow.yml
+++ b/docker-compose.airflow.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '2.1'
 services:
   redis:
     image: redis:3-alpine

--- a/docker-compose.spark.yml
+++ b/docker-compose.spark.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '2.1'
 services:
   spark-master:
     image: raster-foundry-spark

--- a/docker-compose.swagger.yml
+++ b/docker-compose.swagger.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '2.1'
 services:
   swagger-editor:
     image: swaggerapi/swagger-editor:latest

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,31 +1,48 @@
-version: '2'
+version: '2.1'
 services:
   nginx:
-    image: raster-foundry-nginx:${GIT_COMMIT}
+    image: raster-foundry-nginx:${GIT_COMMIT:-latest}
     build:
       context: ./nginx
       dockerfile: Dockerfile
 
+  app-frontend:
+    image: kkarczmarczyk/node-yarn:6.9-wheezy
+    working_dir: /opt/raster-foundry/app-frontend/
+    volumes:
+      - ./app-frontend/.babelrc:/opt/raster-foundry/app-frontend/.babelrc
+      - ./app-frontend/config/:/opt/raster-foundry/app-frontend/config/
+      - ./nginx/srv/dist/:/opt/raster-foundry/app-frontend/dist/
+      - ./app-frontend/yarn.lock:/opt/raster-foundry/app-frontend/yarn.lock
+      - ./app-frontend/.eslintrc:/opt/raster-foundry/app-frontend/.eslintrc
+      - ./app-frontend/karma.conf.js:/opt/raster-foundry/app-frontend/karma.conf.js
+      - ./.node_modules:/opt/raster-foundry/app-frontend/node_modules
+      - ./app-frontend/package.json:/opt/raster-foundry/app-frontend/package.json
+      - ./app-frontend/src:/opt/raster-foundry/app-frontend/src
+      - ./app-frontend/webpack.config.js:/opt/raster-foundry/app-frontend/webpack.config.js
+    entrypoint: yarn
+    command: run build
+
   app-server:
-    image: raster-foundry-app-server:${GIT_COMMIT}
+    image: raster-foundry-app-server:${GIT_COMMIT:-latest}
     build:
       context: ./app-backend/app
       dockerfile: Dockerfile
 
   tile-server:
-    image: raster-foundry-tile-server:${GIT_COMMIT}
+    image: raster-foundry-tile-server:${GIT_COMMIT:-latest}
     build:
       context: ./app-backend/tile
       dockerfile: Dockerfile
 
   app-migrations:
-    image: raster-foundry-app-migrations:${GIT_COMMIT}
+    image: raster-foundry-app-migrations:${GIT_COMMIT:-latest}
     build:
       context: ./app-backend
       dockerfile: Dockerfile
 
   airflow:
-    image: raster-foundry-airflow:${GIT_COMMIT}
+    image: raster-foundry-airflow:${GIT_COMMIT:-latest}
     build:
       context: ./app-tasks
       dockerfile: Dockerfile

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '2.1'
 services:
   postgres:
     image: quay.io/azavea/postgis:postgres9.5-postgis2.2
@@ -29,23 +29,6 @@ services:
       - ./nginx/etc/nginx/nginx.conf:/etc/nginx/nginx.conf
       - ./nginx/etc/nginx/includes/:/etc/nginx/includes/
       - ./nginx/etc/nginx/conf.d/:/etc/nginx/conf.d/
-
-  app-frontend:
-    image: kkarczmarczyk/node-yarn:6.9-wheezy
-    working_dir: /opt/raster-foundry/app-frontend/
-    volumes:
-      - ./app-frontend/.babelrc:/opt/raster-foundry/app-frontend/.babelrc
-      - ./app-frontend/config/:/opt/raster-foundry/app-frontend/config/
-      - ./nginx/srv/dist/:/opt/raster-foundry/app-frontend/dist/
-      - ./app-frontend/yarn.lock:/opt/raster-foundry/app-frontend/yarn.lock
-      - ./app-frontend/.eslintrc:/opt/raster-foundry/app-frontend/.eslintrc
-      - ./app-frontend/karma.conf.js:/opt/raster-foundry/app-frontend/karma.conf.js
-      - ./.node_modules:/opt/raster-foundry/app-frontend/node_modules
-      - ./app-frontend/package.json:/opt/raster-foundry/app-frontend/package.json
-      - ./app-frontend/src:/opt/raster-foundry/app-frontend/src
-      - ./app-frontend/webpack.config.js:/opt/raster-foundry/app-frontend/webpack.config.js
-    entrypoint: yarn
-    command: run start
 
   app-server:
     image: openjdk:8-jre

--- a/scripts/cibuild
+++ b/scripts/cibuild
@@ -32,15 +32,19 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
 
         echo "Building static asset bundle"
         docker-compose \
-            run --rm --no-deps app-frontend install
+            -f "${DIR}/../docker-compose.yml" \
+            -f "${DIR}/../docker-compose.test.yml" \
+            run --rm app-frontend install
         docker-compose \
-            run --rm --no-deps app-frontend run build
+            -f "${DIR}/../docker-compose.yml" \
+            -f "${DIR}/../docker-compose.test.yml" \
+            run --rm app-frontend run build
 
         echo "Building Airflow container image"
         GIT_COMMIT="${GIT_COMMIT}" docker-compose \
                   -f "${DIR}/../docker-compose.yml" \
                   -f "${DIR}/../docker-compose.airflow.yml" \
-                  -f "${DIR}/../docker-compose.test.yml"\
+                  -f "${DIR}/../docker-compose.test.yml" \
                   build airflow
 
         echo "Running tests"

--- a/scripts/console
+++ b/scripts/console
@@ -20,6 +20,7 @@ then
         usage
     else
         docker-compose -f "${DIR}/../docker-compose.yml" \
+                       -f "${DIR}/../docker-compose.test.yml" \
                        -f "${DIR}/../docker-compose.swagger.yml" \
                        -f "${DIR}/../docker-compose.airflow.yml" \
                        run --rm --service-ports --entrypoint \

--- a/scripts/setup
+++ b/scripts/setup
@@ -106,9 +106,13 @@ then
 
         echo "Building static asset bundle"
         docker-compose \
-            run --rm --no-deps app-frontend install
+            -f "${DIR}/../docker-compose.yml" \
+            -f "${DIR}/../docker-compose.test.yml" \
+            run --rm app-frontend install
         docker-compose \
-            run --rm --no-deps app-frontend run build
+            -f "${DIR}/../docker-compose.yml" \
+            -f "${DIR}/../docker-compose.test.yml" \
+            run --rm app-frontend run build
     fi
     exit
 fi

--- a/scripts/test
+++ b/scripts/test
@@ -41,7 +41,9 @@ then
         # TODO: https://github.com/azavea/raster-foundry/issues/435
         # echo "Executing JavaScript test suite"
         # docker-compose \
-        #     run --rm --no-deps app-frontend run test
+        #     -f "${DIR}/../docker-compose.yml" \
+        #     -f "${DIR}/../docker-compose.test.yml" \
+        #     run --rm app-frontend run test
 
         echo "Executing Airflow task test suite"
         GIT_COMMIT="${GIT_COMMIT}" docker-compose \


### PR DESCRIPTION
## Overview

*This change makes it so that frontend development can only happen from outside of the virtual machine, via the instructions outlined in the `README`.*

In order to continue supporting static bundle creation, move the `app-frontend` service configuration to `docker-compose.test.yml` and change its default command to `yarn run build`.

In addition, upgrade the Docker Compose configuration file format so that we can take advantage of default environment variables, which help suppress warning messages when using `console` with `app-frontend`.

Fixes https://github.com/azavea/raster-foundry/issues/882

## Testing Instructions

Execute the following scripts within the virtual machine and ensure that they complete successfully:

- `setup`
- `cibuild` (this exercises `test`)

For `console`, use the following command to get a shell inside of the `app-frontend` container:

```bash
vagrant@vagrant-ubuntu-trusty-64:/opt/raster-foundry$ ./scripts/console app-frontend bash
```

Also, running `server` should remove any stray references to the `app-frontend` service that may have been present.