### PR TITLE
Include related items in tool response

### DIFF
--- a/docs/swagger/spec.yml
+++ b/docs/swagger/spec.yml
@@ -2035,12 +2035,12 @@ definitions:
           type: array
           description: Tool tags associated with a tool
           items:
-            type: string
+            $ref: '#/definitions/ToolTag'
         categories:
           type: array
           description: Category of geoprocessing tool
           items:
-            type: string
+            $ref: '#/definitions/ToolCategory'
         license:
           type: string
           description: Usage license of tool


### PR DESCRIPTION
## Overview

This PR seeks to minimize the number of requests needed to get a full representation of a tool.

When we display a list of tools we would like to be able to show the tool's tags, categories, owning organization, and possibly event the name of the user that created the tool (see note). Previously, our strategy to handle related items was to return the ids of these items. This would require many subsequent requests to get the data needed for display.

Rather than return ids, this PR adds fully embedded records of those related items (sans user) into the representation of a tool returned by the API.

### Checklist

~- [ ] Styleguide updated, if necessary~
- [x] Swagger specification updated, if necessary
~- [ ] Symlinks from new migrations present or corrected for any new migrations~

### Demo

Trimmed response:

```
{
  "count": 4,
  "pageSize": 30,
  "hasPrevious": false,
  "page": 0,
  "results": [
    {
      "modifiedAt": "2017-01-30T21:49:11.427348Z",
      "compatibleDataSources": [
        "Sentinel-2",
        "Landsat 8"
      ],
      "organization": {
        "id": "9e2bef18-3f46-426b-a5bd-9913ee1ff840",
        "createdAt": "2016-11-16T01:55:32.916196Z",
        "modifiedAt": "2016-11-16T01:55:32.916196Z",
        "name": "root organization"
      },
      "stars": 5,
      "description": "Compares the change in vegetation over time from two compatible projects.",
      "tags": [],
      "license": "",
      "id": "b237a825-203e-44bc-9cfa-81cff9f28641",
      "requirements": "2 scenes, each with NIR-1 and red band information.",
      "categories": [],
      "createdAt": "2017-01-30T21:49:11.427348Z",
      "createdBy": "default",
      "definition": {
        ...
      },
      "title": "NDVI Change Detection",
      "modifiedBy": "default",
      "visibility": "PUBLIC"
    },
    {
      "modifiedAt": "2016-12-29T19:16:13.758662Z",
      "compatibleDataSources": [
        "Sentinel-2",
        "Landsat 8"
      ],
      "organization": {
        "id": "9e2bef18-3f46-426b-a5bd-9913ee1ff840",
        "createdAt": "2016-11-16T01:55:32.916196Z",
        "modifiedAt": "2016-11-16T01:55:32.916196Z",
        "name": "root organization"
      },
      "stars": 4.699999809265137,
      "description": "Measures angular direction of surface change.",
      "tags": [
        {
          "modifiedAt": "2016-12-29T19:16:13.758662Z",
          "tag": "Image Classification",
          "id": "38ce33f3-30a4-4870-977e-6847f806aaca",
          "createdAt": "2016-12-29T19:16:13.758662Z",
          "createdBy": "default",
          "organizationId": "9e2bef18-3f46-426b-a5bd-9913ee1ff840",
          "modifiedBy": "default"
        },
        {
          "modifiedAt": "2016-12-29T19:16:13.758662Z",
          "tag": "Vegetation Index",
          "id": "cb5df426-321d-49c6-afe0-07f2f185b9db",
          "createdAt": "2016-12-29T19:16:13.758662Z",
          "createdBy": "default",
          "organizationId": "9e2bef18-3f46-426b-a5bd-9913ee1ff840",
          "modifiedBy": "default"
        }
      ],
      "license": "",
      "id": "a115269a-69b4-49c6-bbcf-289f765be969",
      "requirements": "1 scene with NIR-1 and red band information.",
      "categories": [
        {
          "modifiedAt": "2016-12-29T19:16:13.758662Z",
          "createdAt": "2016-12-29T19:16:13.758662Z",
          "createdBy": "default",
          "category": "Aggregates",
          "slugLabel": "aggregates",
          "modifiedBy": "default"
        }
      ],
      "createdAt": "2016-12-29T19:16:13.758662Z",
      "createdBy": "default",
      "definition": {},
      "title": "Direction of Surface Change",
      "modifiedBy": "default",
      "visibility": "PUBLIC"
    },
    ...
  ],
  "hasNext": false
}
```

### Notes

We aren't embedding user data yet. Our data for user's resides on Auth0 so we will need to address this.

## Testing Instructions
 * Curl for tools and notice that the organization, tags, and categories are now embedded

AND/OR

 * Run the app
 * Open dev tools to monitor requests
 * Go to the tool catalog
 * Inspect tool request
 * See that the response includes the embedded entities

Connects #814
