### PR TITLE
Feature/lk/maintain zoom level node preview

### DIFF
--- a/app-frontend/src/app/components/diagramContainer/diagramContainer.controller.js
+++ b/app-frontend/src/app/components/diagramContainer/diagramContainer.controller.js
@@ -102,7 +102,7 @@ export default class DiagramContainerController {
         });
 
         let ndviAfter = this.createRectangle({
-            label: 'Vegeation index',
+            label: 'Vegetation index',
             inputs: ['Input'],
             outputs: ['Output']
         });

--- a/app-frontend/src/app/pages/lab/run/run.controller.js
+++ b/app-frontend/src/app/pages/lab/run/run.controller.js
@@ -155,7 +155,6 @@ export default class LabRunController {
         if (!this.sideBySideAdded) {
             this.sideBySideAdded = true;
             this.getMap().then((m) => {
-                debugger;
                 this.sideBySideControl.addTo(m.map);
             });
         }
@@ -176,8 +175,8 @@ export default class LabRunController {
                         this.sideBySideControl.remove();
                         this.sideBySideAdded = false;
                     }
-                    if (!this.alreadyFitted) {
-                        this.alreadyFitted = true;
+                    if (!this.alreadyPreviewed) {
+                        this.alreadyPreviewed = true;
                         this.$timeout(() => {
                             this.fitSceneList(this.inputs[0].id);
                         });

--- a/app-frontend/src/app/pages/lab/run/run.controller.js
+++ b/app-frontend/src/app/pages/lab/run/run.controller.js
@@ -11,6 +11,14 @@ export default class LabRunController {
         this.authService = authService;
         this.projectService = projectService;
         this.getMap = () => mapService.getMap('lab-run-preview');
+
+        $scope.$watch('$ctrl.isShowingPreview', () => {
+            this.getMap().then((mapWrapper) => {
+                $timeout(() => {
+                    mapWrapper.map.invalidateSize();
+                }, 50);
+            });
+        });
     }
 
     $onInit() {
@@ -146,7 +154,10 @@ export default class LabRunController {
 
         if (!this.sideBySideAdded) {
             this.sideBySideAdded = true;
-            this.getMap().then(m => this.sideBySideControl.addTo(m.map));
+            this.getMap().then((m) => {
+                debugger;
+                this.sideBySideControl.addTo(m.map);
+            });
         }
     }
 
@@ -165,10 +176,12 @@ export default class LabRunController {
                         this.sideBySideControl.remove();
                         this.sideBySideAdded = false;
                     }
-                    this.$timeout(() => {
-                        m.map.invalidateSize();
-                        this.fitSceneList(this.inputs[0].id);
-                    });
+                    if (!this.alreadyFitted) {
+                        this.alreadyFitted = true;
+                        this.$timeout(() => {
+                            this.fitSceneList(this.inputs[0].id);
+                        });
+                    }
                 });
             }
         }

--- a/app-frontend/src/app/pages/lab/run/run.html
+++ b/app-frontend/src/app/pages/lab/run/run.html
@@ -167,7 +167,7 @@
       <rf-map-container map-id="lab-run-preview"></rf-map-container>
       <div class="preview-control-bar">
           <button ng-if="$ctrl.previewLayers.length > 1" class="btn btn-default" ng-click="$ctrl.closePreview()">Exit Node Comparison</button>
-          <button ng-if="$ctrl.previewLayers.length == 1" class="btn btn-default" ng-click="$ctrl.closePreview()">Exit Node Preview</button>
+          <button ng-if="!$ctrl.previewLayers || $ctrl.previewLayers.length === 1" class="btn btn-default" ng-click="$ctrl.closePreview()">Exit Node Preview</button>
       </div>
       <div class="preview-info-bar" ng-show="$ctrl.previewLayers.length > 1">
         <div class="split-container">


### PR DESCRIPTION
## Overview

Maintain zoom level when moving between nodes previews in lab/run.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~


## Testing
* Using two ingested scenes, run a tool
* Preview a node, then zoom / pan the map
* Exit the preview, then preview another node (should work the same whether or not the same node is previewed)
* Verify that the preview has the same map state as when you exited it last

Fixes #971
