### PR TITLE
Add token parameter to thumbnail urls that start with '/'

### DIFF
--- a/app-frontend/src/app/components/sceneDetail/sceneDetail.html
+++ b/app-frontend/src/app/components/sceneDetail/sceneDetail.html
@@ -12,8 +12,8 @@
 <div class="sidebar-scrollable">
   <div class="content">
     <img ng-if="$ctrl.scene.thumbnails.length && $ctrl.showThumbnail"
-         ng-attr-src="{{$ctrl.thumbnailService.getBestFit($ctrl.scene.thumbnails, 275).url}}"
-         class="center-img rounded-img detail-img">
+        ng-attr-src="{{$ctrl.thumbnailService.getBestFitUrl($ctrl.scene.thumbnails, 275)}}"
+        class="center-img rounded-img detail-img">
     <img ng-if="!$ctrl.scene.thumbnails.length && $ctrl.showThumbnail"
          src="https://placehold.it/275x275"
          class="center-img rounded-img detail-img">

--- a/app-frontend/src/app/components/sceneItem/sceneItem.html
+++ b/app-frontend/src/app/components/sceneItem/sceneItem.html
@@ -3,7 +3,7 @@
     <i class="icon-gripper"></i>
   </div>
   <img ng-if="$ctrl.scene.thumbnails[0]"
-       ng-attr-src="{{$ctrl.thumbnailService.getBestFit($ctrl.scene.thumbnails, 75).url}}"
+       ng-attr-src="{{$ctrl.thumbnailService.getBestFitUrl($ctrl.scene.thumbnails, 75)}}"
        class="rounded-img item-img">
   <img ng-if="!$ctrl.scene.thumbnails.length"
        src="https://placehold.it/75x75"

--- a/app-frontend/src/app/core/services/imageOverlay.service.js
+++ b/app-frontend/src/app/core/services/imageOverlay.service.js
@@ -66,7 +66,7 @@ export default (app) => {
                     let layer = this.layer = new Konva.Layer();
 
                     let img = this.img = L.DomUtil.create('img');
-                    img.src = this.options.thumbnail.url;
+                    img.src = this.options.thumbnail;
 
                     let lineConfig = {
                         points: points,

--- a/app-frontend/src/app/core/services/thumbnail.service.js
+++ b/app-frontend/src/app/core/services/thumbnail.service.js
@@ -1,12 +1,21 @@
 export default (app) => {
     class ThumbnailService {
-        getBestFit(thumbnails, size) {
-            return thumbnails.reduce((thumb, next) => {
+        constructor(authService) {
+            'ngInject';
+            this.authService = authService;
+        }
+
+        getBestFitUrl(thumbnails, size) {
+            let url = thumbnails.reduce((thumb, next) => {
                 if (Math.abs(size - next.widthPx) < Math.abs(size - thumb.widthPx)) {
                     return next;
                 }
                 return thumb;
-            });
+            }).url;
+            if (url.startsWith('/')) {
+                return `${url}?token=${this.authService.token()}`;
+            }
+            return url;
         }
     }
 


### PR DESCRIPTION
## Overview

Add token parameter to thumbnail urls that start with '/'

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~

## Testing Instructions

 * Load a view that displays a scene thumbnail
 * Verify that for urls that start with '/', a token gets added to the request
 * If you don't have any scenes with thumnails that start with '/', set a breakpoint in thumnail.service on the if statement, and set the url to something like '/thumnail/url/123' and resume. You can check the network tab in chrome to verify that the parameter is set correctly.

Closes #1059 
