### PR TITLE
Add loading indicator to map component

### DIFF
--- a/app-frontend/src/app/components/mapContainer/mapContainer.component.js
+++ b/app-frontend/src/app/components/mapContainer/mapContainer.component.js
@@ -1,6 +1,6 @@
-// import mapTpl from './mapContainer.html';
+import mapTpl from './mapContainer.html';
 const mapContainer = {
-    template: '<div></div>',
+    templateUrl: mapTpl,
     controller: 'MapContainerController',
     bindings: {
         mapId: '@',

--- a/app-frontend/src/app/components/mapContainer/mapContainer.controller.js
+++ b/app-frontend/src/app/components/mapContainer/mapContainer.controller.js
@@ -1,3 +1,5 @@
+import Map from 'es6-map';
+
 export default class MapContainerController {
     constructor($log, $element, $scope, $timeout, mapService) {
         'ngInject';
@@ -9,6 +11,10 @@ export default class MapContainerController {
     }
 
     $onInit() {
+        this.isLoadingTiles = false;
+        this.hasTileLoadingError = false;
+        this.tileLoadingErrors = new Map();
+        this.tileLoadingStatus = new Map();
         this.initMap();
     }
 
@@ -45,7 +51,50 @@ export default class MapContainerController {
 
         this.$timeout(() => {
             this.map.invalidateSize();
-            this.mapService.registerMap(this.map, this.mapId, this.options);
+            this.mapWrapper = this.mapService.registerMap(this.map, this.mapId, this.options);
+            this.addLoadingIndicator();
         }, 400);
+    }
+
+    addLoadingIndicator() {
+        this.mapWrapper.onLayerGroupEvent('layeradd', this.handleLayerAdded, this);
+    }
+
+    handleLayerAdded(e) {
+        let layer = e.layer;
+        let isTileLayer = layer._tiles && layer._url;
+        let layerId = layer._leaflet_id;
+
+        if (isTileLayer) {
+            this.setLoading(layerId, true);
+            layer.on('loading', () => {
+                this.setLoadingError(layerId, false);
+                this.setLoading(layerId, true);
+            });
+            layer.on('load', () => {
+                this.setLoading(layerId, false);
+            });
+            layer.on('tileerror', () => {
+                // @TODO: when tiles outside the extent of projects are
+                // properly returned, we should uncomment the following line
+                // this.setLoadingError(layerId, true);
+            });
+        }
+    }
+
+    setLoading(layerId, status) {
+        this.tileLoadingStatus.set(layerId, status);
+        this.$scope.$evalAsync(() => {
+            this.isLoadingTiles =
+                Array.from(this.tileLoadingStatus.values()).reduce((acc, cur) => acc || cur, false);
+        });
+    }
+
+    setLoadingError(layerId, status) {
+        this.tileLoadingErrors.set(layerId, status);
+        this.$scope.$evalAsync(() => {
+            this.hasTileLoadingError =
+                Array.from(this.tileLoadingErrors.values()).reduce((acc, cur) => acc || cur, false);
+        });
     }
 }

--- a/app-frontend/src/app/components/mapContainer/mapContainer.html
+++ b/app-frontend/src/app/components/mapContainer/mapContainer.html
@@ -1,1 +1,8 @@
-<div ng-attr-id="{{ ctrl.mapId }}"></div>
+<div class="map-container">
+  <div class="map-container-loading" ng-show="$ctrl.isLoadingTiles">
+    <div class="bg-primary">Loading</div>
+  </div>
+  <div class="map-container-loading" ng-show="$ctrl.hasTileLoadingError">
+    <div class="bg-warning color-dark">There was an error loading tiles</div>
+  </div>
+</div>

--- a/app-frontend/src/app/components/mapContainer/mapContainer.scss
+++ b/app-frontend/src/app/components/mapContainer/mapContainer.scss
@@ -1,4 +1,25 @@
 .leaflet-container {
   height: 100%;
   width: 100%;
+  z-index: 900;
+}
+
+.map-container-loading {
+  position: absolute;
+  top: 0;
+  right: 0;
+  left: 0;
+  padding: 16px;
+  pointer-events: none;
+  & > * {
+    pointer-events: true;
+  }
+  text-align: center;
+  z-index: 2000;
+  div {
+    padding: 4px 12px;
+    color: #fff;
+    display: inline-block;
+    background: rgba(0,0,0,.5);
+  }
 }


### PR DESCRIPTION
## Overview

This PR adds a tile loading and loading error indicator to the map component. We want to be able to provide feedback to the user while tiles are loading rather than presenting them with an empty map. In addition, we'd like to provide error feedback when some tiles cannot be loaded.

This indicator is automatically wired up to any tile layers that are added via the map service's `addLayer` method. Layers added directly via Leaflet will not send events to the indicator.

Indicating loading errors is currently disabled (via a comment). See notes for more info on this.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~

### Demo

<img width="1270" alt="screen shot 2017-02-23 at 4 36 10 pm" src="https://cloud.githubusercontent.com/assets/2442245/23280216/5c61c66c-f9e6-11e6-91d5-3a3576ba2f88.png">
<img width="1280" alt="screen shot 2017-02-23 at 4 36 45 pm" src="https://cloud.githubusercontent.com/assets/2442245/23280217/5c66691a-f9e6-11e6-8c6e-f55c65cb47e4.png">

### Notes

@designmatty We'll definitely need some styling here. One thing to look out for is that our loading indicator shouldn't interfere with the controls on the lab preview. The current solution would if it were visible.

The layers in the lab are added using Leaflet directly, so there is currently no loading indicator in any lab previews.

The tile-server currently returns empty responses when a tile is requested outside of the extent of a project. This causes Leaflet to detect `tileerror`s when there was not actually any error, which then causes our indicator to show an error message. For this reason, we are not sending error info to the indicator. Once the tile-server is sending empty pngs this can be enabled.

## Testing Instructions

 * Run the server and front-end
 * Navigate to the color-correction page with an ingested scene and check that the loading indicator is present and disappears when all tiles are loaded
 * Check that the indicator is present on zoom-in and panning and disappears as expected

Connects #1119
