### PR TITLE
Fix login redirect

### DIFF
--- a/app-frontend/src/app/core/services/auth.service.js
+++ b/app-frontend/src/app/core/services/auth.service.js
@@ -119,14 +119,14 @@ export default (app) => {
                     return configFlags.includes(flag.key);
                 });
                 this.featureFlags.set(flagOverrides);
+                this.isLoggedIn = true;
+                this.lock.hide();
+                if (authResult.refreshToken) {
+                    this.promise.resolve(authResult);
+                    delete this.promise;
+                }
+                this.$state.go('home');
             });
-            this.isLoggedIn = true;
-            this.lock.hide();
-            if (authResult.refreshToken) {
-                this.promise.resolve(authResult);
-                delete this.promise;
-            }
-            this.$state.go('browse');
         }
 
         onLoginFail(error) {


### PR DESCRIPTION
## Overview

This PR ensures that navigation post-login in delayed until the profile information from Auth0 is loaded into the cache.

This fixes a bug that occurred when the login page attempted to redirect before the cache was available, and as a result, the user was prevented from navigating away, resulting in a blank purple page after logging in. A refresh would then take the user to the home page.


## Testing Instructions

 * Log out
 * Log in and make sure you are taken to the home page
