### PR TITLE
Improve Non-Azavea Provisioning

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,0 +1,39 @@
+# Development Settings
+POSTGRES_USER=rasterfoundry
+POSTGRES_PASSWORD=rasterfoundry
+POSTGRES_DB=rasterfoundry
+AIRFLOW_POSTGRES_DB=airflow
+AIRFLOW_DAG_CONCURRENCY=4
+
+# Rollbar Support
+ROLLBAR_API_TOKEN=PLACEHOLDER
+ENVIRONMENT=development
+
+# Auth0 Settings for development
+AUTH0_DOMAIN=PLACEHOLDER
+AUTH0_CLIENT_ID=PLACEHOLDER
+AUTH0_CLIENT_SECRET=PLACEHOLDER
+AUTH0_MANAGEMENT_CLIENT_ID=PLACEHOLDER
+AUTH0_MANAGEMENT_SECRET=PLACEHOLDER
+
+# AWS Profile to use for AWS SDK
+AWS_PROFILE=PLACEHOLDER
+AWS_DEFAULT_REGION=us-east-1
+
+# AWS Resources
+# S3 Bucket - where Raster RDDs are stored to power the tile server
+TILE_SERVER_BUCKET=PLACEHOLDER
+
+# S3 Bucket - stores generated thumbnails
+THUMBNAIL_BUCKET=PLACEHOLDER
+
+# S3 Bucket - stores preprocessed data uploaded by users
+DATA_BUCKET=PLACEHOLDER
+
+# Batch settings for ingest job and queues - these can be generated manually by following
+# instructions available in the AWS documentation on Batch.
+# http://docs.aws.amazon.com/batch/latest/userguide/Batch_GetStarted.html
+# NOTE: This is only necessary if you intend to run ingest jobs, if you are only updating
+# the UI and need the server component, this is not necessary
+BATCH_INGEST_JOB_NAME=PLACEHOLDER
+BATCH_INGEST_JOB_QUEUE=PLACEHOLDER

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,18 +7,24 @@ node {
       checkout scm
     }
 
+    env.AWS_DEFAULT_REGION = 'us-east-1'
+    env.RF_ARTIFACTS_BUCKET = 'rasterfoundry-global-artifacts-us-east-1'
+
     // Execute `cibuild` wrapped within a plugin that translates
     // ANSI color codes to something that renders inside the Jenkins
     // console.
     stage('cibuild') {
+
+      // Override Settings bucket for testing
+      env.RF_SETTINGS_BUCKET = 'rasterfoundry-testing-config-us-east-1'
       wrap([$class: 'AnsiColorBuildWrapper']) {
         sh 'scripts/cibuild'
       }
     }
 
+    env.RF_SETTINGS_BUCKET = 'rasterfoundry-staging-config-us-east-1'
+
     if (env.BRANCH_NAME == 'develop' || env.BRANCH_NAME.startsWith('release/')) {
-      env.AWS_DEFAULT_REGION = 'us-east-1'
-      env.RF_SETTINGS_BUCKET = 'rasterfoundry-staging-config-us-east-1'
 
       // Publish container images built and tested during `cibuild`
       // to the private Amazon Container Registry tagged with the

--- a/README.md
+++ b/README.md
@@ -10,18 +10,47 @@ A virtual machine is used to encapsulate Docker dependencies. `docker-compose` i
 - VirtualBox 5.0+
 - Ansible 1.8+ (on host)
 - AWS CLI 1.10+
+- AWS Account (to store artifacts, secrets)
+- [Auth0 Account](https://auth0.com/) (user management)
+- [Rollbar Account](https://rollbar.com/) (error reporting -- optional)
 
-On your host machine you need to set up a `raster-foundry` profile for the Raster Foundry AWS account using the following command:
+#### Setting Up AWS Account
 
+There are a set of tasks necessary before starting development in order to provision Raster Foundry. Raster Foundry depends heavily on AWS resources and using AWS resources to manage secrets/containers/artifacts in development. If only local development is being done, the primary resource that will be used are S3 buckets to store secrets.
+
+In the AWS account you need to create a few buckets for the following:
+ - A bucket to house raw data (e.g. geotiffs, JPEG2000, ingest definitions, etc.)
+ - A config bucket that will store secrets for development and or other environments, an exported database for development data
+ - A bucket to house processed data (e.g. thumbnails, processed raster RDDs)
+
+The names of the buckets are not important, but they should be memorable and easy to parse for your own sake. On your host machine you need to set up an AWS profile for the account with the S3 buckets. For instance, to set up an AWS profile called `raster-foundry` with the AWS cli the following command would be used:
 ```
 $ aws configure --profile raster-foundry
 ```
 
 You will be prompted for an access key and secret key.
 
+#### Setting Development Environment Variables
+
+The `.env.template` file is a template file with environemnt variables that get injected into running containers during development. This file should be copied into the AWS config bucket created after filling in sensitive information (replacing all `PLACEHOLDER` values with appropriate values for your AWS setup). When provisioning this file is copied to the development environment and injected into containers with `docker-compose`.
+
+In addition to setting up an AWS account, you must register for an Auth0 account to produce secrets to use in the `.env` file. You need to go through setting up an application and copying over the client IDs, domain, and secret.
+
+Additionally, if you want to exercise token management in the application, you need to generate a management API app to handle managing the generation of [refresh tokens for users via the management API](https://auth0.com/docs/api/management/v2/tokens). This is not necessary for most functionality in the application and can be deferred until later if you desire.
+
+The last thing to set up with Auth0 are the allowed callback URLs and logout URLs. These need to be edited to allow interaction for local development from `localhost:9091` and `localhost:9100`.
+
 ### Development
 
-_tldr_
+Vagrant is used to manage VirtualBox provisioning and configuration. Raster Foundry follows the approach outlined [here](https://githubengineering.com/scripts-to-rule-them-all/) ("Scripts to Rule Them All") to have as consistent a development experience as possible. Almost all interaction with consoles and servers can be managed via calls to a script located in `./scripts`. Default values for the S3 config and data buckets in addition to AWS profile will be used if they are not set with an environment variable. Before running vagrant, these should be injected into your shell environment:
+```bash
+export RF_AWS_PROFILE=raster-foundry
+export RF_SETTINGS_BUCKET=rf-dev-config-us-east-1
+export RF_ARTIFACTS_BUCKET=rf-global-artifacts-us-east-1
+```
+
+After exporting your environment settings, you are ready to get started:
+
 ```bash
 $ vagrant up
 $ vagrant ssh
@@ -31,6 +60,8 @@ $ ./scripts/server
 Use `vagrant up` to provision a virtual machine. During provisioning `docker` and `docker-compose` will be installed on the guest machine. Additionally, docker images will be downloaded for the database and created for the `akka-http` application server.
 
 Once the machine is provisioned you can start services or development by ssh-ing into the machine (`vagrant ssh`) and using the helper scripts in the `/opt/raster-foundry/scripts` directory.
+
+If you do not have a development database to seed your database with, you will need to initialize the database with `mg init` inside an `sbt` console `./scripts/console api-server ./sbt`
 
 Development workflow varies by developer, but a typical development experience might include the following:
 
@@ -62,7 +93,7 @@ To do frontend development you will want to install [`nvm`](https://github.com/c
 
 Then _outside_ the VM, while the server is still running, run `yarn run start` while inside the `app-frontend/` directory. This will start a `webpack-dev-server` on port 9091 that will auto-reload after javascript and styling changes.
 
-There are three options to rebuild the static assets served by Nginx:
+The two options to rebuild the static assets served by Nginx:
 
  - Run `yarn run build` outside the VM
  - Run `./scripts/console app-frontend "yarn run build"`
@@ -71,7 +102,6 @@ There are three options to rebuild the static assets served by Nginx:
 To run tests you can do one of the following (in order of speed):
 
  - Run `yarn run test` outside the VM (or `yarn run test-watch`)
- - Run `./scripts/console app-frontend "yarn run test"` inside the VM
  - Run `./scripts/test` inside the VM (will also run additional project tests)
 
 ## Ports

--- a/deployment/ansible/raster-foundry.yml
+++ b/deployment/ansible/raster-foundry.yml
@@ -19,6 +19,15 @@
       lineinfile: dest=/etc/environment regexp=^AWS_PROFILE line="AWS_PROFILE={{aws_profile}}"
       when: aws_profile is defined
 
+    - name: Set Environment variable for Raster Foundry AWS Config Bucket
+      lineinfile: dest=/etc/environment regexp=^RF_SETTINGS_BUCKET line="RF_SETTINGS_BUCKET={{rf_settings_bucket}}"
+      when: rf_aws_settings_bucket is defined
+
+    - name: Set Environment variable for Raster Foundry AWS Artifacts Bucket
+      lineinfile: dest=/etc/environment regexp=^RF_ARTIFACTS_BUCKET
+                  line="RF_ARTIFACTS_BUCKET={{rf_artifacts_bucket}}"
+      when: rf_aws_artifacts_bucket is defined
+
     - name: Set Environment variable for host user (used to namespace jars and other artifacts in development)
       lineinfile: dest=/etc/environment regexp=^RF_HOST_USER line="RF_HOST_USER={{host_user}}"
       when: host_user is defined

--- a/scripts/bootstrap
+++ b/scripts/bootstrap
@@ -19,7 +19,7 @@ function main() {
     echo "Pulling down development environment..."
     pushd "${DIR}/.."
     # Download environment configuration from S3
-    aws s3 cp "s3://rasterfoundry-development-config-us-east-1/.env" ".env"
+    aws s3 cp "s3://${RF_SETTINGS_BUCKET}/.env" ".env"
     popd
 
     echo "Building/Pulling containers..."

--- a/scripts/cibuild
+++ b/scripts/cibuild
@@ -27,7 +27,7 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
     else
         echo "Pulling down configuration settings for test environment"
         pushd "${DIR}/.."
-        aws s3 cp "s3://rasterfoundry-testing-config-us-east-1/.env" ".env"
+        aws s3 cp "s3://${RF_SETTINGS_BUCKET}/.env" ".env"
         popd
 
         echo "Building static asset bundle"

--- a/scripts/cipublish
+++ b/scripts/cipublish
@@ -84,7 +84,7 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
             echo "Uploading Spark Ingest JAR to S3"
             aws s3 cp \
                 "${DIR}/../app-backend/ingest/target/scala-2.11/rf-ingest.jar" \
-                "s3://rasterfoundry-global-artifacts-us-east-1/ingest/rf-ingest-${GIT_COMMIT}.jar"
+                "s3://${RF_ARTIFACTS_BUCKET}/ingest/rf-ingest-${GIT_COMMIT}.jar"
         else
             echo "ERROR: No AWS_ECR_ENDPOINT variable defined."
             exit 1

--- a/scripts/load_development_data
+++ b/scripts/load_development_data
@@ -22,7 +22,8 @@ function load_database_backup() {
     check_database
 
     pushd "${DIR}/.."
-    aws s3 cp "s3://rasterfoundry-development-config-us-east-1/database.pgdump" "data/database.pgdump"
+    echo "Downloading database from s3"
+    aws s3 cp "s3://${RF_SETTINGS_BUCKET}/database.pgdump" "data/database.pgdump"
     popd
 
     echo "Drop rasterfoundry database"


### PR DESCRIPTION
## Overview
This PR is to improve the provisioning of Raster Foundry for developers that do not have access to AWS resources. It replaces areas where resource names are hardcoded with configurable resource names via environment variables.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~

### Demo

Optional. Screenshots, `curl` examples, etc.

### Notes

I think this hits a nice medium ground between easing development for non-Azaveans while ensuring that setup is not particularly difficult. Some experience with AWS is assumed, but I think if there are blind spots in the documentation that can be remedied.

## Testing Instructions

 * Provision from this branch
 * Ensure the application runs as expected
 * Verify instructions make sense

Closes #810 and #1241 
