### PR TITLE
Remove call to get JWT in airflow scheduler

### DIFF
--- a/app-tasks/dags/ingest/find_scenes_to_ingest.py
+++ b/app-tasks/dags/ingest/find_scenes_to_ingest.py
@@ -15,7 +15,7 @@ from airflow.operators.python_operator import PythonOperator
 from airflow.models import DAG
 from airflow.bin.cli import trigger_dag
 
-from rf.utils.io import get_jwt, get_session, IngestStatus
+from rf.utils.io import get_session, IngestStatus
 from rf.utils.exception_reporting import wrap_rollbar
 
 rf_logger = logging.getLogger('rf')
@@ -34,11 +34,7 @@ default_args = {
 }
 
 
-http_connection_id = 'raster-foundry'
 base_params = {'ingestStatus': IngestStatus.TOBEINGESTED}
-headers = {'Authorization': 'Bearer {}'.format(get_jwt())}
-host = os.getenv('RF_HOST')
-
 DagArgs = namedtuple('DagArgs', 'dag_id, conf, run_id')
 
 
@@ -53,6 +49,7 @@ def get_uningested_scenes():
     params['page'] = 0
     session = get_session()
 
+    host = os.getenv('RF_HOST')
     scene_url = '{host}/api/scenes/'.format(host=host)
     scene_response = session.get(scene_url, params=params).json()
     scenes = scene_response['results']


### PR DESCRIPTION
## Overview

This commit removes the call to get a JWT from the "find scenes to
ingest" DAG. This caused an error in the airflow scheduler because the
airflow scheduler does not have the Auth0 client token injected into its
environment. Instead, this commit moves the creation of a session inside
a function to ensure it only gets called when run inside an Airflow worker.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~

## Testing Instructions

There isn't a great way to test this that I could come up with. It might be easier to deploy, I think the logic is pretty straightforward though. The main problem was that the scheduler was running code, which we should try to minimize in the future.

Closes #1221
