### PR TITLE
Return empty png rather than empty response

### DIFF
--- a/app-backend/tile/src/main/scala/image/Mosaic.scala
+++ b/app-backend/tile/src/main/scala/image/Mosaic.scala
@@ -267,10 +267,8 @@ object Mosaic {
           val tiles = maybeTiles.flatten
           if (tiles.nonEmpty)
             Option(tiles.reduce(_ merge _))
-          else {
-            val cellType = IntUserDefinedNoDataCellType(0)
-            Option(ArrayMultibandTile.empty(cellType, 3, 256, 256))
-          }
+          else
+            None
       }
     }
   }

--- a/app-backend/tile/src/main/scala/image/Mosaic.scala
+++ b/app-backend/tile/src/main/scala/image/Mosaic.scala
@@ -267,8 +267,10 @@ object Mosaic {
           val tiles = maybeTiles.flatten
           if (tiles.nonEmpty)
             Option(tiles.reduce(_ merge _))
-          else
-            Option.empty[MultibandTile]
+          else {
+            val cellType = IntUserDefinedNoDataCellType(0)
+            Option(ArrayMultibandTile.empty(cellType, 3, 256, 256))
+          }
       }
     }
   }

--- a/app-backend/tile/src/main/scala/routes/MosaicRoutes.scala
+++ b/app-backend/tile/src/main/scala/routes/MosaicRoutes.scala
@@ -5,6 +5,7 @@ import com.azavea.rf.tile.image._
 import com.azavea.rf.datamodel.ColorCorrect.Params.colorCorrectParams
 import com.azavea.rf.database.Database
 
+import geotrellis.raster._
 import geotrellis.raster.render.Png
 import akka.http.scaladsl.server._
 import akka.http.scaladsl.server.Directives._
@@ -16,6 +17,8 @@ import java.util.UUID
 
 
 object MosaicRoutes extends LazyLogging {
+
+  val emptyTilePng = IntArrayTile.ofDim(256, 256).renderPng
 
   def pngAsHttpResponse(png: Png): HttpResponse =
     HttpResponse(entity = HttpEntity(ContentType(MediaTypes.`image/png`), png.bytes))
@@ -37,7 +40,9 @@ object MosaicRoutes extends LazyLogging {
           get {
             complete {
               Mosaic(projectId, zoom, x, y, tag).map { maybeTile =>
-                maybeTile.map { tile => pngAsHttpResponse(tile.renderPng()) }
+                pngAsHttpResponse {
+                  maybeTile.map(_.renderPng()).getOrElse(emptyTilePng)
+                }
               }
             }
           }

--- a/app-frontend/src/app/components/mapContainer/mapContainer.controller.js
+++ b/app-frontend/src/app/components/mapContainer/mapContainer.controller.js
@@ -75,9 +75,7 @@ export default class MapContainerController {
                 this.setLoading(layerId, false);
             });
             layer.on('tileerror', () => {
-                // @TODO: when tiles outside the extent of projects are
-                // properly returned, we should uncomment the following line
-                // this.setLoadingError(layerId, true);
+                this.setLoadingError(layerId, true);
             });
         }
     }


### PR DESCRIPTION
## Overview
 
This PR alters the way in which the tile server handles returning tiles for areas outside of the extent of the scenes tiles are being generated for. Previously, the tiler returned empty responses of type `text/plain` for these areas. It now returns an empty png of the proper size.

The motivations for this center around how tile loading errors are detected with Leaflet. Empty responses are treated as errors. We can expect some consumers of the api would be using Leaflet or services built on top of Leaflet, so we should handle this accordingly.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~

## Testing Instructions

 * With a project consisting only of ingested scenes, go to a mosiaced page (editor) and see that no requests to the tile server are being returned as empty responses.
