### PR TITLE
Make Scene filters inclusive

### DIFF
--- a/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Scenes.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Scenes.scala
@@ -416,14 +416,14 @@ class ScenesTableQuery[M, U, C[_]](scenes: Scenes.TableQuery) extends LazyLoggin
   def filterBySceneParams(sceneParams: SceneQueryParameters): Scenes.TableQuery = {
     val filteredScenes = scenes.filter{ scene =>
       val sceneFilterConditions = List(
-        sceneParams.maxAcquisitionDatetime.map(scene.acquisitionDate < _),
-        sceneParams.minAcquisitionDatetime.map(scene.acquisitionDate > _),
-        sceneParams.maxCloudCover.map(scene.cloudCover < _),
-        sceneParams.minCloudCover.map(scene.cloudCover > _),
-        sceneParams.minSunAzimuth.map(scene.sunAzimuth > _),
-        sceneParams.maxSunAzimuth.map(scene.sunAzimuth < _),
-        sceneParams.minSunElevation.map(scene.sunElevation > _),
-        sceneParams.maxSunElevation.map(scene.sunElevation < _),
+        sceneParams.maxAcquisitionDatetime.map(scene.acquisitionDate <= _),
+        sceneParams.minAcquisitionDatetime.map(scene.acquisitionDate >= _),
+        sceneParams.maxCloudCover.map(scene.cloudCover <= _),
+        sceneParams.minCloudCover.map(scene.cloudCover >= _),
+        sceneParams.minSunAzimuth.map(scene.sunAzimuth >= _),
+        sceneParams.maxSunAzimuth.map(scene.sunAzimuth <= _),
+        sceneParams.minSunElevation.map(scene.sunElevation >= _),
+        sceneParams.maxSunElevation.map(scene.sunElevation <= _),
         sceneParams.pointGeom.map(scene.dataFootprint.intersects(_))
       )
       sceneFilterConditions
@@ -493,14 +493,14 @@ class ScenesTableQuery[M, U, C[_]](scenes: Scenes.TableQuery) extends LazyLoggin
   def filterByGridParams(gridParams: GridQueryParameters): Scenes.TableQuery = {
     val filteredScenes = scenes.filter{ scene =>
       val sceneFilterConditions = List(
-        gridParams.maxAcquisitionDatetime.map(scene.acquisitionDate < _),
-        gridParams.minAcquisitionDatetime.map(scene.acquisitionDate > _),
-        gridParams.maxCloudCover.map(scene.cloudCover < _),
-        gridParams.minCloudCover.map(scene.cloudCover > _),
-        gridParams.minSunAzimuth.map(scene.sunAzimuth > _),
-        gridParams.maxSunAzimuth.map(scene.sunAzimuth < _),
-        gridParams.minSunElevation.map(scene.sunElevation > _),
-        gridParams.maxSunElevation.map(scene.sunElevation < _)
+        gridParams.maxAcquisitionDatetime.map(scene.acquisitionDate <= _),
+        gridParams.minAcquisitionDatetime.map(scene.acquisitionDate >= _),
+        gridParams.maxCloudCover.map(scene.cloudCover <= _),
+        gridParams.minCloudCover.map(scene.cloudCover >= _),
+        gridParams.minSunAzimuth.map(scene.sunAzimuth >= _),
+        gridParams.maxSunAzimuth.map(scene.sunAzimuth <= _),
+        gridParams.minSunElevation.map(scene.sunElevation >= _),
+        gridParams.maxSunElevation.map(scene.sunElevation <= _)
       )
       sceneFilterConditions
         .collect({case Some(criteria)  => criteria})

--- a/app-frontend/src/app/components/filterPane/filterPane.controller.js
+++ b/app-frontend/src/app/components/filterPane/filterPane.controller.js
@@ -168,7 +168,7 @@ export default class FilterPaneController {
             options: {
                 floor: this.cloudCoverRange.min,
                 ceil: this.cloudCoverRange.max,
-                minRange: 10,
+                minRange: 0,
                 showTicks: 10,
                 showTicksValues: true,
                 step: 10,
@@ -189,7 +189,7 @@ export default class FilterPaneController {
             options: {
                 floor: this.sunElevationRange.min,
                 ceil: this.sunElevationRange.max,
-                minRange: 10,
+                minRange: 0,
                 showTicks: 30,
                 showTicksValues: true,
                 step: 10,
@@ -210,7 +210,7 @@ export default class FilterPaneController {
             options: {
                 floor: this.sunAzimuthRange.min,
                 ceil: this.sunAzimuthRange.max,
-                minRange: 10,
+                minRange: 0,
                 showTicks: 60,
                 showTicksValues: true,
                 step: 10,


### PR DESCRIPTION
## Overview

Make scene filters inclusive

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~

### Demo
Filtered to scenes with exactly 0 cloud coverage:
![image](https://cloud.githubusercontent.com/assets/4392704/22713721/936ea3e6-ed57-11e6-92b5-0eb81bc5a113.png)

### Notes 
This allows sitting min / max to the same value to achieve an exact match filter, so I've enabled the same on the frontend. It's a little harder to test stuff like sun elevation/azimuth using the frontend, so use a curl or ARC request to filter down to a scene you know exists

## Testing Instructions

* Verify that when filtering by cloudCover, the filter is inclusive (shows scenes with 0 cloud cover)
*  Verify that the aquisitionDate filter is inclusive
* Verify that the sunAzimuth filter is inclusive
* Verify that the sunElevation filter is inclusive

Fixes #1069
