### PR TITLE
Set environment variables within the VM

### DIFF
--- a/deployment/ansible/raster-foundry.yml
+++ b/deployment/ansible/raster-foundry.yml
@@ -16,18 +16,18 @@
       lineinfile: dest=/home/vagrant/.bashrc regexp=^raster-foundry_PROFILE line="cd /opt/raster-foundry/"
 
     - name: Set Environment variable for AWS profile
-      lineinfile: dest=/etc/environment regexp=^AWS_PROFILE line="AWS_PROFILE={{aws_profile}}"
+      lineinfile: dest=/etc/environment regexp=^AWS_PROFILE line="AWS_PROFILE={{ aws_profile }}"
       when: aws_profile is defined
 
     - name: Set Environment variable for Raster Foundry AWS Config Bucket
-      lineinfile: dest=/etc/environment regexp=^RF_SETTINGS_BUCKET line="RF_SETTINGS_BUCKET={{rf_settings_bucket}}"
-      when: rf_aws_settings_bucket is defined
+      lineinfile: dest=/etc/environment regexp=^RF_SETTINGS_BUCKET line="RF_SETTINGS_BUCKET={{ rf_settings_bucket }}"
+      when: rf_settings_bucket is defined
 
     - name: Set Environment variable for Raster Foundry AWS Artifacts Bucket
       lineinfile: dest=/etc/environment regexp=^RF_ARTIFACTS_BUCKET
-                  line="RF_ARTIFACTS_BUCKET={{rf_artifacts_bucket}}"
-      when: rf_aws_artifacts_bucket is defined
+                  line="RF_ARTIFACTS_BUCKET={{ rf_artifacts_bucket }}"
+      when: rf_artifacts_bucket is defined
 
     - name: Set Environment variable for host user (used to namespace jars and other artifacts in development)
-      lineinfile: dest=/etc/environment regexp=^RF_HOST_USER line="RF_HOST_USER={{host_user}}"
+      lineinfile: dest=/etc/environment regexp=^RF_HOST_USER line="RF_HOST_USER={{ host_user }}"
       when: host_user is defined


### PR DESCRIPTION
## Overview

Update the `when` clauses so that they use the same variable name we intend to template into `/etc/environment`.

Fixes https://github.com/azavea/raster-foundry/issues/1350

## Testing Instructions

Provision the Vagrant virtual machine with this branch:

```bash
$ vagrant provision
```

Then, SSH in and run the following commands to inspect the environment:

```bash
$ vagrant ssh
vagrant@vagrant-ubuntu-trusty-64:/opt/raster-foundry$ env | egrep "^RF_"
RF_SETTINGS_BUCKET=rasterfoundry-development-config-us-east-1
RF_ARTIFACTS_BUCKET=rasterfoundry-global-artifacts-us-east-1
RF_HOST_USER=hector
vagrant@vagrant-ubuntu-trusty-64:/opt/raster-foundry$ cat /etc/environment
PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games"
AWS_PROFILE=raster-foundry
RF_HOST_USER=hector
RF_SETTINGS_BUCKET=rasterfoundry-development-config-us-east-1
RF_ARTIFACTS_BUCKET=rasterfoundry-global-artifacts-us-east-1
```