### PR TITLE
Bump Terraform version to 0.8.7

### DIFF
--- a/deployment/ansible/group_vars/jenkins
+++ b/deployment/ansible/group_vars/jenkins
@@ -3,6 +3,6 @@ docker_users:
   - "{{ ansible_user }}"
   - "{{ jenkins_name }}"
 
-terraform_version: "0.8.2"
+terraform_version: "0.8.7"
 
 java_version: "7u121*"


### PR DESCRIPTION
## Overview

Terraform state is current at 0.8.5 and we have 0.8.2 defined in Ansible. This updates us to the most recent patch release, 0.8.7.

See:
https://github.com/hashicorp/terraform/blob/master/CHANGELOG.md#087-february-15-2017

## Testing Instructions

These changes are currently running on staging:

```bash
athena Projects/raster-foundry ‹feature/hmc/terraform-0.8.7› » ssh -l ubuntu -i ~/.ssh/raster-foundry-stg.pem jenkins.staging.rasterfoundry.com
Welcome to Ubuntu 14.04.5 LTS (GNU/Linux 3.13.0-110-generic x86_64)

 * Documentation:  https://help.ubuntu.com/

  System information as of Fri Feb 24 18:22:38 EST 2017

  System load:                    0.05
  Usage of /:                     70.3% of 251.84GB
  Memory usage:                   22%
  Swap usage:                     0%
  Processes:                      131
  Users logged in:                1
  IP address for eth0:            172.31.52.80
  IP address for br-f75a3f1b1e08: 172.20.0.1
  IP address for br-1df3d127d1c6: 172.22.0.1
  IP address for br-3f9ccbcb7a5f: 172.18.0.1
  IP address for br-6fb775fa9392: 172.19.0.1
  IP address for docker0:         172.17.0.1
  IP address for br-ae5fdda52e39: 172.23.0.1
  IP address for br-dbbee083f16d: 172.26.0.1
  IP address for br-b4138938e384: 172.24.0.1

  Graph this data and manage this system at:
    https://landscape.canonical.com/

  Get cloud support with Ubuntu Advantage Cloud Guest:
    http://www.ubuntu.com/business/services/cloud

0 packages can be updated.
0 updates are security updates.

New release '16.04.2 LTS' available.
Run 'do-release-upgrade' to upgrade to it.


Last login: Fri Feb 24 18:24:50 2017 from 66.212.12.106
ubuntu@ip-172-31-52-80:~$ terraform -v
Terraform v0.8.7
```

See: http://jenkins.staging.rasterfoundry.com/job/raster-foundry/job/raster-foundry/job/develop/275/