### PR TITLE
Add validation to project create forms

### DIFF
--- a/app-frontend/src/app/components/projectAddModal/projectAddModal.controller.js
+++ b/app-frontend/src/app/components/projectAddModal/projectAddModal.controller.js
@@ -41,15 +41,25 @@ export default class ProjectAddModalController {
     }
 
     createNewProject(name) {
-        delete this.newProjectName;
-        this.projectService.createProject(name).then(
-            () => {
-                this.populateProjectList(this.currentPage);
-            },
-            (err) => {
-                this.$log.error('Error creating project:', err);
-            }
-        );
+        this.showProjectCreateError = false;
+        if (name) {
+            delete this.newProjectName;
+            this.projectService.createProject(name).then(
+                () => {
+                    this.populateProjectList(this.currentPage);
+                },
+                (err) => {
+                    this.projectCreateErrorText =
+                        'There was an error creating the project';
+                    this.showProjectCreateError = true;
+                    this.$log.error('Error creating project:', err);
+                }
+            );
+        } else {
+            this.projectCreateErrorText =
+                'A name is needed to create a new project';
+            this.showProjectCreateError = true;
+        }
     }
 
     isSelected(project) {

--- a/app-frontend/src/app/components/projectAddModal/projectAddModal.html
+++ b/app-frontend/src/app/components/projectAddModal/projectAddModal.html
@@ -29,13 +29,17 @@
 	</div>
   <form class="modal-form">
     <div class="form-group all-in-one">
-      <label for="name"><i class="icon-bucket"></i></label>
+      <label for="name"><i class="icon-project"></i></label>
       <input id="name" type="text" class="form-control"
              placeholder="New project name" ng-model="$ctrl.newProjectName">
       <button class="btn btn-link" type="submit"
               ng-click="$ctrl.createNewProject($ctrl.newProjectName)">
         Create
       </button>
+    </div>
+    <div class="form-group color-danger"
+         ng-if="$ctrl.showProjectCreateError && $ctrl.projectCreateErrorText">
+         {{$ctrl.projectCreateErrorText}}
     </div>
   </form>
 	<div class="modal-body">

--- a/app-frontend/src/app/pages/library/projects/list/list.controller.js
+++ b/app-frontend/src/app/pages/library/projects/list/list.controller.js
@@ -69,14 +69,25 @@ class ProjectsListController {
     }
 
     createNewProject(name) {
-        this.projectService.createProject(name).then(
-            () => {
-                this.populateProjectList(this.currentPage);
-            },
-            (err) => {
-                this.$log.error('Error creating project:', err);
-            }
-        );
+        this.showProjectCreateError = false;
+        if (name) {
+            delete this.newProjectName;
+            this.projectService.createProject(name).then(
+                () => {
+                    this.populateProjectList(this.currentPage);
+                },
+                (err) => {
+                    this.projectCreateErrorText =
+                        'There was an error creating the project';
+                    this.showProjectCreateError = true;
+                    this.$log.error('Error creating project:', err);
+                }
+            );
+        } else {
+            this.projectCreateErrorText =
+                'A name is needed to create a new project';
+            this.showProjectCreateError = true;
+        }
     }
 }
 

--- a/app-frontend/src/app/pages/library/projects/list/list.html
+++ b/app-frontend/src/app/pages/library/projects/list/list.html
@@ -5,7 +5,7 @@
     </div>
     <form>
       <div class="form-group all-in-one">
-        <label for="name"><i class="icon-bucket"></i></label>
+        <label for="name"><i class="icon-project"></i></label>
         <input id="name" type="text" class="form-control"
                placeholder="New project name" ng-model="$ctrl.newProjectName">
         <button class="btn btn-link"
@@ -13,6 +13,10 @@
                 ng-click="$ctrl.createNewProject($ctrl.newProjectName)">
           Create
         </button>
+      </div>
+      <div class="form-group color-danger"
+          ng-if="$ctrl.showProjectCreateError && $ctrl.projectCreateErrorText">
+          {{$ctrl.projectCreateErrorText}}
       </div>
     </form>
     <div class="list-group">

--- a/app-frontend/src/app/pages/settings/settings.html
+++ b/app-frontend/src/app/pages/settings/settings.html
@@ -5,8 +5,6 @@
         <a ui-sref="settings.profile" ui-sref-active="active">Profile</a>
         <a ui-sref="settings.account" ui-sref-active="active">Account</a>
         <a ui-sref="settings.tokens" ui-sref-active="active">API tokens</a>
-        <a ui-sref="settings.notifications" ui-sref-active="active">Notifications</a>
-        <a ui-sref="settings.billing" ui-sref-active="active">Billing</a>
         <a ui-sref="settings.organizations"
            ui-sref-active="active"
            feature-flag="profile-org-edit"


### PR DESCRIPTION
## Overview

This PR adds client-side validation to the project create forms found within modals and on the library project list.

I've also tacked on the removal of the 'notifications' and 'billing' links within the user settings.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~

### Demo

<img width="850" alt="screen shot 2017-02-10 at 11 23 48 am" src="https://cloud.githubusercontent.com/assets/2442245/22834924/e29ecf02-ef84-11e6-8da5-1c4b02c556d4.png">

<img width="885" alt="screen shot 2017-02-10 at 11 26 58 am" src="https://cloud.githubusercontent.com/assets/2442245/22834929/e5f86a1e-ef84-11e6-82a6-cbac8ae92a97.png">

## Testing Instructions

 * From the browse page, select a scene and click the 'x scenes selected button'
 * Click the 'Add to project' button
 * Try to create a project without entering a name (it shouldn't work, and there should be an error message)
 * Check that no request was sent
 * Go to the library project list page and do the same test
 * Go to your user settings and check that the 'notifications' and 'billing' links are not present in the left-hand list

Connects #1086 
Connects #934
