### PR TITLE
Create and alter permissions on AIRFLOW_HOME

### DIFF
--- a/app-tasks/Dockerfile
+++ b/app-tasks/Dockerfile
@@ -11,6 +11,8 @@ RUN set -ex \
                --uid 1000 --home /var/lib/airflow \
                --shell /usr/sbin/nologin \
                airflow \
+    && mkdir -p ${AIRFLOW_HOME} \
+    && chown airflow:airflow -R ${AIRFLOW_HOME} \
     && buildDeps=' \
        python-dev \
     ' \


### PR DESCRIPTION
## Overview

Previously, the `AIRFLOW_HOME` directory was being created by the `adduser` command, which created it and ensured that the `airflow` user was given correct permissions.

Because of the new disconnect between `airflow` user `HOME` and `AIRFLOW_HOME`, the `AIRFLOW_HOME` directory needs to be created (before `COPY`) and the `airflow` user granted proper permissions.

## Testing Instructions

First, execute the `bootstrap` script to ensure that your local container image for Airflow is built using the changes in this branch. From there, apply the following diff to `docker-compose.airflow.yml`:

```diff
diff --git a/docker-compose.airflow.yml b/docker-compose.airflow.yml
index 29fec0f4..2fc0f44e 100644
--- a/docker-compose.airflow.yml
+++ b/docker-compose.airflow.yml
@@ -6,10 +6,10 @@ services:
   airflow-webserver:
     image: raster-foundry-airflow
     volumes:
-      - ./app-tasks/usr/local/airflow/:/usr/local/airflow/
-      - ./app-tasks/dags/:/opt/raster-foundry/app-tasks/dags/
-      - ./app-tasks/rf/:/opt/raster-foundry/app-tasks/rf/
-      - ./app-tasks/rf/src/rf/:/usr/local/bin/rf/
+      # - ./app-tasks/usr/local/airflow/:/usr/local/airflow/
+      # - ./app-tasks/dags/:/opt/raster-foundry/app-tasks/dags/
+      # - ./app-tasks/rf/:/opt/raster-foundry/app-tasks/rf/
+      # - ./app-tasks/rf/src/rf/:/usr/local/bin/rf/
       - $HOME/.aws:/var/lib/airflow/.aws:ro
     build:
       context: ./app-tasks
@@ -35,7 +35,7 @@ services:
   airflow-flower:
     image: raster-foundry-airflow
     volumes:
-      - ./app-tasks/usr/local/airflow/:/usr/local/airflow/
+      # - ./app-tasks/usr/local/airflow/:/usr/local/airflow/
     build:
       context: ./app-tasks
       dockerfile: Dockerfile
@@ -62,10 +62,10 @@ services:
   airflow-scheduler:
     image: raster-foundry-airflow
     volumes:
-      - ./app-tasks/usr/local/airflow/:/usr/local/airflow/
-      - ./app-tasks/dags/:/opt/raster-foundry/app-tasks/dags/
-      - ./app-tasks/rf/:/opt/raster-foundry/app-tasks/rf/
-      - ./app-tasks/rf/src/rf/:/usr/local/bin/rf/
+      # - ./app-tasks/usr/local/airflow/:/usr/local/airflow/
+      # - ./app-tasks/dags/:/opt/raster-foundry/app-tasks/dags/
+      # - ./app-tasks/rf/:/opt/raster-foundry/app-tasks/rf/
+      # - ./app-tasks/rf/src/rf/:/usr/local/bin/rf/
       - $HOME/.aws:/var/lib/airflow/.aws:ro
     build:
       context: ./app-tasks
@@ -93,10 +93,10 @@ services:
   airflow-worker:
     image: raster-foundry-airflow
     volumes:
-      - ./app-tasks/usr/local/airflow/:/usr/local/airflow/
-      - ./app-tasks/dags/:/opt/raster-foundry/app-tasks/dags/
-      - ./app-tasks/rf/:/opt/raster-foundry/app-tasks/rf/
-      - ./app-tasks/rf/src/rf/:/usr/local/bin/rf/
+      # - ./app-tasks/usr/local/airflow/:/usr/local/airflow/
+      # - ./app-tasks/dags/:/opt/raster-foundry/app-tasks/dags/
+      # - ./app-tasks/rf/:/opt/raster-foundry/app-tasks/rf/
+      # - ./app-tasks/rf/src/rf/:/usr/local/bin/rf/
       - $HOME/.aws:/var/lib/airflow/.aws:ro
     build:
       context: ./app-tasks
@@ -123,10 +123,10 @@ services:
   airflow-worker-spark:
     image: raster-foundry-airflow
     volumes:
-      - ./app-tasks/usr/local/airflow/:/usr/local/airflow/
-      - ./app-tasks/dags/:/opt/raster-foundry/app-tasks/dags/
-      - ./app-tasks/rf/:/opt/raster-foundry/app-tasks/rf/
-      - ./app-tasks/rf/src/rf/:/usr/local/bin/rf/
+      # - ./app-tasks/usr/local/airflow/:/usr/local/airflow/
+      # - ./app-tasks/dags/:/opt/raster-foundry/app-tasks/dags/
+      # - ./app-tasks/rf/:/opt/raster-foundry/app-tasks/rf/
+      # - ./app-tasks/rf/src/rf/:/usr/local/bin/rf/
       - $HOME/.aws:/var/lib/airflow/.aws:ro
     build:
       context: ./app-tasks
```

This makes it so that only the instructions inside of the `Dockerfile` are used to drive the image (other than threading in the AWS credentials).

Once that diff is applied, execute `scripts` with the `--with-airflow` option. You should not encounter any errors. More precisely, you shouldn't see anything like:

```
Feb 08 17:36:43 52.207.133.116 airflow-scheduler:  Traceback (most recent call last):
Feb 08 17:36:43 52.207.133.116 airflow-scheduler:    File "/usr/local/bin/airflow", line 4, in <module>
Feb 08 17:36:43 52.207.133.116 airflow-scheduler:      from airflow import configuration
Feb 08 17:36:43 52.207.133.116 airflow-scheduler:    File "/usr/local/lib/python2.7/site-packages/airflow/__init__.py", line 29, in <module>
Feb 08 17:36:43 52.207.133.116 airflow-scheduler:      from airflow import configuration as conf
Feb 08 17:36:43 52.207.133.116 airflow-scheduler:    File "/usr/local/lib/python2.7/site-packages/airflow/configuration.py", line 638, in <module>
Feb 08 17:36:43 52.207.133.116 airflow-scheduler:      with open(TEST_CONFIG_FILE, 'w') as f:
Feb 08 17:36:43 52.207.133.116 airflow-scheduler:  IOError: [Errno 13] Permission denied: '/usr/local/airflow/unittests.cfg'
```