### PR TITLE
Remove bintray warning

### DIFF
--- a/.bintray/.credentials
+++ b/.bintray/.credentials
@@ -1,4 +1,4 @@
-realm = RasterFoundry API Realm
-host = api.rasterfoundry.com
+realm = Bintray API Realm
+host = api.bintray.com
 user =
 password =

--- a/.bintray/.credentials
+++ b/.bintray/.credentials
@@ -1,0 +1,4 @@
+realm = RasterFoundry API Realm
+host = api.rasterfoundry.com
+user =
+password =

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,6 +58,7 @@ services:
     volumes:
       - ./app-backend/:/opt/raster-foundry/app-backend/
       - ./.sbt:/root/.sbt
+      - ./.bintray:/root/.bintray
       - $HOME/.aws:/root/.aws:ro
     working_dir: /opt/raster-foundry/app-backend/
     entrypoint: ./sbt

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,7 @@ services:
     volumes:
       - ./app-backend/:/opt/raster-foundry/app-backend/
       - ./.sbt:/root/.sbt
+      - ./.bintray:/root/.bintray
       - $HOME/.aws:/root/.aws:ro
     working_dir: /opt/raster-foundry/app-backend/
     entrypoint: ./sbt


### PR DESCRIPTION
## Overview

Removes distracting bintray warning.

### Demo

Before:

```
$ ./scripts/console api-server './sbt'
Starting vagrant_postgres_1
[info] Loading project definition from /opt/raster-foundry/app-backend/project
Missing bintray credentials /root/.bintray/.credentials. Some bintray features depend on this.
Missing bintray credentials /root/.bintray/.credentials. Some bintray features depend on this.
Missing bintray credentials /root/.bintray/.credentials. Some bintray features depend on this.
Missing bintray credentials /root/.bintray/.credentials. Some bintray features depend on this.
Missing bintray credentials /root/.bintray/.credentials. Some bintray features depend on this.
Missing bintray credentials /root/.bintray/.credentials. Some bintray features depend on this.
Missing bintray credentials /root/.bintray/.credentials. Some bintray features depend on this.
Missing bintray credentials /root/.bintray/.credentials. Some bintray features depend on this.
Missing bintray credentials /root/.bintray/.credentials. Some bintray features depend on this.
[info] Set current project to rf-backend (in build file:/opt/raster-foundry/app-backend/)
root >
```

After:

```
$ ./scripts/console api-server './sbt'
[info] Loading project definition from /opt/raster-foundry/app-backend/project
[info] Set current project to rf-backend (in build file:/opt/raster-foundry/app-backend/)
root >
```

### Notes

Controversial storing empty credentials in the repo. What if we ever need to use real ones?

I think the reduction in noise is worth it.

## Testing Instructions

 * Check out this branch.
 * Open the `sbt` console. Ensure you don't see any bintray messages.
