### PR TITLE
Add Facebook mention-bot configuration

### DIFF
--- a/.mention-bot
+++ b/.mention-bot
@@ -1,0 +1,17 @@
+{
+    "maxReviewers": 5,
+    "numFilesToCheck": 10,
+    "findPotentialReviewers": true,
+    "fileBlacklist": ["*.md"],
+    "userBlacklist": [],
+    "userBlacklistForPR": [],
+    "requiredOrgs": ["azavea"],
+    "actions": ["opened"],
+    "skipAlreadyAssignedPR": false,
+    "skipAlreadyMentionedPR": false,
+    "assignToReviewer": false,
+    "createReviewRequest": false,
+    "createComment": true,
+    "skipTitle": "WIP",
+    "skipCollaboratorPR": false
+}


### PR DESCRIPTION
## Overview

An instance of mention-bot was setup for Azavea usage. This configuration file provides project specific settings for mention-bot's behavior.

See: https://github.com/facebook/mention-bot#configuration

## Testing Instructions

Open a pull request with changes, and determine if @azaveaci comments on it with recommended reviewers.