### PR TITLE
Fix ingest definition parsing and add tests

### DIFF
--- a/app-backend/ingest/src/main/scala/com/azavea/rf/ingest/model/SourceDefinition.scala
+++ b/app-backend/ingest/src/main/scala/com/azavea/rf/ingest/model/SourceDefinition.scala
@@ -46,8 +46,8 @@ object SourceDefinition extends LazyLogging {
         SourceDefinition(
           uri,
           extent.get,
-          crs.get,
           extentCrs.getOrElse(LatLng),
+          crs.get,
           cellSize.get,
           bandMaps
         )
@@ -57,8 +57,8 @@ object SourceDefinition extends LazyLogging {
         SourceDefinition(
           uri,
           extent.getOrElse(tt.extent),
-          crs.getOrElse(tt.crs),
           extentCrs.getOrElse(tt.crs),
+          crs.getOrElse(tt.crs),
           cellSize.getOrElse(tt.cellSize),
           bandMaps
         )

--- a/app-backend/ingest/src/test/scala/com/azavea/rf/ingest/model/IngestDefinitionSpec.scala
+++ b/app-backend/ingest/src/test/scala/com/azavea/rf/ingest/model/IngestDefinitionSpec.scala
@@ -40,12 +40,12 @@ class IngestDefinitionSpec extends FunSpec with Matchers {
       |            141.4502449,
       |            37.1094577
       |          ],
-      |          "extentCrs": "epsg:32654",
+      |          "extentCrs": "epsg:4326",
       |          "cellSize": {
       |            "width": 37.15144765106289,
       |            "height": -37.15144765106289
       |          },
-      |          "crs": "epsg:32654",
+      |          "crs": "epsg:32619",
       |          "bandMaps": [
       |            {
       |              "source": 1,
@@ -61,12 +61,12 @@ class IngestDefinitionSpec extends FunSpec with Matchers {
       |            141.4502449,
       |            37.1094577
       |          ],
-      |          "extentCrs": "epsg:32654",
+      |          "extentCrs": "epsg:4326",
       |          "cellSize": {
       |            "width": 37.15144765106289,
       |            "height": -37.15144765106289
       |          },
-      |          "crs": "epsg:32654",
+      |          "crs": "epsg:32619",
       |          "bandMaps": [
       |            {
       |              "source": 1,
@@ -82,12 +82,12 @@ class IngestDefinitionSpec extends FunSpec with Matchers {
       |            141.4502449,
       |            37.1094577
       |          ],
-      |          "extentCrs": "epsg:32654",
+      |          "extentCrs": "epsg:4326",
       |          "cellSize": {
       |            "width": 37.15144765106289,
       |            "height": -37.15144765106289
       |          },
-      |          "crs": "epsg:32654",
+      |          "crs": "epsg:32619",
       |          "bandMaps": [
       |            {
       |              "source": 1,
@@ -103,12 +103,12 @@ class IngestDefinitionSpec extends FunSpec with Matchers {
       |            141.4502449,
       |            37.1094577
       |          ],
-      |          "extentCrs": "epsg:32654",
+      |          "extentCrs": "epsg:4326",
       |          "cellSize": {
       |            "width": 37.15144765106289,
       |            "height": -37.15144765106289
       |          },
-      |          "crs": "epsg:32654",
+      |          "crs": "epsg:32619",
       |          "bandMaps": [
       |            {
       |              "source": 1,
@@ -153,8 +153,8 @@ class IngestDefinitionSpec extends FunSpec with Matchers {
       |            "width": 37.15144765106289,
       |            "height": -37.15144765106289
       |          },
-      |          "extentCrs": "epsg:32654",
-      |          "crs": "epsg:32654",
+      |          "extentCrs": "epsg:4326",
+      |          "crs": "epsg:32619",
       |          "bandMaps": [
       |            {
       |              "source": 1,
@@ -174,8 +174,8 @@ class IngestDefinitionSpec extends FunSpec with Matchers {
       |            "width": 37.15144765106289,
       |            "height": -37.15144765106289
       |          },
-      |          "extentCrs": "epsg:32654",
-      |          "crs": "epsg:32654",
+      |          "extentCrs": "epsg:4326",
+      |          "crs": "epsg:32619",
       |          "bandMaps": [
       |            {
       |              "source": 1,
@@ -195,8 +195,8 @@ class IngestDefinitionSpec extends FunSpec with Matchers {
       |            "width": 37.15144765106289,
       |            "height": -37.15144765106289
       |          },
-      |          "extentCrs": "epsg:32654",
-      |          "crs": "epsg:32654",
+      |          "extentCrs": "epsg:4326",
+      |          "crs": "epsg:32619",
       |          "bandMaps": [
       |            {
       |              "source": 1,
@@ -216,8 +216,8 @@ class IngestDefinitionSpec extends FunSpec with Matchers {
       |            "width": 37.15144765106289,
       |            "height": -37.15144765106289
       |          },
-      |          "extentCrs": "epsg:32654",
-      |          "crs": "epsg:32654",
+      |          "extentCrs": "epsg:4326",
+      |          "crs": "epsg:32619",
       |          "bandMaps": [
       |            {
       |              "source": 1,
@@ -298,6 +298,28 @@ class IngestDefinitionSpec extends FunSpec with Matchers {
         .parseJson
         .convertTo[IngestDefinition]
     }
+  }
+
+  it("preserves ingest definition source crs") {
+    val ingestDef =
+      localJson
+        .parseJson
+        .convertTo[IngestDefinition]
+
+    val srcCrs = ingestDef.layers.head.sources.head.crs.epsgCode
+
+    srcCrs shouldEqual Some(32619)
+  }
+
+  it("preserves ingest definition extent crs") {
+    val ingestDef =
+      localJson
+        .parseJson
+        .convertTo[IngestDefinition]
+
+    val extentCrs = ingestDef.layers.head.sources.head.extentCrs.epsgCode
+
+    extentCrs shouldEqual Some(4326)
   }
 
   it("parses the sample, aws definition") {


### PR DESCRIPTION
## Overview

This PR fixes the construction of sources in an ingest definition. Previously, each source's `extentCrs` was being passed as the `crs` and vice versa. There have been some explicit tests added as well.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~

## Testing Instructions

 * Console into the ingest project (`./scripts/console app-server ./sbt` and `project ingest`)
 * Run tests (`test`)
 * You could flip the lines changed in `SourceDefinition.scala` back to the way they were and see that the tests fails

Connects #1167
