### PR TITLE
Populate color mode dropdown from API

### DIFF
--- a/app-frontend/src/app/components/colorCorrectScenes/colorCorrectScenes.html
+++ b/app-frontend/src/app/components/colorCorrectScenes/colorCorrectScenes.html
@@ -10,8 +10,8 @@
             <a href
                ng-class="{'active': $ctrl.isActiveColorMode(key)}"
                ng-click="$ctrl.setBands(key)"
-               ng-repeat="(key, band) in $ctrl.bands track by $index">
-              {{band.label}}
+               ng-repeat="(key, composite) in $ctrl.unifiedComposites track by $index">
+              {{composite.label}}
             </a>
           </li>
         </ul>

--- a/app-frontend/src/app/pages/editor/project/projectEdit.controller.js
+++ b/app-frontend/src/app/pages/editor/project/projectEdit.controller.js
@@ -120,9 +120,10 @@ export default class ProjectEditController {
 
     getSceneList() {
         this.sceneRequestState = {loading: true};
-        this.projectService.getAllProjectScenes(
+        this.sceneListQuery = this.projectService.getAllProjectScenes(
             {projectId: this.projectId}
-        ).then(
+        );
+        this.sceneListQuery.then(
             (allScenes) => {
                 this.sceneList = allScenes;
                 for (const scene of this.sceneList) {


### PR DESCRIPTION
## Overview

This PR uses the composites fields defined on a datasource to populate the color mode dropdown.

In order to handle multiple datasources, the dropdown is populated only by the color composites that are common to all datasources. This does not handle the actual correction of scenes from different datasources.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~


### Notes

We may want to consider how we will handle the case of scenes from multiple datasources in a single project and how, in these cases, we would handle composite matching since our composites are loosely defined as JSON.


## Testing Instructions

 * View an ingested scene in the editor
 * Verify that the color mode dropdown is populated
 * Inspect the requests and see that the color modes match the composites in the datasource request
  * Verify the composites actually change the image as expected in regard to the composite values

Connects #1145
