### PR TITLE
Redirect to login page on 401

### DIFF
--- a/app-frontend/src/app/core/services/auth.service.js
+++ b/app-frontend/src/app/core/services/auth.service.js
@@ -126,6 +126,13 @@ export default (app) => {
             });
             return this.promise.promise;
         }
+
+        verifyAuthCache() {
+            this.isLoggedIn = Boolean(
+                this.localStorage.get('id_token') && this.localStorage.get('profile')
+            );
+            return this.isLoggedIn;
+        }
     }
 
     app.service('authService', AuthService);

--- a/app-frontend/src/app/index.config.js
+++ b/app-frontend/src/app/index.config.js
@@ -52,6 +52,19 @@ function config( // eslint-disable-line max-params
     }
 
     $httpProvider.interceptors.push('jwtInterceptor');
+    $httpProvider.interceptors.push(function ($q, $injector) {
+        'ngInject';
+        return {
+            responseError: function (rejection) {
+                let authService = $injector.get('authService');
+                if (rejection.status === 401 &&
+                    rejection.config.url.indexOf('/api') === 0) {
+                    authService.logout();
+                }
+                return $q.reject(rejection);
+            }
+        };
+    });
 
     configProvider.init(process.env);
 

--- a/app-frontend/src/app/pages/login/login.controller.js
+++ b/app-frontend/src/app/pages/login/login.controller.js
@@ -1,7 +1,7 @@
 export default class LoginController {
     constructor(authService, $state) {
         'ngInject';
-        if (authService.isLoggedIn) {
+        if (authService.verifyAuthCache()) {
             $state.go('browse');
         } else {
             authService.login();


### PR DESCRIPTION
## Overview

Redirect to login page on a 401 response

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~

## Notes
This only redirects for requests to urls that start with '/api' so that if for example, the user makes a request
to an S3 URL using an expired token, it shouldn't log them out.

## Testing Instructions

 * Log into the frontend
* In chrome dev tools, change your auth token to an invalid one / delete it
* Make a request by fetching more scenes / anything else really
* Verify that you get redirected to the login view, and tokens/profile are deleted
* Verify that 404's and other errors do not cause the same redirect

Closes #1212
