### PR TITLE
Fix landsat8 tile footprint computation

### DIFF
--- a/app-tasks/rf/src/rf/uploads/landsat8/create_footprint.py
+++ b/app-tasks/rf/src/rf/uploads/landsat8/create_footprint.py
@@ -24,7 +24,7 @@ def create_footprints(csv_row):
     lr = (csv_row['lowerRightCornerLongitude'], csv_row['lowerRightCornerLatitude'])
     ul = (csv_row['upperLeftCornerLongitude'], csv_row['upperLeftCornerLatitude'])
     ur = (csv_row['upperRightCornerLongitude'], csv_row['upperRightCornerLatitude'])
-    src_coords = [ll, lr, ur, ul]
+    src_coords = [(float(c[0]), float(c[1])) for c in [ll, lr, ur, ul]]
 
     min_x = min([coord[0] for coord in src_coords])
     min_y = min([coord[1] for coord in src_coords])


### PR DESCRIPTION
## Overview

This PR ensures that footprints are properly imported by explicitly casting all coordinates to floats (rather than allowing them to be strings) before they are compared to determine min and max coordinates.

~This PR also ensures that min and max coordinates will be properly selected even if they cross the anti-meridian.~

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~

## Testing Instructions

 * Inside the VM, open bash within an airflow container `./scripts/console airflow-worker bash`
 * CD to `app-tasks/rf/src/rf/uploads`
 * Open an ipython session
 * `from landsat8.create_footprint import create_footprints`
 * Set separate vars to the dicts shown below
 * pass each var into `create_footprints` and destructuring the return `(tile_footprint, data_footprint) = create_footprints(<dict>)`
 * For each dict examine `tile_footprint.to_dict()`; they should be the same

Dict with string values
```
{
  'lowerLeftCornerLongitude': '148.5',
  'lowerLeftCornerLatitude': '-10.8',
  'lowerRightCornerLongitude': '150.23',
  'lowerRightCornerLatitude': '-11.17634',
  'upperLeftCornerLongitude': '148.9',
  'upperLeftCornerLatitude': '-9.07',
  'upperRightCornerLongitude': '150.59',
  'upperRightCornerLatitude': '-9.43'
}
```

Dict with float values
```
{
  'lowerLeftCornerLongitude': 148.5,
  'lowerLeftCornerLatitude': -10.8,
  'lowerRightCornerLongitude': 150.23,
  'lowerRightCornerLatitude': -11.17634,
  'upperLeftCornerLongitude': 148.9,
  'upperLeftCornerLatitude': -9.07,
  'upperRightCornerLongitude': 150.59,
  'upperRightCornerLatitude': -9.43
}
```

Connects #965