### PR TITLE
Update Metadata Imports

### DIFF
--- a/app-tasks/dags/landsat8/import_landsat8_scenes.py
+++ b/app-tasks/dags/landsat8/import_landsat8_scenes.py
@@ -19,17 +19,19 @@ rf_logger.addHandler(ch)
 
 logger = logging.getLogger(__name__)
 
-start_date = datetime(2016, 11, 6)
 
+schedule = None if os.getenv('ENVIRONMENT', 'development') == 'development' else '@daily'
+start_date = datetime(2016, 11, 6)
 args = {
     'owner': 'raster-foundry',
     'start_date': start_date
 }
 
+
 dag = DAG(
     dag_id='find_landsat8_scenes',
     default_args=args,
-    schedule_interval='@daily',
+    schedule_interval=schedule,
     concurrency=int(os.getenv('AIRFLOW_DAG_CONCURRENCY', 24))
 )
 

--- a/app-tasks/dags/sentinel2/find_sentinel2_scenes.py
+++ b/app-tasks/dags/sentinel2/find_sentinel2_scenes.py
@@ -21,9 +21,8 @@ rf_logger.addHandler(ch)
 logger = logging.getLogger(__name__)
 
 
+schedule = None if os.getenv('ENVIRONMENT', 'development') == 'development' else '@daily'
 start_date = datetime(2016, 11, 6)
-
-
 args = {
     'owner': 'raster-foundry',
     'start_date': start_date
@@ -33,7 +32,7 @@ args = {
 dag = DAG(
     dag_id='find_sentinel2_scenes',
     default_args=args,
-    schedule_interval='@daily',
+    schedule_interval=schedule,
     concurrency=int(os.getenv('AIRFLOW_DAG_CONCURRENCY', 24))
 )
 

--- a/app-tasks/rf/src/rf/models/base.py
+++ b/app-tasks/rf/src/rf/models/base.py
@@ -46,7 +46,11 @@ class BaseModel(object):
         url = '{HOST}{URL_PATH}'.format(HOST=self.HOST, URL_PATH=self.URL_PATH)
         session = get_session()
         response = session.post(url, json=self.to_dict())
-        response.raise_for_status()
+        try:
+            response.raise_for_status()
+        except:
+            logger.exception('Unable to create object via API: %s', response.text)
+            raise
         return self.from_dict(response.json())
 
     def update(self):

--- a/app-tasks/rf/src/rf/uploads/landsat8/create_footprint.py
+++ b/app-tasks/rf/src/rf/uploads/landsat8/create_footprint.py
@@ -34,15 +34,12 @@ def create_footprints(csv_row):
     transformed_coords = [[
         [transform(src_proj, target_proj, coord[0], coord[1]) for coord in src_coords]
     ]]
-
-    data_geojson = {'type': 'MultiPolygon', 'coordinates': transformed_coords}
-    data_footprint = Footprint(organization, data_geojson)
+    data_footprint = Footprint(organization, transformed_coords)
 
     transformed_tile_coords = [[
         [transform(src_proj, target_proj, coord[0], coord[1]) for coord in
          [(min_x, min_y), (max_x, min_y), (max_x, max_y), (min_x, max_y)]]
     ]]
-    tile_geojson = {'type': 'MultiPolygon', 'coordinates': transformed_tile_coords}
-    tile_footprint = Footprint(organization, tile_geojson)
+    tile_footprint = Footprint(organization, transformed_tile_coords)
 
     return tile_footprint, data_footprint

--- a/app-tasks/rf/src/rf/uploads/sentinel2/create_footprint.py
+++ b/app-tasks/rf/src/rf/uploads/sentinel2/create_footprint.py
@@ -24,8 +24,7 @@ def footprint_from_key(tileinfo, key):
     coords = geom['coordinates'][0]
     src_proj = get_src_proj(geom['crs']['properties']['name'])
     transformed_coords = [[[transform(src_proj, target_proj, coord[0], coord[1]) for coord in coords]]]
-    geojson = {"type": "MultiPolygon", "coordinates": transformed_coords}
-    return Footprint(organization, geojson)
+    return Footprint(organization, transformed_coords)
 
 
 def create_footprints(tileinfo):

--- a/scripts/cipublish
+++ b/scripts/cipublish
@@ -35,13 +35,19 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
 
             echo "Building ingest JAR"
             docker-compose \
+                run --rm --no-deps app-server ingest/clean
+            docker-compose \
                 run --rm --no-deps app-server ingest/assembly
 
             echo "Building application JAR"
             docker-compose \
+                run --rm --no-deps app-server app/clean
+            docker-compose \
                 run --rm --no-deps app-server app/assembly
 
             echo "Building tile server JAR"
+            docker-compose \
+                run --rm --no-deps app-server tile/clean
             docker-compose \
                 run --rm --no-deps tile-server tile/assembly
 


### PR DESCRIPTION
## Overview

This PR fixes a bug that prevented successfully importing metadata for sentinel and landsat imagery.

Also makes development of airflow tasks easier by setting the schedule interval to `None` when in development. 

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~

## Testing Instructions

 * Go to the airflow UI at `localhost:8080`, go to Dag Runs, and click create
 * Kick off a Landsat 8 metadata import
![find-landsat8-scenes](https://cloud.githubusercontent.com/assets/898060/23527424/ce0ca2f8-ff8d-11e6-81e8-6f1375b71672.png)
 * Kick off a Sentinel 2 metadata import
![find-sentinel-scenes](https://cloud.githubusercontent.com/assets/898060/23527428/d0b8c144-ff8d-11e6-9f17-e83605ad01a8.png)
 * Go back to main page and observe that imports are proceeding without errors
![dag-overview](https://cloud.githubusercontent.com/assets/898060/23527440/dd2f1946-ff8d-11e6-878b-01c2e8ba59d5.png)

Closes #1174
