### PR TITLE
Fix filtering for map tokens by project ID

### DIFF
--- a/app-backend/database/src/main/scala/com/azavea/rf/database/tables/MapTokens.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/tables/MapTokens.scala
@@ -15,8 +15,7 @@ import slick.model.ForeignKeyAction
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
-/**
-  * Created by cbrown on 3/11/17.
+/** Tokens associated with projects for sharing purposes
   */
 class MapTokens(_tableTag: Tag) extends Table[MapToken](_tableTag, "map_tokens")
   with NameField
@@ -107,22 +106,22 @@ object MapTokens extends TableQuery(tag => new MapTokens(tag)) with LazyLogging 
 
 class MapTokensTableQuery[M, U, C[_]](mapTokens: MapTokens.TableQuery) {
   def page(pageRequest: PageRequest): MapTokens.TableQuery = {
-    MapTokens
+    mapTokens
       .drop(pageRequest.offset * pageRequest.limit)
       .take(pageRequest.limit)
   }
 
   def filterByProject(projectId: Option[UUID]): MapTokens.TableQuery = {
     projectId match {
-      case Some(id) => MapTokens.filter(_.projectId === id)
-      case _ => MapTokens
+      case Some(id) => mapTokens.filter(_.projectId === id)
+      case _ => mapTokens
     }
   }
 
   def filterByName(name: Option[String]): MapTokens.TableQuery = {
     name match {
-      case Some(s) => MapTokens.filter(_.name === s)
-      case _ => MapTokens
+      case Some(s) => mapTokens.filter(_.name === s)
+      case _ => mapTokens
     }
   }
 }


### PR DESCRIPTION
## Overview

Follow up to #1243 -- only realized the filtering based on projects, others was broken. This was due to using the wrong value for the filters (each filter started with a new table query) so only the last filter was used.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~

### Demo

![no-filter](https://cloud.githubusercontent.com/assets/898060/23917078/9b544c5e-08c4-11e7-9b9f-dbe28a647d90.png)
![with-filter](https://cloud.githubusercontent.com/assets/898060/23917077/9b537f9a-08c4-11e7-80df-378528b8b921.png)

## Testing Instructions

 * Add map tokens for two different projects
 * Make a request using no project filter and make one with one
