### PR TITLE
Add Upload Credentials Endpoint for Scoped S3 Folder

### DIFF
--- a/app-backend/api/src/main/resources/application.conf
+++ b/app-backend/api/src/main/resources/application.conf
@@ -50,6 +50,7 @@ auth0 {
 }
 
 s3 {
+  dataBucket = ${?DATA_BUCKET}
   thumbnailBucket = ${?THUMBNAIL_BUCKET}
 }
 

--- a/app-backend/api/src/main/resources/application.conf
+++ b/app-backend/api/src/main/resources/application.conf
@@ -51,6 +51,7 @@ auth0 {
 
 s3 {
   dataBucket = ${?DATA_BUCKET}
+  userUploadPath = "user-uploads"
   thumbnailBucket = ${?THUMBNAIL_BUCKET}
 }
 

--- a/app-backend/api/src/main/scala/Router.scala
+++ b/app-backend/api/src/main/scala/Router.scala
@@ -20,6 +20,7 @@ import com.azavea.rf.api.grid.GridRoutes
 import com.azavea.rf.api.datasource.DatasourceRoutes
 import com.azavea.rf.api.maptoken.MapTokenRoutes
 import com.azavea.rf.api.feed.FeedRoutes
+import com.azavea.rf.api.upload.UploadRoutes
 import com.azavea.rf.api.utils.Config
 
 /**
@@ -45,6 +46,7 @@ trait Router extends HealthCheckRoutes
     with DatasourceRoutes
     with MapTokenRoutes
     with FeedRoutes
+    with UploadRoutes
     with Config {
 
   val corsSettings = CorsSettings.defaultSettings
@@ -68,6 +70,7 @@ trait Router extends HealthCheckRoutes
       pathPrefix("scene-grid") { gridRoutes } ~
       pathPrefix("datasources") { datasourceRoutes } ~
       pathPrefix("map-tokens") { mapTokenRoutes } ~
+      pathPrefix("uploads") { uploadRoutes } ~
       pathPrefix("feed") { feedRoutes }
     } ~
     pathPrefix("config") {

--- a/app-backend/api/src/main/scala/upload/Routes.scala
+++ b/app-backend/api/src/main/scala/upload/Routes.scala
@@ -1,0 +1,30 @@
+package com.azavea.rf.api.upload
+
+import java.util.UUID
+
+import akka.http.scaladsl.server.Route
+import com.azavea.rf.common.{Authentication, STS, UserErrorHandler}
+import com.azavea.rf.database.Database
+import com.azavea.rf.api.utils.Config
+
+
+trait UploadRoutes extends Authentication
+  with Config
+  with UserErrorHandler {
+
+  implicit def database: Database
+
+  val uploadRoutes: Route = handleExceptions(userExceptionHandler) {
+    pathPrefix(JavaUUID) { uploadId =>
+      pathPrefix("credentials") {
+        pathEndOrSingleSlash {
+          get { getUploadCredentials(uploadId) }
+        }
+      }
+    }
+  }
+
+  def getUploadCredentials(uploadId: UUID): Route = authenticate { _ =>
+    complete(STS.getCredentialsForUpload(uploadId.toString, dataBucket))
+  }
+}

--- a/app-backend/api/src/main/scala/upload/package.scala
+++ b/app-backend/api/src/main/scala/upload/package.scala
@@ -1,0 +1,7 @@
+package com.azavea.rf.api
+
+import com.azavea.rf.common.STS.Credentials
+
+package object upload extends RfJsonProtocols {
+  implicit val getFederationTokenResultFormat = jsonFormat4(Credentials)
+}

--- a/app-backend/api/src/main/scala/utils/Config.scala
+++ b/app-backend/api/src/main/scala/utils/Config.scala
@@ -22,5 +22,6 @@ trait Config {
   val featureFlags = featureFlagConfig.getConfigList("features")
 
   val dataBucket = s3Config.getString("dataBucket")
+  val userUploadPath = s3Config.getString("userUploadPath")
   val thumbnailBucket = s3Config.getString("thumbnailBucket")
 }

--- a/app-backend/api/src/main/scala/utils/Config.scala
+++ b/app-backend/api/src/main/scala/utils/Config.scala
@@ -21,5 +21,6 @@ trait Config {
 
   val featureFlags = featureFlagConfig.getConfigList("features")
 
+  val dataBucket = s3Config.getString("dataBucket")
   val thumbnailBucket = s3Config.getString("thumbnailBucket")
 }

--- a/app-backend/build.sbt
+++ b/app-backend/build.sbt
@@ -122,7 +122,8 @@ lazy val common = Project("common", file("common"))
     Dependencies.elasticacheClient,
     Dependencies.geotrellisS3,
     Dependencies.findbugAnnotations,
-    Dependencies.chill
+    Dependencies.chill,
+    Dependencies.awsSts
   )})
 
 lazy val migrations = Project("migrations", file("migrations"))

--- a/app-backend/common/src/main/scala/STS.scala
+++ b/app-backend/common/src/main/scala/STS.scala
@@ -1,0 +1,83 @@
+package com.azavea.rf.common
+
+import java.sql.Timestamp
+
+import com.amazonaws.regions.Regions
+import com.amazonaws.services.securitytoken.AWSSecurityTokenServiceClientBuilder
+import com.amazonaws.services.securitytoken.model.{GetFederationTokenRequest, Credentials => STSCredentials}
+
+package object STS {
+
+  case class Credentials (
+    AccessKeyId: String,
+    SecretAccessKey: String,
+    SessionToken: String,
+    Expiration: Timestamp
+  )
+
+  def toCredentials(result: STSCredentials): Credentials =
+    Credentials(
+      result.getAccessKeyId,
+      result.getSecretAccessKey,
+      result.getSessionToken,
+      new Timestamp(result.getExpiration.getTime)
+    )
+
+  def getCredentialsForUpload(uploadId: String, bucket: String): Credentials =
+    getCredentialsForUpload(uploadId, bucket, "user-uploads")
+
+  def getCredentialsForUpload(uploadId: String, bucket: String, path: String): Credentials =
+    getCredentialsForUpload(uploadId, bucket, path, Regions.US_EAST_1)
+
+  def getCredentialsForUpload(uploadId: String, bucket: String, path: String, regions: Regions): Credentials = {
+    val client = AWSSecurityTokenServiceClientBuilder.standard.withRegion(regions).build
+
+    // Federation user's name must be less than or equal to 32 characters.
+    // We set it to the uploadId uuid without hyphens, which is exactly 32 characters.
+    // We also cap it to 32 to be safe.
+    val userName = uploadId.filter(_ != '-').take(32)
+
+    // We give the Federation user ability to list objects within their folder,
+    // and upload, download, and delete objects within their folder.
+    // Policy must be less than or equal to 2048 bytes, so we remove all whitespace.
+    val policy =
+      s"""
+         |{
+         |  "Version": "2012-10-17",
+         |  "Statement": [
+         |    {
+         |      "Effect": "Allow",
+         |      "Action": [
+         |        "s3:ListBucket"
+         |      ],
+         |      "Resource": [
+         |        "arn:aws:s3:::${bucket}"
+         |      ],
+         |      "Condition": {
+         |        "StringLike": {
+         |          "s3:prefix": [
+         |            "${path}/${uploadId}/*"
+         |          ]
+         |        }
+         |      }
+         |    },
+         |    {
+         |      "Effect": "Allow",
+         |      "Action": [
+         |        "s3:GetObject",
+         |        "s3:PutObject",
+         |        "s3:DeleteObject"
+         |      ],
+         |      "Resource": [
+         |        "arn:aws:s3:::${bucket}/${path}/${uploadId}/*"
+         |      ]
+         |    }
+         |  ]
+         |}
+       """.stripMargin.filter(_ > ' ')
+
+    val request = new GetFederationTokenRequest(userName).withPolicy(policy)
+    val response = client.getFederationToken(request)
+    toCredentials(response.getCredentials)
+  }
+}

--- a/app-backend/project/Dependencies.scala
+++ b/app-backend/project/Dependencies.scala
@@ -46,4 +46,5 @@ object Dependencies {
   val circeParser             = "io.circe"                    %% "circe-parser"                      % Version.circe
   val circeOptics             = "io.circe"                    %% "circe-optics"                      % Version.circe
   val akkaCirceJson           = "de.heikoseeberger"           %% "akka-http-circe"                   % Version.akkaCirceJson
+  val awsSts                  = "com.amazonaws"                % "aws-java-sdk-sts"                  % Version.aws
 }

--- a/app-backend/project/Version.scala
+++ b/app-backend/project/Version.scala
@@ -30,4 +30,5 @@ object Version {
   val chill              = "0.9.2"
   val circe              = "0.7.0"
   val akkaCirceJson      = "1.12.0"
+  val aws                = "1.11.92"
 }


### PR DESCRIPTION
## Overview

Adds endpoint which fetches credentials allowing listing of, uploading to, downloading from, and delete from a folder in S3 created specifically for this upload. The actual folder creation will be handled in #1265.

### Checklist

- ~~[ ] Styleguide updated, if necessary~~
- ~~[ ] Swagger specification updated, if necessary~~
- ~~[ ] Symlinks from new migrations present or corrected for any new migrations~~

### Demo

```http
$ http --print HhBb :9100/api/uploads/65657592-01a6-4fff-9c9f-c1eb07f0fe49/credentials Authorization:"Bearer $RF_JWT"

GET /api/uploads/65657592-01a6-4fff-9c9f-c1eb07f0fe49/credentials HTTP/1.1
Accept: */*
Accept-Encoding: gzip, deflate
Authorization: Bearer eyJ...
Connection: keep-alive
Host: localhost:9100
User-Agent: HTTPie/0.9.8



HTTP/1.1 200 OK
Connection: keep-alive
Content-Encoding: gzip
Content-Type: application/json
Date: Thu, 23 Mar 2017 19:40:10 GMT
Server: nginx
Strict-Transport-Security: max-age=15552000; preload
Transfer-Encoding: chunked
X-Content-Type-Options: nosniff
X-Frame-Options: SAMEORIGIN
X-XSS-Protection: 1; mode=block

{
    "AccessKeyId": "ASI...",
    "Expiration": "2017-03-24T07:40:10Z",
    "SecretAccessKey": "ptZ...",
    "SessionToken": "FQo..."
}
```

## Testing Instructions

 * Check out this branch, and run the `server` script
 * Log in to S3, and make a folder in `rasterfoundry-staging-data-us-east-1/user-uploads/<upload-id>`, where `<upload-id>` is a random UUID
 * GET `/api/uploads/<upload-id>/credentials`
 * Using the response, export environment variables:

        $ export AWS_ACCESS_KEY_ID=ASI...
        $ export AWS_SECRET_ACCESS_KEY=ptZ...
        $ export AWS_SESSION_TOKEN=FQo...

 * Using `aws-cli`, list the folder

        $ aws s3 ls s3://rasterfoundry-staging-data-us-east-1/user-uploads/<upload-id>/

 * Try uploading a file, downloading a file, and deleting a file

        $ aws s3 cp jabberwocky.txt s3://rasterfoundry-staging-data-us-east-1/user-uploads/<upload-id>/
        $ aws s3 cp s3://rasterfoundry-staging-data-us-east-1/user-uploads/<upload-id>/jabberywocky.txt ./
        $ aws s3 rm s3://rasterfoundry-staging-data-us-east-1/user-uploads/<upload-id>/jabberwocky.txt

Connects #1266 