### PR TITLE
Windowed GeoTiff Ingest

### DIFF
--- a/app-backend/build.sbt
+++ b/app-backend/build.sbt
@@ -160,7 +160,8 @@ lazy val ingest = Project("ingest", file("ingest"))
   .settings(commonSettings:_*)
   .settings(resolvers += Resolver.bintrayRepo("azavea", "geotrellis"))
   .settings({
-    libraryDependencies ++= loggingDependencies ++ testDependencies ++ Seq(
+    libraryDependencies ++= testDependencies ++ Seq(
+      Dependencies.scalaLogging,
       Dependencies.geotrellisSpark,
       Dependencies.geotrellisS3,
       Dependencies.geotrellisUtil,

--- a/app-backend/common/src/main/scala/S3.scala
+++ b/app-backend/common/src/main/scala/S3.scala
@@ -5,7 +5,7 @@ import scala.util.{Success, Failure, Try}
 import org.apache.commons.io.IOUtils
 
 import com.amazonaws.auth._
-import com.amazonaws.services.s3.{AmazonS3Client, AmazonS3URI}
+import com.amazonaws.services.s3.{AmazonS3ClientBuilder, AmazonS3URI}
 import com.amazonaws.services.s3.model.{S3Object, ObjectMetadata}
 
 import java.io._
@@ -13,7 +13,9 @@ import java.net._
 
 package object S3 {
   def getObject(uri: URI): S3Object = {
-    val client = new AmazonS3Client(new DefaultAWSCredentialsProviderChain)
+    val client = AmazonS3ClientBuilder.standard()
+      .withCredentials(new DefaultAWSCredentialsProviderChain())
+      .build()
     val s3uri = new AmazonS3URI(uri)
     Try(client.getObject(s3uri.getBucket, s3uri.getKey)) match {
       case Success(o) => o

--- a/app-backend/ingest/src/main/scala/com/azavea/rf/ingest/CommandLine.scala
+++ b/app-backend/ingest/src/main/scala/com/azavea/rf/ingest/CommandLine.scala
@@ -28,5 +28,13 @@ object CommandLine {
       .text("The location of the json which defines an ingest job")
       .required
 
+    opt[Int]('w',"windowSize")
+      .action( (s, conf) => conf.copy(windowSize = s) )
+      .text("Pixel window size for streaming GeoTiff reads")
+
+    opt[Int]('p',"partitionsPerFile")
+      .action( (s, conf) => conf.copy(partitionsPerFile = s) )
+      .text("Number of RDD partitions to create per each source file")
+
   }
 }

--- a/app-backend/ingest/src/main/scala/com/azavea/rf/ingest/Ingest.scala
+++ b/app-backend/ingest/src/main/scala/com/azavea/rf/ingest/Ingest.scala
@@ -14,6 +14,7 @@ import geotrellis.spark.io._
 import geotrellis.spark.io.s3._
 import geotrellis.spark.tiling._
 import geotrellis.spark.io.file._
+import geotrellis.spark.io.http.util.HttpRangeReader
 import geotrellis.spark.io.index.ZCurveKeyIndexMethod
 import geotrellis.spark.pyramid.Pyramid
 import geotrellis.vector.ProjectedExtent
@@ -153,7 +154,7 @@ object Ingest extends SparkJob with LazyLogging {
         val (bucket, prefix) = S3.parse(uri)
         S3RangeReader(bucket, prefix, S3Client.DEFAULT)
       case "http" | "https" =>
-        ???
+        new HttpRangeReader(uri.toURL())
     }
   }
 

--- a/app-backend/ingest/src/main/scala/com/azavea/rf/ingest/util/S3.scala
+++ b/app-backend/ingest/src/main/scala/com/azavea/rf/ingest/util/S3.scala
@@ -2,7 +2,7 @@ package com.azavea.rf.ingest.util
 
 import com.amazonaws.auth._
 import com.amazonaws.services.s3.model.{ListObjectsRequest, ObjectListing}
-import com.amazonaws.services.s3.{AmazonS3Client, AmazonS3URI}
+import com.amazonaws.services.s3.{AmazonS3Client, AmazonS3URI, AmazonS3ClientBuilder }
 import geotrellis.spark.io.s3.S3LayerWriter
 import org.apache.commons.io.IOUtils
 import org.apache.spark._
@@ -18,8 +18,9 @@ import scala.collection.mutable
 import scala.util.matching.Regex
 
 object S3 {
-  val cred = new DefaultAWSCredentialsProviderChain()
-  val client = new AmazonS3Client(cred)
+  val client = AmazonS3ClientBuilder.standard()
+    .withCredentials(new DefaultAWSCredentialsProviderChain())
+    .build()
 
   // From GT codebase
   private val idRx = "[A-Z0-9]{20}"

--- a/app-backend/ingest/src/main/scala/com/azavea/rf/ingest/util/UrlRangeReader.scala
+++ b/app-backend/ingest/src/main/scala/com/azavea/rf/ingest/util/UrlRangeReader.scala
@@ -1,0 +1,5 @@
+package com.azavea.rf.ingest.util
+
+class UrlRangeReader {
+
+}

--- a/app-backend/ingest/src/main/scala/com/azavea/rf/ingest/util/package.scala
+++ b/app-backend/ingest/src/main/scala/com/azavea/rf/ingest/util/package.scala
@@ -6,15 +6,11 @@ import geotrellis.spark.io.s3.AmazonS3Client
 import geotrellis.spark.io.s3.util.S3RangeReader
 
 import com.amazonaws.services.s3.{ AmazonS3URI, AmazonS3Client => AWSAmazonS3Client }
-import com.amazonaws.services.s3.model.{ListObjectsRequest, ObjectListing}
 import com.amazonaws.auth._
 import org.apache.commons.io.IOUtils
-import org.apache.spark.rdd.RDD
-import org.apache.spark._
 
 import java.io._
 import java.net._
-import java.util._
 
 package object util {
 

--- a/app-backend/project/Dependencies.scala
+++ b/app-backend/project/Dependencies.scala
@@ -23,6 +23,7 @@ object Dependencies {
   val scalaforklift           = "com.liyaos"                  %% "scala-forklift-slick"              % Version.scalaForklift
   val scalatest               = "org.scalatest"               %% "scalatest"                         % Version.scalaTest % "test"
   val slf4j                   = "org.slf4j"                    % "slf4j-simple"                      % Version.slf4j
+  val scalaLogging            = "com.typesafe.scala-logging"  %% "scala-logging"                     % Version.scalaLogging
   val slick                   = "com.typesafe.slick"          %% "slick"                             % Version.slick
   val slickPG                 = "com.github.tminglei"         %% "slick-pg"                          % Version.slickPG
   val slickPGSpray            = "com.github.tminglei"         %% "slick-pg_spray-json"               % Version.slickPG

--- a/app-backend/project/Version.scala
+++ b/app-backend/project/Version.scala
@@ -10,6 +10,7 @@ object Version {
   val scalaTest          = "2.2.6"
   val scapegoat          = "1.2.0"
   val slf4j              = "1.6.4"
+  val scalaLogging       = "3.5.0"
   val slick              = "3.1.1"
   val slickPG            = "0.14.6"
   val json4s             = "3.5.0"

--- a/app-backend/project/Version.scala
+++ b/app-backend/project/Version.scala
@@ -2,7 +2,7 @@ object Version {
   val rasterFoundry      = "0.1"
   val akka               = "2.4.3"
   val akkaHttp           = "10.0.3"
-  val geotrellis         = "1.0.0"
+  val geotrellis         = "1.1.0-RC2"
   val hikariCP           = "3.1.1"
   val postgres           = "9.4-1201-jdbc41"
   val scala              = "2.11.8"

--- a/app-backend/project/plugins.sbt
+++ b/app-backend/project/plugins.sbt
@@ -16,3 +16,5 @@ addSbtPlugin("io.spray" % "sbt-revolver" % "0.8.0")
 addSbtPlugin("com.sksamuel.scapegoat" %% "sbt-scapegoat" % "1.0.4")
 
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.8.2")
+
+addSbtPlugin("org.ensime" % "sbt-ensime" % "1.12.7")

--- a/app-backend/project/plugins.sbt
+++ b/app-backend/project/plugins.sbt
@@ -16,5 +16,3 @@ addSbtPlugin("io.spray" % "sbt-revolver" % "0.8.0")
 addSbtPlugin("com.sksamuel.scapegoat" %% "sbt-scapegoat" % "1.0.4")
 
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.8.2")
-
-addSbtPlugin("org.ensime" % "sbt-ensime" % "1.12.7")


### PR DESCRIPTION
## Overview

Uses windowed GeoTiff reading during ingest to improve parallelism and reduce memory usage.
So far testing shows that we can keep memory usage reasonable during ingest.

### Checklist

- [x] Implement windowed ingest
- [x] Test with GeoTrellis SNAPSHOT build on a kayak scene
- [x] Implement HttpRangeReader
- [x] Update to GeoTrellis 1.1.0-RC2

### Demo
`spark-submit --master 'local[*]' ingest/target/scala-2.11/rf-ingest.jar -j file:/Users/eugene/tmp/kayak/test.json -windowSize 512 --overwrite -partitionsPerFile 4`

Connects #1115
Closes #807 
Requires: https://github.com/locationtech/geotrellis/pull/1905