### PR TITLE
Delay parsing of putative ASTs

### DIFF
--- a/app-backend/api/src/main/scala/tools/Routes.scala
+++ b/app-backend/api/src/main/scala/tools/Routes.scala
@@ -7,17 +7,16 @@ import com.azavea.rf.datamodel._
 import com.azavea.rf.tool.ast._
 
 import com.lonelyplanet.akka.http.extensions.PaginationDirectives
-import de.heikoseeberger.akkahttpcirce.CirceSupport
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.server.Route
-import io.circe._
-import io.circe.generic.auto._
+import spray.json._
+import DefaultJsonProtocol._
 
 import scala.util.{Success, Failure}
 import java.util.UUID
 
 
-trait ToolRoutes extends Authentication with PaginationDirectives with UserErrorHandler with CirceSupport {
+trait ToolRoutes extends Authentication with PaginationDirectives with UserErrorHandler {
   implicit def database: Database
 
   val toolRoutes: Route = handleExceptions(userExceptionHandler) {

--- a/app-backend/api/src/main/scala/tools/package.scala
+++ b/app-backend/api/src/main/scala/tools/package.scala
@@ -9,8 +9,9 @@ import java.sql.Timestamp
 import java.time.Instant
 
 package object tool extends RfJsonProtocols {
-  //implicit val paginatedToolFormat = jsonFormat6(PaginatedResponse[Tool.WithRelated])
-  /** Circe rules */
+  implicit val paginatedToolFormat = jsonFormat6(PaginatedResponse[Tool.WithRelated])
+
+  /** Circe codecs */
   implicit def encodePaginated[A: Encoder] =
     Encoder.forProduct6("count", "hasPrevious", "hasNext", "page", "pageSize", "results")({pr: PaginatedResponse[A] =>
       (pr.count, pr.hasPrevious, pr.hasNext, pr.page, pr.pageSize, pr.results)

--- a/app-backend/database/src/main/scala/com/azavea/rf/database/ExtendedPostgresDriver.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/ExtendedPostgresDriver.scala
@@ -50,14 +50,6 @@ trait ExtendedPostgresDriver extends ExPostgresDriver
     implicit val colorCorrectParamsMapper = MappedJdbcType.base[ColorCorrect.Params, JsValue](_.toJson,
       _.convertTo[ColorCorrect.Params])
 
-    // This is a Circe mapping rather than SprayJson, hence PgCirceJsonSupport above
-    implicit val mapAlgebraASTTypeMapper = MappedJdbcType.base[MapAlgebraAST, Json](_.asJson,
-      _.as[MapAlgebraAST] match {
-        case Right(ast) => ast
-        case Left(e) => throw e
-      }
-    )
-
     implicit val userRoleTypeMapper = createEnumJdbcType[User.Role]("UserRole", _.repr,
       User.Role.fromString, quoteName = false)
     implicit val userRoleTypeListMapper = createEnumListJdbcType[User.Role]("UserRole",

--- a/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Tools.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Tools.scala
@@ -8,7 +8,7 @@ import com.azavea.rf.database.{Database => DB}
 import com.azavea.rf.database.ExtendedPostgresDriver.api._
 import com.azavea.rf.tool.ast._
 
-import io.circe._
+import spray.json._
 import slick.model.ForeignKeyAction
 import com.lonelyplanet.akka.http.extensions.{PageRequest, Order}
 import com.typesafe.scalalogging.LazyLogging
@@ -50,7 +50,7 @@ class Tools(_tableTag: Tag) extends Table[Tool](_tableTag, "tools")
   val compatibleDataSources: Rep[List[String]] = column[List[String]]("compatible_data_sources",
     O.Length(Int.MaxValue, varying = false), O.Default(List.empty))
   val stars: Rep[Float] = column[Float]("stars", O.Default(0.0f))
-  val definition: Rep[MapAlgebraAST] = column[MapAlgebraAST]("definition", O.Length(2147483647,varying=false))
+  val definition: Rep[JsValue] = column[JsValue]("definition", O.Length(2147483647,varying=false))
 
   lazy val organizationsFk =
     foreignKey("tools_organization_id_fkey", organizationId, Organizations)(

--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/Tool.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/Tool.scala
@@ -1,14 +1,12 @@
 package com.azavea.rf.datamodel
 
-import com.azavea.rf.tool.ast._
+import spray.json._
+import DefaultJsonProtocol._
 
 import java.util.UUID
 import java.sql.Timestamp
 
-/** Model Lab Tool
-  *
-  * @note Does not define Spray Json codecs because [[MapAlgebraAST]] is serialized via circe
-  */
+/** Model Lab Tool */
 case class Tool(
   id: UUID,
   createdAt: Timestamp,
@@ -23,7 +21,7 @@ case class Tool(
   visibility: Visibility,
   compatibleDataSources: List[String] = List.empty,
   stars: Float = 0.0f,
-  definition: MapAlgebraAST
+  definition: JsValue
 ) {
   def withRelatedFromComponents(toolTags: Seq[ToolTag], toolCategories: Seq[ToolCategory], organization: Option[Organization]):
       Tool.WithRelated = Tool.WithRelated(
@@ -69,6 +67,8 @@ case class Tool(
 /** Case class for tool creation */
 object Tool {
 
+  implicit val defaultToolFormat = jsonFormat14(Tool.apply _)
+
   def create = Create.apply _
 
   def tupled = (Tool.apply _).tupled
@@ -82,7 +82,7 @@ object Tool {
     visibility: Visibility,
     compatibleDataSources: List[String],
     stars: Float,
-    definition: MapAlgebraAST,
+    definition: JsValue,
     tags: Seq[UUID],
     categories: Seq[String]
   ) {
@@ -114,6 +114,10 @@ object Tool {
     }
   }
 
+  object Create {
+    implicit val defaultToolCreateFormat = jsonFormat11(Create.apply _)
+  }
+
   // join of tool/tag/category
   case class ToolRelationshipJoin(tool: Tool, toolTag: Option[ToolTag], toolCategory: Option[ToolCategory], organization: Option[Organization])
 
@@ -136,12 +140,13 @@ object Tool {
     visibility: Visibility,
     compatibleDataSources: List[String] = List.empty,
     stars: Float = 0.0f,
-    definition: MapAlgebraAST,
+    definition: JsValue,
     tags: Seq[ToolTag],
     categories: Seq[ToolCategory]
   )
 
   object WithRelated {
+    implicit val defaultToolWithRelatedFormat = jsonFormat16(WithRelated.apply)
 
     def fromRecords(records: Seq[(Tool, Option[ToolTag], Option[ToolCategory], Option[Organization])]): Iterable[Tool.WithRelated] = {
       val distinctTools = records.map(_._1).distinct
@@ -175,9 +180,13 @@ object Tool {
     visibility: Visibility,
     compatibleDataSources: List[String] = List.empty,
     stars: Float = 0.0f,
-    definition: MapAlgebraAST,
+    definition: JsValue,
     tags: Seq[UUID],
     categories: Seq[String]
   )
+
+  object WithRelatedUUIDs {
+    implicit val defaultToolWithRelatedUUIDsFormat = jsonFormat16(WithRelatedUUIDs.apply)
+  }
 }
 

--- a/app-backend/tool/src/main/scala/ast/MapAlgebraAST.scala
+++ b/app-backend/tool/src/main/scala/ast/MapAlgebraAST.scala
@@ -42,7 +42,7 @@ object MapAlgebraAST {
 
 
   /** Map Algebra sources (leaves) */
-  sealed abstract class Source[T](val `type`: String) extends MapAlgebraAST {
+  sealed abstract class Source[+T](val `type`: String) extends MapAlgebraAST {
     def value: Option[T]
     def args: List[MapAlgebraAST] = List.empty
     def evaluable = value.isDefined

--- a/app-backend/tool/src/main/scala/ast/codec/MapAlgebraCodec.scala
+++ b/app-backend/tool/src/main/scala/ast/codec/MapAlgebraCodec.scala
@@ -2,13 +2,11 @@ package com.azavea.rf.tool.ast.codec
 
 import com.azavea.rf.tool.ast._
 
-import geotrellis.raster.render._
 import io.circe._
-import io.circe.optics.JsonPath._
 import io.circe.syntax._
 import io.circe.generic.auto._
+import io.circe.optics.JsonPath._
 
-import scala.util.Try
 import java.security.InvalidParameterException
 
 
@@ -19,21 +17,26 @@ trait MapAlgebraCodec
 
   /** TODO: Add codec paths besides `raster source` and `operation` when supported */
   implicit def mapAlgebraDecoder = Decoder.instance[MapAlgebraAST] { ma =>
-    ma._type match {
-      case Some("raster") =>
-        ma.as[MapAlgebraAST.RFMLRasterSource]
-      case Some(unrecognized) =>
-        throw new InvalidParameterException(s"'$unrecognized' is not a recognized map algebra data type")
-      case None =>
+    (ma._type, ma._symbol) match {
+      case (Some(_), None) =>
+        ma.as[MapAlgebraAST.Source[_]]
+      case (None, Some(_)) =>
         ma.as[MapAlgebraAST.Operation]
+      case (Some(_), Some(_)) =>
+        throw new InvalidParameterException(s"The JSON, '$ma.value.noSpaces', has both a 'type' and an 'apply' symbol")
+      case (None, None) =>
+        throw new InvalidParameterException(s"The JSON, '$ma.value.noSpaces', is not a recognized map algebra data type")
     }
   }
 
   implicit def mapAlgebraEncoder: Encoder[MapAlgebraAST] = new Encoder[MapAlgebraAST] {
-      final def apply(ast: MapAlgebraAST): Json = ast match {
-        case operation: MapAlgebraAST.Operation => operation.asJson
-        case rasterSrc: MapAlgebraAST.RFMLRasterSource => rasterSrc.asJson
-        case _ => throw new InvalidParameterException(s"whoa. What even is this: $ast")
-      }
+    final def apply(ast: MapAlgebraAST): Json = ast match {
+      case operation: MapAlgebraAST.Operation =>
+        operation.asJson
+      case source: MapAlgebraAST.Source[_] =>
+        implicitly[Encoder[MapAlgebraAST.Source[_]]].apply(source)
+      case _ =>
+        throw new InvalidParameterException(s"Unrecognized AST: $ast")
     }
+  }
 }

--- a/app-backend/tool/src/main/scala/ast/codec/MapAlgebraSourceCodecs.scala
+++ b/app-backend/tool/src/main/scala/ast/codec/MapAlgebraSourceCodecs.scala
@@ -16,6 +16,27 @@ trait MapAlgebraSourceCodecs {
   implicit def mapAlgebraDecoder: Decoder[MapAlgebraAST]
   implicit def mapAlgebraEncoder: Encoder[MapAlgebraAST]
 
+  // Codec routing for Sources
+  implicit lazy val decodeSources = Decoder.instance[MapAlgebraAST.Source[_]] { src =>
+    src._type match {
+      case Some("raster") => src.as[MapAlgebraAST.RFMLRasterSource]
+      case Some(unrecognized) =>
+        throw new InvalidParameterException(s"'${src.value.noSpaces}' is not a recognized map algebra source")
+      case _ =>
+        throw new InvalidParameterException(s"THIS SHOULD NEVER RUN. Attempted to decode: '${src.value.noSpaces}'.")
+    }
+  }
+
+  implicit lazy val encodeSources: Encoder[MapAlgebraAST.Source[_]] =
+    new Encoder[MapAlgebraAST.Source[_]] {
+      final def apply(src: MapAlgebraAST.Source[_]): Json = src match {
+        case rasterSrc: MapAlgebraAST.RFMLRasterSource =>
+          rasterSrc.asJson
+        case _ =>
+          throw new InvalidParameterException(s"THIS SHOULD NEVER RUN. Attempted to decode: '${src}'.")
+      }
+    }
+
   implicit lazy val decodeRFMLRasterSource: Decoder[MapAlgebraAST.RFMLRasterSource] =
     Decoder.forProduct3("id", "label", "value")(MapAlgebraAST.RFMLRasterSource.apply _)
   implicit lazy val encodeRFMLRasterSource: Encoder[MapAlgebraAST.RFMLRasterSource] =

--- a/app-backend/tool/src/main/scala/ast/codec/MapAlgebraUtilityCodecs.scala
+++ b/app-backend/tool/src/main/scala/ast/codec/MapAlgebraUtilityCodecs.scala
@@ -3,10 +3,12 @@ package com.azavea.rf.tool.ast.codec
 import com.azavea.rf.tool.ast._
 
 import geotrellis.raster.render._
+import cats.syntax.either._
 import io.circe._
-import io.circe.optics.JsonPath._
 import io.circe.syntax._
 import io.circe.generic.auto._
+import io.circe.optics.JsonPath._
+import io.circe.parser._
 
 import scala.util.Try
 import java.security.InvalidParameterException


### PR DESCRIPTION
## Overview

In light of the desire to upload putative tool definitions without errors being thrown in the case of incorrectly structured JSON, this PR removes any attempts to parse the a tool definition's JSON AST into a Map Algebra AST from the API. The changes in this PR, therefore, largely consist in reversion of features from PR #1192

Thinking through when, precisely, JSON should be parsed can likely be avoided until more work is done to flesh out how we will apply a Map Algebra AST as a GeoTrellis operation.