### PR TITLE
Bulk add scenes to a project based on a query

### DIFF
--- a/app-backend/app/src/main/scala/project/Routes.scala
+++ b/app-backend/app/src/main/scala/project/Routes.scala
@@ -63,7 +63,7 @@ trait ProjectRoutes extends Authentication
           put { updateProjectScenes(projectId) } ~
           delete { deleteProjectScenes(projectId) }
         } ~
-          pathPrefix("fromQuery") {
+          pathPrefix("bulk-add-from-query") {
             pathEndOrSingleSlash {
               post { addProjectScenesFromQueryParams(projectId) }
             }

--- a/app-backend/app/src/test/scala/project/ProjectHelpers.scala
+++ b/app-backend/app/src/test/scala/project/ProjectHelpers.scala
@@ -21,6 +21,10 @@ trait ProjectSpecHelper {
     publicOrgId, "Test Two", "This is the second test project", Visibility.Public, List("testing")
   )
 
+  val newProject3 = Project.Create(
+    publicOrgId, "Test Three", "This is the third test project", Visibility.Public, List("testing")
+  )
+
   val landsatId = UUID.fromString("697a0b91-b7a8-446e-842c-97cda155554d")
 
   def newScene(name: String, cloudCover: Option[Float] = None) = Scene.Create(

--- a/app-backend/app/src/test/scala/project/ProjectSceneSpec.scala
+++ b/app-backend/app/src/test/scala/project/ProjectSceneSpec.scala
@@ -309,7 +309,7 @@ class ProjectSceneSpec extends WordSpec
     }
   }
 
-  "/api/projects/{project}/scenes/fromQuery/" should {
+  "/api/projects/{project}/scenes/bulk-add-from-query/" should {
     val scene1 = newScene("fs1", Some(150.toFloat))
     val scene2 = newScene("fs2", Some(150.toFloat))
     val scene3 = newScene("fs3", Some(0.toFloat))
@@ -342,7 +342,7 @@ class ProjectSceneSpec extends WordSpec
         responseAs[Project]
       }
 
-      Post(s"/api/projects/${project.id}/scenes/fromQuery/").withHeadersAndEntity(
+      Post(s"/api/projects/${project.id}/scenes/bulk-add-from-query/").withHeadersAndEntity(
         List(authHeader),
         HttpEntity(
           ContentTypes.`application/json`,
@@ -378,7 +378,7 @@ class ProjectSceneSpec extends WordSpec
         responseAs[Scene.WithRelated]
       }
 
-      Post(s"/api/projects/${project.id}/scenes/fromQuery/").withHeadersAndEntity(
+      Post(s"/api/projects/${project.id}/scenes/bulk-add-from-query/").withHeadersAndEntity(
         List(authHeader),
         HttpEntity(
           ContentTypes.`application/json`,

--- a/app-backend/database/src/main/scala/com/azavea/rf/database/QueryParameterJsonFormat.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/QueryParameterJsonFormat.scala
@@ -1,0 +1,208 @@
+package com.azavea.rf.database.query
+
+import java.util.UUID
+
+import spray.json._
+import spray.json.DefaultJsonProtocol._
+
+import com.azavea.rf.datamodel._
+
+trait QueryParameterJsonFormat extends AdditionalFormats with
+    SerializationUtils {
+
+  object OrgQueryParamsReader extends JsonReader[OrgQueryParameters] {
+    def read(value: JsValue): OrgQueryParameters = {
+      OrgQueryParameters(
+        jsArrayToList(value.asJsObject.getFields("organizations")(0))
+      )
+    }
+  }
+
+  object OrgQueryParamsWriter extends JsonWriter[OrgQueryParameters] {
+    def write(params: OrgQueryParameters): JsValue = JsObject(
+      "organizations" -> params.organizations.toJson
+    )
+  }
+
+  implicit val defaultOrgQueryParamsFormat = jsonFormat(OrgQueryParamsReader, OrgQueryParamsWriter)
+
+  object UserQueryParamsReader extends JsonReader[UserQueryParameters] {
+    def read(value: JsValue): UserQueryParameters = {
+      val fields = value.asJsObject.getFields("createdBy", "modifiedBy")
+      UserQueryParameters(
+        jsOptionToVal[String](fields(0)),
+        jsOptionToVal[String](fields(1))
+      )
+    }
+  }
+
+  object UserQueryParamsWriter extends JsonWriter[UserQueryParameters] {
+    def write(params: UserQueryParameters): JsValue = JsObject(
+      "createdBy" -> params.createdBy.toJson,
+      "modifiedBy" -> params.modifiedBy.toJson
+    )
+  }
+
+  implicit val defaultUserQueryParamsFormat = jsonFormat(UserQueryParamsReader, UserQueryParamsWriter)
+
+  object TimestampQueryParamsReader extends JsonReader[TimestampQueryParameters] {
+    def read(value: JsValue): TimestampQueryParameters = {
+      val fields = value.asJsObject.getFields(
+        "minCreateDatetime",
+        "maxCreateDatetime",
+        "minModifiedDatetime",
+        "maxModifiedDatetime"
+      )
+      TimestampQueryParameters(
+        formatTs(jsOptionToVal[String](fields(0))),
+        formatTs(jsOptionToVal[String](fields(1))),
+        formatTs(jsOptionToVal[String](fields(2))),
+        formatTs(jsOptionToVal[String](fields(3)))
+      )
+    }
+  }
+
+  object TimestampQueryParamsWriter extends JsonWriter[TimestampQueryParameters] {
+    def write(params: TimestampQueryParameters): JsValue = JsObject(
+      "minCreateDatetime" -> params.minCreateDatetime.toJson,
+      "maxCreateDatetime" -> params.maxCreateDatetime.toJson,
+      "minModifiedDatetime" -> params.minModifiedDatetime.toJson,
+      "maxModifiedDatetime" -> params.maxModifiedDatetime.toJson
+    )
+  }
+
+  implicit val defaultTimestampQueryParamsFormat = jsonFormat(TimestampQueryParamsReader, TimestampQueryParamsWriter)
+
+  object ImageQueryParamsReader extends JsonReader[ImageQueryParameters] {
+    def read(value: JsValue): ImageQueryParameters = {
+      val fields = value.asJsObject.getFields(
+        "minRawDataBytes",
+        "maxRawDataBytes",
+        "minResolution",
+        "maxResolution",
+        "scene"
+      )
+      ImageQueryParameters(
+        jsOptionToVal[Int](fields(0)),
+        jsOptionToVal[Int](fields(1)),
+        jsOptionToVal[Float](fields(2)),
+        jsOptionToVal[Float](fields(3)),
+        jsArrayToList[UUID](fields(4))
+      )
+    }
+  }
+
+  object ImageQueryParamsWriter extends JsonWriter[ImageQueryParameters] {
+    def write(params: ImageQueryParameters): JsValue = JsObject(
+      "minRawDataBytes" -> params.minRawDataBytes.toJson,
+      "maxRawDataBytes" -> params.maxRawDataBytes.toJson,
+      "minResolution" -> params.minResolution.toJson,
+      "maxResolution" -> params.maxResolution.toJson,
+      "scene" -> params.scene.toJson
+    )
+  }
+
+  implicit val defaultImageQueryParamsFormat = jsonFormat(ImageQueryParamsReader, ImageQueryParamsWriter)
+
+  object SceneQueryParamsReader extends JsonReader[SceneQueryParameters] {
+    def read(value: JsValue): SceneQueryParameters = {
+      val fields = value.asJsObject.getFields(
+        "maxCloudCover", // 0
+        "minCloudCover",
+        "minAcquisitionDatetime",
+        "maxAcquisitionDatetime",
+        "datasource",
+        "month", // 5
+        "minDayOfMonth",
+        "maxDayOfMonth",
+        "maxSunAzimuth",
+        "minSunAzimuth",
+        "maxSunElevation", // 10
+        "minSunElevation",
+        "bbox",
+        "point",
+        "project",
+        "ingested", // 15
+        "ingestStatus"
+      )
+
+      SceneQueryParameters(
+        jsOptionToVal[Float](fields(0)),
+        jsOptionToVal[Float](fields(1)),
+        formatTs(jsOptionToVal[String](fields(2))),
+        formatTs(jsOptionToVal[String](fields(3))),
+        jsArrayToList[UUID](fields(4)),
+        jsArrayToList[Int](fields(5)),
+        jsOptionToVal[Int](fields(6)),
+        jsOptionToVal[Int](fields(7)),
+        jsOptionToVal[Float](fields(8)),
+        jsOptionToVal[Float](fields(9)),
+        jsOptionToVal[Float](fields(10)),
+        jsOptionToVal[Float](fields(11)),
+        jsOptionToVal[String](fields(12)),
+        jsOptionToVal[String](fields(13)),
+        jsOptionToVal[UUID](fields(14)),
+        jsOptionToVal[Boolean](fields(15)),
+        jsArrayToList[String](fields(16))
+      )
+    }
+  }
+
+  object SceneQueryParamsWriter extends JsonWriter[SceneQueryParameters] {
+    def write(params: SceneQueryParameters): JsValue = JsObject(
+      "maxCloudCover" -> params.maxCloudCover.toJson,
+      "minCloudCover" -> params.minCloudCover.toJson,
+      "minAcquisitionDatetime" -> params.minAcquisitionDatetime.toJson,
+      "maxAcquisitionDatetime" -> params.maxAcquisitionDatetime.toJson,
+      "datasource" -> params.datasource.toJson,
+      "month" -> params.month.toJson,
+      "minDayOfMonth" -> params.minDayOfMonth.toJson,
+      "maxDayOfMonth" -> params.maxDayOfMonth.toJson,
+      "maxSunAzimuth" -> params.maxSunAzimuth.toJson,
+      "minSunAzimuth" -> params.minSunAzimuth.toJson,
+      "maxSunElevation" -> params.maxSunElevation.toJson,
+      "minSunElevation" -> params.minSunElevation.toJson,
+      "bbox" -> params.bbox.toJson,
+      "point" -> params.point.toJson,
+      "project" -> params.project.toJson,
+      "ingested" -> params.ingested.toJson,
+      "ingestStatus" -> params.ingestStatus.toJson
+    )
+  }
+
+  implicit val defaultSceneQueryParamsFormat = jsonFormat(SceneQueryParamsReader, SceneQueryParamsWriter)
+
+  object CombinedSceneQueryParamsReader extends JsonReader[CombinedSceneQueryParams] {
+    def read(value: JsValue): CombinedSceneQueryParams = {
+      val fields = value.asJsObject.getFields(
+        "orgParams",
+        "userParams",
+        "timestampParams",
+        "sceneParams",
+        "imageQueryParameters"
+      )
+
+      CombinedSceneQueryParams(
+        OrgQueryParamsReader.read(fields(0)),
+        UserQueryParamsReader.read(fields(1)),
+        TimestampQueryParamsReader.read(fields(2)),
+        SceneQueryParamsReader.read(fields(3)),
+        ImageQueryParamsReader.read(fields(4))
+      )
+    }
+  }
+
+  object CombinedSceneQueryParamsWriter extends JsonWriter[CombinedSceneQueryParams] {
+    def write(params: CombinedSceneQueryParams): JsValue = JsObject(
+      "orgParams" -> params.orgParams.toJson,
+      "userParams" -> params.userParams.toJson,
+      "timestampParams" -> params.timestampParams.toJson,
+      "sceneParams" -> params.sceneParams.toJson,
+      "imageQueryParameters" -> params.imageQueryParameters.toJson
+    )
+  }
+
+  implicit val defaultCombinedSceneQueryParamsFormat = jsonFormat(
+    CombinedSceneQueryParamsReader, CombinedSceneQueryParamsWriter
+  )
+}

--- a/app-backend/database/src/main/scala/com/azavea/rf/database/QueryParameters.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/QueryParameters.scala
@@ -29,7 +29,6 @@ case class ImageQueryParameters(
   scene: Iterable[UUID] = Seq[UUID]()
 )
 
-
 /** Case class representing all possible query parameters */
 case class SceneQueryParameters(
   maxCloudCover: Option[Float] = None,
@@ -156,13 +155,11 @@ case class OrgQueryParameters(
   organizations: Iterable[UUID] = Seq[UUID]()
 )
 
-
 /** Query parameters to filter by users */
 case class UserQueryParameters(
   createdBy: Option[String] = None,
   modifiedBy: Option[String] = None
 )
-
 
 /** Query parameters to filter by modified/created times */
 case class TimestampQueryParameters(

--- a/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Projects.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Projects.scala
@@ -322,6 +322,17 @@ object Projects extends TableQuery(tag => new Projects(tag)) with LazyLogging {
     listSelectProjectScenes(projectId, sceneIds)
   }
 
+  def addScenesToProjectFromQuery(combinedParams: CombinedSceneQueryParams, projectId: UUID, user: User)
+                                 (implicit database: DB): Future[Iterable[Scene.WithRelated]] = {
+    val sceneAction = Scenes.filterScenes(combinedParams)
+      .filterUserVisibility(user)
+      .map(_.id)
+      .result
+    database.db.run(sceneAction) flatMap { ids =>
+      Projects.addScenesToProject(ids, projectId)
+    }
+  }
+
   /** Removes scenes from project
     *
     * @param sceneIds Seq[UUID] primary key of scenes to remove from project

--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/SceneSerialization.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/SceneSerialization.scala
@@ -7,28 +7,8 @@ import spray.json._
 import geotrellis.vector.Geometry
 import geotrellis.slick.Projected
 
-object ScenesJsonProtocol extends DefaultJsonProtocol {
-
-  def jsArrayToList[T](jsArr: JsValue): List[T] = {
-    jsArr match {
-      case arr: JsArray => arr.elements.map(_.asInstanceOf[T]).to[List]
-      case _ => List.empty[T]
-    }
-  }
-
-  // Reimplements OptionFormat.read because OptionFormat is mysteriously not in scope
-  def jsOptionToVal[T](jsOpt: JsValue): Option[T] = {
-    jsOpt match {
-      case JsNull => None
-      case v: Any => Some(v.asInstanceOf[T])
-    }
-  }
-
-  def formatTs(ts: String): Timestamp = {
-    Timestamp.valueOf(
-      ts.replace("Z", "").replace("T", " ")
-    )
-  }
+object ScenesJsonProtocol extends DefaultJsonProtocol
+    with SerializationUtils {
 
   implicit object SceneWithRelatedFormat extends RootJsonFormat[Scene.WithRelated] {
     def write(scene: Scene.WithRelated): JsObject = JsObject(

--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/SerializationUtils.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/SerializationUtils.scala
@@ -1,0 +1,80 @@
+package com.azavea.rf.datamodel
+
+import java.sql.Timestamp
+import java.util.UUID
+import spray.json._
+import spray.json.DefaultJsonProtocol._
+
+trait SerializationUtils {
+  def jsArrayToList[T](jsArr: JsValue): List[T] = {
+    jsArr match {
+      case arr: JsArray => arr.elements.map(_.asInstanceOf[T]).to[List]
+      case _ => List.empty[T]
+    }
+  }
+
+  // Reimplements OptionFormat.read because OptionFormat is mysteriously not in scope
+  def jsOptionToVal[T: JsonFormat](jsOpt: JsValue): Option[T] = {
+    try {
+      jsOpt match {
+        case JsNull => None
+        case v: JsValue => Some(v.convertTo[T])
+      }
+    }
+  }
+
+  def formatTs(ts: String): Timestamp = {
+    Timestamp.valueOf(
+      ts.replace("Z", "").replace("T", " ")
+    )
+  }
+
+  def formatTs(ts: Option[String]): Option[Timestamp] = {
+    ts match {
+      case Some(t) => Some(formatTs(t))
+      case _ => None
+    }
+  }
+
+  /** Serializers for simple types not covered by DefaultJsonProtocol */
+  implicit object TimestampOptionJsonProtocol extends RootJsonFormat[Option[Timestamp]] {
+    def write(ts: Option[Timestamp]): JsValue = {
+      ts match {
+        case Some(t) => t.toJson
+        case _ => JsNull
+      }
+    }
+
+    def read(v: JsValue): Option[Timestamp] = {
+      v match {
+        case JsNull => None
+        case _ => Some(formatTs(StringJsonFormat.read(v)))
+      }
+    }
+  }
+
+  implicit object UUIDOptionJsonProtocol extends RootJsonFormat[Option[UUID]] {
+    def write(uuid: Option[UUID]): JsValue = {
+      uuid match {
+        case Some(u) => u.toJson
+        case _ => JsNull
+      }
+    }
+
+    def read(v: JsValue): Option[UUID] = {
+      v match {
+        case JsNull => None
+        case s: JsString => Some(UUID.fromString(StringJsonFormat.read(s)))
+        case _ => throw new DeserializationException("Invalid UUID parameter: $v")
+      }
+    }
+  }
+
+  implicit object IterableUUIDJsonProtocol extends RootJsonFormat[Iterable[UUID]] {
+    def write(uuids: Iterable[UUID]): JsArray = JsArray(
+      (uuids map { uuid => uuid.toJson }).to[List]
+    )
+
+    def read(uuidsArr: JsValue): Iterable[UUID] = jsArrayToList[UUID](uuidsArr)
+  }
+}

--- a/docs/swagger/spec.yml
+++ b/docs/swagger/spec.yml
@@ -594,11 +594,73 @@ paths:
           schema:
             type: array
             items:
-              type: string
-              format: uuid
+              - $ref: '#/parameters/uuid'
       responses:
         204:
           description: No content, delete successful
+  /projects/{uuid}/scenes/bulk-add-from-query/:
+    post:
+      summary: Create a new association between a set of scenes and this project
+      tags:
+        - Imagery
+      parameters:
+        - name: orgParams
+          in: body
+          type: object
+          properties:
+            organizations:
+              type: array
+              description: List of organizations to filter scenes to
+              items:
+                $ref: '#/definitions/UserOrg'
+        - name: userParams
+          in: body
+          allOf:
+            - $ref: '#/definitions/UserTrackingMixin'
+        - name: timestampParams
+          in: body
+          properties:
+            $ref: '#/parameters/minAcquisitionDatetime'
+            $ref: '#/parameters/maxAcquisitionDatetime'
+            $ref: '#/parameters/minCreateDatetime'
+            $ref: '#/parameters/maxCreateDatetime'
+        - name: sceneParams
+          in: body
+          type: object
+          properties:
+            $ref: '#/parameters/maxCloudCover'
+            $ref: '#/parameters/minCloudCover'
+            $ref: '#/parameters/minAcquisitionDatetime'
+            $ref: '#/parameters/maxAcquisitionDatetime'
+            $ref: '#/parameters/datasource'
+            $ref: '#/parameters/month'
+            $ref: '#/parameters/minDayOfMonth'
+            $ref: '#/parameters/maxDayOfMonth'
+            $ref: '#/parameters/maxSunAzimuth'
+            $ref: '#/parameters/minSunAzimuth'
+            $ref: '#/parameters/maxSunElevation'
+            $ref: '#/parameters/minSunElevation'
+            $ref: '#/parameters/bbox'
+            $ref: '#/parameters/point'
+            $ref: '#/parameters/project'
+            $ref: '#/parameters/ingested'
+            $ref: '#/parameters/ingestStatus'
+        - name: imageQueryParameters
+          in: body
+          type: object
+          properties:
+            $ref: '#/parameters/sceneId'
+            $ref: '#/parameters/minRawDataBytes'
+            $ref: '#/parameters/maxRawDataBytes'
+            $ref: '#/parameters/minResolution'
+            $ref: '#/parameters/maxResolution'
+      responses:
+        201:
+          description: List of scenes added to project
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Scene'
   /projects/{uuid}/mosaic/:
     get:
       summary: List of a project's scene IDs and their associated color correction parameters to be used in mosaicing


### PR DESCRIPTION
## Overview

This PR enables adding scenes to a project based on a query for scenes. We need to do this because even scrolling through the list of scenes and clicking select all over and over again isn't convenient for adding large numbers of scenes, and users who know what they want should be able to add those scenes to a project.

### Checklist

- ~[ ] Styleguide updated, if necessary~
- [x] Swagger specification updated, if necessary
- ~[ ] Symlinks from new migrations present or corrected for any new migrations~

### Notes

This could maybe use more thorough testing, but there are about 25 total fields to check "should filter by x correctly" for, and scene filtering is well tested in a number of other places, so I thought probably it's fine.

We should abandon `spray` for [`circe`](https://circe.github.io/circe/), or at least I believe this because I am easily marketable to and everything sounds better than writing serialization boilerplate over and over again.

## Testing Instructions

 * Run tests
 * If you want: go to the console, create dumb combinations of scene query parameters, and check the results

Connects #974
