### PR TITLE
Increase memcached max object size in development

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
 
   memcached:
     image: memcached:1.4-alpine
+    command: -I 5242880b
 
   nginx:
     image: raster-foundry-nginx


### PR DESCRIPTION
## Overview

Increase memcached max object size to match production and staging.

### Checklist

- [ ] Styleguide updated, if necessary
- [ ] Swagger specification updated, if necessary
- [ ] Symlinks from new migrations present or corrected for any new migrations

### Demo

Optional. Screenshots, `curl` examples, etc.

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.


## Testing Instructions

Start `memcached` (detached), then login to a shell
 * `docker-compose up -d memcached`
 * `docker-compose exec memcached /bin/sh`
Create a file ~100B smaller than the max file size, and try to insert it into memcache.
```bash
/ $ cd ~
~ $ for i in $(seq 1 5242700); do printf "1"  >> out.txt; done
~ $ ls -l
total 5120
-rw-r--r--    1 memcache memcache   5242700 Mar  6 20:13 out.txt
~ $ printf "set test_key 0 120 5242700 \r\n$(cat out.txt)\r\n" | nc localhost 11211
STORED
```

This same option should fail on a bigger file.
```bash
~ rm out.txt
~ $ for i in $(seq 1 5242881); do printf "1"  >> out.txt; done
~ $ ls -l
total 5120
-rw-r--r--    1 memcache memcache   5242881 Mar  6 20:13 out.txt
~ $ printf "set test_key 0 120 5242881 \r\n$(cat out.txt)\r\n" | nc localhost 11211
SERVER_ERROR object too large for cache
~ $ printf "delete test_key\r\n" | nc localhost 11211
```
Connects #1187 
