### PR TITLE
Add share policy to project share modal

### DIFF
--- a/app-frontend/src/app/components/publishModal/publishModal.controller.js
+++ b/app-frontend/src/app/components/publishModal/publishModal.controller.js
@@ -1,6 +1,9 @@
 export default class PublishModalController {
-    constructor() {
+    constructor(projectService, $log) {
         'ngInject';
+
+        this.projectService = projectService;
+        this.$log = $log;
     }
 
     $onInit() {
@@ -21,8 +24,71 @@ export default class PublishModalController {
             }
         ];
 
+        let sharePolicies = [
+            {
+                label: 'Private',
+                description:
+                `Only you and those you create tokens for
+                 will be able to view tiles for this project`,
+                enum: 'PRIVATE',
+                active: false
+            },
+            {
+                label: 'Organization',
+                description:
+                `Users in your organization will be able to use
+                 their own tokens to view tiles for this project`,
+                enum: 'ORGANIZATION',
+                active: false
+            },
+            {
+                label: 'Public',
+                description: 'Anyone can view tiles for this project without a token',
+                enum: 'PUBLIC',
+                active: false
+            }
+        ];
+
+        this.sharePolicies = sharePolicies.map(
+            (policy) => {
+                let isActive = policy.enum === this.resolve.project.tileVisibility;
+                policy.active = isActive;
+                return policy;
+            }
+        );
+
+        this.activePolicy = this.sharePolicies.find((policy) => policy.active);
+
         this.mappedTileUrl =
             this.hydrateTileUrl(this.getActiveMapping());
+    }
+
+    onPolicyChange(policy) {
+        let project = this.resolve.project;
+        let shouldUpdate = true;
+
+        let oldPolicy = this.activePolicy;
+        if (this.activePolicy) {
+            this.activePolicy.active = false;
+        } else {
+            shouldUpdate = false;
+        }
+
+        this.activePolicy = policy;
+        policy.active = true;
+
+        project.tileVisibility = policy.enum;
+        if (shouldUpdate) {
+            this.projectService.updateProject(project).then((res) => {
+                this.$log.log(res);
+            }, (err) => {
+                // TODO: Toast this
+                this.$log.debug('Error while updating project share policy', err);
+                this.activePolicy.active = false;
+                oldPolicy.active = true;
+                this.activePolicy = oldPolicy;
+            });
+        }
     }
 
     onUrlMappingChange(mapping) {

--- a/app-frontend/src/app/components/publishModal/publishModal.html
+++ b/app-frontend/src/app/components/publishModal/publishModal.html
@@ -35,6 +35,24 @@
           </button>
         </div>
       </div>
+      <div class="form-group">
+        <label>Tile Visibility</label>
+        <div class="form-group">
+          <div class="btn-group inline">
+            <button class="btn btn-primary"
+                    ng-repeat="policy in $ctrl.sharePolicies"
+                    ng-click="$ctrl.onPolicyChange(policy)"
+                    ng-class="{'active': policy.active}">
+              {{policy.label}}
+            </button>
+          </div>
+        </div>
+        <div class="panel">
+          <div class="panel-body">
+            {{$ctrl.activePolicy.description}}
+          </div>
+        </div>
+      </div>
     </div>
     <div class="content">
       <h4>Exporting</h4>


### PR DESCRIPTION
## Overview

Add Tile Visibility field selection to share modal

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [x] Handle bad requests instead of silently failing

### Demo

![image](https://cloud.githubusercontent.com/assets/4392704/23815871/b5bac448-05b7-11e7-9ca6-b0fcbb8fedb4.png)

### Notes

Copy needs improvement, but I think we can leave that for later

## Testing Instructions

 * Open a project in the project editor
* Click the "share" button
* Verify that changing the Tile Visibility selector will make requests to change the model and persist through 
reloads
Connects #1207
