### PR TITLE
Allow updating user profile and password from frontend

### DIFF
--- a/app-backend/api/src/main/scala/RfJsonProtocols.scala
+++ b/app-backend/api/src/main/scala/RfJsonProtocols.scala
@@ -8,6 +8,7 @@ import spray.json._
 
 import com.azavea.rf.datamodel._
 import com.azavea.rf.database.RFDatabaseJsonProtocol
+import com.azavea.rf.api.utils.ManagementBearerToken
 
 
 trait RfJsonProtocols extends SprayJsonSupport
@@ -22,4 +23,6 @@ trait RfJsonProtocols extends SprayJsonSupport
       case _ => throw new DeserializationException(s"Expected ISO 8601 Date but got $json")
     }
   }
+
+  implicit val managementBearerTokenJson = jsonFormat4(ManagementBearerToken)
 }

--- a/app-backend/api/src/main/scala/token/Routes.scala
+++ b/app-backend/api/src/main/scala/token/Routes.scala
@@ -3,6 +3,7 @@ package com.azavea.rf.api.token
 import akka.http.scaladsl.server.Route
 
 import com.azavea.rf.common.{Authentication, UserErrorHandler}
+import com.azavea.rf.api.utils.{Auth0ErrorHandler}
 
 
 /**

--- a/app-backend/api/src/main/scala/token/Token.scala
+++ b/app-backend/api/src/main/scala/token/Token.scala
@@ -14,12 +14,12 @@ import scala.concurrent.Future
 
 import com.azavea.rf.datamodel.User
 import com.azavea.rf.api.utils.Config
+import com.azavea.rf.api.utils.{Auth0Exception, ManagementBearerToken}
 
 
 case class RefreshToken(refresh_token: String)
 case class DeviceCredential(id: String, device_name: String)
 case class AuthorizedToken(id_token: String, expires_in: Int, token_type: String)
-case class ManagementBearerToken(access_token: String, expires_in: Int, token_type: String, scope: String)
 
 object TokenService extends Config {
 

--- a/app-backend/api/src/main/scala/token/package.scala
+++ b/app-backend/api/src/main/scala/token/package.scala
@@ -4,5 +4,4 @@ package object token extends RfJsonProtocols {
   implicit val refreshTokenJson = jsonFormat1(RefreshToken)
   implicit val deviceCredentialJson = jsonFormat2(DeviceCredential)
   implicit val authorizedTokenJson = jsonFormat3(AuthorizedToken)
-  implicit val managementBearerTokenJson = jsonFormat4(ManagementBearerToken)
 }

--- a/app-backend/api/src/main/scala/user/Auth0User.scala
+++ b/app-backend/api/src/main/scala/user/Auth0User.scala
@@ -1,0 +1,162 @@
+package com.azavea.rf.api.user
+
+import spray.json._
+import akka.http.scaladsl.Http
+import akka.http.scaladsl.model.HttpMethods._
+import akka.http.scaladsl.model._
+import akka.http.scaladsl.model.Uri.{Path, Query}
+import akka.http.scaladsl.model.headers.{Authorization, GenericHttpCredentials}
+import akka.http.scaladsl.unmarshalling.Unmarshal
+import akka.http.scaladsl.marshalling.Marshal
+import com.azavea.rf.datamodel.SerializationUtils
+import com.github.blemale.scaffeine.{AsyncLoadingCache, Scaffeine}
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration._
+import scala.concurrent.Future
+
+import com.azavea.rf.datamodel.User
+import com.azavea.rf.api.utils.Config
+import com.azavea.rf.api.utils.{ManagementBearerToken, Auth0Exception}
+
+import com.typesafe.scalalogging.LazyLogging
+
+case class Auth0User(
+  email: Option[String], email_verified: Option[Boolean],
+  username: Option[String],
+  phone_number: Option[String], phone_verified: Option[String],
+  user_id: Option[String],
+  created_at: Option[String], updated_at: Option[String],
+  identities: Option[Seq[Map[String, Any]]],
+  // app_metadata: Option[Map[String, Any]],
+  user_metadata: Option[Map[String, Any]],
+  picture: Option[String],
+  name: Option[String],
+  nickname: Option[String],
+  // multifactor: Option[Seq[String]],
+  // last_ip: Option[String],
+  // last_login: Option[String],
+  // logins_count: Option[Int],
+  // blocked: Option[Boolean],
+  given_name: Option[String],
+  family_name: Option[String]
+)
+
+case class Auth0UserUpdate(
+  email: Option[String],
+  phone_number: Option[String],
+  user_metadata: Option[Map[String, Any]],
+  username: Option[String]
+)
+object Auth0UserUpdate extends SerializationUtils {
+  implicit val inner = jsonFormat4(Auth0UserUpdate.apply _)
+}
+
+object Auth0UserService extends Config with LazyLogging{
+  import com.azavea.rf.api.AkkaSystem._
+
+  val uri = Uri(s"https://$auth0Domain/api/v2/device-credentials")
+  val userUri = Uri(s"https://$auth0Domain/api/v2/users")
+  val auth0BearerHeader = List(
+    Authorization(GenericHttpCredentials("Bearer", auth0Bearer))
+  )
+
+  val authBearerTokenCache: AsyncLoadingCache[Int, ManagementBearerToken] =
+    Scaffeine()
+      .expireAfterWrite(1.hour)
+      .maximumSize(1)
+      .buildAsyncFuture((i: Int) => getManagementBearerToken())
+
+  def getManagementBearerToken(): Future[ManagementBearerToken] = {
+    val bearerTokenUri = Uri(s"https://$auth0Domain/oauth/token")
+
+    val params = FormData(
+      "client_id" -> auth0ManagementClientId,
+      "client_secret" -> auth0ManagementSecret,
+      "audience" -> s"https://$auth0Domain/api/v2/",
+      "grant_type" -> "client_credentials"
+    ).toEntity
+
+    Http()
+      .singleRequest(HttpRequest(
+                       method = POST,
+                       uri = bearerTokenUri,
+                       entity = params
+                     ))
+      .flatMap {
+        case HttpResponse(StatusCodes.OK, _, entity, _) =>
+          Unmarshal(entity).to[ManagementBearerToken]
+        case HttpResponse(errCode, _, error, _) =>
+          throw new Auth0Exception(errCode, error.toString)
+      }
+  }
+
+  def getAuth0User(user: User) : Future[Auth0User] = {
+    for {
+      bearerToken <- authBearerTokenCache.get(1)
+      auth0User <- requestAuth0User(user, bearerToken)
+    } yield auth0User
+  }
+
+  def requestAuth0User(user: User, bearerToken: ManagementBearerToken): Future[Auth0User] = {
+    val auth0UserBearerHeader = List(
+      Authorization(GenericHttpCredentials("Bearer", bearerToken.access_token))
+    )
+    Http().singleRequest(HttpRequest(
+        method = GET,
+        uri = s"$userUri/${user.id}",
+        headers = auth0UserBearerHeader
+      ))
+      .flatMap {
+      case HttpResponse(StatusCodes.OK, _, entity, _) =>
+          Unmarshal(entity).to[Auth0User]
+      case HttpResponse(StatusCodes.Unauthorized, _, error, _) =>
+        if (error.toString.contains("invalid_refresh_token")) {
+          throw new IllegalArgumentException("Refresh token not recognized")
+        } else {
+          throw new Auth0Exception(StatusCodes.Unauthorized, error.toString)
+        }
+      case HttpResponse(errCode, _, error, _) =>
+          logger.info(s"error $error")
+        throw new Auth0Exception(errCode, error.toString)
+    }
+  }
+
+  def updateAuth0User(user: User, auth0UserUpdate: Auth0UserUpdate): Future[Auth0User] = {
+    for {
+      bearerToken <- authBearerTokenCache.get(1)
+      auth0User <- requestAuth0UserUpdate(user, auth0UserUpdate, bearerToken)
+    } yield auth0User
+  }
+
+  def requestAuth0UserUpdate(user: User, auth0UserUpdate: Auth0UserUpdate, bearerToken: ManagementBearerToken):
+      Future[Auth0User] = {
+    val auth0UserBearerHeader = List(
+      Authorization(GenericHttpCredentials("Bearer", bearerToken.access_token))
+    )
+    Http().singleRequest(HttpRequest(
+                           method = PATCH,
+                           uri = s"$userUri/${user.id}",
+                           headers = auth0UserBearerHeader,
+                           entity = HttpEntity(
+                             ContentTypes.`application/json`,
+                             auth0UserUpdate.toJson.toString
+                           )
+                         ))
+      .flatMap {
+        case HttpResponse(StatusCodes.OK, _, entity, _) =>
+          Unmarshal(entity).to[Auth0User]
+        case HttpResponse(StatusCodes.ClientError(400), _, error, _) =>
+          throw new IllegalArgumentException("Request must specify a valid field to update")
+        case HttpResponse(StatusCodes.Unauthorized, _, error, _) =>
+          if (error.toString.contains("invalid_refresh_token")) {
+            throw new IllegalArgumentException("Refresh token not recognized")
+          } else {
+            throw new Auth0Exception(StatusCodes.Unauthorized, error.toString)
+          }
+        case HttpResponse(errCode, _, error, _) =>
+          logger.info(s"error $error")
+          throw new Auth0Exception(errCode, error.toString)
+      }
+  }
+}

--- a/app-backend/api/src/main/scala/user/Routes.scala
+++ b/app-backend/api/src/main/scala/user/Routes.scala
@@ -25,6 +25,14 @@ trait UserRoutes extends Authentication with PaginationDirectives with UserError
       get { listUsers } ~
       post { createUser }
     } ~
+    pathPrefix("me") {
+      get {
+        getAuth0User
+      } ~
+      patch {
+        updateAuth0User
+      }
+    } ~
     pathPrefix(Segment) { authIdEncoded =>
       pathEndOrSingleSlash {
         get { getUserByEncodedAuthId(authIdEncoded) }
@@ -48,6 +56,20 @@ trait UserRoutes extends Authentication with PaginationDirectives with UserError
           case Some(user) => complete((StatusCodes.Created, user))
           case None => throw new IllegalStateException("Unable to create user")
         }
+      }
+    }
+  }
+
+  def getAuth0User: Route = authenticate { user =>
+    complete {
+      Auth0UserService.getAuth0User(user)
+    }
+  }
+  def updateAuth0User: Route = authenticate {
+    user =>
+    entity(as[Auth0UserUpdate]) { userUpdate =>
+      complete {
+        Auth0UserService.updateAuth0User(user, userUpdate)
       }
     }
   }

--- a/app-backend/api/src/main/scala/user/package.scala
+++ b/app-backend/api/src/main/scala/user/package.scala
@@ -6,7 +6,7 @@ import com.azavea.rf.datamodel._
   * Json formats for user
   */
 package object user extends RfJsonProtocols {
-
   implicit val paginatedUserWithOrgsFormat = jsonFormat6(PaginatedResponse[User.WithOrgs])
-
+  implicit val auth0UserFormat = jsonFormat15(Auth0User)
+  implicit val auth0UserUpdateFormat = jsonFormat4(Auth0UserUpdate.apply _)
 }

--- a/app-backend/api/src/main/scala/utils/Auth0ErrorHandler.scala
+++ b/app-backend/api/src/main/scala/utils/Auth0ErrorHandler.scala
@@ -1,4 +1,4 @@
-package com.azavea.rf.api.token
+package com.azavea.rf.api.utils
 
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.server.{Directives, ExceptionHandler}

--- a/app-backend/api/src/main/scala/utils/Auth0Exception.scala
+++ b/app-backend/api/src/main/scala/utils/Auth0Exception.scala
@@ -1,4 +1,4 @@
-package com.azavea.rf.api.token
+package com.azavea.rf.api.utils
 
 import akka.http.scaladsl.model.StatusCode
 

--- a/app-backend/api/src/main/scala/utils/Auth0Util.scala
+++ b/app-backend/api/src/main/scala/utils/Auth0Util.scala
@@ -1,0 +1,3 @@
+package com.azavea.rf.api.utils
+
+case class ManagementBearerToken(access_token: String, expires_in: Int, token_type: String, scope: String)

--- a/app-frontend/src/app/components/navBar/navBar.html
+++ b/app-frontend/src/app/components/navBar/navBar.html
@@ -35,16 +35,11 @@
     </nav>
     <span class="navbar-vertical-divider"></span>
     <nav>
-      <div ng-if="!$ctrl.authService.isLoggedIn">
-        <a href ng-click="$ctrl.signin()">
-          Sign In
-        </a>
-      </div>
-      <a ng-if="$ctrl.authService.isLoggedIn" href ui-sref="library.scenes.list">My library</a>
+      <a href ui-sref="library.scenes.list">My library</a>
       <div ng-if="$ctrl.authService.isLoggedIn" uib-dropdown class="dropdown-my-account" on-toggle="toggled($ctrl.optionsOpen)">
         <a href uib-dropdown-toggle>
           <img ng-if="$ctrl.authService.profile().picture" class="avatar" ng-src="{{$ctrl.authService.profile().picture}}">
-          <div class="avatar image-placeholder" ng-if="!$ctrl.authService.profile().picture"></div>
+          <div class="avatar image-placeholder" ng-if="$ctrl.authService.profile() && !$ctrl.authService.profile().picture"></div>
           <span class="username">{{$ctrl.authService.profile().nickname}}</span>
           <i class="icon-caret-down"></i>
         </a>

--- a/app-frontend/src/app/core/services/auth.service.js
+++ b/app-frontend/src/app/core/services/auth.service.js
@@ -1,8 +1,10 @@
+/* globals Auth0Lock */
+import assetLogo from '../../../assets/images/logo-raster-foundry.png';
 export default (app) => {
     class AuthService {
         constructor( // eslint-disable-line max-params
             lock, jwtHelper, $q, featureFlagOverrides, featureFlags,
-            $state, localStorage
+            $state, APP_CONFIG, localStorage
         ) {
             this.lock = lock;
             this.localStorage = localStorage;
@@ -11,6 +13,24 @@ export default (app) => {
             this.$state = $state;
             this.featureFlags = featureFlags;
             this.featureFlagOverrides = featureFlagOverrides;
+
+            let options = {
+                initialScreen: 'forgotPassword',
+                prefill: {
+                    email: this.profile() && this.profile().email
+                },
+                allowLogin: false,
+                closable: true,
+                auth: {
+                    redirect: false,
+                    sso: true
+                },
+                theme: {
+                    logo: assetLogo,
+                    primaryColor: '#5e509b'
+                }
+            };
+            this.resetLock = new Auth0Lock(APP_CONFIG.clientId, APP_CONFIG.auth0Domain, options);
 
             lock.on('authenticated', this.onLogin.bind(this));
             lock.on('authorization_error', this.onLoginFail.bind(this));
@@ -27,6 +47,10 @@ export default (app) => {
             } else {
                 this.lock.show();
             }
+        }
+
+        changePassword() {
+            this.resetLock.show();
         }
 
         onLogin(authResult) {

--- a/app-frontend/src/app/core/services/user.service.js
+++ b/app-frontend/src/app/core/services/user.service.js
@@ -1,8 +1,9 @@
 export default (app) => {
     class UserService {
-        constructor($resource, authService) {
+        constructor($resource, authService, APP_CONFIG, localStorage) {
             'ngInject';
             this.authService = authService;
+            this.localStorage = localStorage;
             this.User = $resource('/api/users/:id', {
                 id: '@id'
             }, {
@@ -15,11 +16,37 @@ export default (app) => {
                     cache: false
                 }
             });
+            this.UserMetadata = $resource(
+                'https://' + APP_CONFIG.auth0Domain +
+                    '/api/v2/users/:userid',
+                {userid: '@id'},
+                {
+                    get: {
+                        method: 'GET',
+                        cache: false
+                    },
+                    patch: {
+                        method: 'PATCH',
+                        cache: false
+                    }
+                });
         }
 
         getCurrentUser() {
             let id = this.authService.profile().user_id;
             return this.User.get({id: id}).$promise;
+        }
+
+        updateUserMetadata(userdata) {
+            let id = this.authService.profile().user_id;
+            return this.UserMetadata.patch(
+                {userid: id},
+                {user_metadata: userdata} // eslint-disable-line camelcase
+            ).$promise.then((res) => {
+                // TODO toast this!
+                this.localStorage.set('profile', res);
+                return res;
+            }, (err) => err);
         }
     }
 

--- a/app-frontend/src/app/pages/settings/account/account.controller.js
+++ b/app-frontend/src/app/pages/settings/account/account.controller.js
@@ -1,9 +1,13 @@
 /* globals process */
 class AccountController {
-    constructor($log) {
+    constructor($log, localStorage, authService) {
         'ngInject';
         this.$log = $log;
         this.env = process.env.NODE_ENV;
+        this.authService = authService;
+
+        this.profile = localStorage.get('profile');
+        this.provider = this.profile.identities[0].provider;
     }
 }
 

--- a/app-frontend/src/app/pages/settings/account/account.html
+++ b/app-frontend/src/app/pages/settings/account/account.html
@@ -3,21 +3,10 @@
     <div class="library-header">
       <h1 class="h3 page-title">Account</h1>
     </div>
-    <form action="">
-      <div class="form-group">
-        <label for="password-old">Old Password</label>
-        <input id="password-old" type="password" class="form-control">
-      </div>
-      <div class="form-group">
-        <label for="password-new">New Password</label>
-        <input id="password-new" type="password" class="form-control">
-      </div>
-      <div class="form-group">
-        <label for="password-confrim">Confirm Password</label>
-        <input id="password-confrim" type="password" class="form-control">
-      </div>
-      <button type="submit" class="btn btn-primary btn-large">Update Profile</button>
-    </form>
+    <button ng-if="$ctrl.provider === 'auth0'"
+            class="btn btn-primary btn-large"
+            ng-click="$ctrl.authService.changePassword()"
+    >Change Password</button>
     <rf-feature-flag-overrides ng-if="$ctrl.env === 'development'"></rf-feature-flag-overrides>
   </div>
   <div class="column-4">
@@ -26,7 +15,7 @@
         <div class="panel-body">
           <h5>Delete Account</h5>
           <p>Once you delete your account, there is no going back. Please be certain.</p>
-          <button class="btn btn-danger btn-large">Delete your account</button>
+          <button class="btn btn-danger btn-large" disabled>Delete your account</button>
         </div>
       </div>
     </div>

--- a/app-frontend/src/app/pages/settings/profile/profile.controller.js
+++ b/app-frontend/src/app/pages/settings/profile/profile.controller.js
@@ -1,9 +1,39 @@
 class ProfileController {
-    constructor($log, store) {
+    constructor($log, localStorage, authService, $window, userService) {
         'ngInject';
         this.$log = $log;
+        this.authService = authService;
+        this.$window = $window;
+        this.userService = userService;
+        this.localStorage = localStorage;
 
-        this.profile = store.get('profile');
+        this.profile = localStorage.get('profile');
+    }
+
+    $onInit() {
+        let providerMap = {
+            'google-oauth2': 'Google',
+            auth0: 'Gravatar',
+            facebook: 'Facebook',
+            twitter: 'Twitter'
+        };
+        this.provider = this.profile.identities[0].provider;
+        this.providerName = providerMap[this.provider];
+    }
+
+    updateGoogleProfile() {
+        this.$window.open('https://aboutme.google.com/', '_blank');
+    }
+
+    updateUserMetadata() {
+        this.userService.updateUserMetadata(this.profile.user_metadata)
+            .then((profile) => {
+                this.$log.debug('Profile updated!');
+                this.profile = profile;
+            }, (err) => {
+                this.$log.debug('Error updating profile:', err);
+                this.profile = this.localStorage.get('profile');
+            });
     }
 }
 

--- a/app-frontend/src/app/pages/settings/profile/profile.html
+++ b/app-frontend/src/app/pages/settings/profile/profile.html
@@ -4,38 +4,76 @@
       <h1 class="h3 page-title">Profile</h1>
     </div>
     <form action="">
-      <div class="form-group">
-        <label for="upload-profile-picture">Profile picture</label><br>
-        <img ng-if="$ctrl.profile.picture" class="avatar md" ng-src="{{$ctrl.profile.picture}}">
-        <div ng-if="!$ctrl.profile.picture"
-             class="avatar md image-placeholder">
+      <label for="upload-profile-picture">Profile picture</label>
+      <div class="picture-section">
+        <div class="form-group picture">
+          <img ng-if="$ctrl.profile.picture" class="avatar md" ng-src="{{$ctrl.profile.picture}}">
+          <div ng-if="!$ctrl.profile.picture" class="avatar md image-placeholder"></div>
         </div>
-        <div class="avatar-upload">
-          <label for="upload-profile-picture" class="btn">
-            Upload new picture
-            <input id="upload-profile-picture" type="file" class="manual-file-chooser">
-          </label>
+        <div class="picture-description">
+          <div class="panel panel-info">
+            <div class="panel-body">
+              To change your profile picture, upload a new one to your {{$ctrl.providerName}} account
+            </div>
+          </div>
         </div>
       </div>
 
-      <div class="form-group">
-        <label for="name">Name</label>
-        <input id="name" type="text" class="form-control" placeholder="Name">
+      <div ng-if="$ctrl.provider === 'google-oauth2'">
+        <div class="form-group">
+          <label for="name">Name</label>
+          <input id="name"
+                 type="text"
+                 class="form-control"
+                 placeholder="Name"
+                 ng-attr-value="{{$ctrl.profile.name}}"
+                 disabled
+          >
+        </div>
+        <div class="form-group">
+          <label for="username">Google Id</label>
+          <input id="username"
+                 type="text"
+                 class="form-control"
+                 ng-attr-value="{{$ctrl.profile.email}}"
+                 disabled
+          >
+          <p class="help-block">Contact support to change your ID</p>
+        </div>
+        <button type="button"
+                ng-click="$ctrl.updateGoogleProfile()"
+                class="btn btn-primary btn-large">
+          Go to Google profile settings
+        </button>
       </div>
-      <div class="form-group">
-        <label for="username">Username</label>
-        <input id="username" type="text" class="form-control" placeholder="Email" disabled value="myusername">
-        <p class="help-block">Contact support to change your username</p>
+
+      <div ng-if="$ctrl.provider === 'auth0'">
+        <div class="form-group">
+          <label for="name">Name</label>
+          <input id="name" type="text"
+                 class="form-control"
+                 ng-attr-value="{{$ctrl.profile.nickname}}"
+                 disabled
+          >
+        </div>
+        <div class="form-group">
+          <label for="username">Username</label>
+          <input id="username" type="text"
+                 class="form-control"
+                 placeholder="Email"
+                 ng-attr-value="{{$ctrl.profile.email}}"
+          disabled
+          >
+          <p class="help-block">Contact support to change your username</p>
+        </div>
       </div>
-      <div class="form-group">
-        <label for="email">Email</label>
-        <input id="email" type="text" class="form-control" placeholder="Email">
+      <div ng-if="$ctrl.profile.user_metadata">
+        <div class="form-group" ng-repeat="(id, field) in $ctrl.profile.user_metadata track by id">
+          <label>{{field.label}}</label>
+          <input type="text" class="form-control" ng-model="field.value">
+        </div>
+      <button ng-click="$ctrl.updateUserMetadata()" type="button" class="btn btn-primary btn-large">Update Profile</button>
       </div>
-      <div class="form-group">
-        <label for="location">Location</label>
-        <input id="location" type="text" class="form-control" placeholder="Location">
-      </div>
-      <button type="submit" class="btn btn-primary btn-large">Update Profile</button>
     </form>
   </div>
 </div>

--- a/app-frontend/src/app/pages/settings/profile/profile.module.js
+++ b/app-frontend/src/app/pages/settings/profile/profile.module.js
@@ -1,4 +1,5 @@
 import ProfileController from './profile.controller.js';
+require('./profile.scss');
 
 const ProfileModule = angular.module('pages.settings.profile', []);
 

--- a/app-frontend/src/app/pages/settings/profile/profile.scss
+++ b/app-frontend/src/app/pages/settings/profile/profile.scss
@@ -1,0 +1,12 @@
+.picture-section {
+  display: flex;
+  flex: 1;
+  flex-direction: row;
+}
+.picture {
+  padding-right: 1rem;
+}
+
+.picture-description {
+  flex: 1;
+}

--- a/app-frontend/src/assets/styles/sass/components/_login.scss
+++ b/app-frontend/src/assets/styles/sass/components/_login.scss
@@ -35,7 +35,8 @@
   }
 }
 
-body #auth0-lock-container-1 {
+#auth0-lock-container-1,
+#auth0-lock-container-2 {
   .auth0-lock-widget {
     box-shadow: 0 0 40px -5px #111118;
   }

--- a/docs/swagger/spec.yml
+++ b/docs/swagger/spec.yml
@@ -70,6 +70,38 @@ paths:
           description: Unexpected error
           schema:
             $ref: '#/definitions/Error'
+  /users/me/:
+    get:
+      summary: Get logged in user profile
+      tags:
+        - Users
+      responses:
+        200:
+          description: Profile found
+          schema:
+            $ref: '#/definitions/Auth0User'
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+    patch:
+      summary: Update user profile
+      parameters:
+        - name: Profile
+          in: body
+          schema:
+            $ref: '#/definitions/Auth0UserProfile'
+      tags:
+        - Users
+      responses:
+        200:
+          description: Profile updated
+          schema:
+            $ref: '#/definitions/Auth0User'
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
   /users/{uuid}/:
     get:
       summary: Get a single user
@@ -1442,6 +1474,50 @@ definitions:
         description: List of organization\'s a user belongs to and their level of membership
         items:
           $ref: '#/definitions/UserOrg'
+  Auth0User:
+    type: object
+    properties:
+      email:
+        type: string
+      email_verified:
+        type: boolean
+      username:
+        type: string
+      phone_number:
+        type: string
+      phone_verified:
+        type: boolean
+      user_id:
+        type: string
+      created_at:
+        type: string
+      updated_at:
+        type: string
+      identities:
+        type: array
+      user_metadata:
+        type: object
+      picture:
+        type: string
+      name:
+        type: string
+      nickname:
+        type: string
+      given_name:
+        type: string
+      family_name:
+        type: string
+  Auth0UserProfile:
+    type: object
+    properties:
+      email:
+        type: string
+      phone_number:
+        type: string
+      user_metadata:
+        type: object
+      username:
+        type: string
   RefreshToken:
     type: object
     properties:


### PR DESCRIPTION
## Overview

Allow updating user profile and password from frontend and api

* Add password change button to profile
* Add users/me endpoint to get auth0 user from api
* Add user/me patch endpoint to update user data
* Allow updating user_metadata from profile page
* Misc other profile related updates


### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [x] Swagger specification updated, if necessary


### Demo

![image](https://cloud.githubusercontent.com/assets/4392704/23511900/c7a53350-ff2c-11e6-8778-109fdfad9512.png)

### Notes

Not all user fields on users/me are helpful to the user. Keeping them commented as documentation of their existence
TODO: Embed the user info inside a rasterfoundry user object

## Testing Instructions

 * On a non-oauth account, change your password from the profile/account view
 * Verify that the change password button doesn't show for oauth accounts
 * Add a user_metadata field to your user by making a patch request to users/me like 
 ```json
 { "user_metadata": {"stuff": {"label": "This is a label", "value": "This is a value"}}}
 ```
 
 * Verify that it persists through reloads and that the user object is correctly updated in auth0
 * Verify that making a GET request to /users/me returns your auth0 user profile

Closes #1083 
Closes #1084
