### PR TITLE
Feature/jis/validate swagger spec in ci

### DIFF
--- a/app-backend/database/src/main/scala/com/azavea/rf/database/QueryParameterJsonFormat.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/QueryParameterJsonFormat.scala
@@ -179,7 +179,7 @@ trait QueryParameterJsonFormat extends AdditionalFormats with
         "userParams",
         "timestampParams",
         "sceneParams",
-        "imageQueryParameters"
+        "imageParams"
       )
 
       CombinedSceneQueryParams(
@@ -198,7 +198,7 @@ trait QueryParameterJsonFormat extends AdditionalFormats with
       "userParams" -> params.userParams.toJson,
       "timestampParams" -> params.timestampParams.toJson,
       "sceneParams" -> params.sceneParams.toJson,
-      "imageQueryParameters" -> params.imageQueryParameters.toJson
+      "imageParams" -> params.imageParams.toJson
     )
   }
 

--- a/app-backend/database/src/main/scala/com/azavea/rf/database/QueryParameters.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/QueryParameters.scala
@@ -101,7 +101,7 @@ case class CombinedSceneQueryParams(
   userParams: UserQueryParameters = UserQueryParameters(),
   timestampParams: TimestampQueryParameters = TimestampQueryParameters(),
   sceneParams: SceneQueryParameters = SceneQueryParameters(),
-  imageQueryParameters: ImageQueryParameters = ImageQueryParameters()
+  imageParams: ImageQueryParameters = ImageQueryParameters()
 )
 
 /** Combined all query parameters for grids */

--- a/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Scenes.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Scenes.scala
@@ -259,7 +259,7 @@ object Scenes extends TableQuery(tag => new Scenes(tag)) with LazyLogging {
       .filterByUser(combinedParams.userParams)
       .filterByTimestamp(combinedParams.timestampParams)
       .filterBySceneParams(combinedParams.sceneParams)
-      .filterByImageParams(combinedParams.imageQueryParameters)
+      .filterByImageParams(combinedParams.imageParams)
   }
 
   /** Get scenes given a page request and query parameters */
@@ -578,7 +578,7 @@ class ScenesJoinQuery[M, U, C[_]](sceneJoin: Scenes.JoinQuery) {
       .filterByUser(combinedParams.userParams)
       .filterByTimestamp(combinedParams.timestampParams)
       .filterBySceneParams(combinedParams.sceneParams)
-      .filterByImageParams(combinedParams.imageQueryParameters)
+      .filterByImageParams(combinedParams.imageParams)
       .sort(pageRequest.sort)
       .drop(pageRequest.offset * pageRequest.limit)
       .take(pageRequest.limit)

--- a/app-frontend/package.json
+++ b/app-frontend/package.json
@@ -105,6 +105,7 @@
     "sass-loader": "^3.1.1",
     "sort-package-json": "~1.4.0",
     "style-loader": "~0.13.0",
+    "swagger-cli": "1.0.0-beta.2",
     "transform-loader": "~0.2.3",
     "url": "~0.11.0",
     "url-loader": "~0.5.6",

--- a/app-frontend/yarn.lock
+++ b/app-frontend/yarn.lock
@@ -1153,7 +1153,7 @@ blueimp-tmpl@^2.5.5:
   version "2.5.7"
   resolved "https://registry.yarnpkg.com/blueimp-tmpl/-/blueimp-tmpl-2.5.7.tgz#33fb12c139d65512ae40afbd8e2def8d9db96490"
 
-body-parser@^1.12.4:
+body-parser@^1.12.4, body-parser@^1.13.3:
   version "1.15.2"
   resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.15.2.tgz#d7578cf4f1d11d5f6ea804cef35dc7a7ff6dae67"
   dependencies:
@@ -1255,6 +1255,13 @@ builtin-modules@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
 
+busboy@~0.2.9:
+  version "0.2.14"
+  resolved "https://registry.yarnpkg.com/busboy/-/busboy-0.2.14.tgz#6c2a622efcf47c57bbbe1e2a9c37ad36c7925453"
+  dependencies:
+    dicer "0.2.5"
+    readable-stream "1.1.x"
+
 bytes@2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-2.3.0.tgz#d5b680a165b6201739acb611542aabc2d8ceb070"
@@ -1262,6 +1269,10 @@ bytes@2.3.0:
 bytes@2.4.0, bytes@^2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-2.4.0.tgz#7d97196f9d5baf7f6935e25985549edd2a6c2339"
+
+call-me-maybe@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/call-me-maybe/-/call-me-maybe-1.0.1.tgz#26d208ea89e37b5cbde60250a15f031c16a4d66b"
 
 caller-path@^0.1.0:
   version "0.1.0"
@@ -1561,7 +1572,7 @@ commander@2.8.x, commander@~2.8.1:
   dependencies:
     graceful-readlink ">= 1.0.0"
 
-commander@2.9.x, commander@^2.9.0:
+commander@2.9.x, commander@^2.7.1, commander@^2.8.1, commander@^2.9.0:
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.9.0.tgz#9c99094176e12240cb22d6c5146098400fe0f7d4"
   dependencies:
@@ -1700,6 +1711,13 @@ convert-source-map@^1.1.0, convert-source-map@^1.1.1:
 convert-source-map@~1.1.2:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.1.3.tgz#4829c877e9fe49b3161f3bf3673888e204699860"
+
+cookie-parser@^1.3.5:
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/cookie-parser/-/cookie-parser-1.4.3.tgz#0fe31fa19d000b95f4aadf1f53fdc2b8a203baa5"
+  dependencies:
+    cookie "0.3.1"
+    cookie-signature "1.0.6"
 
 cookie-signature@1.0.6:
   version "1.0.6"
@@ -2038,9 +2056,20 @@ di@^0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/di/-/di-0.0.1.tgz#806649326ceaa7caa3306d75d985ea2748ba913c"
 
+dicer@0.2.5:
+  version "0.2.5"
+  resolved "https://registry.yarnpkg.com/dicer/-/dicer-0.2.5.tgz#5996c086bb33218c812c090bddc09cd12facb70f"
+  dependencies:
+    readable-stream "1.1.x"
+    streamsearch "0.1.2"
+
 diff@^2.2.1:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/diff/-/diff-2.2.3.tgz#60eafd0d28ee906e4e8ff0a52c1229521033bf99"
+
+directory-search@0.0.32:
+  version "0.0.32"
+  resolved "https://registry.yarnpkg.com/directory-search/-/directory-search-0.0.32.tgz#7735b975776b4ccb345f618e44a0b7552609020d"
 
 doctrine@^1.2.2:
   version "1.5.0"
@@ -2287,13 +2316,13 @@ es6-map@^0.1.3, es6-map@~0.1.4:
     es6-symbol "~3.1.0"
     event-emitter "~0.3.4"
 
+es6-promise@^3.0.2, es6-promise@~3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-3.0.2.tgz#010d5858423a5f118979665f46486a95c6ee2bb6"
+
 es6-promise@~2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-2.3.0.tgz#96edb9f2fdb01995822b263dd8aadab6748181bc"
-
-es6-promise@~3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-3.0.2.tgz#010d5858423a5f118979665f46486a95c6ee2bb6"
 
 es6-promise@~4.0.3:
   version "4.0.5"
@@ -3767,7 +3796,7 @@ js-tokens@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-2.0.0.tgz#79903f5563ee778cc1162e6dcf1a0027c97f9cb5"
 
-js-yaml@3.x, js-yaml@^3.5.1:
+js-yaml@3.x, js-yaml@^3.4.6, js-yaml@^3.5.1:
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.7.0.tgz#5c967ddd837a9bfdca5f2de84253abe8a1c03b80"
   dependencies:
@@ -3813,6 +3842,16 @@ json-fallback@0.0.1:
 json-loader@~0.5.4:
   version "0.5.4"
   resolved "https://registry.yarnpkg.com/json-loader/-/json-loader-0.5.4.tgz#8baa1365a632f58a3c46d20175fc6002c96e37de"
+
+json-schema-ref-parser@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/json-schema-ref-parser/-/json-schema-ref-parser-1.4.1.tgz#c0c2e438bf0796723b02451bae8bc7dd0b37fed0"
+  dependencies:
+    call-me-maybe "^1.0.1"
+    debug "^2.2.0"
+    es6-promise "^3.0.2"
+    js-yaml "^3.4.6"
+    ono "^2.0.1"
 
 json-schema@0.2.3:
   version "0.2.3"
@@ -4150,6 +4189,10 @@ lodash.get@^3.7.0:
     lodash._baseget "^3.0.0"
     lodash._topath "^3.0.0"
 
+lodash.get@^4.1.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
+
 lodash.indexof@^4.0.5:
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/lodash.indexof/-/lodash.indexof-4.0.5.tgz#53714adc2cddd6ed87638f893aa9b6c24e31ef3c"
@@ -4162,7 +4205,7 @@ lodash.isarray@^3.0.0:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/lodash.isarray/-/lodash.isarray-3.0.4.tgz#79e4eb88c36a8122af86f844aa9bcd851b5fbb55"
 
-lodash.isequal@^4.0.0:
+lodash.isequal@^4.0.0, lodash.isequal@^4.4.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
 
@@ -4443,7 +4486,7 @@ mime-types@^2.1.12, mime-types@~2.1.11, mime-types@~2.1.13, mime-types@~2.1.7:
   dependencies:
     mime-db "~1.25.0"
 
-mime-types@~2.0.4:
+mime-types@~2.0.4, mime-types@~2.0.9:
   version "2.0.14"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.0.14.tgz#310e159db23e077f8bb22b748dabfa4957140aa6"
   dependencies:
@@ -4490,6 +4533,10 @@ mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkd
   dependencies:
     minimist "0.0.8"
 
+mkdirp@~0.3.5:
+  version "0.3.5"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.3.5.tgz#de3e5f8961c88c787ee1368df849ac4413eca8d7"
+
 ms@0.7.1:
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.1.tgz#9cd13c03adbff25b65effde7ce864ee952017098"
@@ -4497,6 +4544,15 @@ ms@0.7.1:
 ms@0.7.2:
   version "0.7.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.2.tgz#ae25cf2512b3885a1d95d7f037868d8431124765"
+
+multer@^0.1.8:
+  version "0.1.8"
+  resolved "https://registry.yarnpkg.com/multer/-/multer-0.1.8.tgz#551b8a6015093701bcacc964916b1ae06578f37b"
+  dependencies:
+    busboy "~0.2.9"
+    mkdirp "~0.3.5"
+    qs "~1.2.2"
+    type-is "~1.5.2"
 
 multipipe@^0.1.2:
   version "0.1.2"
@@ -4805,6 +4861,14 @@ onetime@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/onetime/-/onetime-1.1.0.tgz#a1f7838f8314c516f05ecefcbc4ccfe04b4ed789"
 
+ono@^1.0.22:
+  version "1.0.22"
+  resolved "https://registry.yarnpkg.com/ono/-/ono-1.0.22.tgz#5f4ecbea7e3d3e972c0a03a3fd7f361368604a68"
+
+ono@^2.0.1:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/ono/-/ono-2.2.4.tgz#f6c1d9ea64da07a54863986535da3de67e502696"
+
 open@0.0.5:
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/open/-/open-0.0.5.tgz#42c3e18ec95466b6bf0dc42f3a2945c3f0cad8fc"
@@ -4876,7 +4940,7 @@ os-shim@^0.1.2:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/os-shim/-/os-shim-0.1.3.tgz#6b62c3791cf7909ea35ed46e17658bb417cb3917"
 
-os-tmpdir@^1.0.0, os-tmpdir@^1.0.1, os-tmpdir@~1.0.1:
+os-tmpdir@^1.0.0, os-tmpdir@^1.0.1, os-tmpdir@~1.0.0, os-tmpdir@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
 
@@ -5387,6 +5451,10 @@ qs@^6.2.1, qs@~6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.3.0.tgz#f403b264f23bc01228c74131b407f18d5ea5d442"
 
+qs@~1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-1.2.2.tgz#19b57ff24dc2a99ce1f8bdf6afcda59f8ef61f88"
+
 query-string@^4.1.0:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/query-string/-/query-string-4.3.1.tgz#54baada6713eafc92be75c47a731f2ebd09cd11d"
@@ -5500,18 +5568,18 @@ read@^1.0.7:
   dependencies:
     mute-stream "~0.0.4"
 
-"readable-stream@>=1.0.33-1 <1.1.0-0", readable-stream@~1.0.17, readable-stream@~1.0.2, readable-stream@~1.0.27-1:
-  version "1.0.34"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.0.34.tgz#125820e34bc842d2f2aaafafe4c2916ee32c157c"
+readable-stream@1.1.x, readable-stream@^1.0.27-1, readable-stream@^1.1.13, readable-stream@~1.1.9:
+  version "1.1.14"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.1.14.tgz#7cf4c54ef648e3813084c636dd2079e166c081d9"
   dependencies:
     core-util-is "~1.0.0"
     inherits "~2.0.1"
     isarray "0.0.1"
     string_decoder "~0.10.x"
 
-readable-stream@^1.0.27-1, readable-stream@^1.1.13, readable-stream@~1.1.9:
-  version "1.1.14"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.1.14.tgz#7cf4c54ef648e3813084c636dd2079e166c081d9"
+"readable-stream@>=1.0.33-1 <1.1.0-0", readable-stream@~1.0.17, readable-stream@~1.0.2, readable-stream@~1.0.27-1:
+  version "1.0.34"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.0.34.tgz#125820e34bc842d2f2aaafafe4c2916ee32c157c"
   dependencies:
     core-util-is "~1.0.0"
     inherits "~2.0.1"
@@ -6194,6 +6262,10 @@ stream-shift@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/stream-shift/-/stream-shift-1.0.0.tgz#d5c752825e5367e786f78e18e445ea223a155952"
 
+streamsearch@0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/streamsearch/-/streamsearch-0.1.2.tgz#808b9d0e56fc273d809ba57338e929919a1a9f1a"
+
 strict-uri-encode@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#279b225df1d582b1f54e65addd4352e18faa0713"
@@ -6325,6 +6397,66 @@ svgo@^0.7.0:
     sax "~1.2.1"
     whet.extend "~0.9.9"
 
+swagger-cli@1.0.0-beta.2:
+  version "1.0.0-beta.2"
+  resolved "https://registry.yarnpkg.com/swagger-cli/-/swagger-cli-1.0.0-beta.2.tgz#4011c8cfb3c859873c36a977595974c768966352"
+  dependencies:
+    chalk "^1.1.1"
+    commander "^2.8.1"
+    es6-promise "^3.0.2"
+    lodash "^3.10.1"
+    swagger-parser "^3.1.0"
+    swagger-server "^1.0.0-alpha.18"
+
+swagger-express-middleware@>=1.0.0-alpha.12:
+  version "1.0.0-alpha.12"
+  resolved "https://registry.yarnpkg.com/swagger-express-middleware/-/swagger-express-middleware-1.0.0-alpha.12.tgz#3e9ecbcb3fc34c9cbfe04afb8b788f1e6d5ab360"
+  dependencies:
+    body-parser "^1.13.3"
+    cookie-parser "^1.3.5"
+    debug "^2.2.0"
+    lodash "^3.10.1"
+    mkdirp "^0.5.1"
+    multer "^0.1.8"
+    ono "^1.0.22"
+    swagger-methods "^1.0.0"
+    swagger-parser ">=3.0.0-alpha.8"
+    tmp "0.0.27"
+    tv4 "^1.2.5"
+    type-is "^1.6.8"
+
+swagger-methods@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/swagger-methods/-/swagger-methods-1.0.0.tgz#b39c77957d305a6535c0a1e015081185b99d61fc"
+
+swagger-parser@>=3.0.0-alpha.8, swagger-parser@^3.1.0:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/swagger-parser/-/swagger-parser-3.4.1.tgz#0290529dbae254d178b442a95df60d23d142301d"
+  dependencies:
+    call-me-maybe "^1.0.1"
+    debug "^2.2.0"
+    es6-promise "^3.0.2"
+    json-schema-ref-parser "^1.4.1"
+    ono "^2.0.1"
+    swagger-methods "^1.0.0"
+    swagger-schema-official "2.0.0-bab6bed"
+    z-schema "^3.16.1"
+
+swagger-schema-official@2.0.0-bab6bed:
+  version "2.0.0-bab6bed"
+  resolved "https://registry.yarnpkg.com/swagger-schema-official/-/swagger-schema-official-2.0.0-bab6bed.tgz#70070468d6d2977ca5237b2e519ca7d06a2ea3fd"
+
+swagger-server@^1.0.0-alpha.18:
+  version "1.0.0-alpha.18"
+  resolved "https://registry.yarnpkg.com/swagger-server/-/swagger-server-1.0.0-alpha.18.tgz#8ffe132041cd984a441b0ef015711e040e707ed1"
+  dependencies:
+    debug "^2.2.0"
+    directory-search "0.0.32"
+    express "^4.13.3"
+    lodash "^3.10.1"
+    swagger-express-middleware ">=1.0.0-alpha.12"
+    swagger-methods "^1.0.0"
+
 swap-case@^1.1.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/swap-case/-/swap-case-1.1.2.tgz#c39203a4587385fad3c850a0bd1bcafa081974e3"
@@ -6445,6 +6577,12 @@ title-case@^1.1.0:
     sentence-case "^1.1.1"
     upper-case "^1.0.3"
 
+tmp@0.0.27:
+  version "0.0.27"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.27.tgz#6aaf42a2d7664150ab528287068ecbc27139a013"
+  dependencies:
+    os-tmpdir "~1.0.0"
+
 tmp@0.0.28:
   version "0.0.28"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.28.tgz#172735b7f614ea7af39664fa84cf0de4e515d120"
@@ -6511,6 +6649,10 @@ tunnel-agent@^0.4.0, tunnel-agent@~0.4.1:
   version "0.4.3"
   resolved "https://registry.yarnpkg.com/tunnel-agent/-/tunnel-agent-0.4.3.tgz#6373db76909fe570e08d73583365ed828a74eeeb"
 
+tv4@^1.2.5:
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/tv4/-/tv4-1.2.7.tgz#bd29389afc73ade49ae5f48142b5d544bf68d120"
+
 tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
@@ -6521,12 +6663,19 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
-type-is@~1.6.13:
+type-is@^1.6.8, type-is@~1.6.13:
   version "1.6.14"
   resolved "https://registry.yarnpkg.com/type-is/-/type-is-1.6.14.tgz#e219639c17ded1ca0789092dd54a03826b817cb2"
   dependencies:
     media-typer "0.3.0"
     mime-types "~2.1.13"
+
+type-is@~1.5.2:
+  version "1.5.7"
+  resolved "https://registry.yarnpkg.com/type-is/-/type-is-1.5.7.tgz#b9368a593cc6ef7d0645e78b2f4c64cbecd05e90"
+  dependencies:
+    media-typer "0.3.0"
+    mime-types "~2.0.9"
 
 typedarray@^0.0.6, typedarray@~0.0.5:
   version "0.0.6"
@@ -6708,6 +6857,10 @@ validate-npm-package-license@^3.0.1:
   dependencies:
     spdx-correct "~1.0.0"
     spdx-expression-parse "~1.0.0"
+
+validator@^6.0.0:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/validator/-/validator-6.2.1.tgz#bc575b78d15beb2e338a665ba9530c7f409ef667"
 
 vary@~1.1.0:
   version "1.1.0"
@@ -7075,3 +7228,13 @@ yauzl@2.4.1, yauzl@^2.2.1:
 yeast@0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/yeast/-/yeast-0.1.2.tgz#008e06d8094320c372dbc2f8ed76a0ca6c8ac419"
+
+z-schema@^3.16.1:
+  version "3.18.2"
+  resolved "https://registry.yarnpkg.com/z-schema/-/z-schema-3.18.2.tgz#e422196b5efe60b46adef3c3f2aef2deaa911161"
+  dependencies:
+    lodash.get "^4.1.2"
+    lodash.isequal "^4.4.0"
+    validator "^6.0.0"
+  optionalDependencies:
+    commander "^2.7.1"

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -20,6 +20,7 @@ services:
       - ./app-frontend/package.json:/opt/raster-foundry/app-frontend/package.json
       - ./app-frontend/src:/opt/raster-foundry/app-frontend/src
       - ./app-frontend/webpack.config.js:/opt/raster-foundry/app-frontend/webpack.config.js
+      - ./docs/swagger/spec.yml:/opt/swagger/spec.yml
     entrypoint: yarn
     command: run build
 

--- a/docs/swagger/spec.yml
+++ b/docs/swagger/spec.yml
@@ -244,7 +244,7 @@ paths:
           schema:
             $ref: '#/definitions/Error'
     put:
-      summary: Update a user's role
+      summary: Update a user\'s role
       tags:
         - Users
       parameters:
@@ -278,6 +278,10 @@ paths:
         - Datasources
       parameters:
         - $ref: '#/parameters/name'
+      # TODO: fill in all possible responses
+      responses:
+        200:
+          description: SUCCESS
   /scenes/:
     get:
       summary: Lists paginated scenes that a user has access to
@@ -586,7 +590,6 @@ paths:
       tags:
         - Imagery
       parameters:
-        - $ref: '#/parameters/uuid'
         - name: scenes
           in: body
           required: true
@@ -594,7 +597,9 @@ paths:
           schema:
             type: array
             items:
-              - $ref: '#/parameters/uuid'
+              type: string
+              format: uuid
+        - $ref: '#/parameters/uuid'
       responses:
         204:
           description: No content, delete successful
@@ -604,56 +609,12 @@ paths:
       tags:
         - Imagery
       parameters:
-        - name: orgParams
+        - $ref: '#/parameters/uuid'
+        - name: combinedSceneQueryParameters
+          description: combined query parameters for finding scenes to add to this project
           in: body
-          type: object
-          properties:
-            organizations:
-              type: array
-              description: List of organizations to filter scenes to
-              items:
-                $ref: '#/definitions/UserOrg'
-        - name: userParams
-          in: body
-          allOf:
-            - $ref: '#/definitions/UserTrackingMixin'
-        - name: timestampParams
-          in: body
-          properties:
-            $ref: '#/parameters/minAcquisitionDatetime'
-            $ref: '#/parameters/maxAcquisitionDatetime'
-            $ref: '#/parameters/minCreateDatetime'
-            $ref: '#/parameters/maxCreateDatetime'
-        - name: sceneParams
-          in: body
-          type: object
-          properties:
-            $ref: '#/parameters/maxCloudCover'
-            $ref: '#/parameters/minCloudCover'
-            $ref: '#/parameters/minAcquisitionDatetime'
-            $ref: '#/parameters/maxAcquisitionDatetime'
-            $ref: '#/parameters/datasource'
-            $ref: '#/parameters/month'
-            $ref: '#/parameters/minDayOfMonth'
-            $ref: '#/parameters/maxDayOfMonth'
-            $ref: '#/parameters/maxSunAzimuth'
-            $ref: '#/parameters/minSunAzimuth'
-            $ref: '#/parameters/maxSunElevation'
-            $ref: '#/parameters/minSunElevation'
-            $ref: '#/parameters/bbox'
-            $ref: '#/parameters/point'
-            $ref: '#/parameters/project'
-            $ref: '#/parameters/ingested'
-            $ref: '#/parameters/ingestStatus'
-        - name: imageQueryParameters
-          in: body
-          type: object
-          properties:
-            $ref: '#/parameters/sceneId'
-            $ref: '#/parameters/minRawDataBytes'
-            $ref: '#/parameters/maxRawDataBytes'
-            $ref: '#/parameters/minResolution'
-            $ref: '#/parameters/maxResolution'
+          schema:
+            $ref: '#/definitions/CombinedSceneQueryParams'
       responses:
         201:
           description: List of scenes added to project
@@ -661,35 +622,60 @@ paths:
             type: array
             items:
               $ref: '#/definitions/Scene'
+
   /projects/{uuid}/mosaic/:
     get:
-      summary: List of a project's scene IDs and their associated color correction parameters to be used in mosaicing
+      summary: List of a project\'s scene IDs and their associated color correction parameters to be used in mosaicing
       tags:
         - Imagery
+      parameters:
+        - $ref: '#/parameters/uuid'
       responses:
         200:
           description: An ordered list of scene IDs and corresponding color correction parameters
-  /projects/{uuid}/mosaic/{uuid}:
+  /projects/{uuid}/mosaic/{uuid2}:
     get:
-      summary: A project/scene pairing's persisted color correction parameters
+      summary: A project/scene pairing\'s persisted color correction parameters
       tags:
         - Imagery
+      parameters:
+        - $ref: '#/parameters/uuid'
+        - $ref: '#/parameters/uuid2'
       responses:
         200:
           description: Color correction parameters
     post:
       summary: Associate posted color correction parameters with a project/scene pairing
       tags:
-        -Imagery
+        - Imagery
+      parameters:
+        - $ref: '#/parameters/uuid'
+        - $ref: '#/parameters/uuid2'
+      # TODO: fill in all possible responses
+      responses:
+        200:
+          description: SUCCESS
   /projects/{uuid}/order:
     get:
       summary: An ordered list of scene IDs belonging to the specified project
       tags:
         - Imagery
+      parameters:
+        - $ref: '#/parameters/uuid'
+      # TODO: fill in all possible responses
+      responses:
+        200:
+          description: SUCCESS
     post:
       summary: Create/update an ordering among scenes within the specified project
       tags:
         - Imagery
+      parameters:
+        - $ref: '#/parameters/uuid'
+      # TODO: fill in all possible responses
+      responses:
+        200:
+          description: SUCCESS
   /images/:
     get:
       summary: Paginated list of project images
@@ -1141,6 +1127,12 @@ parameters:
     required: true
     type: string
     format: uuid
+  uuid2:
+    name: uuid2
+    in: path
+    required: true
+    type: string
+    format: uuid
   slugLabel:
     name: slugLabel
     description: A url-safe slug label
@@ -1388,17 +1380,18 @@ parameters:
     required: false
   tool:
     name: toolId
-    description: Filter by tool's slug label
+    description: Filter by tool\'s slug label
     in: query
     type: string
     format: uuid
     required: false
   createdBy:
     name: createdBy
-    description: Filter by creator's slug label
+    description: Filter by creator\'s slug label
     in: query
     type: string
     required: false
+
 definitions:
   BaseModel:
     type: object
@@ -1446,7 +1439,7 @@ definitions:
         description: User ID for Raster Foundry
       organizations:
         type: array
-        description: List of organization's a user belongs to and their level of membership
+        description: List of organization\'s a user belongs to and their level of membership
         items:
           $ref: '#/definitions/UserOrg'
   RefreshToken:
@@ -1651,12 +1644,13 @@ definitions:
             type: string
             format: uuid
             description: Data source scene originated from
+          # TODO: make work with geometry objects
           dataFootprint:
-            type: geojson
             description: polygon for which this scene has data
             readOnly: true
+          # TODO: make work with geometry objects
           tileFootprint:
-            type: geojson
+            type: object
             description: polygon enclosing this scene
             readOnly: true
           sceneMetadata:
@@ -2010,3 +2004,272 @@ definitions:
         format: int32
       message:
         type: string
+
+  OrgParams:
+    type: object
+    description: Organization parameters to filter scenes
+    properties:
+      organizations:
+        type: array
+        items:
+          type: string
+          format: uuid
+
+  UserParams:
+    type: object
+    description: User parameters to filter scenes
+    properties:
+      createdBy:
+        type: string
+      modifiedBy:
+        type: string
+
+  TimestampParams:
+    type: object
+    description: Timestamp parameters to filter scenes
+    properties:
+      minCreateDatetime:
+        type: string
+        format: datetime
+      maxCreateDateTime:
+        type: string
+        format: datetime
+      minModifiedDatetime:
+        type: string
+        format: datetime
+      maxModifiedDatetime:
+        type: string
+        format: datetime
+
+  SceneParams:
+    type: object
+    description: scene params
+    properties:
+      maxCloudCover:
+        type: number
+        format: float32
+      minCloudCover:
+        type: number
+        format: float32
+      minAcquisitionDatetime:
+        type: string
+        format: datetime
+      maxAcquisitionDatetime:
+        type: string
+        format: datetime
+      datasource:
+        type: array
+        items:
+          type: string
+          format: uuid
+      month:
+        type: array
+        items:
+          type: number
+          format: int
+      minDayOfMonth:
+        type: number
+        format: int
+      maxDayOfMonth:
+        type: number
+        format: int
+      maxSunAzimuth:
+        type: number
+        format: float32
+      minSunAzimuth:
+        type: number
+        format: float32
+      maxSunElevation:
+        type: number
+        format: float32
+      minSunElevation:
+        type: number
+        format: float32
+      bbox:
+        type: string
+      point:
+        type: string
+      project:
+        type: string
+        format: uuid
+      ingested:
+        type: boolean
+      ingestStatus:
+        type: string
+        enum:
+          - NOTINGESTED
+          - TOBEINGESTED
+          - INGESTING
+          - INGESTED
+          - FAILED
+
+  ImageParams:
+    type: object
+    description: image params
+    properties:
+      minRawDataBytes:
+        type: number
+        format: int
+      maxRawDataBytes:
+        type: number
+        format: int
+      minResolution:
+        type: number
+        format: float32
+      maxResolution:
+        type: number
+        format: float32
+      scene:
+        type: array
+        items:
+          type: string
+          format: uuid
+
+  CombinedSceneQueryParams:
+    type: object
+    description: Combined query parameters for filtering scenes
+    discriminator: type
+    properties:
+      orgParams:
+        $ref: '#/definitions/OrgParams'
+      userParams:
+        $ref: '#/definitions/UserParams'
+      timestampParams:
+        $ref: '#/definitions/TimestampParams'
+      sceneParams:
+        $ref: '#/definitions/SceneParams'
+      imageParams:
+        $ref: '#/definitions/ImageParams'
+
+  # geometry types all lifted from:
+  # https://gist.github.com/idkw/fc35bb78c4bf08e47708f57b060996fe
+  # GPS License v3
+  Geometry:
+    type: object
+    description: GeoJSon geometry
+    discriminator: type
+    required:
+      - type
+    externalDocs:
+      url: http://geojson.org/geojson-spec.html#geometry-objects
+    properties:
+      type:
+        type: string
+        enum:
+        - Point
+        - LineString
+        - Polygon
+        - MultiPoint
+        - MultiLineString
+        - MultiPolygon
+        description: the geometry type
+  
+  Point2D:
+    type: array
+    maxItems: 2
+    minItems: 2
+    items:
+      type: number
+  
+  Point:
+    type: object
+    description: GeoJSon geometry
+    externalDocs:
+      url: http://geojson.org/geojson-spec.html#id2
+    allOf:
+      - $ref: "#/definitions/Geometry"
+      - properties:
+          coordinates:
+            $ref: '#/definitions/Point2D'
+    
+  LineString:
+    type: object
+    description: GeoJSon geometry
+    externalDocs:
+      url: http://geojson.org/geojson-spec.html#id3
+    allOf:
+      - $ref: "#/definitions/Geometry"
+      - properties:
+          coordinates:
+            type: array
+            items:
+              $ref: '#/definitions/Point2D'
+
+  Polygon:
+    type: object
+    description: GeoJSon geometry
+    externalDocs:
+      url: http://geojson.org/geojson-spec.html#id4
+    allOf:
+      - $ref: "#/definitions/Geometry"
+      - properties:
+          coordinates:
+            type: array
+            items:
+              type: array
+              items:
+                $ref: '#/definitions/Point2D'
+      
+  MultiPoint:
+    type: object
+    description: GeoJSon geometry
+    externalDocs:
+      url: http://geojson.org/geojson-spec.html#id5
+    allOf:
+      - $ref: "#/definitions/Geometry"
+      - properties:
+          coordinates:
+            type: array
+            items:
+              $ref: '#/definitions/Point2D'
+            
+  MultiLineString:
+    type: object
+    description: GeoJSon geometry
+    externalDocs:
+      url: http://geojson.org/geojson-spec.html#id6
+    allOf:
+      - $ref: "#/definitions/Geometry"   
+      - properties:
+          coordinates:
+            type: array
+            items:
+              type: array
+              items:
+                $ref: '#/definitions/Point2D'
+      
+      
+  MultiPolygon:
+    type: object
+    description: GeoJSon geometry
+    externalDocs:
+      url: http://geojson.org/geojson-spec.html#id6
+    allOf:
+      - $ref: "#/definitions/Geometry"
+      - properties:
+          coordinates:
+            type: array
+            items:
+              type: array
+              items:
+                type: array
+                items:
+                  $ref: '#/definitions/Point2D'
+      
+  GeometryCollection:
+    type: object
+    description: GeoJSon geometry collection
+    required:
+     - type
+     - geometries
+    externalDocs:
+      url: http://geojson.org/geojson-spec.html#geometrycollection
+    properties:
+      type:
+        type: string
+        enum:
+        - GeometryCollection
+      geometries:
+        type: array
+        items:
+          $ref: '#/definitions/Geometry'

--- a/scripts/test
+++ b/scripts/test
@@ -26,6 +26,12 @@ then
             find ./scripts -type f -print0 | xargs -0 -r shellcheck
         fi
 
+        echo "Validating swagger specification"
+        docker-compose \
+            -f docker-compose.test.yml \
+            run --rm app-frontend \
+            swagger validate /opt/swagger/spec.yml
+
         echo "Updating Scala dependencies"
         docker-compose \
             run --rm --no-deps app-server update


### PR DESCRIPTION
## Overview

This PR

- adds a swagger validation step to `scripts/test` (4ffd058)
- makes the swagger spec valid (4674d95)
- fixes a naming inconsistency in `CombinedSceneQueryParameters` (cc52637)

### Checklist

- [x] ~Styleguide updated, if necessary~
- [x] Swagger specification updated, if necessary
- [x] ~Symlinks from new migrations present or corrected for any new migrations~

### Notes

I left a bunch of `TODO`s in the swagger spec for things that are currently not desirable behavior (like generic SUCCESS and FAILURE descriptions, rather than complete descriptions of possible responses from each endpoint where responses were missing). Will add if it seems like that should be in the scope of this PR.

Also, we know there are some out-of-date things in the swagger spec, like `extent` missing from the `Project` definition and who knows what else.

Double also: If you want a pre-push hook that validates the swagger spec, add one of these to `.git/hooks/pre-push`:

```bash
#!/bin/sh

# one of these
# 1. just swagger validation
vagrant ssh -c \
    "docker-compose -f /opt/raster-foundry/docker-compose.test.yml run --rm app-frontend swagger validate /opt/swagger/spec.yml"

# 2. all tests
vagrant ssh -c \
    "cd /opt/raster-foundry/ && ./scripts/test"
```

and `chmod a+x .git/hooks/pre-push`

## Testing Instructions

 * Run `./scripts/test` from the vm (should pass, feel free to stop it after it validates the swagger spec)
 * Add a good, obviously invalid string to your swagger spec somewhere. One string I've found that works is `khakskdjlf;jal;shdf;klsk;ajlfdjkl;sajkldf;jaslk;dflkgj;jsal;fjds`, but you may want to choose your own.
 * Rerun `./scripts/test` and verify that the whole build dies.

Connects #1143 
Connects #1136
