### PR TITLE
Scoped S3 Credentials

### DIFF
--- a/app-backend/api/src/main/resources/application.conf
+++ b/app-backend/api/src/main/resources/application.conf
@@ -55,6 +55,8 @@ rollbar {
 }
 
 s3 {
+  region = "us-east-1"
+  region = ${?AWS_REGION}
   dataBucket = ${?DATA_BUCKET}
   thumbnailBucket = ${?THUMBNAIL_BUCKET}
 }

--- a/app-backend/api/src/main/resources/application.conf
+++ b/app-backend/api/src/main/resources/application.conf
@@ -55,6 +55,7 @@ rollbar {
 }
 
 s3 {
+  dataBucket = ${?DATA_BUCKET}
   thumbnailBucket = ${?THUMBNAIL_BUCKET}
 }
 

--- a/app-backend/api/src/main/scala/uploads/Credentials.scala
+++ b/app-backend/api/src/main/scala/uploads/Credentials.scala
@@ -1,0 +1,76 @@
+package com.azavea.rf.api.uploads
+
+import java.util.UUID
+
+import com.azavea.rf.api.utils.{Auth0Exception, Config}
+import com.azavea.rf.datamodel.User
+
+import akka.http.scaladsl.Http
+import akka.http.scaladsl.model._
+import akka.http.scaladsl.unmarshalling.Unmarshal
+
+import com.typesafe.scalalogging.LazyLogging
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+
+import io.circe.generic.auto._
+import io.circe.optics.JsonPath._
+import io.circe.Json
+import de.heikoseeberger.akkahttpcirce.CirceSupport._
+
+
+case class Credentials (
+  AccessKeyId: String,
+  Expiration: String,
+  SecretAccessKey: String,
+  SessionToken: String
+)
+
+case class CredentialsWithBucketPath (
+  credentials: Credentials,
+  bucketPath: String
+)
+
+object Auth0DelegationService extends Config with LazyLogging {
+  import com.azavea.rf.api.AkkaSystem._
+
+  val uri = Uri(s"https://$auth0Domain/delegation")
+
+  // The AWS Delegation response has many things, most of which we don't care
+  // about. We only want the "Credentials" key, so we setup this path to
+  // optionally retrieve it from Json response.
+  private val credentialsPath = root.Credentials.as[Credentials]
+
+  def getCredentials(user: User, uploadId: UUID, jwt: String): Future[CredentialsWithBucketPath] = {
+    val params = FormData(
+      "api-type" -> "aws",
+      "client_id" -> auth0ClientId,
+      "grant_type" -> "urn:ietf:params:oauth:grant-type:jwt-bearer",
+      "id_token" -> jwt,
+      "target" -> auth0ClientId
+    ).toEntity
+
+    Http()
+      .singleRequest(HttpRequest(
+        method = HttpMethods.POST,
+        uri = uri,
+        entity = params
+      ))
+      .flatMap {
+        case HttpResponse(StatusCodes.OK, _, entity, _) =>
+          Unmarshal(entity).to[Json].map(credentialsPath.getOption).map {
+            case Some(credentials) => CredentialsWithBucketPath(
+              credentials,
+              s"https://s3.amazonaws.com/${dataBucket}/user-uploads/${user.id}/${uploadId.toString}"
+            )
+            case None => throw new Auth0Exception(
+              StatusCodes.InternalServerError,
+              "Missing credentials in AWS STS delegation response"
+            )
+          }
+        case HttpResponse(errCode, _, err, _) =>
+          throw new Auth0Exception(errCode, err.toString)
+      }
+  }
+}

--- a/app-backend/api/src/main/scala/utils/Config.scala
+++ b/app-backend/api/src/main/scala/utils/Config.scala
@@ -27,5 +27,6 @@ trait Config {
 
   val featureFlags = featureFlagConfig.getConfigList("features")
 
+  val dataBucket = s3Config.getString("dataBucket")
   val thumbnailBucket = s3Config.getString("thumbnailBucket")
 }

--- a/app-backend/api/src/main/scala/utils/Config.scala
+++ b/app-backend/api/src/main/scala/utils/Config.scala
@@ -27,6 +27,7 @@ trait Config {
 
   val featureFlags = featureFlagConfig.getConfigList("features")
 
+  val region = s3Config.getString("region")
   val dataBucket = s3Config.getString("dataBucket")
   val thumbnailBucket = s3Config.getString("thumbnailBucket")
 }

--- a/docs/swagger/spec.yml
+++ b/docs/swagger/spec.yml
@@ -358,7 +358,7 @@ paths:
         200:
           description: AWS credentials scoped to the upload bucket with prefix
           schema:
-            $ref: '#/definitions/UploadCredentials'
+            $ref: '#/definitions/UploadCredentialsResponse'
         default:
           description: Unexpected error
           schema:
@@ -2393,15 +2393,22 @@ definitions:
   UploadCredentials:
     type: object
     properties:
-      accessKey:
+      AccessKeyId:
         type: string
-      secretAccessKey:
+      SecretAccessKey:
          type: string
-      sessionToken:
+      SessionToken:
         type: string
-      expiration:
+      Expiration:
         type: string
         format: datetime
+  UploadCredentialsResponse:
+    type: object
+    properties:
+      credentials:
+        $ref: '#/definitions/UploadCredentials'
+      bucketPath:
+        type: string
   SceneParams:
     type: object
     description: scene params


### PR DESCRIPTION
## Overview

Builds on top of #1323 and #1330. This should actually target `develop`, but am targeting #1330 to reduce diff noise. Will rebase this after that has been merged.

Adds an endpoint which gets temporary credentials to an S3 folder, allowing the front-end to upload files from the user's machine to S3. These credentials use Auth0's [`delegation`](https://auth0.com/docs/api/authentication#delegation) API call, along with AWS's STS configuration, about which more can be learned in #1323. This grants the user permission to list, read, write, and delete files in `s3://${RF_DATA_BUCKET}/user-uploads/<user-id>/`.

While the permissions are for the entire user folder, we return a `bucketPath` that appends the `uploadId` to the above path. This path can be used by the front-end to upload files. The endpoint also creates and then deletes a `test.txt` file to ensure that the temporary credentials work as expected before passing them through to the client.

The STS configuration applies to the `rasterfoundry-development-data-us-east-1` bucket. Unfortunately, in the `.env` file, we point to `rasterfoundry-staging-data-us-east-1`. Change the value of `DATA_BUCKET` manually before proceeding.

### Checklist

- ~~Styleguide updated, if necessary~~
- [x] Swagger specification updated, if necessary
- ~~Symlinks from new migrations present or corrected for any new migrations~~

### Demo

###### Create an upload

```http
POST /api/uploads HTTP/1.1
Accept: application/json, */*
Accept-Encoding: gzip, deflate
Authorization: Bearer eyJ...
Connection: keep-alive
Content-Length: 204
Content-Type: application/json
Host: localhost:9100
User-Agent: HTTPie/0.9.8

{
    "datasource": "61c8972f-9461-4e7d-ae2a-46cfb1f94810",
    "fileType": "GEOTIFF",
    "files": [],
    "metadata": {},
    "organizationId": "dfac6307-b5ef-43f7-beda-b9f208bb7726",
    "uploadStatus": "UPLOADING",
    "uploadType": "LOCAL"
}

HTTP/1.1 200 OK
Connection: keep-alive
Content-Encoding: gzip
Content-Type: application/json
Date: Mon, 27 Mar 2017 20:33:09 GMT
Server: nginx
Strict-Transport-Security: max-age=15552000; preload
Transfer-Encoding: chunked
X-Content-Type-Options: nosniff
X-Frame-Options: SAMEORIGIN
X-XSS-Protection: 1; mode=block

{
    "createdAt": "2017-03-27T20:33:09.292Z",
    "createdBy": "google-oauth2|116...",
    "datasource": "61c8972f-9461-4e7d-ae2a-46cfb1f94810",
    "fileType": "GEOTIFF",
    "files": [],
    "id": "433cb5cb-d528-4655-a552-d131b2179f8e",
    "metadata": {},
    "modifiedAt": "2017-03-27T20:33:09.292Z",
    "modifiedBy": "google-oauth2|116...",
    "organizationId": "dfac6307-b5ef-43f7-beda-b9f208bb7726",
    "uploadStatus": "UPLOADING",
    "uploadType": "LOCAL"
}
```

###### Get credentials for it

```http
GET /api/uploads/433cb5cb-d528-4655-a552-d131b2179f8e/credentials HTTP/1.1
Accept: */*
Accept-Encoding: gzip, deflate
Authorization: Bearer eyJ...
Connection: keep-alive
Host: localhost:9100
User-Agent: HTTPie/0.9.8



HTTP/1.1 200 OK
Connection: keep-alive
Content-Encoding: gzip
Content-Type: application/json
Date: Mon, 27 Mar 2017 20:34:49 GMT
Server: nginx
Strict-Transport-Security: max-age=15552000; preload
Transfer-Encoding: chunked
X-Content-Type-Options: nosniff
X-Frame-Options: SAMEORIGIN
X-XSS-Protection: 1; mode=block

{
    "bucketPath": "https://rasterfoundry-development-data-us-east-1.s3.amazonaws.com/user-uploads/google-oauth2%7C116.../433cb5cb-d528-4655-a552-d131b2179f8e",
    "credentials": {
        "AccessKeyId": "ASIA...",
        "Expiration": "2017-03-27T21:35:40.000Z",
        "SecretAccessKey": "zZb...",
        "SessionToken": "FQoDYX..."
    }
}
```

### Notes

Certain strings have been hard coded, such as the upload path and Auth0 delegation variables. Should these be moved into environment variables?

Should we try to cache the credentials retrieved?

## Testing Instructions

 * Checkout this branch
 * Update the value of `DATA_DIR` in your `.env` file to point to the `development` bucket
 * Run `server`
 * Create an upload
 * Get credentials for the upload
 * Use the credentials in your local environment:

        export AWS_ACCESS_KEY_ID=ASIA...
        export AWS_SECRET_ACCESS_KEY=zZb...
        export AWS_SESSION_TOKEN=FQoDYX...

 * Use the credentials to upload test files, download them back, list them, and delete them.

        aws s3 ls "s3://rasterfoundry-development-data-us-east-1/user-uploads/google-oauth2|116.../433cb5cb-d528-4655-a552-d131b2179f8e/"
        aws s3 cp jabberwocky.txt "s3://rasterfoundry-development-data-us-east-1/user-uploads/google-oauth2|116.../433cb5cb-d528-4655-a552-d131b2179f8e/"
        aws s3 cp "s3://rasterfoundry-development-data-us-east-1/user-uploads/google-oauth2|116.../433cb5cb-d528-4655-a552-d131b2179f8e/jabberwocky.txt" ./
        aws s3 rm "s3://rasterfoundry-development-data-us-east-1/user-uploads/google-oauth2|116.../433cb5cb-d528-4655-a552-d131b2179f8e/jabberwocky.txt"

    The quotes around the S3 url are necessary to escape the `|` in the user_id.

Connects #1266 