### PR TITLE
Add custom tile URL format to publish modal

### DIFF
--- a/app-frontend/package.json
+++ b/app-frontend/package.json
@@ -25,6 +25,7 @@
     "angular": "~1.5.8",
     "angular-animate": "~1.5.8",
     "angular-aria": "~1.5.8",
+    "angular-clipboard": "^1.5.0",
     "angular-cookies": "~1.5.8",
     "angular-deferred-bootstrap": "~0.1.9",
     "angular-jwt": "0.0.9",

--- a/app-frontend/src/app/components/publishModal/publishModal.component.js
+++ b/app-frontend/src/app/components/publishModal/publishModal.component.js
@@ -7,7 +7,8 @@ const rfPublishModal = {
         dismiss: '&',
         modalInstance: '<',
         resolve: '<'
-    }
+    },
+    controller: 'PublishModalController'
 };
 
 export default rfPublishModal;

--- a/app-frontend/src/app/components/publishModal/publishModal.controller.js
+++ b/app-frontend/src/app/components/publishModal/publishModal.controller.js
@@ -1,4 +1,49 @@
 export default class PublishModalController {
     constructor() {
+        'ngInject';
+    }
+
+    $onInit() {
+        this.urlMappings = [
+            {
+                label: 'Standard',
+                z: 'z',
+                x: 'x',
+                y: 'y',
+                active: true
+            },
+            {
+                label: 'ArcGIS',
+                z: 'level',
+                x: 'col',
+                y: 'row',
+                active: false
+            }
+        ];
+
+        this.mappedTileUrl =
+            this.hydrateTileUrl(this.getActiveMapping());
+    }
+
+    onUrlMappingChange(mapping) {
+        this.setActiveMappingByLabel(mapping.label);
+        this.mappedTileUrl = this.hydrateTileUrl(mapping);
+    }
+
+    hydrateTileUrl(mapping) {
+        return this.resolve.tileUrl
+            .replace('{z}', `{${mapping.z}}`)
+            .replace('{x}', `{${mapping.x}}`)
+            .replace('{y}', `{${mapping.y}}`);
+    }
+
+    getActiveMapping() {
+        return this.urlMappings.find(m => m.active);
+    }
+
+    setActiveMappingByLabel(label) {
+        this.urlMappings.forEach(m => {
+            m.active = m.label === label;
+        });
     }
 }

--- a/app-frontend/src/app/components/publishModal/publishModal.html
+++ b/app-frontend/src/app/components/publishModal/publishModal.html
@@ -13,7 +13,9 @@
       <h4>Publishing</h4>
       <div class="form-group">
         <div>
-          <a class="btn btn-primary" ui-sref="share({projectid: $ctrl.resolve.project.id})">
+          <a class="btn btn-primary"
+             target="_blank"
+             ui-sref="share({projectid: $ctrl.resolve.project.id})">
             Preview Your Published Project
           </a>
         </div>

--- a/app-frontend/src/app/components/publishModal/publishModal.html
+++ b/app-frontend/src/app/components/publishModal/publishModal.html
@@ -38,10 +38,20 @@
       <h4>Exporting</h4>
       <div class="form-group">
         <label>XYZ resource link</label>
+        <div class="form-group">
+          <div class="btn-group inline">
+            <button class="btn btn-primary"
+                    ng-repeat="mapping in $ctrl.urlMappings"
+                    ng-click="$ctrl.onUrlMappingChange(mapping)"
+                    ng-class="{'active': mapping.active}">
+              {{mapping.label}}
+            </button>
+          </div>
+        </div>
         <div class="form-group all-in-one">
           <label for="tile-link" class="sr-only">URI Link</label>
           <input id="tile-link" type="text" class="form-control"
-                  value="{{$ctrl.resolve.tileUrl}}" readonly>
+                  value="{{$ctrl.mappedTileUrl}}" readonly>
           <!--
             @TODO: the copy button is intended to copy the url for the user which
             is not currently implemented

--- a/app-frontend/src/app/components/publishModal/publishModal.html
+++ b/app-frontend/src/app/components/publishModal/publishModal.html
@@ -58,7 +58,7 @@
             @TODO: the copy button is intended to copy the url for the user which
             is not currently implemented
           -->
-          <button class="btn btn-link">
+          <button clipboard text="$ctrl.mappedTileUrl" class="btn btn-link">
             Copy
           </button>
         </div>

--- a/app-frontend/src/app/components/publishModal/publishModal.module.js
+++ b/app-frontend/src/app/components/publishModal/publishModal.module.js
@@ -9,6 +9,7 @@ const PublishModalModule = angular.module('components.publishModal', []);
 PublishModalModule.controller(
     'PublishModalController', PublishModalController
 );
+
 PublishModalModule.component(
     'rfPublishModal', PublishModalComponent
 );

--- a/app-frontend/src/app/components/publishModal/publishModal.scss
+++ b/app-frontend/src/app/components/publishModal/publishModal.scss
@@ -1,3 +1,5 @@
+// @TODO: styles for publish modal
+
 .modal-body .centered-text {
   padding: 1.5rem;
   display: flex;
@@ -7,4 +9,8 @@
 
 .modal-body .form-group.centered {
   text-align: center;
+}
+
+.btn-group.inline {
+  display: inline-flex !important;
 }

--- a/app-frontend/src/app/index.module.js
+++ b/app-frontend/src/app/index.module.js
@@ -14,6 +14,7 @@ const App = angular.module(
         require('angular-nvd3'),
         'angular-storage',
         'angular-jwt',
+        'angular-clipboard',
         'auth0.lock',
         'ngAnimate',
         'ngCookies',

--- a/app-frontend/src/app/index.vendor.js
+++ b/app-frontend/src/app/index.vendor.js
@@ -13,6 +13,7 @@ import 'angular-storage';
 import 'angular-lock';
 import 'ng-infinite-scroll';
 import 'angular-jwt';
+import 'angular-clipboard';
 import 'angular-resource';
 import 'oclazyload';
 import 'angular-animate';

--- a/app-frontend/yarn.lock
+++ b/app-frontend/yarn.lock
@@ -95,6 +95,10 @@ angular-aria@~1.5.8:
   version "1.5.11"
   resolved "https://registry.yarnpkg.com/angular-aria/-/angular-aria-1.5.11.tgz#26963ac336891ced7b199e59afd7e9b25e53d6a6"
 
+angular-clipboard@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/angular-clipboard/-/angular-clipboard-1.5.0.tgz#5dcfacd8f91184d165852a71c485e675c4233802"
+
 angular-cookies@~1.5.8:
   version "1.5.11"
   resolved "https://registry.yarnpkg.com/angular-cookies/-/angular-cookies-1.5.11.tgz#88558de7c5044dcc3abeb79614d7ef8107ba49c0"


### PR DESCRIPTION
## Overview

This PR adds some structure to enable adding multiple tile URL formats to the publish modal.
Currently there are two formats:
  - Standard
  - ArcGIS

This PR also includes some other improvements:
  - The share preview page now opens in a new tab
  - The tileUrl copy button now actually copies the url to the clipboard

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~

### Demo

<img width="1071" alt="screen shot 2017-02-09 at 3 16 06 pm" src="https://cloud.githubusercontent.com/assets/2442245/22801546/3eaed260-eedb-11e6-8b52-a8dc7fb92df6.png">

## Testing Instructions

 * Open an ingested project in the library or editor, click the publish button
 * Check that the 'Standard' URL is default
 * Check that switching URL formats actually changes the URL
 * Check that the copy works for each URL
 * Click the 'Preview Your Published Project' button and see that the page opens in a new tab

Connects #922
