### PR TITLE
Update Nginx set_real_ip_from for public subnets

### DIFF
--- a/nginx/etc/nginx/nginx.conf
+++ b/nginx/etc/nginx/nginx.conf
@@ -28,10 +28,10 @@ http {
     gzip_types application/javascript text/css application/json;
     gzip_disable "msie6";
 
-    set_real_ip_from 10.0.0.0/24;
-    set_real_ip_from 10.0.2.0/24;
-    set_real_ip_from 10.0.4.0/24;
-    set_real_ip_from 10.0.6.0/24;
+    set_real_ip_from 10.0.0.0/20;
+    set_real_ip_from 10.0.16.0/20;
+    set_real_ip_from 10.0.160.0/20;
+    set_real_ip_from 10.0.176.0/20;
 
     real_ip_header X-Forwarded-For;
 


### PR DESCRIPTION
## Overview

The CIDR ranges listed in this change are used for our public subnets across VPCs. Updating them allows Nginx to properly log the client IP address that initialed the request.

Fixes https://github.com/azavea/raster-foundry/issues/1041

## Testing Instructions

I packaged these changes into a set of container images and pushed them into the staging environment. See the Papertrail logs here that have the correct remote client IP address:

- https://papertrailapp.com/groups/4082193/events?focus=773379959438848017&selected=773379959438848017
