### PR TITLE
Add share option to diagram context menu

### DIFF
--- a/app-frontend/src/app/components/diagramContainer/diagramContainer.component.js
+++ b/app-frontend/src/app/components/diagramContainer/diagramContainer.component.js
@@ -4,6 +4,7 @@ export default {
     templateUrl: diagramContainerTpl,
     controller: 'DiagramContainerController',
     bindings: {
-        onPreview: '&'
+        onPreview: '&',
+        onShare: '&'
     }
 };

--- a/app-frontend/src/app/components/diagramContainer/diagramContainer.controller.js
+++ b/app-frontend/src/app/components/diagramContainer/diagramContainer.controller.js
@@ -199,6 +199,11 @@ export default class DiagramContainerController {
             callback: () => {
                 this.onPreview({data: this.nodes.get(this.selectedCellView.model.id)});
             }
+        }, {
+            label: 'Share',
+            callback: () => {
+                this.onShare({data: this.nodes.get(this.selectedCellView.model.id)});
+            }
         }];
         this.cancelComparisonMenu = [{
             label: 'Cancel',

--- a/app-frontend/src/app/components/publishModal/publishModal.html
+++ b/app-frontend/src/app/components/publishModal/publishModal.html
@@ -9,7 +9,7 @@
     <p>Publish or export your project</p>
   </div>
   <div class="modal-body">
-    <div class="content">
+    <div class="content" ng-show="$ctrl.resolve.shareUrl">
       <h4>Publishing</h4>
       <div class="form-group">
         <div>
@@ -51,7 +51,7 @@
           </button>
         </div>
       </div>
-      <div class="form-group">
+      <div class="form-group" ng-show="!$ctrl.resolve.noDownload">
         <label>Download an image of your project</label>
         <div>
           <a class="btn btn-primary" href="">

--- a/app-frontend/src/app/pages/lab/run/run.controller.js
+++ b/app-frontend/src/app/pages/lab/run/run.controller.js
@@ -186,6 +186,13 @@ export default class LabRunController {
         }
     }
 
+    shareNode(data) {
+        if (data) {
+            let tileUrl = this.getNodeUrl(data);
+            this.publishModal(tileUrl);
+        }
+    }
+
     fitSceneList(projectId) {
         this.sceneRequestState = {loading: true};
         this.projectService.getAllProjectScenes(
@@ -234,5 +241,22 @@ export default class LabRunController {
             this.onParameterChange();
             this.$scope.$evalAsync();
         });
+    }
+
+    publishModal(tileUrl) {
+        if (this.activeModal) {
+            this.activeModal.dismiss();
+        }
+
+        if (tileUrl) {
+            this.activeModal = this.$uibModal.open({
+                component: 'rfPublishModal',
+                resolve: {
+                    tileUrl: () => tileUrl,
+                    noDownload: () => true
+                }
+            });
+        }
+        return this.activeModal;
     }
 }

--- a/app-frontend/src/app/pages/lab/run/run.controller.js
+++ b/app-frontend/src/app/pages/lab/run/run.controller.js
@@ -252,7 +252,7 @@ export default class LabRunController {
             this.activeModal = this.$uibModal.open({
                 component: 'rfPublishModal',
                 resolve: {
-                    tileUrl: () => tileUrl,
+                    tileUrl: () => this.projectService.getBaseURL() + tileUrl,
                     noDownload: () => true
                 }
             });

--- a/app-frontend/src/app/pages/lab/run/run.html
+++ b/app-frontend/src/app/pages/lab/run/run.html
@@ -161,7 +161,8 @@
   </div>
   <div class="main with-position">
     <rf-diagram-container class="with-position"
-                          on-preview="$ctrl.showPreview(data)">
+                          on-preview="$ctrl.showPreview(data)"
+                          on-share="$ctrl.shareNode(data)">
     </rf-diagram-container>
     <div style="position: absolute; top:0; bottom: 0; left: 0; right: 0;" ng-show="$ctrl.isShowingPreview">
       <rf-map-container map-id="lab-run-preview"></rf-map-container>


### PR DESCRIPTION
## Overview

This PR adds a 'Share' option to the context menu for nodes within the lab diagram.

This PR also modifies the `publishModal` to handle cases where a `shareUrl` has not be passed into it and in this case it does not display the publishing options. This is useful since for node previews we are not yet allowing users to create a shareable page (once `tools` and `toolRuns` are more substantially implemented this will change).

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~

### Demo

<img width="457" alt="screen shot 2017-02-09 at 11 39 33 pm" src="https://cloud.githubusercontent.com/assets/2442245/22814603/f4e9a536-ef22-11e6-936a-dcd2b7f5df69.png">
<img width="835" alt="screen shot 2017-02-09 at 11 39 41 pm" src="https://cloud.githubusercontent.com/assets/2442245/22814606/f6518f7e-ef22-11e6-9fee-03d4dcf510ef.png">


### Notes

- Should the wording of the option be 'Publish' or 'Share'?
- Proper disabling of options will be something we can better accomplish when the tool running backend is implemented since we need to be able to validate the inputs against the tool's requirements

## Testing Instructions

 * Go to the lab
 * Click on any any node and see that the 'Share' option is available
 * Check that the 'Share' option does nothing when no projects are selected
 * Check that the 'Share' option opens the publish modal when projects have been selected
 * On the publish modal, check that the sharing preview and link are not present
 * Check that other publish actions (the project edit share button) will still display share preview options


Connects #1077
