### PR TITLE
Prevent filters and grid layer from initializing before login

### DIFF
--- a/app-frontend/src/app/components/filterPane/filterPane.component.js
+++ b/app-frontend/src/app/components/filterPane/filterPane.component.js
@@ -5,7 +5,7 @@ const rfFilterPane = {
     controller: 'FilterPaneController',
     bindings: {
         filters: '=',
-        onCloseClick: '&'
+        opened: '='
     }
 };
 

--- a/app-frontend/src/app/components/filterPane/filterPane.controller.js
+++ b/app-frontend/src/app/components/filterPane/filterPane.controller.js
@@ -1,17 +1,33 @@
 import _ from 'lodash';
 export default class FilterPaneController {
-    constructor(datasourceService) {
+    constructor(datasourceService, authService, $scope, $rootScope, $timeout) {
         'ngInject';
         this.datasourceService = datasourceService;
+        this.authService = authService;
+        this.$scope = $scope;
+        this.$rootScope = $rootScope;
+        this.$timeout = $timeout;
     }
 
     $onInit() {
         this.toggleDrag = {toggle: false, enabled: false};
-        this.initFilters();
+        this.$scope.$watch(() => this.authService.isLoggedIn, (isLoggedIn) => {
+            if (isLoggedIn) {
+                this.initFilters();
+            }
+        });
+        this.$scope.$watch('$ctrl.opened', (opened) => {
+            if (opened) {
+                this.$timeout(() => this.$rootScope.$broadcast('reCalcViewDimensions'), 50);
+            }
+        });
+        if (this.authService.isLoggedIn) {
+            this.initFilters();
+        }
     }
 
     close() {
-        this.onCloseClick();
+        this.opened = false;
     }
 
     onYearFiltersChange(id, minModel, maxModel) {

--- a/app-frontend/src/app/pages/browse/browse.html
+++ b/app-frontend/src/app/pages/browse/browse.html
@@ -103,7 +103,7 @@
 
   <div class="sidebar sidebar-extended map-filters"
        ng-show="$ctrl.showFilterPane && !$ctrl.activeScene">
-    <rf-filter-pane on-close-click="$ctrl.toggleFilterPane()" filters="$ctrl.filters"></rf-filter-pane>
+    <rf-filter-pane data-opened="$ctrl.showFilterPane" filters="$ctrl.filters"></rf-filter-pane>
   </div>
 
   <div class="main">


### PR DESCRIPTION
## Overview
Prevent filters and grid layer from initializing when not logged in
Re-initialize filters/grid layer after every login event (IE when changing users
without reloading)
Re-render filter sliders when opening to prevent weird initializations

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~

## Testing Instructions
* Verify that when opening the filter bar, the sliders initialize correctly
  The first time you open it, the sliders may adjust themselves slightly - this means the fix is working.
* Load the page while not logged in. Verify that no unauthorized requests are made for the grid-layer or filter pane

Fixes #909
Fixes #755