### PR TITLE
Streamline requests for color-correction

### DIFF
--- a/app-frontend/src/app/components/colorCorrectPane/colorCorrectPane.controller.js
+++ b/app-frontend/src/app/components/colorCorrectPane/colorCorrectPane.controller.js
@@ -37,7 +37,7 @@ export default class ColorCorrectPaneController {
     }
 
     $onDestroy() {
-        this.$parent.fitAllScenes();
+        this.$parent.fitProjectExtent();
         this.getMap().then((map) => {
             this.selectedScenes.forEach((scene) => map.deleteGeojson(scene.id));
         });

--- a/app-frontend/src/app/core/services/layer.service.js
+++ b/app-frontend/src/app/core/services/layer.service.js
@@ -40,7 +40,6 @@ export default (app) => {
             this._sceneTiles = null; // eslint-disable-line no-underscore-dangle
             this._mosaicTiles = null; // eslint-disable-line no-underscore-dangle
             this._correction = null; // eslint-disable-line no-underscore-dangle
-            this.getBounds();
         }
 
         /** Function to return bounds from either the project or the scene

--- a/app-frontend/src/app/index.run.js
+++ b/app-frontend/src/app/index.run.js
@@ -11,7 +11,6 @@ function runBlock( // eslint-disable-line max-params
             e.preventDefault();
             $state.go('login');
         }
-
     });
 
     $rootScope.$on('$locationChangeStart', function () {

--- a/app-frontend/src/app/pages/editor/project/projectEdit.controller.js
+++ b/app-frontend/src/app/pages/editor/project/projectEdit.controller.js
@@ -108,6 +108,17 @@ export default class ProjectEditController {
         });
     }
 
+    fitSelectedScenes() {
+        this.fitScenes(Array.from(this.selectedScenes.values()));
+    }
+
+    fitScenes(scenes) {
+        this.getMap().then((map) =>{
+            let sceneFootprints = scenes.map((scene) => scene.dataFootprint);
+            map.map.fitBounds(L.geoJSON(sceneFootprints).getBounds());
+        });
+    }
+
     getSceneList() {
         this.sceneRequestState = {loading: true};
         this.projectService.getAllProjectScenes(

--- a/app-frontend/src/app/pages/lab/edit/edit.controller.js
+++ b/app-frontend/src/app/pages/lab/edit/edit.controller.js
@@ -65,7 +65,7 @@ export default class LabEditController {
         ).then(
             (allScenes) => {
                 this.sceneList = allScenes;
-                this.fitAllScenes();
+                this.fitProjectExtent();
                 this.layersFromScenes();
             },
             (error) => {


### PR DESCRIPTION
## Overview

This PR reduces the minimum number of requests for scenes on color correction from 4 to 1. To do this, we eliminate extraneous requests to determine bounds and alter the page parsing strategy to use the `count` property of the first page, rather than sending a separate request to get the record count.

This also fixes a color correction bug (fitting selected scenes when color correcting now works again) and cleans some lint.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~

## Testing Instructions

 * Go to color correct for a project with less than 30 scenes
 * Monitor requests and check that only a single request was made for a scenes page
 * Go to color correct for a project with greater than 30 scenes
 * Monitor requests and see that only the necessary number of requests were made

 * Test color correcting a single scene to ensure that works again

Connects #1100
