### PR TITLE
Populate blog posts on homepage

### DIFF
--- a/app-backend/api/src/main/scala/Router.scala
+++ b/app-backend/api/src/main/scala/Router.scala
@@ -19,6 +19,7 @@ import com.azavea.rf.api.toolrun.ToolRunRoutes
 import com.azavea.rf.api.grid.GridRoutes
 import com.azavea.rf.api.datasource.DatasourceRoutes
 import com.azavea.rf.api.maptoken.MapTokenRoutes
+import com.azavea.rf.api.feed.FeedRoutes
 import com.azavea.rf.api.utils.Config
 
 /**
@@ -43,6 +44,7 @@ trait Router extends HealthCheckRoutes
     with GridRoutes
     with DatasourceRoutes
     with MapTokenRoutes
+    with FeedRoutes
     with Config {
 
   val corsSettings = CorsSettings.defaultSettings
@@ -65,7 +67,8 @@ trait Router extends HealthCheckRoutes
       pathPrefix("tool-runs") { toolRunRoutes } ~
       pathPrefix("scene-grid") { gridRoutes } ~
       pathPrefix("datasources") { datasourceRoutes } ~
-      pathPrefix("map-tokens") { mapTokenRoutes }
+      pathPrefix("map-tokens") { mapTokenRoutes } ~
+      pathPrefix("feed") { feedRoutes }
     } ~
     pathPrefix("config") {
       configRoutes

--- a/app-backend/api/src/main/scala/feed/Routes.scala
+++ b/app-backend/api/src/main/scala/feed/Routes.scala
@@ -1,0 +1,69 @@
+package com.azavea.rf.api.feed
+
+import akka.http.scaladsl.Http
+import akka.http.scaladsl.model.HttpMethods._
+import akka.http.scaladsl.model._
+import akka.http.scaladsl.model.Uri.{Path, Query}
+import akka.http.scaladsl.server.Route
+import akka.http.scaladsl.unmarshalling._
+
+import com.azavea.rf.common.UserErrorHandler
+
+import com.github.blemale.scaffeine.{AsyncLoadingCache, Scaffeine}
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+import scala.concurrent.duration._
+
+import com.typesafe.scalalogging.LazyLogging
+import com.github.blemale.scaffeine.{AsyncLoadingCache, Scaffeine}
+
+trait FeedRoutes extends UserErrorHandler {
+  val feedRoutes: Route = handleExceptions(userExceptionHandler) {
+    pathEndOrSingleSlash {
+      get { complete { FeedService.getFeed() }}
+    }
+  }
+}
+
+object FeedService extends LazyLogging {
+  import com.azavea.rf.api.AkkaSystem._
+
+  val feedCache: AsyncLoadingCache[Int, String] =
+    Scaffeine()
+      .expireAfterWrite(1.hours)
+      .maximumSize(1)
+      .buildAsyncFuture((i: Int) => fetchFeed())
+
+  val gidUri = Uri("https://medium.com/m/global-identity?redirectUrl=https://blog.rasterfoundry.com/latest?format=json")
+  def fetchFeed(): Future[String] = {
+    Http()
+      .singleRequest(HttpRequest(method = GET, uri = gidUri))
+      .flatMap {
+        case HttpResponse(StatusCodes.Found, headers, _, _) =>
+          val location: Option[HttpHeader] = headers.find((header) => header.is("location"))
+          location match {
+            case Some(loc: HttpHeader) =>
+              Http()
+                .singleRequest(
+                  HttpRequest(
+                    method = GET,
+                    uri = loc.value,
+                    entity = HttpEntity(ContentTypes.`application/json`, "")
+                  )
+                )
+                .flatMap {
+                  case HttpResponse(StatusCodes.OK, _, entity, _) =>
+                    Unmarshal(entity).to[String]
+                  case HttpResponse(errCode, _, error, _) =>
+                    throw new Exception(s"Error fetching feed: $errCode, $error")
+                }
+            case _ =>
+              throw new Exception("Error fetching feed: Unable to obtain global id for request")
+          }
+      }
+  }
+
+  def getFeed(): Future[String] = {
+    feedCache.get(1)
+  }
+}

--- a/app-backend/api/src/main/scala/feed/package.scala
+++ b/app-backend/api/src/main/scala/feed/package.scala
@@ -1,0 +1,4 @@
+package com.azavea.rf.api
+
+package object feed extends RfJsonProtocols {
+}

--- a/app-frontend/src/app/core/core.module.js
+++ b/app-frontend/src/app/core/core.module.js
@@ -19,6 +19,7 @@ require('./services/toolTag.service')(shared);
 require('./services/user.service')(shared);
 require('./services/storage.service')(shared);
 require('./services/mapUtils.service')(shared);
+require('./services/feed.service')(shared);
 
 require('./services/featureFlagOverrides.service')(shared);
 require('./services/featureFlags.provider')(shared);

--- a/app-frontend/src/app/core/services/feed.service.js
+++ b/app-frontend/src/app/core/services/feed.service.js
@@ -1,0 +1,36 @@
+export default (app) => {
+    class FeedService {
+        constructor($resource, $q, $http) {
+            'ngInject';
+
+            this.$q = $q;
+            this.$http = $http;
+        }
+
+        getPosts() {
+            return this.$q((resolve, reject) => {
+                this.$http({
+                    method: 'GET',
+                    url: '/api/feed'
+                }).then(response => {
+                    let raw = response.data;
+                    try {
+                        let json = JSON.parse(raw.substring(raw.indexOf('{')));
+                        let payload = json.payload;
+                        if (payload && payload.posts) {
+                            resolve(payload.posts);
+                        } else {
+                            reject();
+                        }
+                    } catch (err) {
+                        reject();
+                    }
+                }, () => {
+                    reject();
+                });
+            });
+        }
+    }
+
+    app.service('feedService', FeedService);
+};

--- a/app-frontend/src/app/pages/home/home.controller.js
+++ b/app-frontend/src/app/pages/home/home.controller.js
@@ -1,12 +1,15 @@
 class HomeController {
-    constructor(authService, $uibModal) {
+    constructor(authService, $uibModal, feedService) {
         'ngInject';
         this.authService = authService;
         this.$uibModal = $uibModal;
+        this.feedService = feedService;
     }
 
     $onInit() {
-
+        this.feedService.getPosts().then(posts => {
+            this.blogPosts = posts;
+        });
     }
 
     $onDestroy() {

--- a/app-frontend/src/app/pages/home/home.html
+++ b/app-frontend/src/app/pages/home/home.html
@@ -74,18 +74,13 @@
               </div>
             </div>
           </div>
-          <div class="sidebar-section">
+          <div class="sidebar-section" ng-if="$ctrl.blogPosts">
             <div class="sidebar-row">
               <h3 class="no-margin">From our blog</h3>
             </div>
-            <div class="sidebar-row">
-              <a>A blog post...</a>
-            </div>
-            <div class="sidebar-row">
-              <a>A blog post...</a>
-            </div>
-            <div class="sidebar-row">
-              <a>A blog post...</a>
+            <div class="sidebar-row" ng-repeat="post in $ctrl.blogPosts">
+              <a ng-href="https://blog.rasterfoundry.com/{{post.uniqueSlug}}"
+                 target="about:blank">{{post.title}}</a>
             </div>
           </div>
         </div>

--- a/docs/swagger/spec.yml
+++ b/docs/swagger/spec.yml
@@ -1208,7 +1208,14 @@ paths:
       responses:
         204:
           description: Successfully deleted a tool run
-
+  /feed/:
+    get:
+      summary: Get the cached RSS feed
+      tags:
+        - Users
+      responses:
+        200:
+          description: RSS feed json as a string
 
 parameters:
 


### PR DESCRIPTION
## Overview

Populate blog posts on the homepage from the rss feed

### Checklist

~- [ ] Styleguide updated, if necessary~
- [x] Swagger specification updated, if necessary
~- [ ] Symlinks from new migrations present or corrected for any new migrations~

### Demo

![image](https://cloud.githubusercontent.com/assets/4392704/23968540/7d590066-0999-11e7-860c-11dcd1206753.png)

### Notes

I had to proxy the requests through our backend to get around CORs. This does let us cache it though, which is nice since their api tends to be inconsistent (250ms - 3000ms in my testing)

## Testing Instructions

 * Load the homepage and verify that blog posts appear once they load

Closes #1247 
