### PR TITLE
ToolRun API

### DIFF
--- a/app-backend/app/src/main/scala/Router.scala
+++ b/app-backend/app/src/main/scala/Router.scala
@@ -15,6 +15,7 @@ import com.azavea.rf.tool.ToolRoutes
 import com.azavea.rf.tooltag.ToolTagRoutes
 import com.azavea.rf.token.TokenRoutes
 import com.azavea.rf.toolcategory.ToolCategoryRoutes
+import com.azavea.rf.toolrun.ToolRunRoutes
 import com.azavea.rf.grid.GridRoutes
 import com.azavea.rf.datasource.DatasourceRoutes
 import com.azavea.rf.utils.Config
@@ -37,6 +38,7 @@ trait Router extends HealthCheckRoutes
     with ToolTagRoutes
     with ConfigRoutes
     with ToolCategoryRoutes
+    with ToolRunRoutes
     with GridRoutes
     with DatasourceRoutes
     with Config {
@@ -58,6 +60,7 @@ trait Router extends HealthCheckRoutes
       pathPrefix("tools") { toolRoutes } ~
       pathPrefix("tool-tags") { toolTagRoutes } ~
       pathPrefix("tool-categories") { toolCategoryRoutes } ~
+      pathPrefix("tool-runs") { toolRunRoutes } ~
       pathPrefix("scene-grid") { gridRoutes } ~
       pathPrefix("datasources") { datasourceRoutes }
     } ~

--- a/app-backend/app/src/main/scala/toolrun/Routes.scala
+++ b/app-backend/app/src/main/scala/toolrun/Routes.scala
@@ -1,0 +1,85 @@
+package com.azavea.rf.toolrun
+
+import java.util.UUID
+
+import scala.util.{Success, Failure}
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.server.Route
+
+import com.azavea.rf.common.{Authentication, UserErrorHandler}
+import com.azavea.rf.database.{ActionRunner, Database}
+import com.azavea.rf.database.tables.ToolRuns
+import com.azavea.rf.datamodel.{PaginatedResponse, ToolRun}
+import com.lonelyplanet.akka.http.extensions.PaginationDirectives
+
+import scala.concurrent.ExecutionContext.Implicits.global
+
+trait ToolRunRoutes extends Authentication
+    with PaginationDirectives
+    with ToolRunQueryParametersDirective
+    with UserErrorHandler
+    with ActionRunner {
+  implicit def database: Database
+
+  val toolRunRoutes: Route = handleExceptions(userExceptionHandler) {
+    pathEndOrSingleSlash {
+      get { listToolRuns } ~
+      post { createToolRun }
+    } ~
+    pathPrefix(JavaUUID) { runId =>
+      pathEndOrSingleSlash {
+        get { getToolRun(runId) } ~
+        put { updateToolRun(runId) } ~
+        delete { deleteToolRun(runId) }
+      }
+    }
+  }
+
+  def listToolRuns: Route = authenticate { user =>
+    (withPagination & toolRunQueryParameters) { (page, runParams) =>
+      complete {
+        list(ToolRuns.listToolRuns(page.offset, page.limit, runParams), page.offset, page.limit)
+      }
+    }
+  }
+
+  def createToolRun: Route = authenticate { user =>
+    entity(as[ToolRun.Create]) { newRun =>
+      onSuccess(write(ToolRuns.insertToolRun(newRun, user.id))) { toolRun =>
+        complete(StatusCodes.Created, toolRun)
+      }
+    }
+  }
+
+  def getToolRun(runId: UUID): Route = authenticate { user =>
+    rejectEmptyResponse {
+      complete(readOne(ToolRuns.getToolRun(runId)))
+    }
+  }
+
+  def updateToolRun(runId: UUID): Route = authenticate { user =>
+    entity(as[ToolRun]) { updatedRun =>
+      onComplete(update(ToolRuns.updateToolRun(updatedRun, runId, user))) {
+        case Success(result) => {
+          result match {
+            case 1 => complete(StatusCodes.NoContent)
+            case count => throw new IllegalStateException(
+              s"Error updating tool run: update result expected to be 1, was $count"
+            )
+          }
+        }
+        case Failure(e) => throw e
+      }
+    }
+  }
+
+  def deleteToolRun(runId: UUID): Route = authenticate { user =>
+    onSuccess(database.db.run(ToolRuns.deleteToolRun(runId))) {
+      case 1 => complete(StatusCodes.NoContent)
+      case 0 => complete(StatusCodes.NotFound)
+      case count => throw new IllegalStateException(
+        s"Error deleting tool run: delete result expected to be 1, was $count"
+      )
+    }
+  }
+}

--- a/app-backend/app/src/main/scala/toolrun/package.scala
+++ b/app-backend/app/src/main/scala/toolrun/package.scala
@@ -1,0 +1,7 @@
+package com.azavea.rf
+
+import com.azavea.rf.datamodel.{PaginatedResponse, ToolRun}
+
+package object toolrun extends RfJsonProtocols {
+    implicit val paginatedToolRunFormat = jsonFormat6(PaginatedResponse[ToolRun])
+}

--- a/app-backend/app/src/test/scala/toolruns/ToolRunSpec.scala
+++ b/app-backend/app/src/test/scala/toolruns/ToolRunSpec.scala
@@ -1,0 +1,96 @@
+package com.azavea.rf.toolrun
+
+import java.util.UUID
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.model.{ContentTypes, HttpEntity, StatusCodes}
+import akka.http.scaladsl.server.Route
+import akka.http.scaladsl.testkit.{RouteTestTimeout, ScalatestRouteTest}
+import com.azavea.rf.datamodel._
+import com.azavea.rf.utils.Config
+import com.azavea.rf.{AuthUtils, DBSpec, Router}
+import concurrent.duration._
+import org.scalatest.{Matchers, WordSpec}
+import spray.json._
+
+class ToolRunSpec extends WordSpec
+    with Matchers
+    with ScalatestRouteTest
+    with Config
+    with Router
+    with DBSpec {
+
+  implicit val ec = system.dispatcher
+  implicit def database = db
+  implicit def default(implicit system: ActorSystem) = RouteTestTimeout(DurationInt(5).second)
+
+  val authorization = AuthUtils.generateAuthHeader("Default")
+  val publicOrgId = UUID.fromString("dfac6307-b5ef-43f7-beda-b9f208bb7726")
+  // Non-functional UUIDs
+  val projectId = UUID.fromString("4b027dff-a31e-4ce3-b928-7f5a9d254bd0")
+  val toolId = UUID.fromString("e609629f-05f5-4b18-a0e9-ea612b3c9ed7")
+  val baseToolRun = "/tool-runs/"
+  val newToolRun = ToolRun.Create(
+    Visibility.Public,
+    publicOrgId,
+    projectId,
+    toolId,
+    Map()
+  )
+
+  val baseRoutes = routes
+
+  "/api/tool-runs/{uuid}" should {
+    "return a 404 for non-existent tool-run" in {
+      Get(s"${baseToolRun}${publicOrgId}") ~> Route.seal(baseRoutes) ~> check {
+        status shouldEqual StatusCodes.NotFound
+      }
+    }
+
+    "update a tool-run" ignore {
+      // TODO: Add updating when creating associated objects doesn't require tons of boilerplate
+    }
+
+    "delete a tool-run" ignore {
+      // TODO: Also add when it is ergonomic to create test objects
+      val toolRunId = ""
+      Delete(s"${baseToolRun}${toolRunId}/") ~> baseRoutes ~> check {
+        status shouldEqual StatusCodes.NoContent
+      }
+    }
+  }
+
+  "/api/tool-runs/" should {
+
+    "reject creating tool-runs without authentication" in {
+      Post("/api/tool-runs/").withEntity(
+        HttpEntity(
+          ContentTypes.`application/json`,
+          newToolRun.toJson.toString()
+        )
+      ) ~> baseRoutes ~> check {
+        reject
+      }
+    }
+
+    "create a tool-run with authorization" ignore {
+      // TODO: Add creation when creating referenced objects is fixed, see above
+      Post("/api/tool-runs/").withHeadersAndEntity(
+        List(authorization),
+        HttpEntity(
+          ContentTypes.`application/json`,
+          newToolRun.toJson.toString()
+        )
+      ) ~> baseRoutes ~> check {
+        responseAs[ToolRun]
+      }
+    }
+
+    "require authentication for list" in {
+      Get("/api/tool-runs/") ~> baseRoutes ~> check {
+        reject
+      }
+    }
+  }
+}
+

--- a/docs/swagger/spec.yml
+++ b/docs/swagger/spec.yml
@@ -969,6 +969,66 @@ paths:
       responses:
         204:
           description: Successfully deleted a tool category
+  /tool-runs/:
+    get:
+      summary: Retrieve a list of tool runs
+      tags:
+        - Lab
+      parameters:
+        - $ref: '#/parameters/project'
+        - $ref: '#/parameters/tool'
+        - $ref: '#/parameters/createdBy'
+      responses:
+        200:
+          description: Paginated list of tool runs
+          schema:
+            $ref: '#/definitions/ToolRunPaginated'
+    post:
+      summary: Create a new tool run
+      tags:
+        - Lab
+      responses:
+        201:
+          description: Successfully created tool run
+          schema:
+            $ref: '#/definitions/ToolRun'
+        400:
+          description: Incorrect values for creating tool run
+  /tool-runs/{uuid}/:
+    get:
+      summary: Retrieve details about a tool run
+      tags:
+        - Lab
+      parameters:
+        - $ref: '#/parameters/uuid'
+      responses:
+        200:
+          description: Details about object
+          schema:
+            $ref: '#/definitions/ToolRun'
+        404:
+          description: Error if insufficient permissions or run not found
+    put:
+      summary: Update a tool run
+      tags:
+        - Lab
+      parameters:
+        - $ref: '#/parameters/uuid'
+      responses:
+        204:
+          description: Successfully updated tool run
+        400:
+          description: Bad parameters for updating tool run
+    delete:
+      summary: Delete a tool run
+      tags:
+        - Lab
+      parameters:
+        - $ref: '#/parameters/uuid'
+      responses:
+        204:
+          description: Successfully deleted a tool run
+
 
 parameters:
   orderingBase:
@@ -1261,6 +1321,19 @@ parameters:
   ingestStatus:
     name: ingestStatus
     description: Filter by specific ingest status
+    in: query
+    type: string
+    required: false
+  tool:
+    name: toolId
+    description: Filter by tool's slug label
+    in: query
+    type: string
+    format: uuid
+    required: false
+  createdBy:
+    name: createdBy
+    description: Filter by creator's slug label
     in: query
     type: string
     required: false
@@ -1562,7 +1635,7 @@ definitions:
         type: number
         format: float32
         description: Elevation of the sun
-      
+
   StatusFields:
     type: object
     properties:
@@ -1840,6 +1913,33 @@ definitions:
             type: array
             items:
               $ref: '#/definitions/ToolCategory'
+  ToolRun:
+    allOf:
+      - $ref: '#/definitions/BaseModel'
+      - $ref: '#/definitions/UserTrackingMixin'
+      - type: object
+        properties:
+          execution_parameters:
+            type: object
+            description: Parameters for running the tool
+          project:
+            type: string
+            format: uuid
+            description: Project with which this run is associated
+          tool:
+            type: string
+            format: uuid
+            description: Tool being run
+  ToolRunPaginated:
+    allOf:
+    - $ref: '#/definitions/PaginatedResponse'
+    - type: object
+      properties:
+        results:
+          type: array
+          items:
+            $ref: '#/definitions/ToolRun'
+
   Error:
     type: object
     properties:


### PR DESCRIPTION
## Overview

Adds a CRUD API for interacting with ToolRun objects

### Checklist

- [ ] ~Styleguide updated, if necessary~
- [x] Swagger specification updated, if necessary
- [ ] ~Symlinks from new migrations present or corrected for any new migrations~

### Notes

I _think_ the new swagger documentation is correct but it is raising errors on one set of lines that I added. However, all the other errors in the file are making it hard to tell if that is a real error or fallout from something else. I've added a comment on those lines; perhaps a second set of eyes can catch a typo I've missed.

Also, the structure of the `Routes.scala` is a bit different than our usual pattern. This is because the existing `ToolRuns` `TableQuery` returns `DBIO` objects rather than `Future`s. I assumed this was done as an improvement over previous iterations in that it decouples the API by pushing what is essentially API presentation logic up into the Routing level. If that wasn't the intent then it's easy enough to refactor so it matches what we do for other resources.

## Testing Instructions

 * Fire up `./scripts/server`, log in to the frontend, intercept your authorization token.
 * Using your preferred REST client, make requests against the `/api/tool-runs/` endpoint:
    * GET -> Returns paginated list of ToolRuns, with valid query parameters `projectId`, `createdBy`, `toolId`
    * POST -> Creates a new ToolRun. The payload should look something like:
```json
{
	"visibility": "PRIVATE",
	"organizationId": "9e2bef18-3f46-426b-a5bd-9913ee1ff840",
	"project": "db18b114-dd4a-403b-aaf5-53d6cb21b793",
	"tool": "7311e8ca-9af7-4fab-b63e-559d2e765388",
	"execution_parameters": {}
}
```
    * GET `/api/tool-runs/{uuid}/` -> Returns a ToolRun, or 404
    * PUT `/api/tool-runs/{uuid}/` -> Updates a ToolRun. The payload should look something like:
```json
{
	"visibility": "PRIVATE",
	"organizationId": "9e2bef18-3f46-426b-a5bd-9913ee1ff840",
	"project": "db18b114-dd4a-403b-aaf5-53d6cb21b793",
	"tool": "7311e8ca-9af7-4fab-b63e-559d2e765388",
	"execution_parameters": {"thing": 5},
	"id": "6307dee4-23ed-4bd1-8e4b-49c90a1eda95",
	"createdAt": "2017-02-20T19:35:52.520Z",
	"createdBy": "google-oauth2|116570040541971129286",
	"modifiedBy": "google-oauth2|116570040541971129286",
	"modifiedAt": "2017-02-20T19:35:52.520Z"
}
```
    * DELETE `/api/tool-runs/{uuid}/` -> Deletes a ToolRun.

There doesn't seem to be an issue for this.
