### PR TITLE
Bump Terraform version on Jenkins to 0.9.1

### DIFF
--- a/deployment/ansible/group_vars/jenkins
+++ b/deployment/ansible/group_vars/jenkins
@@ -3,6 +3,6 @@ docker_users:
   - "{{ ansible_user }}"
   - "{{ jenkins_name }}"
 
-terraform_version: "0.8.7"
+terraform_version: "0.9.1"
 
 java_version: "7u121*"


### PR DESCRIPTION
## Overview

Upgrade the version of Terraform used on Jenkins to 0.9.1. This change coincides with the Terraform configuration changes in https://github.com/azavea/raster-foundry-deployment/pull/35.

## Testing Instructions

After SSHing into the Jenkins host, execute the following command and ensure that 0.9.1 is the reported version:

```bash
ubuntu@ip-172-31-52-80:~$ terraform -v
Terraform v0.9.1
```