### PR TITLE
Move app-frontend to docker-compose.yml

### DIFF
--- a/scripts/console
+++ b/scripts/console
@@ -20,7 +20,6 @@ then
         usage
     else
         docker-compose -f "${DIR}/../docker-compose.yml" \
-                       -f "${DIR}/../docker-compose.test.yml" \
                        -f "${DIR}/../docker-compose.swagger.yml" \
                        -f "${DIR}/../docker-compose.airflow.yml" \
                        run --rm --service-ports --entrypoint \


### PR DESCRIPTION
## Overview
Currently, the `app-frontend` service is defined in docker-compose.test.yml. This configuration requires `scripts/server` and `scripts/console` to include docker-compose.test.yml in commands, which in turn builds/runs production-ready containers instead of the versions we use in development. This PR moves `app-frontend` to docker-compose.yml, allowing `scripts/console` and `scripts/server` to build the development versions of each service container.

### Checklist

~~- [ ] Styleguide updated, if necessary~~
~~- [ ] Swagger specification updated, if necessary~~
~~- [ ] Symlinks from new migrations present or corrected for any new migrations~~

### Demo

Optional. Screenshots, `curl` examples, etc.

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.


## Testing Instructions

* Ensure `scripts/console app-server ./sbt` runs correctly
* Run `scripts/server`. Make sure that `app-frontend` is not running.

Closes #1098
