### PR TITLE
Authorization logic for adding scenes to a project

### DIFF
--- a/app-backend/app/src/main/scala/project/Routes.scala
+++ b/app-backend/app/src/main/scala/project/Routes.scala
@@ -197,7 +197,7 @@ trait ProjectRoutes extends Authentication
       }
 
       complete {
-        Projects.addScenesToProject(sceneIds, projectId)
+        Projects.addScenesToProject(sceneIds, projectId, user)
       }
     }
   }

--- a/app-backend/app/src/test/scala/project/ProjectHelpers.scala
+++ b/app-backend/app/src/test/scala/project/ProjectHelpers.scala
@@ -25,10 +25,26 @@ trait ProjectSpecHelper {
     publicOrgId, "Test Three", "This is the third test project", Visibility.Public, List("testing")
   )
 
+  val newProject4 = Project.Create(
+    publicOrgId, "Test Three", "This is the third test project", Visibility.Private, List("testing")
+  )
+
   val landsatId = UUID.fromString("697a0b91-b7a8-446e-842c-97cda155554d")
 
   def newScene(name: String, cloudCover: Option[Float] = None) = Scene.Create(
     None, publicOrgId, 0, Visibility.Public, List("Test", "Public", "Low Resolution"), landsatId,
+    Map("instrument type" -> "satellite", "splines reticulated" -> 0):Map[String, Any],
+    name, None, None, List.empty[String], List.empty[Image.Banded],
+    List.empty[Thumbnail.Identified], None,
+    SceneFilterFields(cloudCover,
+                      Some(Timestamp.from(Instant.parse("2016-09-19T14:41:58.408544Z"))),
+                      None,
+                      None),
+    SceneStatusFields(JobStatus.Processing, JobStatus.Processing, IngestStatus.NotIngested)
+  )
+
+  def newPrivateScene(name: String, cloudCover: Option[Float] = None) = Scene.Create(
+    None, publicOrgId, 0, Visibility.Private, List("Test", "Public", "Low Resolution"), landsatId,
     Map("instrument type" -> "satellite", "splines reticulated" -> 0):Map[String, Any],
     name, None, None, List.empty[String], List.empty[Image.Banded],
     List.empty[Thumbnail.Identified], None,


### PR DESCRIPTION
## Overview

This PR ensures the API consumer is not performing unauthorized actions when adding scenes to a project. This really boils down to two checks:
  
  1) Is the user the owner of the project in question?
  2) Are all of the scenes in question public?

When either of these conditions is false, we stop processing the request and throw an exception with a relevant message.

We could possibly handle point 2 differently, and allow the request to proceed if at least one scene is public and filter the unauthorized scenes out before adding them rather than a wholesale failure. That being said, it is unlikely that such an action would be unintentional.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~

### Notes

We will most likely want to generalize authorization in the near future.

We may want to revisit this logic depending on our handling of organizational permissions.

## Testing Instructions

 * From the sbt shell `./scripts/console app-server ./sbt` run `app/test`
 * All the tests should pass (there are two additional tests)
 * There should also be output of the exceptions thrown from the attempted operations

One could also test this manually by using psql to find an unowned project id and set a scene to be created by 'default' and visibility to 'PRIVATE', and then sending post requests to the endpoint with your auth headers properly set.

Connects #1123
