### PR TITLE
Remove foul language from project source code

### DIFF
--- a/app-backend/tool/src/main/scala/Parse.scala
+++ b/app-backend/tool/src/main/scala/Parse.scala
@@ -48,10 +48,10 @@ class DivParser extends RootJsonReader[Op] {
     json match {
       case obj: JsObject =>
         ??? // named argument list
-        // get HMap of JsReader for shit, use it to parse, delicate
+        // get HMap of JsReader for stuff, use it to parse, delicate
       case arr: JsArray =>
         ??? // positional argument list
-        // get HList of JsReader for shit, use it to parse, deligate
+        // get HList of JsReader for stuff, use it to parse, deligate
       case _ =>
         throw new DeserializationException(s"Expected argument list, found: $json")
     }

--- a/app-frontend/src/assets/styles/sass/components/_modal.scss
+++ b/app-frontend/src/assets/styles/sass/components/_modal.scss
@@ -5,7 +5,7 @@
 // .modal-open      - body class for killing the scroll
 // .modal           - container to scroll within
 // .modal-dialog    - positioning shell for the actual modal
-// .modal-content   - actual modal w/ bg and corners and shit
+// .modal-content   - actual modal w/ bg and corners and stuff
 
 // Kill the scroll on the body
 .modal-open {

--- a/app-frontend/src/assets/styles/sass/layout/_container.scss
+++ b/app-frontend/src/assets/styles/sass/layout/_container.scss
@@ -1,7 +1,7 @@
 /*
  Fix this.
  the wrapper is preventing the library pages from working correctly. Columns arent stretching.
- If this is removed than map pages become broken. its fucked as is.
+ If this is removed than map pages become broken. its broken as is.
  */
 .app-wrapper {
   //height: 100%;

--- a/docs/swagger/swagger-ui.js
+++ b/docs/swagger/swagger-ui.js
@@ -16853,7 +16853,7 @@ var hasIntrospection = (function(){'_';}).toString().indexOf('_') > -1,
     needCheckProps = true,
     testPropObj = { toString : '' };
 
-for(var i in testPropObj) { // fucking ie hasn't toString, valueOf in for
+for(var i in testPropObj) { // ie hasn't toString, valueOf in for
     testPropObj.hasOwnProperty(i) && (needCheckProps = false);
 }
 

--- a/prototype/app/assets/sass/components/_modal.scss
+++ b/prototype/app/assets/sass/components/_modal.scss
@@ -5,7 +5,7 @@
 // .modal-open      - body class for killing the scroll
 // .modal           - container to scroll within
 // .modal-dialog    - positioning shell for the actual modal
-// .modal-content   - actual modal w/ bg and corners and shit
+// .modal-content   - actual modal w/ bg and corners and stuff
 
 // Kill the scroll on the body
 .modal-open {


### PR DESCRIPTION
## Overview

Remove any instances of foul language based on the outputs of the `alex` command line tool.

See: https://github.com/wooorm/alex

## Testing Instructions

I ran the following commands against the repository to identify possibly infractions based on the rules encoded into `alex`. From there, I evaluated the output and manually removed a subset of the detected infractions:

```bash
$ find . -name "*.js" -type f | xargs alex
$ find . -name "*.scala" -type f | xargs alex
$ find . -name "*.py" -type f | xargs alex
$ find . -name "*.scss" -type f | xargs alex
```