### PR TITLE
Work around layer deletion bug in GT

### DIFF
--- a/app-backend/ingest/src/main/scala/com/azavea/rf/ingest/util/Validation.scala
+++ b/app-backend/ingest/src/main/scala/com/azavea/rf/ingest/util/Validation.scala
@@ -20,6 +20,7 @@ import DefaultJsonProtocol._
 
 import java.net.URI
 import java.util.UUID
+import java.security.InvalidParameterException
 
 import com.azavea.rf.ingest.model._
 
@@ -55,6 +56,8 @@ object Validation extends LazyLogging {
       validateS3CatalogEntry(catalogURI, layerID)
     case "file" =>
       validateFileCatalogEntry(catalogURI, layerID)
+    case scheme =>
+      throw new InvalidParameterException(s"Unable to validate catalog for scheme: $scheme")
   }
 
 }

--- a/app-backend/ingest/src/test/resources/awsJob.json
+++ b/app-backend/ingest/src/test/resources/awsJob.json
@@ -13,32 +13,32 @@
             "pyramid": true,
             "native": true
         },
-        "sourceOverrides": [{
+        "sources": [{
             "uri": "http://landsat-pds.s3.amazonaws.com/L8/107/035/LC81070352015218LGN00/LC81070352015218LGN00_B4.TIF",
             "extent": [138.8339238,  34.9569460, 141.4502449,  37.1094577],
-            "cellSize": {"width": 37.151447651062888, "height": -37.151447651062888},
             "extentCrs": "epsg:32654",
+            "cellSize": {"width": 37.151447651062888, "height": -37.151447651062888},
             "crs": "epsg:32654",
             "bandMaps": [{"source": 1, "target": 1}]
         }, {
             "uri": "http://landsat-pds.s3.amazonaws.com/L8/107/035/LC81070352015218LGN00/LC81070352015218LGN00_B3.TIF",
             "extent": [138.8339238,  34.9569460, 141.4502449,  37.1094577],
-            "cellSize": {"width": 37.151447651062888, "height": -37.151447651062888},
             "extentCrs": "epsg:32654",
+            "cellSize": {"width": 37.151447651062888, "height": -37.151447651062888},
             "crs": "epsg:32654",
             "bandMaps": [{"source": 1, "target": 2}]
         }, {
             "uri": "http://landsat-pds.s3.amazonaws.com/L8/107/035/LC81070352015218LGN00/LC81070352015218LGN00_B2.TIF",
             "extent": [138.8339238,  34.9569460, 141.4502449,  37.1094577],
-            "cellSize": {"width": 37.151447651062888, "height": -37.151447651062888},
             "extentCrs": "epsg:32654",
+            "cellSize": {"width": 37.151447651062888, "height": -37.151447651062888},
             "crs": "epsg:32654",
             "bandMaps": [{"source": 1, "target": 3}]
         }, {
             "uri": "http://landsat-pds.s3.amazonaws.com/L8/107/035/LC81070352015218LGN00/LC81070352015218LGN00_B5.TIF",
             "extent": [138.8339238,  34.9569460, 141.4502449,  37.1094577],
-            "cellSize": {"width": 37.151447651062888, "height": -37.151447651062888},
             "extentCrs": "epsg:32654",
+            "cellSize": {"width": 37.151447651062888, "height": -37.151447651062888},
             "crs": "epsg:32654",
             "bandMaps": [{"source": 1, "target": 4}]
         }]


### PR DESCRIPTION
## Overview

This PR works around a couple of issues encountered when attempting to use the `S3LayerDeleter`. 
1. A failed ingest will have metadata with no related tile information - this causes malformed XML to be sent to AWS and prevents successful clobbering of failed ingest directories.
2. If metadata cannot be located for a given layer, no further deletion logic is attempted despite the fact that we should be able to delete `_attributes` data even if we can't magically remove a layer's associated tiles (which it won't have anyway if the ingest fails).

A PR is being crafted for GT's 1.0.1 release which will resolve this in a cleaner way. The solution implemented in the meantime is just to catch exceptions on attempted deletion and manually fall back on deleting `_attributes` data we can find.


## Testing Instructions

Running an ingest with the `--overwrite` flag on a previously failed ingest definition should successfully purge metadata and carry out said ingest.

Connects #1036
Closes #1053