### PR TITLE
Kayak Geotiff import DAG

### DIFF
--- a/app-tasks/dags/geotiff/find_geotiff_scenes.py
+++ b/app-tasks/dags/geotiff/find_geotiff_scenes.py
@@ -1,0 +1,102 @@
+from collections import namedtuple
+import json
+import logging
+import os
+import boto3
+from datetime import datetime
+
+from airflow.models import DAG
+from airflow.bin.cli import trigger_dag
+from airflow.operators.python_operator import PythonOperator
+
+
+rf_logger = logging.getLogger('rf')
+ch = logging.StreamHandler()
+ch.setLevel(logging.INFO)
+formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+ch.setFormatter(formatter)
+rf_logger.addHandler(ch)
+
+logger = logging.getLogger(__name__)
+
+args = {
+    'start_date': datetime(2017, 2, 21)
+}
+
+DagArgs = namedtuple('DagArgs', 'dag_id, conf, run_id')
+
+dag = DAG(
+    dag_id='find_geotiff_scenes',
+    default_args=args,
+    schedule_interval=None,
+    concurrency=int(os.getenv('AIRFLOW_DAG_CONCURRENCY', 24))
+)
+
+
+def chunkify(lst, n):
+    """Helper function to split a list into roughly n chunks
+
+    Args:
+        lst (List): list of things to split
+        n (Int): number of chunks to split into
+    """
+    return [lst[i::n] for i in xrange(n)]
+
+
+def find_geotiffs(*args, **kwargs):
+    """Find geotiffs which match the bucket and prefix and kick off imports
+    """
+
+    logging.info("Finding geotiff scenes...")
+
+    conf = kwargs['dag_run'].conf
+
+    bucket = conf.get('bucket')
+    prefix = conf.get('prefix')
+
+    execution_date = kwargs['execution_date']
+
+    try:
+        tilepaths = find_geotiff_scenes(
+            bucket, prefix
+        )
+    except:
+        logger.error('encountered error finding tile paths')
+        raise
+
+
+    dag_id = 'import_geotiff_scenes'
+
+    group_max = int(os.getenv('AIRFLOW_CHUNK_SIZE', 32))
+    num_groups = group_max if len(tilepaths) >= group_max else len(tilepaths)
+    logger.info('Kicking off %s dags to import scene groups', num_groups)
+
+    tilepath_groups = chunkify(tilepaths, num_groups)
+    for idx, path_group in enumerate(tilepath_groups):
+        slug_path = '_'.join(path_group[0].split('/'))
+        run_id = 'geotiff_import_{year}_{month}_{day}_{idx}_{slug}'.format(
+            year=execution_date.year, month=execution_date.month, day=execution_date.day,
+            idx=idx, slug=slug_path
+        )
+        logger.info('Kicking off new scene import: %s', run_id)
+        conf['tilepaths'] = path_group
+        confjson = json.dumps(conf)
+        dag_args = DagArgs(dag_id=dag_id, conf=confjson, run_id=run_id)
+        trigger_dag(dag_args)
+
+    logger.info('Finished kicking off new Geotiff scene dags')
+
+
+def find_geotiff_scenes(bucket_name, files_prefix):
+    s3 = boto3.resource('s3')
+    bucket = s3.Bucket(bucket_name)
+    keys = [s3_tif.key for s3_tif in bucket.objects.filter(Prefix=files_prefix)]
+    return keys
+
+
+PythonOperator(
+    task_id='find_new_geotiff_scenes',
+    provide_context=True,
+    python_callable=find_geotiffs,
+    dag=dag
+)

--- a/app-tasks/dags/geotiff/import_geotiff_scenes.py
+++ b/app-tasks/dags/geotiff/import_geotiff_scenes.py
@@ -1,0 +1,85 @@
+import logging
+import os
+import tempfile
+import boto3
+from datetime import datetime
+
+from airflow.operators.python_operator import PythonOperator
+
+from airflow.models import DAG
+
+from rf.uploads.geotiff import GeoTiffS3SceneFactory
+from rf.uploads.geotiff.io import s3_url
+from rf.uploads.geotiff.create_thumbnails import create_thumbnails
+from rf.utils.io import Visibility
+
+rf_logger = logging.getLogger('rf')
+ch = logging.StreamHandler()
+ch.setLevel(logging.INFO)
+formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+ch.setFormatter(formatter)
+rf_logger.addHandler(ch)
+
+logger = logging.getLogger(__name__)
+
+args = {
+    'start_date': datetime(2017, 2, 21)
+}
+
+dag = DAG(
+    dag_id='import_geotiff_scenes',
+    default_args=args,
+    schedule_interval=None,
+    concurrency=int(os.getenv('AIRFLOW_DAG_CONCURRENCY', 24))
+)
+
+
+def import_geotiffs(*args, **kwargs):
+    """Find geotiffs which match the bucket and prefix and kick off imports
+    """
+
+    logging.info("Finding geotiff scenes...")
+    conf = kwargs['dag_run'].conf
+
+    tilepaths = conf.get('tilepaths')
+    organization = conf.get('organization')
+    datasource = conf.get('datasource')
+    capture_date = conf.get('capture_date')
+    bucket_name = conf.get('bucket')
+
+    factory = GeoTiffS3SceneFactory(
+        organization, Visibility.PRIVATE, datasource,
+        capture_date, bucket_name, ''
+    )
+
+    s3 = boto3.resource('s3')
+    bucket = s3.Bucket(bucket_name)
+
+    for path in tilepaths:
+        local_tif = tempfile.NamedTemporaryFile(delete=False)
+        try:
+            bucket.download_file(path, local_tif.name)
+            # We need to override the autodetected filename because we're loading into temp
+            # files which don't preserve the file name that is on S3.
+            filename = os.path.basename(path)
+            scene = factory.create_geotiff_scene(local_tif.name, os.path.splitext(filename)[0])
+            image = factory.create_geotiff_image(
+                local_tif.name, s3_url(bucket.name, path),
+                scene.id, filename
+            )
+
+            scene.thumbnails = create_thumbnails(local_tif.name, scene.id, organization)
+            scene.images = [image]
+            scene.create()
+        finally:
+            os.remove(local_tif.name)
+
+    logger.info('Finished importing scenes')
+
+
+geotiff_importer = PythonOperator(
+    task_id='import_geotiffs',
+    python_callable=import_geotiffs,
+    provide_context=True,
+    dag=dag
+)

--- a/app-tasks/rf/src/rf/models/base.py
+++ b/app-tasks/rf/src/rf/models/base.py
@@ -1,8 +1,11 @@
 
+import logging
 import json
 import os
 
 from rf.utils.io import get_session
+
+logger = logging.getLogger(__name__)
 
 
 class BaseModel(object):

--- a/app-tasks/rf/src/rf/models/scene.py
+++ b/app-tasks/rf/src/rf/models/scene.py
@@ -1,9 +1,12 @@
 """Python class representation of a Raster Foundry Scene"""
 
 import uuid
-
+from requests.exceptions import HTTPError
+import logging
 
 from .base import BaseModel
+
+logger = logging.getLogger(__name__)
 
 
 class Scene(BaseModel):
@@ -111,3 +114,13 @@ class Scene(BaseModel):
             scene_dict['dataFootprint'] = self.dataFootprint.to_dict()
 
         return scene_dict
+
+    def create(self):
+        try:
+            return super(Scene, self).create()
+        except HTTPError as exc:
+            if exc.response.status_code != 409:
+                raise
+            else:
+                logger.info('Tried to create duplicate object: %s', self)
+                return None

--- a/app-tasks/rf/src/rf/uploads/geotiff/create_images.py
+++ b/app-tasks/rf/src/rf/uploads/geotiff/create_images.py
@@ -8,7 +8,7 @@ from .create_bands import create_geotiff_bands
 
 
 def create_geotiff_image(organizationId, tif_path, sourceuri, filename=None,
-                         visibility=Visibility.PRIVATE, imageMetadata=None, scene=None):
+                         visibility=Visibility.PRIVATE, imageMetadata={}, scene=None):
     """Create an Image object from a GeoTIFF.
 
     Args:

--- a/app-tasks/rf/src/rf/uploads/geotiff/create_scenes.py
+++ b/app-tasks/rf/src/rf/uploads/geotiff/create_scenes.py
@@ -101,7 +101,7 @@ class GeoTiffS3SceneFactory(object):
 def create_geotiff_scene(tif_path, organizationId, datasource,
                          ingestSizeBytes=0, visibility=Visibility.PRIVATE, tags=[],
                          sceneMetadata=None, name=None, thumbnailStatus=JobStatus.QUEUED,
-                         boundaryStatus=JobStatus.QUEUED, ingestStatus=IngestStatus.NOTINGESTED,
+                         boundaryStatus=JobStatus.QUEUED, ingestStatus=IngestStatus.TOBEINGESTED,
                          metadataFiles=[],
                          **kwargs):
     """Returns scenes that can be created via API given a local path to a geotiff.


### PR DESCRIPTION
## Overview

* Create DAGS: find_geotiff_scenes and import_geotiff_scenes
* Modify base model so that calling create() checks for a response code of 409 before throwing an error. This will cause the DAGs to skip any scenes that already exist

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~

### Notes

Currently, the geotiff import requires a massive amount of memory to expand the geotiff. 
I've only been able to get a single scene to index at a time before it runs out of memory, but you might not be able to even get that far.

## Testing Instructions
* Start the server with airflow: `./scripts/server --with-airflow`
* start PSQL: `./scripts/psql`
* create a datasource (make sure to insert a user id): `insert into datasources (id, created_at, created_by, modified_at, modified_by, organization_id, name, visibility) values ('6775d413-ed38-45b4-afe5-f51f9d5008e9', now(), '{{SOME USER ID}}', now(), '{{SOME USER ID}}', 'dfac6307-b5ef-43f7-beda-b9f208bb7726', 'Kayak', 'PUBLIC');`
* SSH into the airflow scheduler:  `./scripts/console airflow-scheduler bash`
* Start the DAG: `airflow trigger_dag -c '{"organization": "dfac6307-b5ef-43f7-beda-b9f208bb7726", "datasource": "6775d413-ed38-45b4-afe5-f51f9d5008e9", "capture_date": "2/21/2017", "bucket": "{{INSERT BUCKET}}", "prefix": "{{INSERT PREFIX}}"}' -r {{INSERT A UNIQUE RUN ID}}`

Closes #1072
Closes #1144
