### PR TITLE
Create symlink for migration 41

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,6 +6,7 @@ Brief description of what this PR does, and why it is needed.
 
 - [ ] Styleguide updated, if necessary
 - [ ] Swagger specification updated, if necessary
+- [ ] Symlinks from new migrations present or corrected for any new migrations
 
 ### Demo
 

--- a/app-backend/migrations/src/main/scala/migrations/41.scala
+++ b/app-backend/migrations/src/main/scala/migrations/41.scala
@@ -1,1 +1,1 @@
-/opt/raster-foundry/app-backend/./migrations/src_migrations/main/scala/41.scala
+../../../../src_migrations/main/scala/41.scala


### PR DESCRIPTION
## Overview

The symlink for the 41st migration was no good. This fixes it.

### Checklist

- ~[ ] Styleguide updated, if necessary~
- ~[ ] Swagger specification updated, if necessary~
- [x] symlinks created by forklift present or corrected for any new migrations
