### PR TITLE
Tiler handle missing Histogram, Ingest Location (introduces OptionT usage)

### DIFF
--- a/app-backend/build.sbt
+++ b/app-backend/build.sbt
@@ -122,7 +122,8 @@ lazy val common = Project("common", file("common"))
     Dependencies.elasticacheClient,
     Dependencies.geotrellisS3,
     Dependencies.findbugAnnotations,
-    Dependencies.chill
+    Dependencies.chill,
+    Dependencies.cats
   )})
 
 lazy val migrations = Project("migrations", file("migrations"))

--- a/app-backend/common/src/main/scala/cache/HeapBackedMemcachedClient.scala
+++ b/app-backend/common/src/main/scala/cache/HeapBackedMemcachedClient.scala
@@ -78,7 +78,7 @@ object HeapBackedMemcachedClient {
   case class Options(
     ec: ExecutionContext = defaultExecutionContext,
     heapTTL: FiniteDuration = Config.memcached.heapEntryTTL,
-    memcachedTTL: FiniteDuration = 12.minutes,
+    memcachedTTL: FiniteDuration = Config.memcached.ttl,
     maxSize: Int = Config.memcached.heapMaxEntries
   )
 

--- a/app-backend/common/src/main/scala/cache/MemcachedClientMethods.scala
+++ b/app-backend/common/src/main/scala/cache/MemcachedClientMethods.scala
@@ -4,11 +4,10 @@ import net.spy.memcached._
 import com.typesafe.scalalogging.LazyLogging
 import scala.concurrent._
 import scala.concurrent.duration._
-import scala.concurrent.ExecutionContext.Implicits.global
 
 
 class MemcachedClientMethods(client: MemcachedClient) extends LazyLogging {
-  def getOrElseUpdate[CachedType](cacheKey: String, expensiveOperation: Future[CachedType], ttl: Duration)(implicit ec: ExecutionContext): Future[CachedType] = {
+  def getOrElseUpdate[CachedType](cacheKey: String, expensiveOperation: => Future[CachedType], ttl: Duration)(implicit ec: ExecutionContext): Future[CachedType] = blocking {
     val futureCached = Future { client.asyncGet(cacheKey).get() }
     futureCached.flatMap({ value =>
       if (value != null) { // cache hit

--- a/app-backend/project/Dependencies.scala
+++ b/app-backend/project/Dependencies.scala
@@ -46,4 +46,5 @@ object Dependencies {
   val circeParser             = "io.circe"                    %% "circe-parser"                      % Version.circe
   val circeOptics             = "io.circe"                    %% "circe-optics"                      % Version.circe
   val akkaCirceJson           = "de.heikoseeberger"           %% "akka-http-circe"                   % Version.akkaCirceJson
+  val cats                    = "org.typelevel"               %% "cats"                              % Version.cats
 }

--- a/app-backend/project/Version.scala
+++ b/app-backend/project/Version.scala
@@ -30,4 +30,5 @@ object Version {
   val chill              = "0.9.2"
   val circe              = "0.7.0"
   val akkaCirceJson      = "1.12.0"
+  val cats               = "0.9.0"
 }

--- a/app-backend/tile/src/main/scala/LayerCache.scala
+++ b/app-backend/tile/src/main/scala/LayerCache.scala
@@ -6,27 +6,30 @@ import com.azavea.rf.common.cache.kryo.KryoMemcachedClient
 import com.azavea.rf.ingest.util.S3.S3UrlRx
 import com.azavea.rf.database.Database
 import com.azavea.rf.database.tables.Scenes
-
 import geotrellis.raster._
 import geotrellis.raster.histogram.Histogram
 import geotrellis.spark._
 import geotrellis.raster.io._
 import geotrellis.spark.io._
-import geotrellis.spark.io.s3.{S3AttributeStore, S3ValueReader, S3CollectionLayerReader}
-import com.github.blemale.scaffeine.{ Cache => ScaffeineCache, Scaffeine }
+import geotrellis.spark.io.s3.{S3AttributeStore, S3CollectionLayerReader, S3ValueReader}
+import com.github.blemale.scaffeine.{Scaffeine, Cache => ScaffeineCache}
 import geotrellis.vector.Extent
 import com.github.benmanes.caffeine.cache._
 import spray.json.DefaultJsonProtocol._
 import net.spy.memcached._
 import java.net.InetSocketAddress
-
 import java.util.concurrent.{Executors, TimeUnit}
 import java.util.UUID
+
 import scala.concurrent._
 import scala.collection.JavaConverters._
 import scala.concurrent.duration._
 import scala.util._
+import cats.data._
+import cats.implicits._
 
+import com.typesafe.scalalogging.LazyLogging
+import scala.concurrent.ExecutionContext.Implicits.global
 
 /**
   * ValueReaders need to read layer metadata in order to know how to decode (x/y) queries into resource reads.
@@ -37,96 +40,84 @@ import scala.util._
   * Things that are cheap to construct but contain internal state we want to re-use use LoadingCache.
   * things that require time to generate, usually a network fetch, use AsyncLoadingCache
   */
-object LayerCache extends Config {
+object LayerCache extends Config with LazyLogging {
   implicit val database = Database.DEFAULT
 
   val memcachedClient = KryoMemcachedClient.DEFAULT
 
   /** The caffeine cache to use for attribute stores */
-  val attributeStoreCache: ScaffeineCache[String, Future[S3AttributeStore]] =
+  private val attributeStoreCache: ScaffeineCache[String, AttributeStore] =
     Scaffeine()
       .recordStats()
       .expireAfterAccess(5.minutes)
       .maximumSize(500)
-      .build[String, Future[S3AttributeStore]]()
+      .build[String, AttributeStore]()
 
-  /**
-    * The primary means of interaction with this class: pass as key and
-    *  the costly option caching prevents duplication of.
-    */
-  def attributeStore(bucket: String, prefix: Option[String]): Future[S3AttributeStore] = {
-    val cacheKey = HeapBackedMemcachedClient.sanitizeKey(s"store-$bucket-$prefix")
-    attributeStoreCache.get(cacheKey, { cacheKey =>
-      prefix match {
-        case Some(prefixStr) => Future.successful(S3AttributeStore(bucket, prefixStr))
-        case None => Future.failed(new LayerIOError("Scene has no ingest location"))
-      }
-    })
+  private val histogramCache = HeapBackedMemcachedClient(memcachedClient)
+  private val tileCache = HeapBackedMemcachedClient(memcachedClient)
+  private val layerLocationCache = HeapBackedMemcachedClient(memcachedClient)
+
+  def layerUri(layerId: UUID): OptionT[Future, String] = OptionT {
+    layerLocationCache.caching(s"layer-uri-${layerId.toString}") { _ =>
+      Scenes.getScene(layerId).map(_.flatMap(_.ingestLocation))
+    }
   }
 
-  def attributeStore(prefix: Option[String]): Future[S3AttributeStore] =
-    attributeStore(defaultBucket, prefix)
-
-  val tileCache = HeapBackedMemcachedClient[Option[MultibandTile]](memcachedClient)
-  def maybeRenderExtent(id: UUID, zoom: Int, extent: Extent): Future[Option[MultibandTile]] =
-    tileCache.caching(s"rendered-extent-$id-$zoom-$extent") { implicit ec =>
-      for {
-        prefix <- prefixFromLayerId(id)
-        store <- attributeStore(defaultBucket, prefix)
-      } yield {
-        val reader = new S3ValueReader(store).reader[SpatialKey, MultibandTile](LayerId(id.toString, zoom))
-        val query = S3CollectionLayerReader(store)
-          .query[SpatialKey, MultibandTile, TileLayerMetadata[SpatialKey]](LayerId(id.toString, zoom))
-        val tile = query.where(Intersects(extent))
-          .result
-          .stitch
-          .crop(extent)
-          .tile
-        tile match {
-          case tile: MultibandTile => Some(tile)
-          case _ => None
-        }
+  def attributeStoreForLayer(layerId: UUID): OptionT[Future, AttributeStore] = {
+    // we are not caching the attribute store based on layerId but based on the catalog location
+    layerUri(layerId).mapFilter { catalogUri =>
+      for (result <- S3UrlRx.findFirstMatchIn(catalogUri)) yield {
+        val bucket = result.group("bucket")
+        val prefix = result.group("prefix")
+        // TODO: Decide if we should verify URI is valid. This may be a store that always fails to read
+        attributeStoreCache.get(catalogUri, _ => S3AttributeStore(bucket, prefix))
       }
     }
+  }
 
-  def maybeTile(id: UUID, zoom: Int, key: SpatialKey): Future[Option[MultibandTile]] =
-    tileCache.caching(s"tile-$id-$zoom-$key") { implicit ec =>
-      for {
-        prefix <- prefixFromLayerId(id)
-        store <- attributeStore(defaultBucket, prefix)
-      } yield {
-        val reader = new S3ValueReader(store).reader[SpatialKey, MultibandTile](LayerId(id.toString, zoom))
-        Try(reader.read(key)) match {
-          // Only cache failures through failed query
-          case Success(tile) => Some(tile)
+  def layerHistogram(layerId: UUID, zoom: Int): OptionT[Future, Array[Histogram[Double]]] = {
+    histogramCache.cachingOptionT(s"histogram-$layerId-$zoom") { implicit ec =>
+      attributeStoreForLayer(layerId).map { store =>
+        store.read[Array[Histogram[Double]]](LayerId(layerId.toString, 0), "histogram")
+      }
+    }
+  }
+
+  def layerTile(layerId: UUID, zoom: Int, key: SpatialKey): OptionT[Future, MultibandTile] = {
+    tileCache.cachingOptionT(s"tile-$layerId-$zoom-${key.col}-${key.row}") { implicit ec =>
+      attributeStoreForLayer(layerId).mapFilter { store =>
+        val reader = new S3ValueReader(store).reader[SpatialKey, MultibandTile](LayerId(layerId.toString, zoom))
+        Try {
+          reader.read(key)
+        } match {
+          case Success(tile) => Option(tile)
           case Failure(e: ValueNotFoundError) => None
-          case Failure(e) => throw e
+          case Failure(e) =>
+            logger.error(s"Reading layer $layerId at $key: ${e.getMessage}")
+            None
         }
       }
     }
+  }
 
-
-  val histogramCache = HeapBackedMemcachedClient[Array[Histogram[Double]]](memcachedClient)
-  def bandHistogram(id: UUID, zoom: Int): Future[Array[Histogram[Double]]] =
-    histogramCache.caching(s"histogram-$id-$zoom") { implicit ec =>
-      for {
-        prefix <- prefixFromLayerId(id)
-        store <- attributeStore(defaultBucket, prefix)
-      } yield store.read[Array[Histogram[Double]]](LayerId(id.toString, 0), "histogram")
-    }
-
-  val layerPrefixCache = HeapBackedMemcachedClient[Option[String]](memcachedClient)
-  def prefixFromLayerId(layerId: UUID): Future[Option[String]] =
-    layerPrefixCache.caching(s"rflayer-prefix-${layerId.toString}") { _ =>
-      // The default threadpool can be used for this cache because work is handed off to hikari
-      import scala.concurrent.ExecutionContext.Implicits.global
-      val sceneQuery = Scenes.getScene(layerId)
-      sceneQuery.map { sceneOption =>
-        for {
-          scene <- sceneOption
-          ingestLocation <- scene.ingestLocation
-          result <- S3UrlRx.findFirstMatchIn(ingestLocation)
-        } yield result.group("prefix")
+  def layerTileForExtent(layerId: UUID, zoom: Int, extent: Extent): OptionT[Future, MultibandTile] = {
+    tileCache.cachingOptionT(s"extent-tile-$layerId-$zoom-$extent") { implicit ec =>
+      attributeStoreForLayer(layerId).mapFilter { store =>
+        Try {
+          S3CollectionLayerReader(store)
+            .query[SpatialKey, MultibandTile, TileLayerMetadata[SpatialKey]](LayerId(layerId.toString, zoom))
+            .where(Intersects(extent))
+            .result
+            .stitch
+            .crop(extent)
+            .tile
+        } match {
+          case Success(tile) => Option(tile)
+          case Failure(e) =>
+            logger.error(s"Query layer $layerId at zoom $zoom for $extent: ${e.getMessage}")
+            None
+        }
       }
     }
+  }
 }

--- a/app-backend/tile/src/main/scala/StitchLayer.scala
+++ b/app-backend/tile/src/main/scala/StitchLayer.scala
@@ -35,7 +35,7 @@ object StitchLayer extends LazyLogging with Config {
   val stitchCache = HeapBackedMemcachedClient(memcachedClient)
   def apply(id: UUID, size: Int): OptionT[Future, MultibandTile] =
     stitchCache.cachingOptionT(s"stitch-{$size}") { implicit ec =>
-      LayerCache.attributeStoreForLayer(id).mapFilter { store =>
+      LayerCache.attributeStoreForLayer(id).mapFilter { case (store, _) =>
         stitch(store, id.toString, size)
       }
     }

--- a/app-backend/tile/src/main/scala/image/Mosaic.scala
+++ b/app-backend/tile/src/main/scala/image/Mosaic.scala
@@ -53,7 +53,6 @@ object Mosaic {
   }
 
 
-  val mosaicDefinitionCache = HeapBackedMemcachedClient(memcachedClient)
   def mosaicDefinition(projectId: UUID, tagttl: Option[TagWithTTL])(implicit db: Database): OptionT[Future, Seq[MosaicDefinition]] = {
     val cacheKey = tagttl match {
       case Some(t) => s"mosaic-definition-$projectId-${t.tag}"

--- a/app-backend/tile/src/main/scala/image/Mosaic.scala
+++ b/app-backend/tile/src/main/scala/image/Mosaic.scala
@@ -14,7 +14,8 @@ import geotrellis.raster.GridBounds
 import geotrellis.proj4._
 import geotrellis.slick.Projected
 import geotrellis.vector.{Polygon, Extent}
-
+import cats.data._
+import cats.implicits._
 import java.util.UUID
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent._
@@ -25,6 +26,7 @@ case class TagWithTTL(tag: String, ttl: Duration)
 
 object Mosaic {
   val memcachedClient = LayerCache.memcachedClient
+  val memcached = HeapBackedMemcachedClient(LayerCache.memcachedClient)
 
   /** Cache the result of metadata queries that may have required walking up the pyramid to find suitable layers */
 
@@ -36,7 +38,8 @@ object Mosaic {
       .maximumSize(500)
       .build[String, Future[Option[(Int, TileLayerMetadata[SpatialKey])]]]()
 
-  def tileLayerMetadata(id: UUID, zoom: Int)(implicit database: Database) = {
+  def tileLayerMetadata(id: UUID, zoom: Int)(implicit database: Database): OptionT[Future, (Int, TileLayerMetadata[SpatialKey])] = {
+    // TODO: use a way to get the closest zoom level without multiple reads
     def readMetadata(store: AttributeStore, tryZoom: Int): Option[(Int, TileLayerMetadata[SpatialKey])] =
       try {
         Some(tryZoom -> store.readMetadata[TileLayerMetadata[SpatialKey]](LayerId(id.toString, tryZoom)))
@@ -44,113 +47,76 @@ object Mosaic {
         case e: AttributeNotFoundError if tryZoom > 0 => readMetadata(store, tryZoom - 1)
       }
 
-    tileLayerMetadataCache.get(s"mosaic-tlm-$id-$zoom", { cKey =>
-      for {
-        prefix <- LayerCache.prefixFromLayerId(id)
-        store <- LayerCache.attributeStore(prefix)
-      } yield {
-        readMetadata(store, zoom)
-      }
-    })
+    memcached.cachingOptionT[(Int, TileLayerMetadata[SpatialKey])](s"mosaic-tlm-$id-$zoom") { _ =>
+      LayerCache.attributeStoreForLayer(id).mapFilter { store => readMetadata(store, zoom) }
+    }
   }
 
 
-  val mosaicDefinitionCache = HeapBackedMemcachedClient[Option[Seq[MosaicDefinition]]](memcachedClient)
-  def mosaicDefinition(projectId: UUID, tagttl: Option[TagWithTTL])(implicit db: Database) = {
+  val mosaicDefinitionCache = HeapBackedMemcachedClient(memcachedClient)
+  def mosaicDefinition(projectId: UUID, tagttl: Option[TagWithTTL])(implicit db: Database): OptionT[Future, Seq[MosaicDefinition]] = {
     val cacheKey = tagttl match {
       case Some(t) => s"mosaic-definition-$projectId-${t.tag}"
       case None => s"mosaic-definition-$projectId"
     }
-    mosaicDefinitionCache.caching(cacheKey) { implicit ec =>
-      ScenesToProjects.getMosaicDefinition(projectId)
+
+    memcached.cachingOptionT(cacheKey) { _ =>
+      OptionT(ScenesToProjects.getMosaicDefinition(projectId))
     }
   }
 
   /** Fetch the tile for given resolution. If it is not present, use a tile from a lower zoom level */
-  def fetch(id: UUID, zoom: Int, col: Int, row: Int)(implicit database: Database): Future[Option[MultibandTile]] =
-    tileLayerMetadata(id, zoom).flatMap {
-      case Some((sourceZoom, tlm)) =>
-        val zdiff = zoom - sourceZoom
-        val pdiff = 1 << zdiff
-        val sourceKey = SpatialKey(col / pdiff, row / pdiff)
-        if (tlm.bounds includes sourceKey)
-          for ( maybeTile <- LayerCache.maybeTile(id, sourceZoom, sourceKey) ) yield {
-            for (tile <- maybeTile) yield {
-              val innerCol  = col % pdiff
-              val innerRow  = row % pdiff
-              val cols = tile.cols / pdiff
-              val rows = tile.rows / pdiff
-              tile.crop(GridBounds(
-                colMin = innerCol * cols,
-                rowMin = innerRow * rows,
-                colMax = (innerCol + 1) * cols - 1,
-                rowMax = (innerRow + 1) * rows - 1
-              )).resample(256, 256)
-            }
-          }
-        else
-          Future.successful(None)
-      case None =>
-        Future.successful(None)
+  def fetch(id: UUID, zoom: Int, col: Int, row: Int)(implicit database: Database): OptionT[Future, MultibandTile] =
+    for {
+      (sourceZoom, tlm) <- tileLayerMetadata(id, zoom)
+      zoomDiff = zoom - sourceZoom
+      resolutionDiff = 1 << zoomDiff
+      sourceKey = SpatialKey(col / resolutionDiff, row / resolutionDiff)
+      tile <- LayerCache.layerTile(id, sourceZoom, sourceKey) if tlm.bounds.includes(sourceKey)
+    } yield {
+      val innerCol = col % resolutionDiff
+      val innerRow = row % resolutionDiff
+      val cols = tile.cols / resolutionDiff
+      val rows = tile.rows / resolutionDiff
+      tile.crop(GridBounds(
+        colMin = innerCol * cols,
+        rowMin = innerRow * rows,
+        colMax = (innerCol + 1) * cols - 1,
+        rowMax = (innerRow + 1) * rows - 1
+      )).resample(256, 256)
     }
 
   /** Fetch the rendered tile for the given zoom level and bbox
     * If no bbox is specified, it will use the project tileLayerMetadata layoutExtent
     */
-  def fetchRenderedExtent(id: UUID, zoom: Int, bbox: Option[Projected[Polygon]])(implicit database: Database):
-      Future[Option[MultibandTile]] = {
-    tileLayerMetadata(id, zoom).flatMap {
-      case Some((sourceZoom, tlm)) =>
-        val zdiff = zoom - sourceZoom
-        val pdiff = 1 << zdiff
-
-        val extent = bbox match {
-          case Some(bbox) => bbox.envelope
-          case None =>
-            tlm.layoutExtent
-        }
-        val gridBounds = tlm.layout.mapTransform(extent)
-
-        for (
-          maybeRenderedExtent <- LayerCache.maybeRenderExtent(id, sourceZoom, extent)
-        ) yield maybeRenderedExtent
-      case None =>
-        Future.successful(None)
+  def fetchRenderedExtent(id: UUID, zoom: Int, bbox: Option[Projected[Polygon]])(implicit database: Database): OptionT[Future,MultibandTile] = {
+    tileLayerMetadata(id, zoom).flatMap { case (sourceZoom, tlm) =>
+      val extent: Extent =
+        bbox.map { case Projected(poly, srid) =>
+          poly.envelope.reproject(CRS.fromEpsgCode(srid), tlm.crs)
+        }.getOrElse(tlm.layoutExtent)
+      LayerCache.layerTileForExtent(id, sourceZoom, extent)
     }
   }
 
   /** Fetch all bands of a [[MultibandTile]] and return them without assuming anything of their semantics */
-  def raw(
-    projectId: UUID,
-    zoom: Int, col: Int, row: Int
-  )(implicit db: Database): Future[Option[MultibandTile]] = {
+  def raw(projectId: UUID, zoom: Int, col: Int, row: Int)(implicit db: Database): OptionT[Future, MultibandTile] = {
+    mosaicDefinition(projectId, None).flatMap { mosaic =>
+      val mayhapTiles: Seq[OptionT[Future, MultibandTile]] =
+        for (MosaicDefinition(sceneId, _) <- mosaic) yield
+          for (tile <- Mosaic.fetch(sceneId, zoom, col, row)) yield
+            tile
 
-    // Lookup project definition
-    // NOTE: raw does NOT cache the mosaicDefinition
-    val mayhapMosaic: Future[Option[Seq[MosaicDefinition]]] = mosaicDefinition(projectId, None)
-
-    mayhapMosaic.flatMap {
-      case None => // can't merge a project without mosaic definition
-        Future.successful(Option.empty[MultibandTile])
-
-      case Some(mosaicDefinition) =>
-        val mayhapTiles =
-          for (
-             mosaic <- mosaicDefinition
-          ) yield {
-            for {
-              maybeTile <- Mosaic.fetch(mosaic.sceneId, zoom, col, row)
-            } yield
-              for (tile <- maybeTile) yield tile
-          }
-
-        Future.sequence(mayhapTiles).map { maybeTiles =>
+      val futureMergeTile: Future[Option[MultibandTile]] =
+        Future.sequence(mayhapTiles.map(_.value)).map { maybeTiles =>
           val tiles = maybeTiles.flatten
           if (tiles.nonEmpty)
             Option(tiles.reduce(_ merge _))
           else
             Option.empty[MultibandTile]
         }
+
+      OptionT(futureMergeTile)
     }
   }
 
@@ -168,7 +134,7 @@ object Mosaic {
     *   @param zoomOption  the zoom level to use
     *   @param bboxOption the bounding box for the image
     */
-  def render(projectId: UUID, zoomOption: Option[Int], bboxOption: Option[String])(implicit database: Database): Future[Option[MultibandTile]] = {
+  def render(projectId: UUID, zoomOption: Option[Int], bboxOption: Option[String])(implicit database: Database): OptionT[Future, MultibandTile] = {
     val bboxPolygon: Option[Projected[Polygon]] =
       try {
         bboxOption map { bbox =>
@@ -181,34 +147,28 @@ object Mosaic {
 
     val zoom: Int = zoomOption.getOrElse(8)
 
-    val maybeMosaic: Future[Option[Seq[MosaicDefinition]]] = mosaicDefinition(projectId, None)
-
-    maybeMosaic.flatMap {
-      case None => // can't merge a project without mosaic definition
-        Future.successful(Option.empty[MultibandTile])
-
-      case Some(mosaic) =>
-        val maybeTiles =
-          for (mosaicDefinition <- mosaic) yield {
-              mosaicDefinition.colorCorrections match {
-                case None =>
-                  Future.successful(Option.empty[MultibandTile])
-                case Some(params) =>
-                  for {
-                    maybeTile <- Mosaic.fetchRenderedExtent(mosaicDefinition.sceneId, zoom, bboxPolygon)
-                    hist <- LayerCache.bandHistogram(mosaicDefinition.sceneId, zoom)
-                  } yield
-                    for (tile <- maybeTile) yield params.colorCorrect(tile, hist)
+    mosaicDefinition(projectId, None).flatMap { mosaic =>
+      val mayhapTiles: Seq[OptionT[Future, MultibandTile]] =
+        mosaic.flatMap { case MosaicDefinition(sceneId, maybeColorCorrectParams) =>
+          maybeColorCorrectParams.map { colorCorrectParams =>
+            Mosaic.fetchRenderedExtent(sceneId, zoom, bboxPolygon).flatMap { tile =>
+              LayerCache.layerHistogram(sceneId, zoom).map { hist =>
+                colorCorrectParams.colorCorrect(tile, hist)
               }
-          }
+            }
+          }.toSeq
+        }
 
-        Future.sequence(maybeTiles).map { maybeTiles =>
+      val futureMergeTile: Future[Option[MultibandTile]] =
+        Future.sequence(mayhapTiles.map(_.value)).map { maybeTiles =>
           val tiles = maybeTiles.flatten
           if (tiles.nonEmpty)
             Option(tiles.reduce(_ merge _))
           else
             Option.empty[MultibandTile]
-      }
+        }
+
+      OptionT(futureMergeTile)
     }
   }
 
@@ -226,50 +186,37 @@ object Mosaic {
     rgbOnly: Boolean = true
   )(
     implicit db: Database
-  ): Future[Option[MultibandTile]] = {
-
+  ): OptionT[Future, MultibandTile] = {
     // Lookup project definition
-    val maybeMosaic: Future[Option[Seq[MosaicDefinition]]] = tag match {
-      case Some(t) =>
-        // tag present, include in lookup to re-use cache
-        mosaicDefinition(projectId, Option(TagWithTTL(tag=t, ttl=60.seconds)))
-      case None =>
-        // no tag to control cache rollover, so don't cache
-        mosaicDefinition(projectId, None)
-    }
-
-    maybeMosaic.flatMap {
-      case None => // can't merge a project without mosaic definition
-        Future.successful(Option.empty[MultibandTile])
-
-      case Some(mosaic) =>
-        val maybeTiles =
-          for (mosaicDefinition <- mosaic) yield {
-            if (rgbOnly) {
-              mosaicDefinition.colorCorrections match {
-                case None =>
-                  Future.successful(Option.empty[MultibandTile])
-                case Some(params) =>
-                  for {
-                    maybeTile <- Mosaic.fetch(mosaicDefinition.sceneId, zoom, col, row)
-                    hist <- LayerCache.bandHistogram(mosaicDefinition.sceneId, zoom)
-                  } yield
-                    for (tile <- maybeTile) yield params.colorCorrect(tile, hist)
+    // tag present, include in lookup to re-use cache
+    // no tag to control cache rollover, so don't cache
+    mosaicDefinition(projectId, tag.map(s => TagWithTTL(tag=s, ttl=60.seconds))).flatMap { mosaic =>
+      val mayhapTiles: Seq[OptionT[Future, MultibandTile]] =
+        mosaic.flatMap { case MosaicDefinition(sceneId, maybeColorCorrectParams) =>
+          if (rgbOnly) {
+            maybeColorCorrectParams.map { colorCorrectParams =>
+              Mosaic.fetch(sceneId, zoom, col, row).flatMap { tile =>
+                LayerCache.layerHistogram(sceneId, zoom).map { hist =>
+                  colorCorrectParams.colorCorrect(tile, hist)
+                }
               }
-            } else { // Return all bands
-              for {
-                maybeTile <- Mosaic.fetch(mosaicDefinition.sceneId, zoom, col, row)
-              } yield maybeTile
-            }
+            }.toSeq
+          } else {
+            // Wrap in List so it can flattened by the same flatMap above
+            List(Mosaic.fetch(sceneId, zoom, col, row))
           }
+        }
 
-        Future.sequence(maybeTiles).map { maybeTiles =>
+      val futureMergeTile: Future[Option[MultibandTile]] =
+        Future.sequence(mayhapTiles.map(_.value)).map { maybeTiles =>
           val tiles = maybeTiles.flatten
           if (tiles.nonEmpty)
             Option(tiles.reduce(_ merge _))
           else
-            None
-      }
+            Option.empty[MultibandTile]
+        }
+
+      OptionT(futureMergeTile)
     }
   }
 }

--- a/app-backend/tile/src/main/scala/routes/ToolRoutes.scala
+++ b/app-backend/tile/src/main/scala/routes/ToolRoutes.scala
@@ -18,7 +18,7 @@ import akka.http.scaladsl.model.{ContentType, HttpEntity, HttpResponse, MediaTyp
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
 import com.typesafe.scalalogging.LazyLogging
 import spray.json._
-
+import cats.implicits._
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent._
 import java.util.UUID
@@ -99,9 +99,9 @@ object ToolRoutes extends LazyLogging {
           complete {
             val varMap = Map(
               'LC8_0 -> { (z: Int, x: Int, y: Int) =>
-                Mosaic.raw(UUID.fromString(p0), z, x, y)},
+                Mosaic.raw(UUID.fromString(p0), z, x, y).value},
               'LC8_1 -> { (z: Int, x: Int, y: Int) =>
-                Mosaic.raw(UUID.fromString(p1), z, x, y)})
+                Mosaic.raw(UUID.fromString(p1), z, x, y).value})
 
             val model: Op = partId match {
               case Some("ndvi0") => ndvi0


### PR DESCRIPTION
## Overview

Addressing the initial issue it became clear that default return type for all IO lookups needs to be `Future[Option[T]]` because any lookup may fail either due to error, missing record, corrupted store. As issue points out failed futures don't compose, so a single failed scene breaks the mosaic.

The next problem is that nested types like `Future[Option[T]]` are difficult to work with, requiring to unwrap first the `Future` and then the `Option`, leading to both lots of opportunity to make an error and temptation to find a shortcut.

The previous implementation of `def attributeStore(bucket: String, prefix: Option[String])` is an example of both of those things.

This PR proposes to standardize around the `cats.data.OptionT` monad transformer which allows `flatMap` and `map` to "drill down" through both `Future` and `Option` to only work with values which will be present. Related doc page: http://typelevel.org/cats/datatypes/optiont.html 

There are two commits, first using `OptionT` as return type and second using it only when its properties are required. The second iteration errs more on the side over verbose but still provides much greater clarity.

### Checklist
- [x] Handle missing layer histogram gracefully
- [x] Handle missing ingest location gracefully
- [ ] Styleguide updated, if merged

Closes: #1182 