### PR TITLE
Improve failed ingest handling

### DIFF
--- a/app-tasks/dags/ingest/ingest_project_scenes.py
+++ b/app-tasks/dags/ingest/ingest_project_scenes.py
@@ -123,8 +123,10 @@ def create_ingest_definition_op(*args, **kwargs):
     """Create ingest definition and upload to S3"""
 
     logger.info('Beginning to create ingest definition...')
+    xcom_client = kwargs['task_instance']
     conf = kwargs['dag_run'].conf
     scene_dict = conf.get('scene')
+    xcom_client.xcom_push(key='ingest_scene_id', value=scene_dict['id'])
     scene = Scene.from_id(scene_dict['id'])
 
     if scene.ingestStatus != IngestStatus.TOBEINGESTED:
@@ -145,10 +147,8 @@ def create_ingest_definition_op(*args, **kwargs):
     logger.info('Successfully created and pushed ingest definition')
 
     # Store values for later tasks
-    xcom_client = kwargs['task_instance']
     xcom_client.xcom_push(key='ingest_def_uri', value=ingest_definition.s3_uri)
     xcom_client.xcom_push(key='ingest_def_id', value=ingest_definition.id)
-    xcom_client.xcom_push(key='ingest_scene_id', value=scene_dict['id'])
 
 
 @wrap_rollbar


### PR DESCRIPTION
## Overview

This PR ensures airflow has sufficient knowledge of scenes when exceptions are hit. Allows airflow to properly handle failure.

## Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~

## Demo

<img width="391" alt="screen shot 2017-03-02 at 1 40 53 pm" src="https://cloud.githubusercontent.com/assets/2442245/23521657/e638c5ae-ff4d-11e6-9204-e71070fb3939.png">

## Testing Instructions

 * Run server with airflow
 * Add a sentinel scene to a project
 * After a little bit, check ingest status and see that it is 'FAILED'
