### PR TITLE
Add Session storage of map filters

### DIFF
--- a/app-frontend/package.json
+++ b/app-frontend/package.json
@@ -34,7 +34,6 @@
     "angular-nvd3": "~1.0.8",
     "angular-resource": "1.5.8",
     "angular-sanitize": "1.5.8",
-    "angular-storage": "0.0.15",
     "angular-touch": "1.5.8",
     "angular-ui-bootstrap": "~2.1.4",
     "angular-ui-router": "~0.3.1",

--- a/app-frontend/src/app/components/navBar/navBar.controller.js
+++ b/app-frontend/src/app/components/navBar/navBar.controller.js
@@ -2,14 +2,14 @@ import assetLogo from '../../../assets/images/logo-raster-foundry.png';
 
 export default class NavBarController {
     constructor( // eslint-disable-line max-params
-        $log, $state, $uibModal, store, $scope, APP_CONFIG, authService
+        $log, $state, $uibModal, $scope, APP_CONFIG, authService, localStorage
     ) {
         'ngInject';
 
         this.$log = $log;
         this.$state = $state;
         this.$uibModal = $uibModal;
-        this.store = store;
+        this.localStorage = localStorage;
         this.authService = authService;
 
         if (APP_CONFIG.error) {

--- a/app-frontend/src/app/core/core.module.js
+++ b/app-frontend/src/app/core/core.module.js
@@ -17,6 +17,7 @@ require('./services/tool.service')(shared);
 require('./services/toolCategory.service')(shared);
 require('./services/toolTag.service')(shared);
 require('./services/user.service')(shared);
+require('./services/storage.service')(shared);
 
 require('./services/featureFlagOverrides.service')(shared);
 require('./services/featureFlags.provider')(shared);

--- a/app-frontend/src/app/core/services/auth.service.js
+++ b/app-frontend/src/app/core/services/auth.service.js
@@ -1,11 +1,11 @@
 export default (app) => {
     class AuthService {
         constructor( // eslint-disable-line max-params
-            lock, store, jwtHelper, $q, featureFlagOverrides, featureFlags,
-            $state
+            lock, jwtHelper, $q, featureFlagOverrides, featureFlags,
+            $state, localStorage
         ) {
             this.lock = lock;
-            this.store = store;
+            this.localStorage = localStorage;
             this.jwtHelper = jwtHelper;
             this.$q = $q;
             this.$state = $state;
@@ -22,7 +22,7 @@ export default (app) => {
             } else if (!this.jwtHelper.isTokenExpired(token)) {
                 this.onLogin({idToken: token});
             } else if (this.jwtHelper.isTokenExpired(token)) {
-                this.store.remove('item_token');
+                this.localStorage.remove('item_token');
                 this.$state.go('login');
             } else {
                 this.lock.show();
@@ -30,7 +30,7 @@ export default (app) => {
         }
 
         onLogin(authResult) {
-            this.store.set('id_token', authResult.idToken);
+            this.localStorage.set('id_token', authResult.idToken);
 
             this.lock.getProfile(authResult.idToken, (error, profile) => {
                 if (error) {
@@ -43,7 +43,7 @@ export default (app) => {
                 }
                 /* eslint-enable no-undef */
 
-                this.store.set('profile', profile);
+                this.localStorage.set('profile', profile);
                 this.featureFlagOverrides.setUser(profile.user_id);
                 let userFlags = profile.user_metadata && profile.user_metadata.featureFlags ?
                     profile.user_metadata.featureFlags : [];
@@ -72,16 +72,16 @@ export default (app) => {
         }
 
         profile() {
-            return this.store.get('profile');
+            return this.localStorage.get('profile');
         }
 
         token() {
-            return this.store.get('id_token', this.token);
+            return this.localStorage.get('id_token', this.token);
         }
 
         logout() {
-            this.store.remove('id_token');
-            this.store.remove('profile');
+            this.localStorage.remove('id_token');
+            this.localStorage.remove('profile');
             this.isLoggedIn = false;
             this.$state.go('login');
         }

--- a/app-frontend/src/app/core/services/featureFlagOverrides.service.js
+++ b/app-frontend/src/app/core/services/featureFlagOverrides.service.js
@@ -13,9 +13,9 @@
  */
 export default app => {
     class FeatureFlagOverrides {
-        constructor($rootElement, store, $log) {
+        constructor($rootElement, $log, localStorage) {
             'ngInject';
-            this.store = store;
+            this.localStorage = localStorage;
             this.$log = $log;
 
             let keyPrefix = 'featureFlags.';
@@ -36,7 +36,7 @@ export default app => {
             if (!this.prefixedKeyFor) {
                 return false;
             }
-            let val = this.store.get(this.prefixedKeyFor(key));
+            let val = this.localStorage.get(this.prefixedKeyFor(key));
             return typeof val !== 'undefined' && val !== null;
         }
 
@@ -45,7 +45,7 @@ export default app => {
                 this.$log.error('featureFlagOverrides.get called before setting a user.');
                 return false;
             }
-            return this.store.get(this.prefixedKeyFor(flagName));
+            return this.localStorage.get(this.prefixedKeyFor(flagName));
         }
 
         set(flag, value) {
@@ -54,7 +54,7 @@ export default app => {
                 return;
             }
             let setFlag = (val, flagName) => {
-                this.store.set(this.prefixedKeyFor(flagName), val);
+                this.localStorage.set(this.prefixedKeyFor(flagName), val);
             };
             if (angular.isObject(flag)) {
                 angular.forEach(flag, setFlag);
@@ -68,7 +68,7 @@ export default app => {
                 this.$log.error('featureFlagOverrides.remove called before setting a user.');
                 return;
             }
-            this.store.remove(this.prefixedKeyFor(flagName));
+            this.localStorage.remove(this.prefixedKeyFor(flagName));
         }
     }
 

--- a/app-frontend/src/app/core/services/storage.service.js
+++ b/app-frontend/src/app/core/services/storage.service.js
@@ -1,0 +1,59 @@
+/* globals window*/
+export default (app) => {
+    class Storage {
+        constructor(storage) {
+            this.storage = storage;
+        }
+
+        // doesn't need to parse jsobject from string
+        has(key) {
+            return Boolean(this.storage.getItem(key));
+        }
+
+        get(key) {
+            let value = this.storage.getItem(key);
+            return value && JSON.parse(value);
+        }
+
+        set(key, value) {
+            this.storage.setItem(key, JSON.stringify(value));
+        }
+
+        // Higher performance for raw strings
+        getString(key) {
+            return this.storage.getItem(key);
+        }
+
+        // Higher performance for raw strings
+        setString(key, value) {
+            this.storage.setItem(key, value);
+        }
+
+        remove(key) {
+            this.storage.removeItem(key);
+        }
+
+        clear() {
+            this.storage.clear();
+        }
+
+        length() {
+            return this.storage.length;
+        }
+    }
+
+    class SessionStorage extends Storage {
+        constructor() {
+            super(window.sessionStorage);
+        }
+    }
+
+    class LocalStorage extends Storage {
+        constructor() {
+            super(window.localStorage);
+        }
+    }
+
+    app.service('sessionStorage', SessionStorage);
+    app.service('localStorage', LocalStorage);
+};

--- a/app-frontend/src/app/index.module.js
+++ b/app-frontend/src/app/index.module.js
@@ -12,7 +12,6 @@ const App = angular.module(
         // plugins
         require('angular-ui-router'),
         require('angular-nvd3'),
-        'angular-storage',
         'angular-jwt',
         'angular-clipboard',
         'auth0.lock',

--- a/app-frontend/src/app/index.run.js
+++ b/app-frontend/src/app/index.run.js
@@ -1,5 +1,5 @@
 function runBlock( // eslint-disable-line max-params
-    $rootScope, store, jwtHelper, $state, $location, APP_CONFIG, authService
+    $rootScope, jwtHelper, $state, $location, APP_CONFIG, authService, localStorage
 ) {
     'ngInject';
 
@@ -15,7 +15,7 @@ function runBlock( // eslint-disable-line max-params
     });
 
     $rootScope.$on('$locationChangeStart', function () {
-        let token = store.get('id_token');
+        let token = localStorage.get('id_token');
         if (token) {
             if (!authService.isLoggedIn) {
                 authService.login(token);

--- a/app-frontend/src/app/index.vendor.js
+++ b/app-frontend/src/app/index.vendor.js
@@ -9,7 +9,6 @@ import 'angular-nvd3';
 import 'angular-ui-router';
 import 'angular-ui-bootstrap';
 import 'angular-deferred-bootstrap';
-import 'angular-storage';
 import 'angular-lock';
 import 'ng-infinite-scroll';
 import 'angular-jwt';

--- a/app-frontend/src/app/pages/browse/browse.controller.js
+++ b/app-frontend/src/app/pages/browse/browse.controller.js
@@ -5,15 +5,18 @@ const _ = require('lodash');
 export default class BrowseController {
     constructor( // eslint-disable-line max-params
         $log, $scope, sceneService, gridLayerService,
-        authService, $state, $uibModal, $timeout, mapService
+        authService, $state, $uibModal, $timeout, mapService,
+        sessionStorage
     ) {
         'ngInject';
+
         this.$log = $log;
         this.sceneService = sceneService;
         this.authService = authService;
         this.$state = $state;
         this.$uibModal = $uibModal;
         this.gridLayerService = gridLayerService;
+        this.sessionStorage = sessionStorage;
 
         this.getBrowseMap = () => mapService.getMap('browse');
         this.getDetailMap = () => mapService.getMap('detail');
@@ -29,12 +32,15 @@ export default class BrowseController {
         this.gridFilterActive = false;
         // initial data
 
-        this.queryParams = _.mapValues($state.params, (val) => {
-            if (val === '' || typeof val === 'undefined') {
-                return null;
-            }
-            return val;
-        });
+        this.queryParams = Object.assign(
+            _.mapValues($state.params, (val) => {
+                if (val === '' || typeof val === 'undefined') {
+                    return null;
+                }
+                return val;
+            }),
+            this.sessionStorage.get('filters') || {}
+        );
 
         if ($state.params.id) {
             this.sceneService.query({id: $state.params.id}).then(
@@ -120,6 +126,7 @@ export default class BrowseController {
     }
 
     onQueryParamsChange() {
+        this.sessionStorage.set('filters', this.queryParams);
         this.$state.go('.', this.queryParams, {notify: false, inherit: false, location: 'replace'});
         this.requestNewSceneList();
     }


### PR DESCRIPTION
## Overview
Add localStorage and sessionStorage services
Remove angular-storage library (doesn't support multiple storage sources)

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~

### Notes

I removed angular-storage because it doesn't support multiple storage sources.
After evaluating other libraries, I just wrote simple wrapper services since it's simple and doesn't run into issues w/ regard to caching / flexibility that I observed in the available libraries.

## Testing Instructions

* Change a filter on the browse view
* Go to a different view
* Go back to the browse view by clicking the browse scenes link at the top of the page
* Verify that the filters are persisted
* Verify that reloading the page doesn't lose filters
  * Note: Navigate to a non-browse view before reloading, so that the url params need to be re-initialized from storage
* Verify that opening a new tab or closing the tab / window resets the filters.
* Verify that services / controllers which used angular-storage still function as they should (namely authService, featureFlags, and navbar)


Closes #1118 
