### PR TITLE
Map Token management views

### DIFF
--- a/app-frontend/src/app/components/publishModal/publishModal.controller.js
+++ b/app-frontend/src/app/components/publishModal/publishModal.controller.js
@@ -1,9 +1,15 @@
 export default class PublishModalController {
-    constructor(projectService, $log) {
+    constructor(projectService, $log, tokenService, authService, $uibModal) {
         'ngInject';
 
+        this.authService = authService;
         this.projectService = projectService;
         this.$log = $log;
+        this.tokenService = tokenService;
+        this.$uibModal = $uibModal;
+
+        // TODO change this when we implement orgs
+        this.userOrg = 'dfac6307-b5ef-43f7-beda-b9f208bb7726'; // default public org
     }
 
     $onInit() {
@@ -31,7 +37,9 @@ export default class PublishModalController {
                 `Only you and those you create tokens for
                  will be able to view tiles for this project`,
                 enum: 'PRIVATE',
-                active: false
+                active: false,
+                enabled: true,
+                token: true
             },
             {
                 label: 'Organization',
@@ -39,15 +47,21 @@ export default class PublishModalController {
                 `Users in your organization will be able to use
                  their own tokens to view tiles for this project`,
                 enum: 'ORGANIZATION',
-                active: false
+                active: false,
+                enabled: false,
+                token: true
             },
             {
                 label: 'Public',
                 description: 'Anyone can view tiles for this project without a token',
                 enum: 'PUBLIC',
-                active: false
+                active: false,
+                enabled: true,
+                token: false
             }
         ];
+
+        this.project = this.resolve.project;
 
         this.sharePolicies = sharePolicies.map(
             (policy) => {
@@ -61,10 +75,11 @@ export default class PublishModalController {
 
         this.mappedTileUrl =
             this.hydrateTileUrl(this.getActiveMapping());
+
+        this.fetchTokens();
     }
 
     onPolicyChange(policy) {
-        let project = this.resolve.project;
         let shouldUpdate = true;
 
         let oldPolicy = this.activePolicy;
@@ -77,10 +92,10 @@ export default class PublishModalController {
         this.activePolicy = policy;
         policy.active = true;
 
-        project.tileVisibility = policy.enum;
+        this.project.tileVisibility = policy.enum;
         if (shouldUpdate) {
-            this.projectService.updateProject(project).then((res) => {
-                this.$log.log(res);
+            this.projectService.updateProject(this.project).then((res) => {
+                this.$log.debug(res);
             }, (err) => {
                 // TODO: Toast this
                 this.$log.debug('Error while updating project share policy', err);
@@ -110,6 +125,74 @@ export default class PublishModalController {
     setActiveMappingByLabel(label) {
         this.urlMappings.forEach(m => {
             m.active = m.label === label;
+        });
+    }
+
+    createMapToken(name) {
+        this.tokenService.createMapToken({
+            name: name,
+            project: this.project.id,
+            organizationId: this.userOrg
+        }).then((res) => {
+            // TODO: Toast this
+            this.$log.debug('token created!', res);
+            this.newTokenName = '';
+            this.fetchTokens();
+        }, (err) => {
+            // TODO: Toast this
+            this.$log.debug('error creating token', err);
+            this.fetchTokens();
+        });
+    }
+
+    fetchTokens() {
+        this.loadingTokens = true;
+        this.tokenService.queryMapTokens({project: this.project.id}).then(
+            (paginatedResponse) => {
+                delete this.error;
+                this.tokens = paginatedResponse.results;
+                this.loadingTokens = false;
+            },
+            (error) => {
+                this.error = error;
+                this.loadingTokens = false;
+            });
+    }
+
+    deleteToken(token) {
+        let deleteModal = this.$uibModal.open({
+            component: 'rfConfirmationModal',
+            resolve: {
+                title: () => 'Delete map token?',
+                content: () => 'Deleting this map token will make any ' +
+                    'further requests with it fail',
+                confirmText: () => 'Delete Map Token',
+                cancelText: () => 'Cancel'
+            }
+        });
+        deleteModal.result.then(
+            () => {
+                this.tokenService.deleteMapToken({id: token.id}).then(
+                    () => {
+                        this.fetchTokens();
+                    },
+                    (err) => {
+                        this.$log.debug('error deleting map token', err);
+                        this.fetchTokens();
+                    }
+                );
+            });
+    }
+
+    updateToken(token, name) {
+        let newToken = Object.assign({}, token, {name: name});
+        this.tokenService.updateMapToken(newToken).then((res) => {
+            // TODO: Toast this
+            this.$log.debug('token updated', res);
+            this.fetchTokens();
+        }, (err) => {
+            this.$log.debug('error updating token', err);
+            this.fetchTokens();
         });
     }
 }

--- a/app-frontend/src/app/components/publishModal/publishModal.html
+++ b/app-frontend/src/app/components/publishModal/publishModal.html
@@ -26,11 +26,8 @@
           <label for="tile-link" class="sr-only">URL</label>
           <input id="tile-link" type="text" class="form-control"
                   value="{{$ctrl.resolve.shareUrl}}" readonly>
-          <!--
-            @TODO: the copy button is intended to copy the url for the user which
-            is not currently implemented
-          -->
-          <button class="btn btn-link">
+          <button class="btn btn-link"
+                  clipboard text="$ctrl.resolve.shareUrl">
             Copy
           </button>
         </div>
@@ -42,7 +39,8 @@
             <button class="btn btn-primary"
                     ng-repeat="policy in $ctrl.sharePolicies"
                     ng-click="$ctrl.onPolicyChange(policy)"
-                    ng-class="{'active': policy.active}">
+                    ng-class="{'active': policy.active}"
+                    ng-disabled="!policy.enabled">
               {{policy.label}}
             </button>
           </div>
@@ -50,6 +48,36 @@
         <div class="panel">
           <div class="panel-body">
             {{$ctrl.activePolicy.description}}
+            <div style="margin-top: 1em;" ng-if="$ctrl.activePolicy.token">
+              <div class="form-group all-in-one">
+                <input type="text" class="form-control" ng-model="$ctrl.newTokenName" placeholder="Token Name">
+                <button class="btn btn-link"
+                        ng-if="$ctrl.activePolicy.token"
+                        type="button"
+                        ng-click="$ctrl.createMapToken($ctrl.newTokenName)">
+                  <i class="icon-plus"></i> Create
+                </button>
+              </div>
+              <div class="list-group">
+                <rf-token-item token="token"
+                               on-delete="$ctrl.deleteToken(token)"
+                               on-update="$ctrl.updateToken(token, name)"
+                               ng-repeat="token in $ctrl.tokens track by token.id">
+                </rf-token-item>
+              </div>
+              <div class="list-group" ng-show="$ctrl.loadingTokens">
+                <span class="list-placeholder">
+                  <i class="icon-load"></i>
+                </span>
+              </div>
+              <div class="list-group"
+                   ng-if="(!$ctrl.tokens || !$ctrl.tokens.length) && !$ctrl.loadingTokens">
+                You have not generated any tokens.
+              </div>
+              <button class="btn btn-primary" type="button" ui-sref="settings.tokens.map">
+                Manage All Tokens
+              </button>
+            </div>
           </div>
         </div>
       </div>
@@ -72,10 +100,6 @@
           <label for="tile-link" class="sr-only">URI Link</label>
           <input id="tile-link" type="text" class="form-control"
                   value="{{$ctrl.mappedTileUrl}}" readonly>
-          <!--
-            @TODO: the copy button is intended to copy the url for the user which
-            is not currently implemented
-          -->
           <button clipboard text="$ctrl.mappedTileUrl" class="btn btn-link">
             Copy
           </button>

--- a/app-frontend/src/app/components/sceneItem/sceneItem.module.js
+++ b/app-frontend/src/app/components/sceneItem/sceneItem.module.js
@@ -1,7 +1,6 @@
 import angular from 'angular';
 import SceneItemComponent from './sceneItem.component.js';
 import SceneItemController from './sceneItem.controller.js';
-require('../../../assets/font/fontello/css/fontello.css');
 
 const SceneItemModule = angular.module('components.sceneItem', []);
 

--- a/app-frontend/src/app/components/tokenItem/tokenItem.component.js
+++ b/app-frontend/src/app/components/tokenItem/tokenItem.component.js
@@ -1,0 +1,13 @@
+import tokenTpl from './tokenItem.html';
+
+const rfTokenItem = {
+    templateUrl: tokenTpl,
+    controller: 'TokenItemController',
+    bindings: {
+        token: '<',
+        onDelete: '&',
+        onUpdate: '&'
+    }
+};
+
+export default rfTokenItem;

--- a/app-frontend/src/app/components/tokenItem/tokenItem.controller.js
+++ b/app-frontend/src/app/components/tokenItem/tokenItem.controller.js
@@ -1,0 +1,27 @@
+export default class TokenItem {
+    constructor() {
+    }
+
+    $onInit() {
+        this.editing = false;
+        this.newName = this.token.name;
+    }
+
+    onDelete() {
+        this.onDelete({token: this.token});
+    }
+
+    startEditing() {
+        this.editing = true;
+    }
+
+    onEditComplete(name) {
+        this.editing = false;
+        this.onUpdate({token: this.token, name: name});
+    }
+
+    onEditCancel() {
+        this.newName = this.token.name;
+        this.editing = false;
+    }
+}

--- a/app-frontend/src/app/components/tokenItem/tokenItem.html
+++ b/app-frontend/src/app/components/tokenItem/tokenItem.html
@@ -1,0 +1,44 @@
+<div class="token-item-container">
+  <div class="list-group-right">
+    <div class="form-group all-in-one" ng-if="$ctrl.token.name">
+      <input type="text" class="form-control"
+             ng-model="$ctrl.newName"
+             ng-disabled="!$ctrl.editing">
+      <input type="text"
+             ng-if="!$ctrl.editing"
+             class="form-control"
+             style="cursor: text"
+             ng-value="$ctrl.token.id" disabled>
+      <button class="btn btn-link"
+              ng-if="!$ctrl.editing"
+              clipboard text="$ctrl.token.id">
+        Copy
+      </button>
+      <button class="btn"
+              ng-if="!$ctrl.editing"
+              ng-click="$ctrl.startEditing()">
+        <i class="icon-pencil"></i>
+      </button>
+      <button class="btn"
+              ng-if="$ctrl.editing"
+              ng-click="$ctrl.onEditComplete($ctrl.newName)">
+        <i class="icon-check"></i>
+      </button>
+      <button class="btn"
+              ng-if="$ctrl.editing"
+              ng-click="$ctrl.onEditCancel()">
+        <i class="icon-cross"></i>
+      </button>
+      <button class="btn" ng-click="$ctrl.onDelete()">
+        <i class="icon-trash"></i>
+      </button>
+    </div>
+    <div class="form-group all-in-one" ng-if="$ctrl.token.device_name">
+      <input type="text" class="form-control" ng-value="$ctrl.token.device_name" disabled>
+      <button class="btn btn-link"
+              ng-click="$ctrl.deleteToken(token.id)">
+        <i class="icon-trash"></i>
+      </button>
+    </div>
+  </div>
+</div>

--- a/app-frontend/src/app/components/tokenItem/tokenItem.module.js
+++ b/app-frontend/src/app/components/tokenItem/tokenItem.module.js
@@ -1,0 +1,10 @@
+import angular from 'angular';
+import TokenItemComponent from './tokenItem.component.js';
+import TokenItemController from './tokenItem.controller.js';
+
+const TokenItemModule = angular.module('components.tokenItem', []);
+
+TokenItemModule.component('rfTokenItem', TokenItemComponent);
+TokenItemModule.controller('TokenItemController', TokenItemController);
+
+export default TokenItemModule;

--- a/app-frontend/src/app/core/services/token.service.js
+++ b/app-frontend/src/app/core/services/token.service.js
@@ -1,9 +1,11 @@
 export default (app) => {
     class TokenService {
-        constructor($resource) {
+        constructor($resource, $q, $log) {
             'ngInject';
+            this.$q = $q;
+            this.$log = $log;
 
-            this.Token = $resource(
+            this.ApiToken = $resource(
                 '/api/tokens/:id', {
                     id: '@id'
                 }, {
@@ -17,14 +19,50 @@ export default (app) => {
                     }
                 }
             );
+
+            this.MapToken = $resource(
+                '/api/map-tokens/:id', {
+                    id: '@id'
+                }, {
+                    create: {
+                        method: 'POST'
+                    },
+                    query: {
+                        method: 'GET',
+                        cache: false,
+                        isArray: false
+                    },
+                    delete: {
+                        method: 'DELETE'
+                    },
+                    update: {
+                        method: 'PUT'
+                    }
+                });
         }
 
-        query(params = {}) {
-            return this.Token.query(params).$promise;
+        queryApiTokens(params = {}) {
+            return this.ApiToken.query(params).$promise;
         }
 
-        delete(params) {
-            return this.Token.delete(params).$promise;
+        deleteApiToken(params) {
+            return this.ApiToken.delete(params).$promise;
+        }
+
+        createMapToken(params) {
+            return this.MapToken.create(params).$promise;
+        }
+
+        queryMapTokens(params = {}) {
+            return this.MapToken.query(params).$promise;
+        }
+
+        deleteMapToken(params) {
+            return this.MapToken.delete(params).$promise;
+        }
+
+        updateMapToken(params) {
+            return this.MapToken.update(params).$promise;
         }
     }
 

--- a/app-frontend/src/app/index.components.js
+++ b/app-frontend/src/app/index.components.js
@@ -26,5 +26,6 @@ export default angular.module('index.components', [
     require('./components/refreshTokenModal/refreshTokenModal.module.js').name,
     require('./components/downloadModal/downloadModal.module.js').name,
     require('./components/featureFlagOverrides/featureFlagOverrides.module.js').name,
-    require('./components/toggle/toggle.module.js').name
+    require('./components/toggle/toggle.module.js').name,
+    require('./components/tokenItem/tokenItem.module.js').name
 ]);

--- a/app-frontend/src/app/index.module.js
+++ b/app-frontend/src/app/index.module.js
@@ -59,6 +59,8 @@ const App = angular.module(
         require('./pages/settings/profile/profile.module.js').name,
         require('./pages/settings/account/account.module.js').name,
         require('./pages/settings/tokens/tokens.module.js').name,
+        require('./pages/settings/tokens/api/api.module.js').name,
+        require('./pages/settings/tokens/map/map.module.js').name,
         require('./pages/error/error.module.js').name,
         require('./pages/home/home.module.js').name
     ]

--- a/app-frontend/src/app/index.routes.js
+++ b/app-frontend/src/app/index.routes.js
@@ -26,6 +26,8 @@ import settingsTpl from './pages/settings/settings.html';
 import profileTpl from './pages/settings/profile/profile.html';
 import accountTpl from './pages/settings/account/account.html';
 import tokensTpl from './pages/settings/tokens/tokens.html';
+import apiTokensTpl from './pages/settings/tokens/api/api.html';
+import mapTokensTpl from './pages/settings/tokens/map/map.html';
 import errorTpl from './pages/error/error.html';
 import shareTpl from './pages/share/share.html';
 import homeTpl from './pages/home/home.html';
@@ -187,6 +189,19 @@ function settingsStates($stateProvider) {
             url: '/tokens',
             templateUrl: tokensTpl,
             controller: 'TokensController',
+            controllerAs: '$ctrl',
+            abstract: true
+        })
+        .state('settings.tokens.api', {
+            url: '/api',
+            templateUrl: apiTokensTpl,
+            controller: 'ApiTokensController',
+            controllerAs: '$ctrl'
+        })
+        .state('settings.tokens.map', {
+            url: '/map',
+            templateUrl: mapTokensTpl,
+            controller: 'MapTokensController',
             controllerAs: '$ctrl'
         });
 }

--- a/app-frontend/src/app/pages/settings/settings.controller.js
+++ b/app-frontend/src/app/pages/settings/settings.controller.js
@@ -1,7 +1,8 @@
 class SettingsController {
-    constructor($log) {
+    constructor($log, $state) {
         'ngInject';
         this.$log = $log;
+        this.$state = $state;
     }
 }
 

--- a/app-frontend/src/app/pages/settings/settings.html
+++ b/app-frontend/src/app/pages/settings/settings.html
@@ -4,7 +4,12 @@
       <nav>
         <a ui-sref="settings.profile" ui-sref-active="active">Profile</a>
         <a ui-sref="settings.account" ui-sref-active="active">Account</a>
-        <a ui-sref="settings.tokens" ui-sref-active="active">API tokens</a>
+        <a ui-sref="settings.tokens.api"
+           ng-class="{
+                     'active': $ctrl.$state.$current.name.includes('settings.tokens')
+                     }">
+          Tokens
+        </a>
         <a ui-sref="settings.organizations"
            ui-sref-active="active"
            feature-flag="profile-org-edit"

--- a/app-frontend/src/app/pages/settings/tokens/api/api.controller.js
+++ b/app-frontend/src/app/pages/settings/tokens/api/api.controller.js
@@ -1,0 +1,72 @@
+class ApiTokensController {
+    constructor($log, $uibModal, tokenService, authService) {
+        'ngInject';
+        this.$log = $log;
+
+        this.tokenService = tokenService;
+        this.authService = authService;
+        this.$uibModal = $uibModal;
+        this.loading = true;
+
+        this.fetchTokens();
+    }
+
+    fetchTokens() {
+        this.loading = true;
+        this.tokenService.queryApiTokens().then(
+            (tokens) => {
+                delete this.error;
+                this.tokens = tokens;
+                this.loading = false;
+            },
+            (error) => {
+                this.error = error;
+                this.loading = false;
+            });
+    }
+
+    createToken(name) {
+        this.authService.createRefreshToken(name).then((authResult) => {
+            this.$uibModal.open({
+                component: 'rfRefreshTokenModal',
+                resolve: {
+                    refreshToken: () => authResult.refreshToken,
+                    name: () => this.lastTokenName
+                }
+            });
+            delete this.newTokenName;
+            this.fetchTokens();
+        }, (error) => {
+            this.$log.debug('error while creating refresh token', error);
+            this.fetchTokens();
+        });
+    }
+
+    deleteToken(token) {
+        let id = token.id;
+        let deleteModal = this.$uibModal.open({
+            component: 'rfConfirmationModal',
+            resolve: {
+                title: () => 'Delete refresh token?',
+                content: () => 'Deleting this refresh token will make any ' +
+                    'further requests with it fail',
+                confirmText: () => 'Delete Refresh Token',
+                cancelText: () => 'Cancel'
+            }
+        });
+        deleteModal.result.then(
+            () => {
+                this.tokenService.deleteApiToken({id: id}).then(
+                    () => {
+                        this.fetchTokens();
+                    },
+                    (err) => {
+                        this.$log.debug('error deleting refresh token', err);
+                        this.fetchTokens();
+                    }
+                );
+            });
+    }
+}
+
+export default ApiTokensController;

--- a/app-frontend/src/app/pages/settings/tokens/api/api.html
+++ b/app-frontend/src/app/pages/settings/tokens/api/api.html
@@ -1,0 +1,31 @@
+<div class="panel tab-description">
+  Api tokens allow an application access our API and
+  to act on your behalf. Treat these the same way you would a password.
+  <br>
+  For security, we recommend creating a separate access token for each
+  application or integration.
+</div>
+<form action="">
+  <label for="new-token">Create token</label>
+  <div class="form-group all-in-one">
+    <input id="new-token" type="text"
+           ng-model="$ctrl.newTokenName"
+           class="form-control"
+           placeholder="Token Name">
+    <button type="button" class="btn btn-link" ng-click="$ctrl.createToken($ctrl.newTokenName)">
+      <i class="icon-plus"></i>Create
+    </button>
+  </div>
+</form>
+<div class="list-group">
+  <rf-token-item token="token" ng-repeat="token in $ctrl.tokens track by token.id">
+</div>
+<div class="list-group"
+     ng-if="(!$ctrl.tokens || !$ctrl.tokens.length) && !$ctrl.loading">
+  You have not generated any tokens.
+</div>
+<div class="list-group" ng-show="$ctrl.loading">
+  <span class="list-placeholder">
+    <i class="icon-load"></i>
+  </span>
+</div>

--- a/app-frontend/src/app/pages/settings/tokens/api/api.module.js
+++ b/app-frontend/src/app/pages/settings/tokens/api/api.module.js
@@ -1,0 +1,7 @@
+import ApiTokensController from './api.controller.js';
+
+const ApiTokensModule = angular.module('pages.settings.tokens.api', []);
+
+ApiTokensModule.controller('ApiTokensController', ApiTokensController);
+
+export default ApiTokensModule;

--- a/app-frontend/src/app/pages/settings/tokens/map/map.html
+++ b/app-frontend/src/app/pages/settings/tokens/map/map.html
@@ -1,0 +1,26 @@
+<div class="panel tab-description">
+  Map tokens allow read-only access to the tiles of a particular project.
+  <br>
+  Share these as freely as you wish.
+</div>
+<div class="form-group all-in-one">
+  <input id="search" type="text" class="form-control" placeholder="Search by Name"
+         ng-model="$ctrl.searchText" disabled>
+  <button class="btn btn-link" type="button" ng-click="$ctrl.search($ctrl.searchText)" disabled>Search</button>
+</div>
+<div class="list-group">
+  <rf-token-item token="token"
+                 on-delete="$ctrl.deleteToken(token)"
+                 on-update="$ctrl.updateToken(token, name)"
+                 ng-repeat="token in $ctrl.tokens track by token.id">
+  </rf-token-item>
+</div>
+<div class="list-group"
+     ng-if="(!$ctrl.tokens || !$ctrl.tokens.length) && !$ctrl.loading">
+  You have not generated any map tokens
+</div>
+<div class="list-group" ng-show="$ctrl.loading">
+  <span class="list-placeholder">
+    <i class="icon-load"></i>
+  </span>
+</div>

--- a/app-frontend/src/app/pages/settings/tokens/map/map.module.js
+++ b/app-frontend/src/app/pages/settings/tokens/map/map.module.js
@@ -1,0 +1,7 @@
+import MapTokensController from './map.controller.js';
+
+const MapTokensModule = angular.module('pages.settings.tokens.map', []);
+
+MapTokensModule.controller('MapTokensController', MapTokensController);
+
+export default MapTokensModule;

--- a/app-frontend/src/app/pages/settings/tokens/tokens.controller.js
+++ b/app-frontend/src/app/pages/settings/tokens/tokens.controller.js
@@ -1,69 +1,7 @@
 class TokensController {
-    constructor($log, tokenService, authService, $uibModal) {
+    constructor($log) {
         'ngInject';
         this.$log = $log;
-        this.tokenService = tokenService;
-        this.authService = authService;
-        this.$uibModal = $uibModal;
-        this.loading = true;
-
-        this.fetchTokens();
-    }
-
-    fetchTokens() {
-        this.loading = true;
-        this.tokenService.query().then(
-            (tokens) => {
-                delete this.error;
-                this.tokens = tokens;
-                this.loading = false;
-            },
-            (error) => {
-                this.error = error;
-                this.loading = false;
-            });
-    }
-
-    createToken(name) {
-        this.$log.log('trying to create new refresh token with name', name);
-        this.authService.createRefreshToken(name).then((authResult) => {
-            this.$uibModal.open({
-                component: 'rfRefreshTokenModal',
-                resolve: {
-                    refreshToken: () => authResult.refreshToken,
-                    name: () => this.lastTokenName
-                }
-            });
-            this.fetchTokens();
-        }, (error) => {
-            this.$log.log('error while creating refresh token', error);
-            this.fetchTokens();
-        });
-    }
-
-    deleteToken(id) {
-        let deleteModal = this.$uibModal.open({
-            component: 'rfConfirmationModal',
-            resolve: {
-                title: () => 'Delete refresh token?',
-                content: () => 'Deleting this refresh token will make any ' +
-                    'further requests with it fail',
-                confirmText: () => 'Delete Refresh Token',
-                cancelText: () => 'Cancel'
-            }
-        });
-        deleteModal.result.then(
-            () => {
-                this.tokenService.delete({id: id}).then(
-                    () => {
-                        this.fetchTokens();
-                    },
-                    (err) => {
-                        this.$log.debug('error deleting refresh token', err);
-                        this.fetchTokens();
-                    }
-                );
-            });
     }
 }
 

--- a/app-frontend/src/app/pages/settings/tokens/tokens.html
+++ b/app-frontend/src/app/pages/settings/tokens/tokens.html
@@ -1,37 +1,21 @@
 <div class="row content stack-sm">
   <div class="column-8">
     <div class="library-header">
-      <h1 class="h3 page-title">API Tokens</h1>
+      <h1 class="h3 page-title">Tokens</h1>
     </div>
-    <form action="">
-      <label for="new-token">Create token</label>
-      <div class="form-group all-in-one">
-        <input id="new-token" type="text" ng-model="$ctrl.newTokenName" class="form-control" placeholder="token name for your reference">
-        <button type="button" class="btn btn-link" ng-click="$ctrl.createToken($ctrl.newTokenName)">
-          <i class="icon-plus"></i>Create
-        </button>
-      </div>
-    </form>
-    <div class="list-group">
-      <div class="list-group-item" ng-repeat="token in $ctrl.tokens track by token.id">
-        <div class="list-group-overflow">
-          <strong class="color-dark">{{token.device_name}}</strong>
-        </div>
-        <div class="list-group-right">
-          <button class="btn" ng-click="$ctrl.deleteToken(token.id)">
-            <i class="icon-trash"></i>
-          </button>
-        </div>
-      </div>
+    <div class="tab-header">
+      <button class="btn btn-tab"
+              ui-sref="settings.tokens.api"
+              ui-sref-active="active">
+        Api
+      </button>
+      <button class="btn btn-tab"
+              ui-sref="settings.tokens.map"
+              ui-sref-active="active">
+        Map
+      </button>
     </div>
-    <div class="list-group"
-         ng-if="(!$ctrl.tokens || !$ctrl.tokens.length) && !$ctrl.loading">
-      You have not generated any tokens.
-    </div>
-    <div class="list-group" ng-show="$ctrl.loading">
-      <span class="list-placeholder">
-        <i class="icon-load"></i>
-      </span>
+    <div class="tab-body" ui-view>
     </div>
   </div>
 </div>

--- a/app-frontend/src/app/pages/settings/tokens/tokens.module.js
+++ b/app-frontend/src/app/pages/settings/tokens/tokens.module.js
@@ -1,4 +1,5 @@
 import TokensController from './tokens.controller.js';
+require('./tokens.scss');
 
 const TokensModule = angular.module('pages.settings.tokens', []);
 

--- a/app-frontend/src/app/pages/settings/tokens/tokens.scss
+++ b/app-frontend/src/app/pages/settings/tokens/tokens.scss
@@ -1,0 +1,29 @@
+@import "../../../../assets/styles/sass/utils/variables";
+
+.tab-header {
+  .btn-tab {
+    border-color: $brand-primary $brand-primary transparent $brand-primary;
+    color: $brand-primary;
+    background-color: transparent;
+    border-radius: 2px 2px 0 0;
+
+    &:hover, &.hover,
+    &:active, &.active, {
+      border-color: $brand-primary $brand-primary transparent $brand-primary;
+      background-color: $brand-primary;
+      color: #fff;
+      box-shadow: none;
+    }
+  }
+}
+
+.tab-body {
+  .panel{
+    padding: 1em;
+    &.tab-description {
+      margin-bottom: 1em;
+      border-radius: 0 0 2px 2px;
+      border-color: $brand-primary $brand-primary $brand-primary $brand-primary;
+    }
+  }
+}

--- a/app-frontend/src/assets/styles/sass/components/_login.scss
+++ b/app-frontend/src/assets/styles/sass/components/_login.scss
@@ -36,7 +36,8 @@
 }
 
 #auth0-lock-container-1,
-#auth0-lock-container-2 {
+#auth0-lock-container-2,
+#auth0-lock-container-3 {
   .auth0-lock-widget {
     box-shadow: 0 0 40px -5px #111118;
   }


### PR DESCRIPTION
## Overview
* Change Token resource to ApiToken, add MapToken $resource to tokenService 
* Add ability to create, view, and edit project tokens in publish modal (project filter is broken right now)
* Add ability to view and edit all map tokens in the map tokens tab

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~

### Demo

![image](https://cloud.githubusercontent.com/assets/4392704/23907781/87820408-08a8-11e7-85a5-3141258fe834.png)
![image](https://cloud.githubusercontent.com/assets/4392704/23907795/924fcad2-08a8-11e7-9237-340b3a448b3b.png)
![image](https://cloud.githubusercontent.com/assets/4392704/23907809/981f156c-08a8-11e7-9f04-1c260a2c4524.png)


### Notes
Disabled org tile visibility option on the frontend b/c we don't really have orgs atm
@designmatty 
* Added `app-frontend/src/app/pages/settings/tokens/tokens.scss` for the tokens view styles. 
* Added a minor fix in `app-frontend/src/assets/styles/sass/components/_login.scss` for the login pages (styles weren't applied to one login modal). Is there a way to just select #auth0-lock-container-* or something?

## Testing Instructions

* Go to the share modal for a project in the project/edit view
* Select the private Tile Visibility option
* Enter a name for the token and click create
* Verify that editing/deleting work and persist through reloads
* Verify that viewing/editing/deleting tokens works in the settings/tokens/map view
* Verify that creating / deleting api tokens in the settings/tokens/api view still works

Closes #1208
