### PR TITLE
Handle app boot without cache

### DIFF
--- a/app-frontend/src/app/index.run.js
+++ b/app-frontend/src/app/index.run.js
@@ -7,7 +7,7 @@ function runBlock( // eslint-disable-line max-params
         if (APP_CONFIG.error && toState.name !== 'error') {
             e.preventDefault();
             $state.go('error');
-        } else if (toState.name !== 'login' && !authService.isLoggedIn) {
+        } else if (toState.name !== 'login' && !authService.verifyAuthCache()) {
             e.preventDefault();
             $state.go('login');
         }
@@ -16,9 +16,11 @@ function runBlock( // eslint-disable-line max-params
     $rootScope.$on('$locationChangeStart', function () {
         let token = localStorage.get('id_token');
         if (token) {
-            if (!authService.isLoggedIn) {
+            if (!authService.verifyAuthCache()) {
                 authService.login(token);
             }
+        } else {
+            $state.go('login');
         }
     });
 }


### PR DESCRIPTION
## Overview

This PR adds some extra logic to the `app.run` function that ensures we handle situations where the cache is empty by redirecting to the login page. Without this handling, navigating to the app (unless you go right to the login page) transitions to the `/home` route with a blank page.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~


## Testing Instructions

 * Using dev tools, clear all application data (in chrome, you can use the 'Application' tab, then there is a tab on the left for 'Clear Storage')
 * Manually navigate to the root URL ('localhost:9091'), and you should get redirected to the login page
 * It may be helpful to do this on develop first to see that you can reproduce the problem

Closes #1322
