### PR TITLE
Authorize Tile Access with Map Tokens

### DIFF
--- a/app-backend/common/src/main/scala/Authentication.scala
+++ b/app-backend/common/src/main/scala/Authentication.scala
@@ -62,6 +62,15 @@ trait Authentication extends Directives {
   }
 
   /**
+    * Validates a token parameter and returns true if valid, false otherwise
+    */
+  def isTokenParameterValid: Directive1[Boolean] = {
+    parameter('token).flatMap { token =>
+      provide(Jwt.isValid(token, auth0Secret, Seq(JwtAlgorithm.HS256)))
+    }
+  }
+
+  /**
     * Validates token header, if valid returns token else rejects request
     */
   def validateTokenHeader: Directive1[String] = {

--- a/app-backend/database/src/main/scala/com/azavea/rf/database/ActionRunner.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/ActionRunner.scala
@@ -34,6 +34,9 @@ trait ActionRunner {
   def readOne[T](a: DBIO[Option[T]])(implicit database: DB): Future[Option[T]] =
     database.db.run(a)
 
+  def readOneDirect[T](a: DBIO[T])(implicit database: DB): Future[T] =
+    database.db.run(a)
+
   def write[T](a: DBIO[T])(implicit database: DB): Future[T] = database.db.run(a)
 
   def update(a: DBIO[Int])(implicit database: DB): Future[Int] = database.db.run(a)

--- a/app-backend/tile/src/main/scala/Router.scala
+++ b/app-backend/tile/src/main/scala/Router.scala
@@ -47,9 +47,14 @@ class Router extends LazyLogging
       } ~
       tileAuthenticateOption { _ =>
         SceneRoutes.root ~
-        MosaicRoutes.mosaicProject(database) ~
         pathPrefix("tools") {
           ToolRoutes.root(database)
+        }
+      } ~
+      pathPrefix(JavaUUID) { projectId =>
+        tileAccessAuthorized(projectId) {
+          case true => MosaicRoutes.mosaicProject(projectId)(database)
+          case _ => reject(AuthorizationFailedRejection)
         }
       }
     }


### PR DESCRIPTION
## Overview

This expands tile request authorization to include map tokens and tile visibility settings.

When a request comes in, we first check if it has a `token` parameter. This corresponds to the current method of specifying JWT in the query string, and is present for backward compatibility. This is also checked first since JWT authentication doesn't require a database call, and may potentially be quicker. If the request contains a `mapToken` parameter, we check to see if that corresponds with the `projectId` in the path. Finally, if neither is specified, we check to see if the project's `tileVisibility` is set to `Public`. If none of these conditions are satisfied, we reject the request with a `403`.

Authorization is evaluated in the order of: `token` JWT, `mapToken`, `project.tileVisibility`. Thus, if more than one apply, but an earlier one fails, the result is a `403`. For example, if request supplies an incorrect `token` but a correct `mapToken`, it would fail, but vice versa would succeed. Similarly, if a request specifies an incorrect `mapToken`, the request would fail even if the underlying project has `Public` `tileVisibility`. We err on the side of restrictiveness. These policies can be updated in the future with user feedback.

### Checklist

~~- [ ] Styleguide updated, if necessary~~
~~- [ ] Swagger specification updated, if necessary~~
~~- [ ] Symlinks from new migrations present or corrected for any new migrations~~

### Demo

###### With `token` query parameter:

```http
> http :9100/tiles/27fe6068-a7b6-45ff-b339-7ae185b797dc/7/59/53/ token==$RF_JWT
HTTP/1.1 200 OK
Connection: keep-alive
Content-Length: 1666
Content-Type: image/png
Date: Wed, 15 Mar 2017 21:47:57 GMT
Server: nginx
Strict-Transport-Security: max-age=15552000; preload
X-Content-Type-Options: nosniff
X-Frame-Options: SAMEORIGIN
X-XSS-Protection: 1; mode=block



+-----------------------------------------+
| NOTE: binary data not shown in terminal |
+-----------------------------------------+
```

###### With `mapToken` query parameter:

```http
> http :9100/tiles/27fe6068-a7b6-45ff-b339-7ae185b797dc/7/59/53/ mapToken==0b8e0935-b79f-4bfa-a19c-0d98f6198497
HTTP/1.1 200 OK
Connection: keep-alive
Content-Length: 1666
Content-Type: image/png
Date: Wed, 15 Mar 2017 22:06:22 GMT
Server: nginx
Strict-Transport-Security: max-age=15552000; preload
X-Content-Type-Options: nosniff
X-Frame-Options: SAMEORIGIN
X-XSS-Protection: 1; mode=block



+-----------------------------------------+
| NOTE: binary data not shown in terminal |
+-----------------------------------------+
```

###### Accessing a project with `tileVisibility` set to `Private`:

```http
> http :9100/tiles/27fe6068-a7b6-45ff-b339-7ae185b797dc/7/59/53/
HTTP/1.1 403 Forbidden
Connection: keep-alive
Content-Length: 69
Content-Type: text/plain; charset=UTF-8
Date: Wed, 15 Mar 2017 22:07:26 GMT
Server: nginx
Strict-Transport-Security: max-age=15552000; preload
X-Content-Type-Options: nosniff
X-Frame-Options: SAMEORIGIN
X-XSS-Protection: 1; mode=block

The supplied authentication is not authorized to access this resource
```

###### Accessing a project with `tileVisibility` set to `Public`:

```http
> http :9100/tiles/27fe6068-a7b6-45ff-b339-7ae185b797dc/7/59/53/
HTTP/1.1 200 OK
Connection: keep-alive
Content-Length: 1666
Content-Type: image/png
Date: Wed, 15 Mar 2017 22:08:04 GMT
Server: nginx
Strict-Transport-Security: max-age=15552000; preload
X-Content-Type-Options: nosniff
X-Frame-Options: SAMEORIGIN
X-XSS-Protection: 1; mode=block



+-----------------------------------------+
| NOTE: binary data not shown in terminal |
+-----------------------------------------+
```

### Notes

We make three new directives for authorizing the requests. These directives are composed into a single one, in the order described above. The `|` composing operator selects at most one of the component directives, thus there is no fall-through on failure by an earlier directive. This serves our restrictive design well.

An attempt was made at defining a single directive with multiple `case` statements for each block. I thought this PR's design, of defining individual directives and composing them, was more idiomatic of AKKA HTTP thus am submitting this, but if we prefer the other one we should switch to that.

The other approach is in the branch [`feature/tt/map-token-authorization-2`](https://github.com/azavea/raster-foundry/tree/feature/tt/map-token-authorization-2), and the main difference is this:

```scala
def tileAccessAuthorized(projectId: UUID): Directive1[Boolean] = {
  parameters('token.?, 'mapToken.?).tflatMap {
    case (Some(token), None) => provide(isTokenParameterValid(token))
    case (_, Some(mapToken)) => {
      val mapTokenId = UUID.fromString(mapToken)
      onSuccess(readOneDirect(MapTokens.validateMapToken(projectId, mapTokenId))).flatMap {
        case 1 => provide(true)
        case _ => provide(false)
      }
    }
    case _ => onSuccess(Projects.getProject(projectId)).flatMap {
      case Some(project) => provide(project.tileVisibility == Visibility.Public)
      case _ => provide(false)
    }
  }
}
```

as opposed to this PR's

```scala
def tileAccessAuthorized(projectId: UUID): Directive1[Boolean] =
  isTokenParameterValid | isMapTokenValid(projectId) | isProjectPublic(projectId)
```

with the component directives declared elsewhere.

I didn't update the Swagger Spec because we don't seem to have one corresponding to the `/tiles` endpoint.

## Testing Instructions

 * Check out this branch and run `./scripts/server`
 * Create a project if you don't already have one
 * Try to access a tile from the project, without any query parameters. Ensure you get a 403.
 * Try to access the tile using your JWT in the `token` query parameter. Ensure you get a 200 and the tile is returned.
 * Create a map token for the project. Try to access the tile using this new map token's id in the `mapToken` query parameter. Ensure you get a 200 and the tile is returned.
 * Update the project's `tileVisibility` to `Public`. Try to access the tile without any query parameters. Ensure you get a 200 and the tile is returned.

Connects #1209 