### PR TITLE
Fix scene grid param mismatch

### DIFF
--- a/app-frontend/src/app/core/services/gridLayer.service.js
+++ b/app-frontend/src/app/core/services/gridLayer.service.js
@@ -18,7 +18,11 @@ export default (app) => {
          */
         requestGrid(coords, params) {
             let url = `/api/scene-grid/${coords.z}/${coords.x}/${coords.y}/`;
-            return this.$http.get(url, {params: params});
+            let validParams = Object.assign(
+                params,
+                {minCloudCover: params.minCloudCover ? params.minCloudCover : 0}
+            );
+            return this.$http.get(url, {params: validParams});
         }
 
         /** Create grid layer given a set of filter parameters


### PR DESCRIPTION
## Overview

This PR adjusts the scene grid service to ensure that bad Landsat8 imports (cloudcover < 0) are not counted in the scene grid, just as they are not counted in the scene list.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~

## Testing Instructions

 * On the browse page, use the scene-grid to filter to a single grid-cell (this is the only time the list is guaranteed to match the numbers on the grid)
 * Check that for any single grid-cell, the number displayed in the cell matches the result total shown in the scene list

Connects #1055
