### PR TITLE
Return error code when webpack build fails

### DIFF
--- a/app-frontend/config/webpack/environments/production.js
+++ b/app-frontend/config/webpack/environments/production.js
@@ -6,6 +6,7 @@
 
 const webpack = require('webpack');
 const CleanWebpackPlugin = require('clean-webpack-plugin');
+const WebpackFailPlugin = require('webpack-fail-plugin');
 
 module.exports = function (_path) {
     return {
@@ -17,6 +18,7 @@ module.exports = function (_path) {
             filename: '[name].[chunkhash].js'
         },
         plugins: [
+            WebpackFailPlugin,
             new webpack.NoErrorsPlugin(),
             new CleanWebpackPlugin(['dist'], {
                 root: _path,

--- a/app-frontend/package.json
+++ b/app-frontend/package.json
@@ -49,7 +49,8 @@
     "leaflet-draw": "~0.4.7",
     "lodash": "~4.5.0",
     "ng-infinite-scroll": "~1.3.0",
-    "nvd3": "~1.8.4"
+    "nvd3": "~1.8.4",
+    "webpack-fail-plugin": "^1.0.6"
   },
   "devDependencies": {
     "angular-mocks": "~1.5.8",

--- a/app-frontend/yarn.lock
+++ b/app-frontend/yarn.lock
@@ -6839,6 +6839,10 @@ webpack-dev-server@1.16.2:
     supports-color "^3.1.1"
     webpack-dev-middleware "^1.4.0"
 
+webpack-fail-plugin@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/webpack-fail-plugin/-/webpack-fail-plugin-1.0.6.tgz#a135ee070a258548837f921d452004c695889ee7"
+
 webpack@~1.12.12:
   version "1.12.15"
   resolved "https://registry.yarnpkg.com/webpack/-/webpack-1.12.15.tgz#d4611335a5d455269850aeb9b4ae74cc35192286"


### PR DESCRIPTION
## Overview

Webpack returns 0 after every run, even if the static asset bundle build fails. As a result, Jenkins jobs will pass and deploy broken javascript to staging. This PR forces Webpack to return 1 when building static files fails.

### Checklist

~~- [ ] Styleguide updated, if necessary~~
~~- [ ] Swagger specification updated, if necessary~~
~~- [ ] Symlinks from new migrations present or corrected for any new migrations~~

### Notes

This is a bug in webpack 1.x, documented in webpack/webpack#708. They have no intention on fixing it in this major version, but it's been fixed in webpack 2.x. Upgrading webpack may be a cleaner solution in the long run.

## Testing Instructions
 * Add an error to a javascript file:
```diff
diff --git a/app-frontend/src/app/pages/editor/editor.controller.js b/app-frontend/src/app/pages/editor/editor.controller.js
index 79242e1..be08986 100644
--- a/app-frontend/src/app/pages/editor/editor.controller.js
+++ b/app-frontend/src/app/pages/editor/editor.controller.js
@@ -1,6 +1,6 @@
 class EditorController {
     constructor() {
-        'ngInject';
+        ngInject;
 
         // This is an abstract view so it's just a container for its children
     }
```

* Run `scripts/cibuild`, and make sure it fails after building static assets.
* See the Jenkins job failure [here](http://jenkins.staging.rasterfoundry.com/job/raster-foundry/job/raster-foundry/job/feature%252Ftnation%252Fjenkins/12/consoleFull)
Connects #967 
