### PR TITLE
Include both database and auth0 users in /me endpoint

### DIFF
--- a/docs/swagger/spec.yml
+++ b/docs/swagger/spec.yml
@@ -79,7 +79,7 @@ paths:
         200:
           description: Profile found
           schema:
-            $ref: '#/definitions/Auth0User'
+            $ref: '#/definitions/UserWithOAuth'
         default:
           description: Unexpected error
           schema:
@@ -1658,6 +1658,13 @@ definitions:
         description: List of organization\'s a user belongs to and their level of membership
         items:
           $ref: '#/definitions/UserOrg'
+  UserWithOAuth:
+    type: object
+    properties:
+      user:
+        $ref: '#/definitions/User'
+      oauth:
+        $ref: '#/definitions/Auth0User'
   Auth0User:
     type: object
     properties:


### PR DESCRIPTION
## Overview
Include db and auth0 info in the /me endpoint

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [x] Swagger specification updated, if necessary


### Demo
```json
{
  "user": {
    "id": "google-oauth2|116753943799198027869",
    "organizations": [
      {
        "id": "dfac6307-b5ef-43f7-beda-b9f208bb7726",
        "name": "Public",
        "role": "Viewer"
      }
    ]
  },
  "oauth": {
    "name": "Lucien Knechtli",
    "user_metadata": {
      "1": {
        "label": "Label goes here",
        "value": "Value goes here"
      }
    },
    "email_verified": true,
    "email": "lknechtli@azavea.com",
    "family_name": "Knechtli",
    "user_id": "google-oauth2|116753943799198027869",
    "identities": [
      {
        "provider": "google-oauth2",
        "user_id": "116753943799198027869",
        "connection": "google-oauth2",
        "isSocial": true
      }
    ],
    "picture": "https://lh3.googleusercontent.com/-bkBBxMfFOT8/AAAAAAAAAAI/AAAAAAAAAQo/INgNG0lFKS0/photo.jpg",
    "created_at": "2017-02-15T21:07:40.585Z",
    "updated_at": "2017-03-16T18:06:00.671Z",
    "given_name": "Lucien",
    "nickname": "lknechtli"
  }
}
```

### Notes

I don't like the names I've chosen for the case class / fields in the object, but I can't think of anything better. Suggestions are welcome


## Testing Instructions

 * Make a request to `/api/users/me` with a valid bearer token, and verify that the response looks correct

Closes#844 
