### PR TITLE
Fix metadata urls in sentinel2 import

### DIFF
--- a/app-tasks/rf/src/rf/uploads/sentinel2/create_scenes.py
+++ b/app-tasks/rf/src/rf/uploads/sentinel2/create_scenes.py
@@ -54,7 +54,7 @@ def create_sentinel2_scenes(tile_path):
     tileFootprint, dataFootprint = create_footprints(tileinfo)
     thumbnails = create_thumbnails(scene_id, tile_path)
     tags = ['Sentinel-2', 'JPEG2000']
-    aws_base = bucket.name + '.s3.amazonaws.com'
+    aws_base = 'https://' + bucket.name + '.s3.amazonaws.com'
     metadataFiles = [
         os.path.join(aws_base, tile_path, 'tileInfo.json'),
         os.path.join(aws_base, tile_path, 'metadata.xml'),


### PR DESCRIPTION
## Overview

This ensures the metadataFile urls generated by the importer are fully qualified and will not result in relative linking client-side.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~


## Testing Instructions

* Inside the VM, open bash within an airflow container `./scripts/console airflow-worker bash`
* CD to `/opt/raster-foundry/app-tasks/rf/src/rf/uploads`
* Open an ipython session
* `from sentinel2.create_scenes import create_scenes`
* `scene = create_sentinel2_scene('tiles/10/U/DC/2017/2/8/0')[0]`
* Check that the output of `scene.metadatFiles` is a list of fully defined urls (with the https)

Connects #740