### PR TITLE
Add Scene Ingest Trigger

### DIFF
--- a/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Projects.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Projects.scala
@@ -234,15 +234,15 @@ object Projects extends TableQuery(tag => new Projects(tag)) with LazyLogging {
     }
     val redBand = bands.get("redBand") match {
       case Some(b) => b.asInstanceOf[Int]
-      case _ => 1
+      case _ => 0
     }
     val greenBand = bands.get("greenBand") match {
       case Some(b) => b.asInstanceOf[Int]
-      case _ => 2
+      case _ => 1
     }
     val blueBand = bands.get("blueBand") match {
       case Some(b) => b.asInstanceOf[Int]
-      case _ => 3
+      case _ => 2
     }
 
     (redBand, greenBand, blueBand)

--- a/app-tasks/dags/ingest/find_scenes_to_ingest.py
+++ b/app-tasks/dags/ingest/find_scenes_to_ingest.py
@@ -1,0 +1,106 @@
+"""DAG to check if there are scenes to be ingested.
+
+Queries the API for scenes that have a status 'TOBEINGESTED'
+and kicks off an ingest DAG for each scene.
+"""
+
+from collections import namedtuple
+import datetime
+import json
+import logging
+import os
+from time import time
+
+from airflow.operators.python_operator import PythonOperator
+from airflow.models import DAG
+from airflow.bin.cli import trigger_dag
+
+from rf.utils.io import get_jwt, get_session, IngestStatus
+
+rf_logger = logging.getLogger('rf')
+ch = logging.StreamHandler()
+ch.setLevel(logging.INFO)
+formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+ch.setFormatter(formatter)
+rf_logger.addHandler(ch)
+
+logger = logging.getLogger(__name__)
+
+
+default_args = {
+    'owner': 'raster-foundry',
+    'start_date': datetime.datetime(2017, 1, 1)
+}
+
+
+http_connection_id = 'raster-foundry'
+base_params = {'ingestStatus': IngestStatus.TOBEINGESTED}
+headers = {'Authorization': 'Bearer {}'.format(get_jwt())}
+host = os.getenv('RF_HOST')
+
+DagArgs = namedtuple('DagArgs', 'dag_id, conf, run_id')
+
+
+def get_uningested_scenes():
+    """Requests uningested scenes from API and returns list
+
+    Returns:
+        List[Dict]
+    """
+    params = base_params.copy()
+    params['page'] = 0
+    session = get_session()
+
+    scene_url = '{host}/api/scenes/'.format(host=host)
+    scene_response = session.get(scene_url, params=params).json()
+    scenes = scene_response['results']
+    scenes_remain = scene_response['hasNext']
+    while scenes_remain:
+        params['page'] += 1
+        logger.debug('Requesting page %s for scenes', params['page'])
+        scene_response = session.get(scene_url, params=params).json()
+        scenes += scene_response['results']
+        scenes_remain = scene_response['hasNext']
+    return scenes
+
+
+def check_for_scenes_to_ingest():
+    """Requests uningested scenes, kicks off ingest DAG for each scene
+
+    Notes
+      At some point this should batch scene ingests together, but for now
+      they are kept separate for debugging and because the ingests themselves
+      do not parallelize well
+    """
+    logger.info("Requesting uningested scenes...")
+    scenes = get_uningested_scenes()
+
+    dag_id = 'ingest_project_scenes'
+
+    if len(scenes) == 0:
+        return 'No scenes to ingest'
+
+    logger.info('Kicking off ingests for %s scenes', len(scenes))
+    for scene in scenes:
+        run_id = 'scene_ingest_{}_{}'.format(scene['id'], time())
+        logger.info('Kicking off new scene ingest: %s', run_id)
+        conf = json.dumps({'scene': scene})
+        dag_args = DagArgs(dag_id=dag_id, conf=conf, run_id=run_id)
+        trigger_dag(dag_args)
+    return "Finished kicking off ingests"
+
+
+dag = DAG(
+    dag_id='find_scenes_to_ingest',
+    default_args=default_args,
+    concurrency=int(os.getenv('AIRFLOW_DAG_CONCURRENCY', 24)),
+    schedule_interval=datetime.timedelta(minutes=2),
+    max_active_runs=1
+)
+
+
+PythonOperator(
+    task_id='check_for_scenes_to_ingest',
+    python_callable=check_for_scenes_to_ingest,
+    dag=dag
+)

--- a/app-tasks/rf/src/rf/models/base.py
+++ b/app-tasks/rf/src/rf/models/base.py
@@ -1,24 +1,8 @@
-from datetime import datetime, timedelta
-import requests
-import jwt
+
 import json
 import os
 
-
-def get_session():
-    """Helper method to create a requests Session"""
-
-    jwt_secret = os.getenv('AUTH0_CLIENT_SECRET')
-    claims = {
-        'sub': 'rf|airflow-user',
-        'iat': datetime.utcnow(),
-        'exp': datetime.utcnow() + timedelta(hours=3)
-    }
-    encoded_jwt = jwt.encode(claims, jwt_secret, algorithm='HS256')
-    session = requests.Session()
-
-    session.headers.update({'Authorization': 'Bearer {}'.format(encoded_jwt)})
-    return session
+from rf.utils.io import get_session
 
 
 class BaseModel(object):


### PR DESCRIPTION
## Overview

This commit adds a DAG to check if scenes need to be ingested and kicks
off an ingest _per_ scene to be ingested.

A few notes:
 - Decided against using a sensor here because of issues with the
 semantics for a sensor. A sensor can run on a schedule and continues
 poking until it reaches a true status. Which in our case is not quite
 what we want -- instead we want this to run at a regular interval and
 at most 1 running per time.
 - Subsequent PRs will address kicking off ingests actually, for now
 this kicks off the dummy DAG for ingests
 - `max_active_runs` is set to 1 to prevent us from DDOSing ourselves
 - DAG is set to run every two minutes, this might need to be adjusted
 down later

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~

### Demo

![dag-overview](https://cloud.githubusercontent.com/assets/898060/22930627/35dd876e-f28f-11e6-9ad5-afc1ae99d2dd.png)
![detail-dag-graph](https://cloud.githubusercontent.com/assets/898060/22930629/3913a53a-f28f-11e6-86cd-119097453280.png)
![dag-tree-view](https://cloud.githubusercontent.com/assets/898060/22930630/3b15d5e2-f28f-11e6-9103-fcdded66cabd.png)
![dag-log-ex](https://cloud.githubusercontent.com/assets/898060/22930633/3ceabf90-f28f-11e6-9cb1-b0b4f0de6f41.png)

### Notes

I adjusted the default bands for RGB false color composites -- they are zero-indexed when ingested so the previous default had an off-by-one error.

## Testing Instructions

 * Load a fresh development database: `./scripts/load_development_data`
 * Start server with airflow
 * It might be necessary/desirable to disable other DAGs in the UI to prevent a flood of DAGs running
 * Go to airflow page and observe DAGs are kicked off and work once API server comes up

Closes #985 
