### PR TITLE
Update Color Correct API

### DIFF
--- a/app-backend/api/src/main/scala/project/Routes.scala
+++ b/app-backend/api/src/main/scala/project/Routes.scala
@@ -75,13 +75,13 @@ trait ProjectRoutes extends Authentication
         } ~
         pathPrefix(JavaUUID) { sceneId =>
           get { getProjectSceneColorCorrectParams(projectId, sceneId) } ~
-          post { setProjectSceneColorCorrectParams(projectId, sceneId) }
+          put { setProjectSceneColorCorrectParams(projectId, sceneId) }
         }
       } ~
       pathPrefix("order") {
         pathEndOrSingleSlash {
           get { listProjectSceneOrder(projectId) } ~
-          post { setProjectSceneOrder(projectId) }
+          put { setProjectSceneOrder(projectId) }
         }
       }
     }
@@ -156,8 +156,8 @@ trait ProjectRoutes extends Authentication
         complete(StatusCodes.RequestEntityTooLarge)
       }
 
-      complete {
-        ScenesToProjects.setManualOrder(projectId, sceneIds)
+      onSuccess(ScenesToProjects.setManualOrder(projectId, sceneIds)) { updatedOrder =>
+        complete(StatusCodes.NoContent)
       }
     }
   }
@@ -172,11 +172,8 @@ trait ProjectRoutes extends Authentication
   /** Set color correction parameters for a project/scene pairing */
   def setProjectSceneColorCorrectParams(projectId: UUID, sceneId: UUID) = authenticate { user =>
     entity(as[ColorCorrect.Params]) { ccParams =>
-      onSuccess(ScenesToProjects.setColorCorrectParams(projectId, sceneId, ccParams)) {
-        case 1 => complete(StatusCodes.NoContent)
-        case count => throw new IllegalStateException(
-          s"Error updating scene's color correction: update result expected to be 1, was $count"
-        )
+      onSuccess(ScenesToProjects.setColorCorrectParams(projectId, sceneId, ccParams)) { sceneToProject =>
+        complete(StatusCodes.NoContent)
       }
     }
   }

--- a/app-backend/api/src/test/scala/project/ProjectSceneSpec.scala
+++ b/app-backend/api/src/test/scala/project/ProjectSceneSpec.scala
@@ -256,14 +256,14 @@ class ProjectSceneSpec extends WordSpec
         ) ~> baseRoutes ~> check {
           val sceneIds1 = responseAs[PaginatedResponse[UUID]].results
 
-          Post(s"/api/projects/${projectId}/order/").withHeadersAndEntity(
+          Put(s"/api/projects/${projectId}/order/").withHeadersAndEntity(
             List(authHeader),
             HttpEntity(
               ContentTypes.`application/json`,
               sceneIds1.reverse.toJson.toString()
             )
           ) ~> baseRoutes ~> check {
-            status shouldEqual StatusCodes.OK
+            status shouldEqual StatusCodes.NoContent
 
             Get(s"/api/projects/${projectId}/order/").withHeaders(
               List(authHeader)
@@ -300,7 +300,7 @@ class ProjectSceneSpec extends WordSpec
         ) ~> baseRoutes ~> check {
           val sceneId = responseAs[PaginatedResponse[UUID]].results.head
 
-          Post(s"/api/projects/${projectId}/mosaic/${sceneId}/").withHeadersAndEntity(
+          Put(s"/api/projects/${projectId}/mosaic/${sceneId}/").withHeadersAndEntity(
             List(authHeader),
             HttpEntity(
               ContentTypes.`application/json`,
@@ -320,7 +320,7 @@ class ProjectSceneSpec extends WordSpec
             Get(s"/api/projects/${projectId}/mosaic/").withHeaders(
               List(authHeader)
             ) ~> baseRoutes ~> check {
-              val mosaicDef = responseAs[MosaicDefinition]
+              val mosaicDef = responseAs[Seq[MosaicDefinition]]
               status shouldEqual StatusCodes.OK
 
               // TODO: Add additional tests once #880 is resolved

--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/MosaicDefinition.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/MosaicDefinition.scala
@@ -5,15 +5,14 @@ import spray.json.DefaultJsonProtocol._
 
 import java.util.UUID
 
-case class MosaicDefinition(definition: Seq[(UUID, Option[ColorCorrect.Params])])
+case class MosaicDefinition(sceneId: UUID, colorCorrections: Option[ColorCorrect.Params])
 
 object MosaicDefinition {
-  implicit val defaultMosaicDefinitionFormat = jsonFormat1(MosaicDefinition.apply _)
+  implicit val defaultMosaicDefinitionFormat = jsonFormat2(MosaicDefinition.apply)
 
-  def fromScenesToProjects(scenesToProjects: Seq[SceneToProject]): MosaicDefinition =
-    MosaicDefinition(
-      scenesToProjects.map { case SceneToProject(sceneId, projectId, sceneOrder, colorCorrection) =>
-        sceneId -> colorCorrection
-      }
-    )
+  def fromScenesToProjects(scenesToProjects: Seq[SceneToProject]): Seq[MosaicDefinition] = {
+    scenesToProjects.map { case SceneToProject(sceneId, projectId, sceneOrder, colorCorrection) =>
+      MosaicDefinition(sceneId, colorCorrection)
+    }
+  }
 }

--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/PaginatedResponse.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/PaginatedResponse.scala
@@ -11,7 +11,7 @@ import spray.json.DefaultJsonProtocol._
  * @param hasNext whether or not additional results are available
  * @param page current page of results
  * @param pageSize number of results per page
- * @parma results sequence of results for a page
+ * @param results sequence of results for a page
  */
 case class PaginatedResponse[A](
   count: Int,

--- a/app-frontend/src/app/core/services/colorCorrect.service.js
+++ b/app-frontend/src/app/core/services/colorCorrect.service.js
@@ -57,7 +57,7 @@ export default (app) => {
          * @return {null} null
          */
         reset(sceneId, projectId) {
-            return this.updateOrCreate(sceneId, projectId, this.getDefaultColorCorrection());
+            return this.update(sceneId, projectId, this.getDefaultColorCorrection());
         }
 
         /** Function to obtain a scene's color correction for a given project
@@ -74,15 +74,13 @@ export default (app) => {
 
         /** Function to update or create color correction for scene/project
          *
-         * @TODO: Refactor once #880 is fixed and API is better
-         *
          * @param {string} sceneId id for scene to update/create color correction
          * @param {string} projectId id for project the scene's color correction belongs to
          * @param {object} data json data to send as payload
          * @return {Promise} response with data
          */
-        updateOrCreate(sceneId, projectId, data) {
-            return this.colorCorrect.create(
+        update(sceneId, projectId, data) {
+            return this.colorCorrect.update(
                 {sceneId: sceneId, projectId: projectId}, data
             ).$promise.then(() => {
                 return data;

--- a/app-frontend/src/app/core/services/layer.service.js
+++ b/app-frontend/src/app/core/services/layer.service.js
@@ -80,16 +80,12 @@ export default (app) => {
          */
         getSceneTileLayer() {
             if (this._sceneTiles) { // eslint-disable-line no-underscore-dangle
-                return this.$q((resolve) => {
-                    resolve(this._sceneTiles); // eslint-disable-line no-underscore-dangle
-                });
-            }
-            return this.getSceneLayerURL().then((url) => {
-                this._sceneTiles = L.tileLayer(url, // eslint-disable-line no-underscore-dangle
-                    {bounds: this.bounds, attribution: 'Raster Foundry'}
-                );
                 return this._sceneTiles; // eslint-disable-line no-underscore-dangle
-            });
+            }
+            this._sceneTiles = L.tileLayer(this.getSceneLayerURL(),
+                {bounds: this.bounds, attribution: 'Raster Foundry'}
+            );
+            return this._sceneTiles; // eslint-disable-line no-underscore-dangle
         }
 
         /** Function to return a promise that resolves into a leaflet tile layer for mosaic
@@ -128,9 +124,7 @@ export default (app) => {
          * @returns {string} URL for this tile layer
          */
         getSceneLayerURL() {
-            return this.formatColorParams().then((formattedParams) => {
-                return `/tiles/${this.scene.id}/rgb/{z}/{x}/{y}/?${formattedParams}`;
-            });
+            return `/tiles/${this.scene.id}/rgb/{z}/{x}/{y}/?${this.formatColorParams()}`;
         }
 
         getMosaicLayerURL(params = {}) {
@@ -150,9 +144,7 @@ export default (app) => {
          * @returns {string} URL for the histogram
          */
         getHistogramURL() {
-            return this.formatColorParams().then((formattedParams) => {
-                return `/tiles/${this.scene.id}/rgb/histogram/?${formattedParams}`;
-            });
+            return `/tiles/${this.scene.id}/rgb/histogram/?${this.formatColorParams()}`;
         }
 
         /**
@@ -188,11 +180,9 @@ export default (app) => {
         }
 
         formatColorParams() {
-            return this.getColorCorrection().then((colorCorrection) => {
-                colorCorrection.token = this.authService.token();
-                let formattedParams = L.Util.getParamString(colorCorrection);
-                return formattedParams;
-            });
+            this._correction.token = this.authService.token();
+            let formattedParams = L.Util.getParamString(this._correction);
+            return formattedParams;
         }
 
         /**
@@ -239,7 +229,7 @@ export default (app) => {
 
         updateColorCorrection(corrections) {
             this._correction = corrections; // eslint-disable-line no-underscore-dangle
-            return this.colorCorrectService.updateOrCreate(
+            return this.colorCorrectService.update(
                 this.scene.id, this.projectId, corrections
             ).then(() => this.colorCorrect());
         }
@@ -250,12 +240,10 @@ export default (app) => {
          * @returns {null} null
          */
         colorCorrect() {
-            this.getSceneTileLayer().then((tiles) => {
-                this.getSceneLayerURL().then((url) => {
-                    return tiles.setUrl(url);
-                });
-            });
+            let tiles = this.getSceneTileLayer();
+            return tiles.setUrl(this.getSceneLayerURL());
         }
+
 
         /**
          * Helper function to get user params from scene or list of scenes

--- a/app-frontend/src/app/pages/editor/project/projectEdit.controller.js
+++ b/app-frontend/src/app/pages/editor/project/projectEdit.controller.js
@@ -95,10 +95,9 @@ export default class ProjectEditController {
     bringSelectedScenesToFront() {
         this.cachedZIndices = new Map();
         for (const [id, l] of this.selectedLayers) {
-            l.getSceneTileLayer().then((tiles) => {
-                this.cachedZIndices.set(id, tiles.options.zIndex);
-                tiles.bringToFront();
-            });
+            let tiles = l.getSceneTileLayer();
+            this.cachedZIndices.set(id, tiles.options.zIndex);
+            tiles.bringToFront();
         }
     }
 

--- a/docs/swagger/spec.yml
+++ b/docs/swagger/spec.yml
@@ -665,6 +665,8 @@ paths:
       responses:
         200:
           description: An ordered list of scene IDs and corresponding color correction parameters
+          schema:
+            $ref: '#/definitions/MosaicDefinition'
   /projects/{uuid}/mosaic/{uuid2}:
     get:
       summary: A project/scene pairing\'s persisted color correction parameters
@@ -676,17 +678,23 @@ paths:
       responses:
         200:
           description: Color correction parameters
-    post:
+          schema:
+            $ref: '#/definitions/ColorCorrection'
+    put:
       summary: Associate posted color correction parameters with a project/scene pairing
       tags:
         - Imagery
       parameters:
         - $ref: '#/parameters/uuid'
         - $ref: '#/parameters/uuid2'
-      # TODO: fill in all possible responses
+        - name: updatedColorCorrection
+          description: Updated color corrections
+          in: body
+          schema:
+            $ref: '#/definitions/ColorCorrection'
       responses:
-        200:
-          description: SUCCESS
+        204:
+          description: Successfully updated color correction parameters
   /projects/{uuid}/order:
     get:
       summary: An ordered list of scene IDs belonging to the specified project
@@ -697,8 +705,8 @@ paths:
       # TODO: fill in all possible responses
       responses:
         200:
-          description: SUCCESS
-    post:
+          description: Order of scenes in project for mosaic purposes
+    put:
       summary: Create/update an ordering among scenes within the specified project
       tags:
         - Imagery
@@ -706,8 +714,8 @@ paths:
         - $ref: '#/parameters/uuid'
       # TODO: fill in all possible responses
       responses:
-        200:
-          description: SUCCESS
+        204:
+          description: Successfully updated order of scenes in project
   /images/:
     get:
       summary: Paginated list of project images
@@ -1430,6 +1438,56 @@ definitions:
       organizationId:
         type: string
         description: uuid for organization
+  MosaicDefinition:
+    type: object
+    properties:
+      sceneId:
+        type: string
+        format: uuid
+      colorCorrection:
+        $ref: '#/definitions/ColorCorrection'
+  ColorCorrection:
+    type: object
+    properties:
+      alpha:
+        type: number
+        format: float
+      beta:
+        type: number
+        format: float
+      redBand:
+        type: number
+        format: integer
+      greenBand:
+        type: number
+        format: integer
+      blueBand:
+        type: number
+        format: integer
+      redGamma:
+        type: number
+        format: float
+      greenGamma:
+        type: number
+        format: float
+      blueGamma:
+        type: number
+        format: float
+      brightness:
+        type: number
+        format: float
+      min:
+        type: number
+        format: float
+      max:
+        type: number
+        format: float
+      equalize:
+        type: boolean
+      contrast:
+        type: number
+        format: float
+
   TimeModelMixin:
     type: object
     readOnly: true
@@ -1490,7 +1548,7 @@ definitions:
       identities:
         type: array
         items:
-          type: object
+          type: string
       user_metadata:
         type: object
       picture:
@@ -1876,7 +1934,7 @@ definitions:
           metadataFiles:
             type: array
             items:
-              type: object
+              type: string
             description: |
               Metadata files that should be present for processing all
               images in a scene (e.g. relevant .mtl files or .xml)
@@ -2227,48 +2285,3 @@ definitions:
         $ref: '#/definitions/SceneParams'
       imageParams:
         $ref: '#/definitions/ImageParams'
-
-  # geometry types all lifted from:
-  # https://gist.github.com/idkw/fc35bb78c4bf08e47708f57b060996fe
-  # GPS License v3
-  Geometry:
-    type: object
-    description: GeoJSon geometry
-    discriminator: type
-    required:
-      - type
-    externalDocs:
-      url: http://geojson.org/geojson-spec.html#geometry-objects
-    properties:
-      type:
-        type: string
-        enum:
-        - Point
-        - LineString
-        - Polygon
-        - MultiPoint
-        - MultiLineString
-        - MultiPolygon
-        description: the geometry type
-
-  Point2D:
-    type: array
-    maxItems: 2
-    minItems: 2
-    items:
-      type: number
-
-  Polygon:
-    type: object
-    description: GeoJSon geometry
-    externalDocs:
-      url: http://geojson.org/geojson-spec.html#id4
-    allOf:
-      - $ref: "#/definitions/Geometry"
-      - properties:
-          coordinates:
-            type: array
-            items:
-              type: array
-              items:
-                $ref: '#/definitions/Point2D'


### PR DESCRIPTION
## Overview

This updates the color correction/mosaic API to be slightly more user friendly.

A few changes were made:
 - updates the JSON format for mosaic definition (this required updating the case class/etc) so we probably need to scratch the cache after this is deployed
 - removes POST options for order/color correction -- both are defined already when a scene is added to a project, so additional updates are PUT requests now that return the normal response of empty content/204
 - removes additional requests/promises from front-end code to get updated color corrections

### Checklist

~- [ ] Styleguide updated, if necessary~
- [x] Swagger specification updated, if necessary
~- [ ] Symlinks from new migrations present or corrected for any new migrations~

### Demo
Note two requests on staging when color correcting a single scene:
![two-requests](https://cloud.githubusercontent.com/assets/898060/23707769/8d51ff62-03e1-11e7-8b77-3cd22a199f14.png)

After this PR only one request:
![one-request](https://cloud.githubusercontent.com/assets/898060/23707831/cc5cc732-03e1-11e7-83ab-5fa2ccf6a186.png)

## Testing Instructions

 * Go to color correction editor, verify works as expected

Closes #880
