### PR TITLE
Initialize Rollbar only once in Airflow

### DIFF
--- a/app-tasks/rf/src/rf/utils/exception_reporting.py
+++ b/app-tasks/rf/src/rf/utils/exception_reporting.py
@@ -5,6 +5,12 @@ import rollbar
 
 logger = logging.getLogger(__name__)
 
+environment = os.getenv('ENVIRONMENT')
+rollbar_token = os.getenv('ROLLBAR_API_TOKEN')
+
+# Avoid use of threads by default in case the worker exits before sending message
+rollbar.init(rollbar_token, environment, handler='blocking')
+
 
 def wrap_rollbar(func):
     """Decorator to wrap functions to report exceptions to rollbar
@@ -12,11 +18,6 @@ def wrap_rollbar(func):
     Note:
       This re-raises the exception after notifying rollbar
     """
-    environment = os.getenv('ENVIRONMENT')
-    rollbar_token = os.getenv('ROLLBAR_API_TOKEN')
-
-    # Avoid use of threads by default in case the worker exits before sending message
-    rollbar.init(rollbar_token, environment, handler='blocking')
 
     def func_wrapper(*args, **kwargs):
         try:


### PR DESCRIPTION
## Overview

Rollbar was being initialized multiple times because its initialization was happening inside the decorator code. This moves it into the module code so that it only gets run the first time the module is imported.

### Checklist

- [ ] ~Styleguide updated, if necessary~
- [ ] ~Swagger specification updated, if necessary~
- [ ] ~Symlinks from new migrations present or corrected for any new migrations~

## Testing Instructions

 * If you want, prior to checking out this branch, run `./scripts/server --with-airflow | grep Rollbar` to confirm that the problem still exists.
 * Check out this branch and re-run the previous command, and confirm that the error message disappears.
 * Edit a DAG (I used `import_geotiff_scenes`) and add an exception (`raise Exception('test exception')`). Re-run the above command a third time and confirm that your exception appears in Rollbar (make sure you're using a DAG that is being automatically executed, or trigger a run manually).

Closes #1219 
