### PR TITLE
Add batched correction to API spec

### DIFF
--- a/docs/swagger/spec.yml
+++ b/docs/swagger/spec.yml
@@ -716,6 +716,24 @@ paths:
           description: An ordered list of scene IDs and corresponding color correction parameters
           schema:
             $ref: '#/definitions/MosaicDefinition'
+
+  /projects/{uuid}/mosaic/bulk-update-color-corrections/:
+    post:
+      summary: Persist a batch of project/scene pairing\'s color correction parameters
+      tags:
+        - Imagery
+      parameters:
+        - $ref: '#/parameters/uuid'
+        - name: combinedSceneCorrectionParameters
+          description: Combined color correction parameters
+          in: body
+          schema:
+            $ref: '#/definitions/CombinedSceneCorrectionParams'
+      responses:
+        200:
+          description: Successfully updated all scenes' color correction parameters
+        
+      
   /projects/{uuid}/mosaic/{uuid2}:
     get:
       summary: A project/scene pairing\'s persisted color correction parameters
@@ -2501,3 +2519,19 @@ definitions:
         $ref: '#/definitions/SceneParams'
       imageParams:
         $ref: '#/definitions/ImageParams'
+
+  SceneCorrectionParam:
+    type: object
+    description: A paired scene ID and color correction parameter list
+    properties:
+      sceneId:
+        type: string
+        format: uuid
+      params:
+        $ref: '#/definitions/ColorCorrection'
+          
+  CombinedSceneCorrectionParams:
+    type: array
+    description: Combined color correction parameters for multiple scenes
+    items:
+      $ref: '#/definitions/SceneCorrectionParam'


### PR DESCRIPTION
## Overview

This PR revises the swagger API spec to add an endpoint at `/projects/{uuid}/mosaic/batched-corrections/` that will allow sending multiple scene/parameter sets in one request.

### Checklist

~~- [ ] Styleguide updated, if necessary~~
- [x] Swagger specification updated, if necessary
~~- [ ] Symlinks from new migrations present or corrected for any new migrations~~

### Demo

![download 26](https://cloud.githubusercontent.com/assets/18290666/24464355/8a62dafa-1477-11e7-8e55-973b405043e1.png)


### Notes



## Testing Instructions

* review the updated spec for correctness and fitness with respect to #1354 

Connects #1353 
