### PR TITLE
Utilize server computed project extent

### DIFF
--- a/app-frontend/src/app/core/core.module.js
+++ b/app-frontend/src/app/core/core.module.js
@@ -18,6 +18,7 @@ require('./services/toolCategory.service')(shared);
 require('./services/toolTag.service')(shared);
 require('./services/user.service')(shared);
 require('./services/storage.service')(shared);
+require('./services/mapUtils.service')(shared);
 
 require('./services/featureFlagOverrides.service')(shared);
 require('./services/featureFlags.provider')(shared);

--- a/app-frontend/src/app/core/services/map.service.js
+++ b/app-frontend/src/app/core/services/map.service.js
@@ -379,16 +379,6 @@ class MapWrapper {
         this.heldState = state;
         return this;
     }
-
-    /** Get the extent from a project (if it exists) and fit the map to it
-      * @param {Project} project to hold, e.g. specifying latlng center and zoom
-      * @returns {this} this
-      */
-    fitProjectExtent(project) {
-        if (project.extent) {
-            this.map.fitBounds(L.geoJSON(project.extent).getBounds());
-        }
-    }
 }
 
 export default (app) => {

--- a/app-frontend/src/app/core/services/map.service.js
+++ b/app-frontend/src/app/core/services/map.service.js
@@ -379,6 +379,16 @@ class MapWrapper {
         this.heldState = state;
         return this;
     }
+
+    /** Get the extent from a project (if it exists) and fit the map to it
+      * @param {Project} project to hold, e.g. specifying latlng center and zoom
+      * @returns {this} this
+      */
+    fitProjectExtent(project) {
+        if (project.extent) {
+            this.map.fitBounds(L.geoJSON(project.extent).getBounds());
+        }
+    }
 }
 
 export default (app) => {

--- a/app-frontend/src/app/core/services/mapUtils.service.js
+++ b/app-frontend/src/app/core/services/mapUtils.service.js
@@ -1,0 +1,18 @@
+export default (app) => {
+    class MapUtilsService {
+
+        /** Get the extent from a project (if it exists) and fit the map to it
+          * @param {MapWrapper} mapWrapper mapWrapper object of map to interact with
+          * @param {Project} project to hold, e.g. specifying latlng center and zoom
+          * @return {MapUtilsService} this service
+          */
+        fitMapToProject(mapWrapper, project) {
+            if (project.extent) {
+                mapWrapper.map.fitBounds(L.geoJSON(project.extent).getBounds());
+            }
+            return this;
+        }
+    }
+
+    app.service('mapUtilsService', MapUtilsService);
+};

--- a/app-frontend/src/app/pages/editor/project/projectEdit.controller.js
+++ b/app-frontend/src/app/pages/editor/project/projectEdit.controller.js
@@ -2,7 +2,8 @@ const Map = require('es6-map');
 
 export default class ProjectEditController {
     constructor( // eslint-disable-line max-params
-        $scope, $rootScope, $location, $state, mapService, projectService, layerService, $uibModal
+        $scope, $rootScope, $location, $state, mapService, projectService, layerService, $uibModal,
+        mapUtilsService
     ) {
         'ngInject';
         this.$state = $state;
@@ -11,6 +12,7 @@ export default class ProjectEditController {
         this.$rootScope = $rootScope;
         this.projectService = projectService;
         this.layerService = layerService;
+        this.mapUtilsService = mapUtilsService;
         this.$uibModal = $uibModal;
         this.getMap = () => mapService.getMap('project');
 
@@ -102,7 +104,7 @@ export default class ProjectEditController {
 
     fitProjectExtent() {
         this.getMap().then(m => {
-            m.fitProjectExtent(this.project);
+            this.mapUtilsService.fitMapToProject(m, this.project);
         });
     }
 

--- a/app-frontend/src/app/pages/editor/project/projectEdit.controller.js
+++ b/app-frontend/src/app/pages/editor/project/projectEdit.controller.js
@@ -36,6 +36,7 @@ export default class ProjectEditController {
                 this.projectService.query({id: this.projectId}).then(
                     (project) => {
                         this.project = project;
+                        this.fitProjectExtent();
                         this.loadingProject = false;
                     },
                     () => {
@@ -48,8 +49,6 @@ export default class ProjectEditController {
                 this.selectProjectModal();
             }
         }
-
-        this.$scope.$watch('$ctrl.sceneList', this.fitAllScenes.bind(this));
 
         this.$scope.$on('$destroy', () => {
             if (this.activeModal) {
@@ -91,10 +90,6 @@ export default class ProjectEditController {
         }
     }
 
-    fitSelectedScenes() {
-        this.fitScenes(Array.from(this.selectedScenes.values()));
-    }
-
     bringSelectedScenesToFront() {
         this.cachedZIndices = new Map();
         for (const [id, l] of this.selectedLayers) {
@@ -105,16 +100,9 @@ export default class ProjectEditController {
         }
     }
 
-    fitAllScenes() {
-        if (this.sceneList.length) {
-            this.fitScenes(this.sceneList);
-        }
-    }
-
-    fitScenes(scenes) {
-        this.getMap().then((map) =>{
-            let sceneFootprints = scenes.map((scene) => scene.dataFootprint);
-            map.map.fitBounds(L.geoJSON(sceneFootprints).getBounds());
+    fitProjectExtent() {
+        this.getMap().then(m => {
+            m.fitProjectExtent(this.project);
         });
     }
 

--- a/app-frontend/src/app/pages/lab/edit/edit.controller.js
+++ b/app-frontend/src/app/pages/lab/edit/edit.controller.js
@@ -24,8 +24,9 @@ export default class LabEditController {
         this.getMap = () => this.mapService.getMap('lab-run');
         this.projectId = this.$state.params.projectid;
         this.sceneLayers = new Map();
-
-        if (this.$parent.toolId && !this.project) {
+        if (this.project) {
+            this.fitProjectExtent();
+        } else if (this.$parent.toolId && !this.project) {
             this.ensureProjectSelected();
         }
     }
@@ -36,6 +37,7 @@ export default class LabEditController {
             this.projectService.query({id: this.projectId}).then(
                 (project) => {
                     this.project = project;
+                    this.fitProjectExtent();
                     this.loadingProject = false;
                     this.getSceneList();
                 },
@@ -49,16 +51,9 @@ export default class LabEditController {
         }
     }
 
-    fitAllScenes() {
-        if (this.sceneList.length) {
-            this.fitScenes(this.sceneList);
-        }
-    }
-
-    fitScenes(scenes) {
-        this.getMap().then((map) =>{
-            let sceneFootprints = scenes.map((scene) => scene.dataFootprint);
-            map.map.fitBounds(L.geoJSON(sceneFootprints).getBounds());
+    fitProjectExtent() {
+        this.getMap().then(m => {
+            m.fitProjectExtent(this.project);
         });
     }
 
@@ -81,7 +76,6 @@ export default class LabEditController {
     }
 
     layersFromScenes() {
-        // Create scene layers to use for color correction
         for (const scene of this.sceneList) {
             let sceneLayer = this.layerService.layerFromScene(scene, this.projectId);
             this.sceneLayers.set(scene.id, sceneLayer);

--- a/app-frontend/src/app/pages/lab/edit/edit.controller.js
+++ b/app-frontend/src/app/pages/lab/edit/edit.controller.js
@@ -2,7 +2,7 @@ const Map = require('es6-map');
 
 export default class LabEditController {
     constructor( // eslint-disable-line max-params
-        $scope, $state, $uibModal, mapService, layerService, projectService) {
+        $scope, $state, $uibModal, mapService, layerService, projectService, mapUtilsService) {
         'ngInject';
         this.$scope = $scope;
         this.$parent = $scope.$parent.$ctrl;
@@ -11,6 +11,7 @@ export default class LabEditController {
         this.mapService = mapService;
         this.layerService = layerService;
         this.projectService = projectService;
+        this.mapUtilsService = mapUtilsService;
         this.inputs = {
             bands: {
                 nir: '5',
@@ -53,7 +54,7 @@ export default class LabEditController {
 
     fitProjectExtent() {
         this.getMap().then(m => {
-            m.fitProjectExtent(this.project);
+            this.mapUtilsService.fitMapToProject(m, this.project);
         });
     }
 

--- a/app-frontend/src/app/pages/lab/run/run.controller.js
+++ b/app-frontend/src/app/pages/lab/run/run.controller.js
@@ -11,14 +11,6 @@ export default class LabRunController {
         this.authService = authService;
         this.projectService = projectService;
         this.getMap = () => mapService.getMap('lab-run-preview');
-
-        $scope.$watch('$ctrl.isShowingPreview', () => {
-            this.getMap().then((mapWrapper) => {
-                $timeout(() => {
-                    mapWrapper.map.invalidateSize();
-                }, 50);
-            });
-        });
     }
 
     $onInit() {
@@ -177,7 +169,7 @@ export default class LabRunController {
                     if (!this.alreadyPreviewed) {
                         this.alreadyPreviewed = true;
                         this.$timeout(() => {
-                            this.fitSceneList(this.inputs[0].id);
+                            this.fitProjectExtent(this.inputs[1]);
                         });
                     }
                 });
@@ -192,27 +184,10 @@ export default class LabRunController {
         }
     }
 
-    fitSceneList(projectId) {
-        this.sceneRequestState = {loading: true};
-        this.projectService.getAllProjectScenes(
-            {projectId: projectId}
-        ).then(
-            (allScenes) => {
-                this.sceneList = allScenes;
-                this.fitScenes(this.sceneList);
-            },
-            (error) => {
-                this.sceneRequestState.errorMsg = error;
-            }
-        ).finally(() => {
-            this.sceneRequestState.loading = false;
-        });
-    }
-
-    fitScenes(scenes) {
-        this.getMap().then((map) =>{
-            let sceneFootprints = scenes.map((scene) => scene.dataFootprint);
-            map.map.fitBounds(L.geoJSON(sceneFootprints).getBounds());
+    fitProjectExtent(project) {
+        this.getMap().then(m => {
+            m.map.invalidateSize();
+            m.fitProjectExtent(project);
         });
     }
 

--- a/app-frontend/src/app/pages/lab/run/run.controller.js
+++ b/app-frontend/src/app/pages/lab/run/run.controller.js
@@ -2,7 +2,8 @@
 
 export default class LabRunController {
     constructor( // eslint-disable-line max-params
-        $scope, $timeout, $element, authService, $uibModal, mapService, projectService) {
+        $scope, $timeout, $element, authService, $uibModal, mapService, projectService,
+        mapUtilsService) {
         'ngInject';
         this.$scope = $scope;
         this.$timeout = $timeout;
@@ -10,6 +11,7 @@ export default class LabRunController {
         this.$uibModal = $uibModal;
         this.authService = authService;
         this.projectService = projectService;
+        this.mapUtilsService = mapUtilsService;
         this.getMap = () => mapService.getMap('lab-run-preview');
     }
 
@@ -187,7 +189,7 @@ export default class LabRunController {
     fitProjectExtent(project) {
         this.getMap().then(m => {
             m.map.invalidateSize();
-            m.fitProjectExtent(project);
+            this.mapUtilsService.fitMapToProject(m, project);
         });
     }
 

--- a/app-frontend/src/app/pages/share/share.controller.js
+++ b/app-frontend/src/app/pages/share/share.controller.js
@@ -2,8 +2,8 @@ import logoAsset from '../../../assets/images/logo-raster-foundry.png';
 /* global L */
 
 export default class ShareController {
-    constructor(
-        $log, $state, authService, projectService, mapService
+    constructor( // eslint-disable-line max-params
+        $log, $state, authService, projectService, mapService, mapUtilsService
     ) {
         'ngInject';
         this.$log = $log;
@@ -11,6 +11,7 @@ export default class ShareController {
         this.logoAsset = logoAsset;
         this.authService = authService;
         this.projectService = projectService;
+        this.mapUtilsService = mapUtilsService;
         this.getMap = () => mapService.getMap('share-map');
     }
 
@@ -49,8 +50,9 @@ export default class ShareController {
     }
 
     fitProjectExtent() {
-        this.getMap().then(m => {
-            m.fitProjectExtent(this.project);
+        this.getMap().then(mapWrapper => {
+            mapWrapper.map.invalidateSize();
+            this.mapUtilsService.fitMapToProject(mapWrapper, this.project);
         });
     }
 }

--- a/app-frontend/src/app/pages/share/share.controller.js
+++ b/app-frontend/src/app/pages/share/share.controller.js
@@ -24,6 +24,7 @@ export default class ShareController {
             this.projectService.query({id: this.projectId}).then(
                 p => {
                     this.project = p;
+                    this.fitProjectExtent();
                     this.loadingProject = false;
                     this.addProjectLayer();
                 },
@@ -32,7 +33,6 @@ export default class ShareController {
                     // @TODO: handle displaying an error message
                 }
             );
-            this.fitSceneList();
         }
     }
 
@@ -48,27 +48,9 @@ export default class ShareController {
         });
     }
 
-    fitSceneList() {
-        this.sceneRequestState = {loading: true};
-        this.projectService.getAllProjectScenes(
-            {projectId: this.projectId}
-        ).then(
-            (allScenes) => {
-                this.sceneList = allScenes;
-                this.fitScenes(this.sceneList);
-            },
-            (error) => {
-                this.sceneRequestState.errorMsg = error;
-            }
-        ).finally(() => {
-            this.sceneRequestState.loading = false;
-        });
-    }
-
-    fitScenes(scenes) {
-        this.getMap().then((map) =>{
-            let sceneFootprints = scenes.map((scene) => scene.dataFootprint);
-            map.map.fitBounds(L.geoJSON(sceneFootprints).getBounds());
+    fitProjectExtent() {
+        this.getMap().then(m => {
+            m.fitProjectExtent(this.project);
         });
     }
 }

--- a/app-frontend/src/app/pages/share/share.html
+++ b/app-frontend/src/app/pages/share/share.html
@@ -41,8 +41,10 @@
     </nav>
   </div>
 </div>
-<div class="container column-stretch container-not-scrollable">
-  <div class="main">
-    <rf-map-container map-id="share-map"></rf-map-container>
+<div class="app-content">
+  <div class="container column-stretch container-not-scrollable">
+    <div class="main">
+      <rf-map-container map-id="share-map"></rf-map-container>
+    </div>
   </div>
 </div>


### PR DESCRIPTION
## Overview

This PR leverages the server-side computed project extent to remove async project extent calculations on the front-end.

These calculations were previously being done for the editor, the share page, and any tool output visualizations.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~

## Testing Instruction

 * Run the server
 * On any page that utilizes the tile-server, check that the map is fit to the project bounds (share page, editor, lab)

Connects #1141
