### PR TITLE
Fix auth0 management tokens

### DIFF
--- a/app-backend/app/src/main/resources/application.conf
+++ b/app-backend/app/src/main/resources/application.conf
@@ -41,6 +41,12 @@ auth0 {
   # Auth0 Bearer with proper permissions for Management API
   bearer = ""
   bearer = ${?AUTH0_MANAGEMENT_BEARER}
+
+  managementClientId = ""
+  managementClientId = ${?AUTH0_MANAGEMENT_CLIENT_ID}
+
+  managementSecret = ""
+  managementSecret = ${?AUTH0_MANAGEMENT_SECRET}
 }
 
 s3 {

--- a/app-backend/app/src/main/scala/token/package.scala
+++ b/app-backend/app/src/main/scala/token/package.scala
@@ -4,4 +4,5 @@ package object token extends RfJsonProtocols {
   implicit val refreshTokenJson = jsonFormat1(RefreshToken)
   implicit val deviceCredentialJson = jsonFormat2(DeviceCredential)
   implicit val authorizedTokenJson = jsonFormat3(AuthorizedToken)
+  implicit val managementBearerTokenJson = jsonFormat4(ManagementBearerToken)
 }

--- a/app-backend/app/src/main/scala/utils/Config.scala
+++ b/app-backend/app/src/main/scala/utils/Config.scala
@@ -16,6 +16,8 @@ trait Config {
   val auth0Bearer = auth0Config.getString("bearer")
   val auth0Secret = auth0Config.getString("secret")
   val auth0ClientId = auth0Config.getString("clientId")
+  val auth0ManagementClientId = auth0Config.getString("managementClientId")
+  val auth0ManagementSecret = auth0Config.getString("managementSecret")
 
   val featureFlags = featureFlagConfig.getConfigList("features")
 

--- a/app-backend/build.sbt
+++ b/app-backend/build.sbt
@@ -14,7 +14,7 @@ lazy val commonSettings = Seq(
   scalacOptions := Seq(
     "-deprecation",
     "-unchecked",
-    "-feature", 
+    "-feature",
     "-language:implicitConversions",
     "-language:reflectiveCalls",
     "-language:higherKinds",
@@ -89,7 +89,10 @@ lazy val appDependencies = dbDependencies ++ migrationsDependencies ++
   Dependencies.commonsIO,
   Dependencies.ammoniteOps,
   Dependencies.geotrellisSlick,
-  Dependencies.geotrellisS3
+  Dependencies.geotrellisS3,
+  Dependencies.caffeine,
+  Dependencies.scaffeine,
+  Dependencies.findbugAnnotations
 )
 
 lazy val root = Project("root", file("."))


### PR DESCRIPTION
## Overview

This commit alters the approach to obtaining a bearer token that granted access to the auth0 management api. We utilize the management api to create device_tokens which we leveraged when created user's api tokens.

Auth0 moved to a more secure token implementation which adopts a 24-hour lifetime token rather than the long-lived token used previously. As a result, we can no longer set an environment variable with the token and use that when doing device_token CRUD operations.

See the following links for more details:
 - [https://auth0.com/docs/api/management/v2/tokens-flows]
 - [https://auth0.com/docs/api/management/v2/tokens]

This commit uses an async-cache with a 12-hour expiration time (adjustable) to handle getting and storing the current management bearer token.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~

### Notes

@hectcastro This will require some adjustments operationally. I added environment variables to account for the fact that we now need to add a new Auth0 non-interactive client for all environments. I have not updated the `.env` file itself. The dev account has been adjusted to handle this (although I don't know if that is how you would like to do it).

I don't know what the ideal expiration time would be for the tokens. I set it to half of the actual lifetime of the tokens.

This doesn't do any hard token revocation via auth0. This could be something we would want when the token is removed from the cache.

## Testing Instructions

This is a little difficult to test. You'll need additional credentials which you can get from me out of band

 * Run the server
 * Go to the tokens page in user settings and see that you can view, create, and delete tokens

Connects #1082 
Connects #1117
