### PR TITLE
Filter library scenes to scenes which are created by user

### DIFF
--- a/app-frontend/src/app/pages/library/scenes/list/list.controller.js
+++ b/app-frontend/src/app/pages/library/scenes/list/list.controller.js
@@ -1,6 +1,6 @@
 class ScenesListController {
     constructor( // eslint-disable-line max-params
-        $log, sceneService, $state, $scope, $uibModal
+        $log, sceneService, $state, $scope, $uibModal, authService
     ) {
         'ngInject';
 
@@ -10,6 +10,7 @@ class ScenesListController {
         this.$scope = $scope;
         this.$parent = $scope.$parent.$ctrl;
         this.$uibModal = $uibModal;
+        this.authService = authService;
 
         this.sceneList = [];
         this.populateSceneList($state.params.page || 1);
@@ -27,7 +28,8 @@ class ScenesListController {
             {
                 sort: 'createdAt,desc',
                 pageSize: '10',
-                page: page - 1
+                page: page - 1,
+                createdBy: this.authService.profile().user_id
             }
         ).then((sceneResult) => {
             this.lastSceneResult = sceneResult;


### PR DESCRIPTION
## Overview

Filter library scenes to scenes which are created by user

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~

### Demo
![image](https://cloud.githubusercontent.com/assets/4392704/22743835/6b2d8ff4-ede9-11e6-907f-ae6be676e5f1.png)


### Notes

This will break once we switch users from auth0 id to uuid in requests. It will be a simple fix once that gets done though: either way, the logged in user profile should be accessed through the authService.

## Testing Instructions

 * Set the created_by field on a couple scenes to your user
* Go to the library scene list view and verify that the only scenes which show up are the ones created by your user

Closes #1078
