### PR TITLE
Create home page for updated UI

### DIFF
--- a/app-frontend/src/app/components/callToActionItem/callToAction.scss
+++ b/app-frontend/src/app/components/callToActionItem/callToAction.scss
@@ -1,7 +1,7 @@
 .cta-row {
   display: flex;
-  margin-bottom: 2rem;
   align-items: stretch;
+  flex-wrap: wrap;
 }
 
 rf-call-to-action-item,
@@ -12,8 +12,9 @@ rf-call-to-action-item,
   min-height: 250px;
   display: flex;
   flex-direction: column;
-  margin-right: 2rem;
+  margin: 0 0 2rem 2rem;
   border-radius: 4px;
+  min-width: 380px;
   h2, h3 {
     margin: 0 0 1rem 0;
   }

--- a/app-frontend/src/app/components/callToActionItem/callToAction.scss
+++ b/app-frontend/src/app/components/callToActionItem/callToAction.scss
@@ -1,0 +1,33 @@
+.cta-row {
+  display: flex;
+  margin-bottom: 2rem;
+  align-items: stretch;
+}
+
+rf-call-to-action-item,
+.cta-item {
+  flex: 1;
+  background: #eee;
+  padding: 2rem;
+  min-height: 250px;
+  display: flex;
+  flex-direction: column;
+  margin-right: 2rem;
+  border-radius: 4px;
+  h2, h3 {
+    margin: 0 0 1rem 0;
+  }
+  .cta-content {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+  }
+}
+.cta-flex-text {
+  flex: 1;
+  margin-bottom: 3rem;
+}
+.cta-button-row {
+  margin: 1rem 0 2rem 0;
+  line-height: 3.5;
+}

--- a/app-frontend/src/app/components/callToActionItem/callToActionItem.component.js
+++ b/app-frontend/src/app/components/callToActionItem/callToActionItem.component.js
@@ -1,0 +1,13 @@
+// Component code
+import callToActionItemTpl from './callToActionItem.html';
+
+const rfCallToActionItem = {
+    templateUrl: callToActionItemTpl,
+    controller: 'CallToActionItemController',
+    transclude: true,
+    bindings: {
+        title: '@'
+    }
+};
+
+export default rfCallToActionItem;

--- a/app-frontend/src/app/components/callToActionItem/callToActionItem.controller.js
+++ b/app-frontend/src/app/components/callToActionItem/callToActionItem.controller.js
@@ -1,0 +1,5 @@
+export default class CallToActionItemController {
+    constructor() {
+        'ngInject';
+    }
+}

--- a/app-frontend/src/app/components/callToActionItem/callToActionItem.html
+++ b/app-frontend/src/app/components/callToActionItem/callToActionItem.html
@@ -1,0 +1,4 @@
+<h3 ng-if="$ctrl.title">
+  {{$ctrl.title}}
+</h3>
+<div class="cta-content" ng-transclude></div>

--- a/app-frontend/src/app/components/callToActionItem/callToActionItem.module.js
+++ b/app-frontend/src/app/components/callToActionItem/callToActionItem.module.js
@@ -1,0 +1,11 @@
+import angular from 'angular';
+import CallToActionItemComponent from './callToActionItem.component.js';
+import CallToActionItemController from './callToActionItem.controller.js';
+require('./callToAction.scss');
+
+const CallToActionItemModule = angular.module('components.callToActionItem', []);
+
+CallToActionItemModule.controller('CallToActionItemController', CallToActionItemController);
+CallToActionItemModule.component('rfCallToActionItem', CallToActionItemComponent);
+
+export default CallToActionItemModule;

--- a/app-frontend/src/app/index.components.js
+++ b/app-frontend/src/app/index.components.js
@@ -5,6 +5,7 @@ export default angular.module('index.components', [
     require('./components/toolSearch/toolSearch.module.js').name,
     require('./components/toolItem/toolItem.module.js').name,
     require('./components/filterPane/filterPane.module.js').name,
+    require('./components/callToActionItem/callToActionItem.module.js').name,
     require('./components/colorCorrectPane/colorCorrectPane.module.js').name,
     require('./components/colorCorrectScenes/colorCorrectScenes.module.js').name,
     require('./components/colorCorrectAdjust/colorCorrectAdjust.module.js').name,

--- a/app-frontend/src/app/index.module.js
+++ b/app-frontend/src/app/index.module.js
@@ -59,8 +59,8 @@ const App = angular.module(
         require('./pages/settings/profile/profile.module.js').name,
         require('./pages/settings/account/account.module.js').name,
         require('./pages/settings/tokens/tokens.module.js').name,
-        require('./pages/error/error.module.js').name
-
+        require('./pages/error/error.module.js').name,
+        require('./pages/home/home.module.js').name
     ]
 );
 

--- a/app-frontend/src/app/index.routes.js
+++ b/app-frontend/src/app/index.routes.js
@@ -28,6 +28,7 @@ import accountTpl from './pages/settings/account/account.html';
 import tokensTpl from './pages/settings/tokens/tokens.html';
 import errorTpl from './pages/error/error.html';
 import shareTpl from './pages/share/share.html';
+import homeTpl from './pages/home/home.html';
 
 function librarySceneStates($stateProvider) {
     $stateProvider
@@ -290,6 +291,17 @@ function loginStates($stateProvider) {
         });
 }
 
+function homeStates($stateProvider) {
+    $stateProvider
+        .state('home',{
+            parent: 'root',
+            url: '/home',
+            templateUrl: homeTpl,
+            controller: 'HomeController',
+            controllerAs: '$ctrl'
+        });
+}
+
 function routeConfig($urlRouterProvider, $stateProvider) {
     'ngInject';
 
@@ -305,6 +317,7 @@ function routeConfig($urlRouterProvider, $stateProvider) {
     settingsStates($stateProvider);
     labStates($stateProvider);
     shareStates($stateProvider);
+    homeStates($stateProvider);
 
     $stateProvider
         .state('error', {

--- a/app-frontend/src/app/index.routes.js
+++ b/app-frontend/src/app/index.routes.js
@@ -293,7 +293,7 @@ function loginStates($stateProvider) {
 
 function homeStates($stateProvider) {
     $stateProvider
-        .state('home',{
+        .state('home', {
             parent: 'root',
             url: '/home',
             templateUrl: homeTpl,

--- a/app-frontend/src/app/pages/home/home.controller.js
+++ b/app-frontend/src/app/pages/home/home.controller.js
@@ -1,0 +1,8 @@
+class HomeController {
+  constructor(authService) {
+    'ngInject';
+    this.authService = authService;
+  }
+}
+
+export default HomeController;

--- a/app-frontend/src/app/pages/home/home.controller.js
+++ b/app-frontend/src/app/pages/home/home.controller.js
@@ -1,8 +1,8 @@
 class HomeController {
-  constructor(authService) {
-    'ngInject';
-    this.authService = authService;
-  }
+    constructor(authService) {
+        'ngInject';
+        this.authService = authService;
+    }
 }
 
 export default HomeController;

--- a/app-frontend/src/app/pages/home/home.html
+++ b/app-frontend/src/app/pages/home/home.html
@@ -1,0 +1,96 @@
+<div class="container column-stretch dashboard">
+  <div class="main">
+    <div class="content stack-sm">
+      <h2>Home</h2>
+    </div>
+    <div class="row content stack-sm">
+      <div class="column-8">
+        <div class="cta-row">
+          <div class="cta-item">
+            <h3 class="no-margin">Projects & Imports</h3>
+            <div class="cta-flex-text">
+              <strong>Import</strong> your own observation imagery or <strong>find</strong> publicly available imagery for use in a project.
+              Use the Editor to color correct and arrange imagery, creating the perfect basemap.
+            </div>
+            <div class="cta-button-row">
+              <a class="btn btn-primary" ui-sref="library.projects.list">View Projects</a>
+              <button class="btn btn-default">Create a new Project</button>
+            </div>
+            <div class="cta-text">
+              <a>Getting started with Projects</a>
+            </div>
+          </div>
+        </div>
+        <div class="cta-row">
+          <div class="cta-item">
+            <h3 class="no-margin">Tools</h3>
+            <div class="cta-flex-text">
+              Use the Raster Foundry Tools to build custom processing tasks and get the most out of your imagery.
+            </div>
+            <div class="cta-button-row">
+              <a class="btn btn-primary" ui-sref="market.search">Browse Tools</a>
+              <button class="btn btn-default">Create a new Tool</button>
+            </div>
+            <div class="cta-text">
+              <a>Getting started with Tools</a>
+            </div>
+          </div>
+          <div class="cta-item">
+            <h3 class="no-margin">Develop</h3>
+            <div class="cta-flex-text">
+              Leverage Raster Foundry's powerful API and infrastructure to create your own imagery application.
+            </div>
+            <div class="cta-button-row">
+              <a class="btn btn-primary" ui-sref="settings.tokens">Manage API Tokens</a>
+              <button class="btn btn-default">API Documentation</button>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="column-4">
+        <div class="content">
+          <div class="sidebar-section">
+            <div class="sidebar-row">
+              <h3 class="no-margin">Account</h3>
+            </div>
+            <div class="sidebar-row">
+              Hello, <strong>{{$ctrl.authService.profile().nickname}}</strong>
+            </div>
+            <div class="sidebar-row">
+              <a class="btn btn-primary" ui-sref="settings.profile">Account Settings</a>
+            </div>
+          </div>
+          <div class="sidebar-section">
+              <div class="sidebar-row">
+                <h3 class="no-margin">Help</h3>
+              </div>
+              <div class="sidebar-row">
+                <a>Raster Foundry guide</a>
+              </div>
+              <div class="sidebar-row">
+                <a>Getting started</a>
+              </div>
+              <div class="sidebar-row">
+                <a>Raster Foundry API Documentation</a>
+              </div>
+            </div>
+          </div>
+          <div class="sidebar-section">
+            <div class="sidebar-row">
+              <h3 class="no-margin">From our blog</h3>
+            </div>
+            <div class="sidebar-row">
+              <a>A blog post...</a>
+            </div>
+            <div class="sidebar-row">
+              <a>A blog post...</a>
+            </div>
+            <div class="sidebar-row">
+              <a>A blog post...</a>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app-frontend/src/app/pages/home/home.html
+++ b/app-frontend/src/app/pages/home/home.html
@@ -4,10 +4,9 @@
       <h2>Home</h2>
     </div>
     <div class="row content stack-sm">
-      <div class="column-8">
+      <div class="column-9">
         <div class="cta-row">
-          <div class="cta-item">
-            <h3 class="no-margin">Projects & Imports</h3>
+          <rf-call-to-action-item title="Projects & Imports">
             <div class="cta-flex-text">
               <strong>Import</strong> your own observation imagery or <strong>find</strong> publicly available imagery for use in a project.
               Use the Editor to color correct and arrange imagery, creating the perfect basemap.
@@ -19,35 +18,35 @@
             <div class="cta-text">
               <a>Getting started with Projects</a>
             </div>
-          </div>
+          </rf-call-to-action-item>
         </div>
         <div class="cta-row">
-          <div class="cta-item">
-            <h3 class="no-margin">Tools</h3>
+          <rf-call-to-action-item title="Tools">
             <div class="cta-flex-text">
               Use the Raster Foundry Tools to build custom processing tasks and get the most out of your imagery.
             </div>
             <div class="cta-button-row">
               <a class="btn btn-primary" ui-sref="market.search">Browse Tools</a>
+              <br/>
               <button class="btn btn-default">Create a new Tool</button>
             </div>
             <div class="cta-text">
               <a>Getting started with Tools</a>
             </div>
-          </div>
-          <div class="cta-item">
-            <h3 class="no-margin">Develop</h3>
+          </rf-call-to-action-item>
+          <rf-call-to-action-item title="Develop">
             <div class="cta-flex-text">
               Leverage Raster Foundry's powerful API and infrastructure to create your own imagery application.
             </div>
             <div class="cta-button-row">
               <a class="btn btn-primary" ui-sref="settings.tokens">Manage API Tokens</a>
+              <br/>
               <button class="btn btn-default">API Documentation</button>
             </div>
-          </div>
+          </rf-call-to-action-item>
         </div>
       </div>
-      <div class="column-4">
+      <div class="column-3">
         <div class="content">
           <div class="sidebar-section">
             <div class="sidebar-row">

--- a/app-frontend/src/app/pages/home/home.module.js
+++ b/app-frontend/src/app/pages/home/home.module.js
@@ -1,0 +1,8 @@
+import HomeController from './home.controller.js';
+require('./home.scss');
+
+const HomeModule = angular.module('pages.home', []);
+
+HomeModule.controller('HomeController', HomeController);
+
+export default HomeModule;

--- a/app-frontend/src/app/pages/home/home.scss
+++ b/app-frontend/src/app/pages/home/home.scss
@@ -2,35 +2,8 @@ h2.no-margin, h3.no-margin {
   margin: 0;
 }
 .sidebar-section {
-  margin-bottom: 2rem;
+  margin-bottom: 3rem;
 }
 .sidebar-row {
   margin-bottom: 1rem;
-}
-
-// These styles will be moved into the cta (call to action) component
-.cta-row {
-  display: flex;
-  margin-bottom: 2rem;
-  align-items: stretch;
-}
-.cta-item {
-  flex: 1;
-  background: #eee;
-  padding: 2rem;
-  min-height: 250px;
-  display: flex;
-  flex-direction: column;
-  margin-right: 2rem;
-  border-radius: 4px;
-  h2, h3 {
-    margin-bottom: 1rem;
-  }
-}
-.cta-flex-text {
-  flex: 1;
-}
-.cta-button-row {
-  margin: 1rem 0 1rem 0;
-  line-height: 3.5;
 }

--- a/app-frontend/src/app/pages/home/home.scss
+++ b/app-frontend/src/app/pages/home/home.scss
@@ -1,0 +1,36 @@
+h2.no-margin, h3.no-margin {
+  margin: 0;
+}
+.sidebar-section {
+  margin-bottom: 2rem;
+}
+.sidebar-row {
+  margin-bottom: 1rem;
+}
+
+// These styles will be moved into the cta (call to action) component
+.cta-row {
+  display: flex;
+  margin-bottom: 2rem;
+  align-items: stretch;
+}
+.cta-item {
+  flex: 1;
+  background: #eee;
+  padding: 2rem;
+  min-height: 250px;
+  display: flex;
+  flex-direction: column;
+  margin-right: 2rem;
+  border-radius: 4px;
+  h2, h3 {
+    margin-bottom: 1rem;
+  }
+}
+.cta-flex-text {
+  flex: 1;
+}
+.cta-button-row {
+  margin: 1rem 0 1rem 0;
+  line-height: 3.5;
+}


### PR DESCRIPTION
## Overview

This PR adds a home page and an `rf-call-to-action-item` component.

The page can be found at `/home` and needs to be manually routed to.

The secondary buttons refer to actions we don't do yet directly (such as creating a tool or project). They are not currently functional.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~

### Demo

<img width="1262" alt="screen shot 2017-03-09 at 1 08 35 pm" src="https://cloud.githubusercontent.com/assets/2442245/23764000/defb39a8-04c9-11e7-8e6a-1be52a2a4862.png">

![screen shot 2017-03-09 at 1 17 59 pm](https://cloud.githubusercontent.com/assets/2442245/23764255/e576454c-04ca-11e7-8a8b-116bce36401e.png)

## Testing Instructions

 * Manually go to the `/home` route.
 * See that the layout matches the mockups
 * Test primary buttons to ensure they navigate to the right place.
 * Test resizing the window to ensure that the call-to-actions stack on narrow viewports

Connects #1213 
Connects #1215
