### PR TITLE
Feature/jis/use slick actions everywhere

### DIFF
--- a/app-backend/app/src/test/scala/datasource/DatasourceSpec.scala
+++ b/app-backend/app/src/test/scala/datasource/DatasourceSpec.scala
@@ -27,7 +27,7 @@ class DatasourceSpec extends WordSpec
   implicit val ec = system.dispatcher
 
   implicit def database = db
-  implicit def default(implicit system: ActorSystem) = RouteTestTimeout(DurationInt(5).second)
+  implicit def default(implicit system: ActorSystem) = RouteTestTimeout(DurationInt(20).second)
 
   val authHeader = AuthUtils.generateAuthHeader("Default")
   val baseDatasourcePath = "/api/datasources/"

--- a/app-backend/database/src/main/scala/com/azavea/rf/database/ActionRunner.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/ActionRunner.scala
@@ -2,14 +2,16 @@ package com.azavea.rf.database
 
 import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
+import scala.util.{Success, Failure}
 
 import slick.lifted.Rep
 import slick.dbio.{DBIO, StreamingDBIO, Streaming}
 
-import com.azavea.rf.datamodel.PaginatedResponse
+import com.azavea.rf.datamodel._
+import com.azavea.rf.datamodel.RelatedManager._
 import com.azavea.rf.database.{Database => DB}
 import com.azavea.rf.database.ExtendedPostgresDriver.api.TableQuery
-import com.azavea.rf.database.query.ListQueryResult
+import com.azavea.rf.database.query._
 
 trait ActionRunner {
 
@@ -28,7 +30,6 @@ trait ActionRunner {
         records
       )
     })
-
   }
 
   def readOne[T](a: DBIO[Option[T]])(implicit database: DB): Future[Option[T]] =
@@ -36,7 +37,68 @@ trait ActionRunner {
 
   def write[T](a: DBIO[T])(implicit database: DB): Future[T] = database.db.run(a)
 
-  def update(a: DBIO[Int])(implicit database: DB): Future[Int] = database.db.run(a)
+  def update(a: DBIO[Int])(implicit database: DB): Future[Int] = {
+    database.db.run(a) map {
+      case 1 => 1
+      case c => throw new IllegalStateException(
+        s"Error updating: update result expected to be 1, was $c"
+      )
+    }
+  }
 
   def drop(a: DBIO[Int])(implicit database: DB): Future[Int] = database.db.run(a)
+
+  def withRelatedSingle1[T : HasRelations1, B, C](a: DBIO[(T, B)])
+                        (implicit ev: HasRelations1.Aux[T, B, C], database: DB): Future[C] = {
+    database.db.run(a) map {
+      case (r1, r2) => ev.relates(r1, r2)
+    }
+  }
+
+  def withRelatedOption1[T : HasRelations1, B, C](a: DBIO[(Option[T], B)])
+                        (implicit ev: HasRelations1.Aux[T, B, C], database: DB): Future[Option[C]] = {
+    database.db.run(a) map {
+      case (Some(r1), r2) => Some(ev.relates(r1, r2))
+      case _ => None
+    }
+  }
+
+  def withRelatedSeq1[T : CanBuildFromRecords2, B, C](a: ListQueryResult[(B, C)],
+                                                      offset: Int, limit: Int)
+                     (implicit ev: CanBuildFromRecords2.Aux[T, B, C], database: DB):
+      Future[PaginatedResponse[T]] = {
+    database.db.run(
+      for {
+        records <- a.records
+        nRecords <- a.nRecords
+      } yield {
+        // Coerce fromRecords to a Seq because PaginatedResponse requires it
+        // It starts as an Iterable[T]
+        PaginatedResponse[T](
+          nRecords,
+          offset > 0,
+          (offset + 1) * limit < nRecords,
+          offset,
+          limit,
+          ev.fromRecords(records).asInstanceOf[Seq[T]]
+        )
+      }
+    )
+  }
+
+  def withRelatedSingle3[T : HasRelations2, B, C, D](a: DBIO[(T, B, C)])
+                        (implicit ev: HasRelations2.Aux[T, B, C, D], database: DB): Future[D] = {
+    database.db.run(a) map {
+      case (r1, r2, r3) => ev.relates(r1, r2, r3)
+    }
+  }
+
+  def withRelatedOption4[T : CanBuildFromRecords4, B, C, D, E](a: DBIO[Seq[(B, C, D, E)]])
+                        (implicit ev: CanBuildFromRecords4.Aux[T, B, C, D, E], database: DB):
+      Future[Option[T]] = {
+    database.db.run(a) map {
+      case results => ev.fromRecords(results).headOption
+      case _ => None
+    }
+  }
 }

--- a/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Scenes.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Scenes.scala
@@ -196,38 +196,22 @@ object Scenes extends TableQuery(tag => new Scenes(tag)) with LazyLogging {
     * This implementation allows a user to post a scene with thumbnails, and
     * images which are all created in a single transaction
     */
-  def insertScene(sceneCreate: Scene.Create, user: User)
-                 (implicit database: DB): Future[Scene.WithRelated] = {
-
+  def insertScene(sceneCreate: Scene.Create, user: User):
+      DBIO[(Scene, Seq[Thumbnail], Seq[(Image, Seq[Band])])] = {
     val scene = sceneCreate.toScene(user.id)
     val thumbnails = sceneCreate.thumbnails.map(_.toThumbnail(user.id))
-    val imageSeq = (sceneCreate.images map { im: Image.Banded => im.toImage(user.id) }).zipWithIndex
-    val bandsSeq = imageSeq map { case (im: Image, ind: Int) =>
-      sceneCreate.images(ind).bands map { bd => bd.toBand(im.id) }
-    }
-
-    val imageBandInsert = DBIO.sequence(
-      imageSeq.zip(bandsSeq) map { case ((im: Image, _: Int), bs: Seq[Band]) =>
-        // == because we're filtering a sequence, not a table
-        for {
-          imageInsert <- (Images returning Images).forceInsert(im)
-          bandInserts <- (Bands returning Bands).forceInsertAll(bs)
-        } yield (imageInsert, bandInserts)
+    val imageSeq = sceneCreate.images
+    val imInsert = DBIO.sequence(
+      imageSeq map {
+        im => Images.insertImage(im, user)
       }
     )
 
-    val actions = for {
-      scenesInsert <- Scenes.forceInsert(scene)
-      thumbnailsInsert <- Thumbnails.forceInsertAll(thumbnails)
-      imageInsert <- imageBandInsert
+    for {
+      scenesInsert <- (Scenes returning Scenes).forceInsert(scene)
+      thumbnailsInsert <- (Thumbnails returning Thumbnails).forceInsertAll(thumbnails)
+      imageInsert <- imInsert
     } yield (scenesInsert, thumbnailsInsert, imageInsert)
-
-    database.db.run {
-      actions.transactionally
-    } map { case (_, _, imSeq: Seq[Tuple2[Image, Seq[Band]]]) =>
-        val imagesWithRelated = imSeq.map({case (im: Image, bs: Seq[Band]) => im.withRelatedFromComponents(bs)})
-      scene.withRelatedFromComponents(imagesWithRelated, thumbnails)
-    }
   }
 
 
@@ -235,19 +219,11 @@ object Scenes extends TableQuery(tag => new Scenes(tag)) with LazyLogging {
     *
     * @param sceneId java.util.UUID ID of scene to query with
     */
-  def getScene(sceneId: UUID)
-              (implicit database: DB): Future[Option[Scene.WithRelated]] = {
-
-    database.db.run {
-      val action = Scenes
-        .filter(_.id === sceneId)
+  def getScene(sceneId: UUID):
+              DBIO[Seq[(Scene, Option[Image], Option[Band], Option[Thumbnail])]] = {
+      Scenes.filter(_.id === sceneId)
         .joinWithRelated
         .result
-      logger.debug(s"Total Query for scenes -- SQL: ${action.statements.headOption}")
-      action
-    } map { result =>
-      Scene.WithRelated.fromRecords(result).headOption
-    }
   }
 
   /** Get scenes given a page request and query parameters */

--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/Image.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/Image.scala
@@ -21,7 +21,9 @@ case class Image(
   resolutionMeters: Float,
   metadataFiles: List[String]
 ) {
-  def withRelatedFromComponents(bands: Seq[Band]): Image.WithRelated = Image.WithRelated(
+  type RelatedType = Band
+  type RelatedResultType = Image.WithRelated
+  def withRelatedFromComponents(bands: Seq[RelatedType]): RelatedResultType = Image.WithRelated(
     this.id,
     this.createdAt,
     this.modifiedAt,

--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/RelatedManager.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/RelatedManager.scala
@@ -1,0 +1,171 @@
+package com.azavea.rf.datamodel
+
+object RelatedManager {
+
+  trait HasRelations1[A] {
+    type Arg
+    type Out
+    def relates(self: A, other: Arg): Out
+  }
+
+  object HasRelations1 {
+    type Aux[In, Arg0, Out0] = HasRelations1[In] { type Arg = Arg0; type Out = Out0 }
+
+    def apply[A, B, C](f: (A, B) => C): HasRelations1.Aux[A, B, C] =
+      new HasRelations1[A] {
+        type Arg = B
+        type Out = C
+        def relates(self: A, related: Arg): Out = f(self, related)
+      }
+
+    implicit val ImageRelatesBand = HasRelations1 {
+      (self: Image, related: Seq[Band]) => Image.WithRelated(
+        self.id,
+        self.createdAt,
+        self.modifiedAt,
+        self.organizationId,
+        self.createdBy,
+        self.modifiedBy,
+        self.rawDataBytes,
+        self.visibility,
+        self.filename,
+        self.sourceUri,
+        self.scene,
+        self.imageMetadata,
+        self.resolutionMeters,
+        self.metadataFiles,
+        related
+      )
+    }
+
+    implicit class withRelateMethod1[A](val self: A) {
+      def relates[B, C](related: B)(implicit ev: HasRelations1.Aux[A, B, C]): C = ev.relates(self, related)
+    }
+  }
+
+  trait HasRelations2[A] {
+    type Arg1
+    type Arg2
+    type Out
+    def relates(self: A, other1: Arg1, other2: Arg2): Out
+  }
+
+  object HasRelations2 {
+    type Aux[In, Arg10, Arg20, Out0] = HasRelations2[In] {
+      type Arg1 = Arg10
+      type Arg2 = Arg20
+      type Out = Out0
+    }
+
+    def apply[A, B, C, D](f: (A, B, C) => D): HasRelations2.Aux[A, B, C, D] =
+      new HasRelations2[A] {
+        type Arg1 = B
+        type Arg2 = C
+        type Out = D
+        def relates(self: A, related1: Arg1, related2: Arg2): Out =
+          f(self, related1, related2)
+      }
+
+    implicit val sceneRelatesImagesThumbnails = HasRelations2 {
+      (self: Scene, related1: Seq[Thumbnail], related2: Seq[(Image, Seq[Band])]) => {
+        val imagesWithRelated = related2 map {
+          case (im, bs) => im.withRelatedFromComponents(bs)
+        }
+        Scene.WithRelated(
+          self.id,
+          self.createdAt,
+          self.createdBy,
+          self.modifiedAt,
+          self.modifiedBy,
+          self.organizationId,
+          self.ingestSizeBytes,
+          self.visibility,
+          self.tags,
+          self.datasource,
+          self.sceneMetadata,
+          self.name,
+          self.tileFootprint,
+          self.dataFootprint,
+          self.metadataFiles,
+          imagesWithRelated,
+          related1,
+          self.ingestLocation,
+          self.filterFields,
+          self.statusFields
+        )
+      }
+    }
+
+    implicit class withRelatedMethod2[A](val self: A) {
+      def relates[B, C, D](related1: B, related2: C)
+                 (implicit ev: HasRelations2.Aux[A, B, C, D]): D =
+        ev.relates(self, related1, related2)
+    }
+  }
+
+  trait CanBuildFromRecords2[A] {
+    type Base
+    type Other
+    def fromRecords(records: Seq[(Base, Other)]): Iterable[A]
+  }
+
+  object CanBuildFromRecords2 {
+    type Aux[A0, Base0, Other0] = CanBuildFromRecords2[A0] { type Base = Base0; type Other = Other0 }
+
+    def apply[A, B, C](f: Seq[(B, C)] => Iterable[A]): CanBuildFromRecords2.Aux[A, B, C] =
+      new CanBuildFromRecords2[A] {
+        type Base = B
+        type Other = C
+        def fromRecords(records: Seq[(B, C)]): Iterable[A] = f(records)
+      }
+
+    implicit val ImageWithRelatedFromRecords = CanBuildFromRecords2 {
+      (records: Seq[(Image, Band)]) => {
+        Image.WithRelated.fromRecords(records): Iterable[Image.WithRelated]
+      }
+    }
+
+    implicit class canBuildFromRecords2[A](val self: A) {
+      def fromRecords[B, C](records: Seq[(B, C)])
+                     (implicit ev: CanBuildFromRecords2.Aux[A, B, C]): Iterable[A] = ev.fromRecords(records)
+    }
+  }
+
+  trait CanBuildFromRecords4[A] {
+    type Base
+    type Other1
+    type Other2
+    type Other3
+    def fromRecords(records: Seq[(Base, Other1, Other2, Other3)]): Iterable[A]
+  }
+
+  object CanBuildFromRecords4 {
+    type Aux[A0, Base0, Other10, Other20, Other30] = CanBuildFromRecords4[A0] {
+      type Base = Base0
+      type Other1 = Other10
+      type Other2 = Other20
+      type Other3 = Other30
+    }
+
+    def apply[A, B, C, D, E](f: Seq[(B, C, D, E)] => Iterable[A]): CanBuildFromRecords4.Aux[A, B, C, D, E] =
+      new CanBuildFromRecords4[A] {
+        type Base = B
+        type Other1 = C
+        type Other2 = D
+        type Other3 = E
+        def fromRecords(records: Seq[(B, C, D, E)]): Iterable[A] = f(records)
+      }
+
+    implicit val SceneWithRelatedFromRecords = CanBuildFromRecords4 {
+      (records: Seq[(Scene, Option[Image], Option[Band], Option[Thumbnail])]) =>
+        Scene.WithRelated.fromRecords(records)
+    }
+
+    implicit class canBuildFromRecords4[A](val self: A) {
+      def fromRecords[B, C, D, E](records: Seq[(B, C, D, E)])
+                     (implicit ev: CanBuildFromRecords4.Aux[A, B, C, D, E]): Iterable[A] =
+        ev.fromRecords(records)
+    }
+  }
+}
+

--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/WithRelatedConstructor.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/WithRelatedConstructor.scala
@@ -1,0 +1,16 @@
+package com.azavea.rf.datamodel
+
+trait CanRelate[Related <: {type RelatedResultType; type RelatedType}] {
+  val inner: Related
+  type RelatedResultType = inner.RelatedResultType
+  type RelatedType = inner.RelatedType
+  def relate(x: Seq[inner.RelatedType]): inner.RelatedResultType
+}
+
+abstract class WithRelated2Constructor {
+  type T1
+  type RelatedType
+  type Related[T1]
+
+  def withRelatedFromComponents(s: Seq[RelatedType]): Related[T1]
+}


### PR DESCRIPTION
## Overview

Add "proof" of concept actions refactor

This was supposed to remove a lot of complexity in our database handling, but
more than anything else it seems to have shifted that complexity elsewhere
without paying off in reusability as I'd hoped it would. Because of our complex
types (not complex in logic, but complex in the sense of "T.WithRelated"), there
isn't a way to go to the database and return a DBIO for a lot of things we might
want. For example, you can't go to the database and get an Image.WithRelated in
a DBIO to combo with a Scene. This wasn't a _waste_ of time, but whatever
unpleasantness we think our current design patterns bakes into developing
against the database is here to stay for a moment at least.

There is a useful pattern that came out of this at least, and that's the Aux
pattern. The aux pattern lets us define type viewability in terms of what types
can do instead of what they are, as long as there's an implicit value meeting
the requirements of the typeclass in scope. Where we have common/repetitive
functionality, we could probably abstract it into a typeclass.

### Checklist

- ~[ ] Styleguide updated, if necessary~
- ~[ ] Swagger specification updated, if necessary~
- ~[ ] Symlinks from new migrations present or corrected for any new migrations~

### Notes

The PR is currently in a compilable/testable state. All tests pass and everything works sort of, except instead of a reduction of complexity complexity appears to have increased and more information is hidden away in implicits.

This was supposed to help with #635, but it seems now either like that wasn't the best idea, or like this tactic just wasn't going to get us there.