### PR TITLE
Add Authorize Directive, Limit Access to Members and Super Users

### DIFF
--- a/app-backend/api/src/main/scala/datasource/Routes.scala
+++ b/app-backend/api/src/main/scala/datasource/Routes.scala
@@ -60,16 +60,20 @@ trait DatasourceRoutes extends Authentication
 
   def createDatasource: Route = authenticate { user =>
     entity(as[Datasource.Create]) { newDatasource =>
-      onSuccess(write[Datasource](Datasources.insertDatasource(newDatasource, user))) { datasource =>
-        complete(datasource)
+      authorize(user.isInRootOrSameOrganizationAs(newDatasource)) {
+        onSuccess(write[Datasource](Datasources.insertDatasource(newDatasource, user))) { datasource =>
+          complete(datasource)
+        }
       }
     }
   }
 
   def updateDatasource(datasourceId: UUID): Route = authenticate { user =>
     entity(as[Datasource]) { updateDatasource =>
-      onSuccess(update(Datasources.updateDatasource(updateDatasource, datasourceId, user))) { count =>
-        complete(StatusCodes.NoContent)
+      authorize(user.isInRootOrSameOrganizationAs(updateDatasource)) {
+        onSuccess(update(Datasources.updateDatasource(updateDatasource, datasourceId, user))) { count =>
+          complete(StatusCodes.NoContent)
+        }
       }
     }
   }

--- a/app-backend/api/src/main/scala/datasource/Routes.scala
+++ b/app-backend/api/src/main/scala/datasource/Routes.scala
@@ -52,7 +52,7 @@ trait DatasourceRoutes extends Authentication
     get {
       rejectEmptyResponse {
         complete {
-          readOne[Datasource](Datasources.getDatasource(datasourceId))
+          readOne[Datasource](Datasources.getDatasource(datasourceId, user))
         }
       }
     }
@@ -79,7 +79,7 @@ trait DatasourceRoutes extends Authentication
   }
 
   def deleteDatasource(datasourceId: UUID): Route = authenticate { user =>
-    onSuccess(drop(Datasources.deleteDatasource(datasourceId))) {
+    onSuccess(drop(Datasources.deleteDatasource(datasourceId, user))) {
       case 1 => complete(StatusCodes.NoContent)
       case 0 => complete(StatusCodes.NotFound)
       case count => throw new IllegalStateException(

--- a/app-backend/api/src/main/scala/datasource/Routes.scala
+++ b/app-backend/api/src/main/scala/datasource/Routes.scala
@@ -41,7 +41,7 @@ trait DatasourceRoutes extends Authentication
     (withPagination & datasourceQueryParams) {
       (page: PageRequest, datasourceParams: DatasourceQueryParameters) =>
       complete {
-        list[Datasource](Datasources.listDatasources(page.offset, page.limit, datasourceParams),
+        list[Datasource](Datasources.listDatasources(page.offset, page.limit, datasourceParams, user),
                          page.offset,
                          page.limit)
       }

--- a/app-backend/api/src/main/scala/image/Routes.scala
+++ b/app-backend/api/src/main/scala/image/Routes.scala
@@ -50,8 +50,10 @@ trait ImageRoutes extends Authentication
 
   def createImage: Route = authenticate { user =>
     entity(as[Image.Banded]) { newImage =>
-      onSuccess(Images.insertImage(newImage, user)) { image =>
-        complete(image)
+      authorize(user.isInRootOrSameOrganizationAs(newImage)) {
+        onSuccess(Images.insertImage(newImage, user)) { image =>
+          complete(image)
+        }
       }
     }
   }
@@ -68,8 +70,10 @@ trait ImageRoutes extends Authentication
 
   def updateImage(imageId: UUID): Route = authenticate { user =>
     entity(as[Image.WithRelated]) { updatedImage =>
-      onSuccess(Images.updateImage(updatedImage, imageId, user)) { count =>
-        complete(StatusCodes.NoContent)
+      authorize(user.isInRootOrSameOrganizationAs(updatedImage)) {
+        onSuccess(Images.updateImage(updatedImage, imageId, user)) { count =>
+          complete(StatusCodes.NoContent)
+        }
       }
     }
   }

--- a/app-backend/api/src/main/scala/image/Routes.scala
+++ b/app-backend/api/src/main/scala/image/Routes.scala
@@ -62,7 +62,7 @@ trait ImageRoutes extends Authentication
     get {
       rejectEmptyResponse {
         complete {
-          Images.getImage(imageId)
+          Images.getImage(imageId, user)
         }
       }
     }
@@ -79,7 +79,7 @@ trait ImageRoutes extends Authentication
   }
 
   def deleteImage(imageId: UUID): Route = authenticate { user =>
-    onSuccess(Images.deleteImage(imageId)) {
+    onSuccess(Images.deleteImage(imageId, user)) {
       case 1 => complete(StatusCodes.NoContent)
       case 0 => complete(StatusCodes.NotFound)
       case count => throw new IllegalStateException(

--- a/app-backend/api/src/main/scala/maptoken/Routes.scala
+++ b/app-backend/api/src/main/scala/maptoken/Routes.scala
@@ -49,8 +49,10 @@ trait MapTokenRoutes extends Authentication
 
   def createMapToken: Route = authenticate { user =>
     entity(as[MapToken.Create]) { newMapToken =>
-      onSuccess(write[MapToken](MapTokens.insertMapToken(newMapToken, user))) { mapToken =>
-        complete(mapToken)
+      authorize(user.isInRootOrSameOrganizationAs(newMapToken)) {
+        onSuccess(write[MapToken](MapTokens.insertMapToken(newMapToken, user))) { mapToken =>
+          complete(mapToken)
+        }
       }
     }
   }
@@ -67,8 +69,10 @@ trait MapTokenRoutes extends Authentication
 
   def updateMapToken(mapTokenId: UUID): Route = authenticate { user =>
     entity(as[MapToken]) { updatedMapToken =>
-      onSuccess(update(MapTokens.updateMapToken(updatedMapToken, mapTokenId, user))) { count =>
-        complete(StatusCodes.NoContent)
+      authorize(user.isInRootOrSameOrganizationAs(updatedMapToken)) {
+        onSuccess(update(MapTokens.updateMapToken(updatedMapToken, mapTokenId, user))) { count =>
+          complete(StatusCodes.NoContent)
+        }
       }
     }
   }

--- a/app-backend/api/src/main/scala/maptoken/Routes.scala
+++ b/app-backend/api/src/main/scala/maptoken/Routes.scala
@@ -61,7 +61,7 @@ trait MapTokenRoutes extends Authentication
     get {
       rejectEmptyResponse {
         complete {
-          readOne[MapToken](MapTokens.getMapToken(mapTokenId))
+          readOne[MapToken](MapTokens.getMapToken(mapTokenId, user))
         }
       }
     }
@@ -78,7 +78,7 @@ trait MapTokenRoutes extends Authentication
   }
 
   def deleteMapToken(mapTokenId: UUID): Route = authenticate { user =>
-    onSuccess(drop(MapTokens.deleteMapToken(mapTokenId))) {
+    onSuccess(drop(MapTokens.deleteMapToken(mapTokenId, user))) {
       case 1 => complete(StatusCodes.NoContent)
       case 0 => complete(StatusCodes.NotFound)
       case count => throw new IllegalStateException(

--- a/app-backend/api/src/main/scala/project/Routes.scala
+++ b/app-backend/api/src/main/scala/project/Routes.scala
@@ -94,7 +94,7 @@ trait ProjectRoutes extends Authentication
   def getProject(projectId: UUID): Route = authenticate { user =>
     rejectEmptyResponse {
       complete {
-        Projects.getProject(projectId)
+        Projects.getProject(projectId, user)
       }
     }
   }
@@ -113,7 +113,7 @@ trait ProjectRoutes extends Authentication
   }
 
   def deleteProject(projectId: UUID): Route = authenticate { user =>
-    onSuccess(Projects.deleteProject(projectId)) {
+    onSuccess(Projects.deleteProject(projectId, user)) {
       case 1 => complete(StatusCodes.NoContent)
       case 0 => complete(StatusCodes.NotFound)
       case count => throw new IllegalStateException(

--- a/app-backend/api/src/main/scala/scene/Routes.scala
+++ b/app-backend/api/src/main/scala/scene/Routes.scala
@@ -61,7 +61,7 @@ trait SceneRoutes extends Authentication
   def getScene(sceneId: UUID): Route = authenticate { user =>
     rejectEmptyResponse {
       complete {
-        Scenes.getScene(sceneId)
+        Scenes.getScene(sceneId, user)
       }
     }
   }
@@ -85,7 +85,7 @@ trait SceneRoutes extends Authentication
   }
 
   def deleteScene(sceneId: UUID): Route = authenticate { user =>
-    onSuccess(Scenes.deleteScene(sceneId)) {
+    onSuccess(Scenes.deleteScene(sceneId, user)) {
       case 1 => complete(StatusCodes.NoContent)
       case 0 => complete(StatusCodes.NotFound)
       case count => throw new IllegalStateException(

--- a/app-backend/api/src/main/scala/tags/Routes.scala
+++ b/app-backend/api/src/main/scala/tags/Routes.scala
@@ -36,7 +36,7 @@ trait ToolTagRoutes extends Authentication with PaginationDirectives with UserEr
   def listToolTags: Route = authenticate { user =>
     (withPagination) { (page) =>
       complete {
-        ToolTags.listToolTags(page)
+        ToolTags.listToolTags(page, user)
       }
     }
   }

--- a/app-backend/api/src/main/scala/tags/Routes.scala
+++ b/app-backend/api/src/main/scala/tags/Routes.scala
@@ -53,7 +53,7 @@ trait ToolTagRoutes extends Authentication with PaginationDirectives with UserEr
 
   def getToolTag(toolTagId: UUID): Route = authenticate { user =>
     rejectEmptyResponse {
-      complete(ToolTags.getToolTag(toolTagId))
+      complete(ToolTags.getToolTag(toolTagId, user))
     }
   }
 
@@ -76,7 +76,7 @@ trait ToolTagRoutes extends Authentication with PaginationDirectives with UserEr
   }
 
   def deleteToolTag(toolTagId: UUID): Route = authenticate { user =>
-    onSuccess(ToolTags.deleteToolTag(toolTagId)) {
+    onSuccess(ToolTags.deleteToolTag(toolTagId, user)) {
       case 1 => complete(StatusCodes.NoContent)
       case 0 => complete(StatusCodes.NotFound)
       case count => throw new IllegalStateException(

--- a/app-backend/api/src/main/scala/thumbnail/Routes.scala
+++ b/app-backend/api/src/main/scala/thumbnail/Routes.scala
@@ -100,7 +100,7 @@ trait ThumbnailRoutes extends Authentication
   def updateThumbnail(thumbnailId: UUID): Route = authenticate { user =>
     entity(as[Thumbnail]) { updatedThumbnail =>
       authorize(user.isInRootOrSameOrganizationAs(updatedThumbnail)) {
-        onSuccess(Thumbnails.updateThumbnail(updatedThumbnail, thumbnailId)) {
+        onSuccess(Thumbnails.updateThumbnail(updatedThumbnail, thumbnailId, user)) {
           case 1 => complete(StatusCodes.NoContent)
           case 0 => complete(StatusCodes.NotFound)
           case count => throw new IllegalStateException(

--- a/app-backend/api/src/main/scala/thumbnail/Routes.scala
+++ b/app-backend/api/src/main/scala/thumbnail/Routes.scala
@@ -58,7 +58,7 @@ trait ThumbnailRoutes extends Authentication
   def listThumbnails: Route = authenticate { user =>
     (withPagination & thumbnailSpecificQueryParameters) { (page, thumbnailParams) =>
       complete {
-        Thumbnails.listThumbnails(page, thumbnailParams)
+        Thumbnails.listThumbnails(page, thumbnailParams, user)
       }
     }
   }

--- a/app-backend/api/src/main/scala/thumbnail/Routes.scala
+++ b/app-backend/api/src/main/scala/thumbnail/Routes.scala
@@ -77,7 +77,7 @@ trait ThumbnailRoutes extends Authentication
     withPagination { page =>
       rejectEmptyResponse {
         complete {
-          Thumbnails.getThumbnail(thumbnailId)
+          Thumbnails.getThumbnail(thumbnailId, user)
         }
       }
     }
@@ -112,7 +112,7 @@ trait ThumbnailRoutes extends Authentication
   }
 
   def deleteThumbnail(thumbnailId: UUID): Route = authenticate { user =>
-    onSuccess(Thumbnails.deleteThumbnail(thumbnailId)) {
+    onSuccess(Thumbnails.deleteThumbnail(thumbnailId, user)) {
       case 1 => complete(StatusCodes.NoContent)
       case 0 => complete(StatusCodes.NotFound)
       case count => throw new IllegalStateException(

--- a/app-backend/api/src/main/scala/toolrun/Routes.scala
+++ b/app-backend/api/src/main/scala/toolrun/Routes.scala
@@ -57,7 +57,7 @@ trait ToolRunRoutes extends Authentication
 
   def getToolRun(runId: UUID): Route = authenticate { user =>
     rejectEmptyResponse {
-      complete(readOne(ToolRuns.getToolRun(runId)))
+      complete(readOne(ToolRuns.getToolRun(runId, user)))
     }
   }
 
@@ -80,7 +80,7 @@ trait ToolRunRoutes extends Authentication
   }
 
   def deleteToolRun(runId: UUID): Route = authenticate { user =>
-    onSuccess(database.db.run(ToolRuns.deleteToolRun(runId))) {
+    onSuccess(database.db.run(ToolRuns.deleteToolRun(runId, user))) {
       case 1 => complete(StatusCodes.NoContent)
       case 0 => complete(StatusCodes.NotFound)
       case count => throw new IllegalStateException(

--- a/app-backend/api/src/main/scala/toolrun/Routes.scala
+++ b/app-backend/api/src/main/scala/toolrun/Routes.scala
@@ -40,7 +40,7 @@ trait ToolRunRoutes extends Authentication
   def listToolRuns: Route = authenticate { user =>
     (withPagination & toolRunQueryParameters) { (page, runParams) =>
       complete {
-        list(ToolRuns.listToolRuns(page.offset, page.limit, runParams), page.offset, page.limit)
+        list(ToolRuns.listToolRuns(page.offset, page.limit, runParams, user), page.offset, page.limit)
       }
     }
   }

--- a/app-backend/api/src/main/scala/tools/Routes.scala
+++ b/app-backend/api/src/main/scala/tools/Routes.scala
@@ -55,7 +55,7 @@ trait ToolRoutes extends Authentication
 
   def getTool(toolId: UUID): Route = authenticate { user =>
     rejectEmptyResponse {
-      complete(Tools.getTool(toolId))
+      complete(Tools.getTool(toolId, user))
     }
   }
 
@@ -78,7 +78,7 @@ trait ToolRoutes extends Authentication
   }
 
   def deleteTool(toolId: UUID): Route = authenticate { user =>
-    onSuccess(Tools.deleteTool(toolId)) {
+    onSuccess(Tools.deleteTool(toolId, user)) {
       case 1 => complete(StatusCodes.NoContent)
       case 0 => complete(StatusCodes.NotFound)
       case count => throw new IllegalStateException(

--- a/app-backend/api/src/main/scala/tools/Routes.scala
+++ b/app-backend/api/src/main/scala/tools/Routes.scala
@@ -38,7 +38,7 @@ trait ToolRoutes extends Authentication
   def listTools: Route = authenticate { user =>
     (withPagination) { (page) =>
       complete {
-        Tools.listTools(page)
+        Tools.listTools(page, user)
       }
     }
   }

--- a/app-backend/api/src/main/scala/uploads/Routes.scala
+++ b/app-backend/api/src/main/scala/uploads/Routes.scala
@@ -48,7 +48,7 @@ trait UploadRoutes extends Authentication
     (withPagination & uploadQueryParams) {
       (page: PageRequest, queryParams: UploadQueryParameters) =>
       complete {
-        list[Upload](Uploads.listUploads(page.offset, page.limit, queryParams),
+        list[Upload](Uploads.listUploads(page.offset, page.limit, queryParams, user),
           page.offset, page.limit)
       }
     }

--- a/app-backend/api/src/main/scala/uploads/Routes.scala
+++ b/app-backend/api/src/main/scala/uploads/Routes.scala
@@ -57,7 +57,7 @@ trait UploadRoutes extends Authentication
   def getUpload(uploadId: UUID): Route = authenticate { user =>
     rejectEmptyResponse {
       complete {
-        readOne[Upload](Uploads.getUpload(uploadId))
+        readOne[Upload](Uploads.getUpload(uploadId, user))
       }
     }
   }
@@ -83,7 +83,7 @@ trait UploadRoutes extends Authentication
   }
 
   def deleteUpload(uploadId: UUID): Route = authenticate { user =>
-    onSuccess(drop(Uploads.deleteUpload(uploadId))) {
+    onSuccess(drop(Uploads.deleteUpload(uploadId, user))) {
       case 1 => complete(StatusCodes.NoContent)
       case 0 => complete(StatusCodes.NotFound)
       case count => throw new IllegalStateException(
@@ -94,7 +94,7 @@ trait UploadRoutes extends Authentication
 
   def getUploadCredentials(uploadId: UUID): Route = authenticate { user =>
     validateTokenHeader { jwt =>
-      onSuccess(readOne[Upload](Uploads.getUpload(uploadId))) {
+      onSuccess(readOne[Upload](Uploads.getUpload(uploadId, user))) {
         case Some(_) => complete(Auth0DelegationService.getCredentials(user, uploadId, jwt))
         case None => complete(StatusCodes.NotFound)
       }

--- a/app-backend/api/src/main/scala/uploads/Routes.scala
+++ b/app-backend/api/src/main/scala/uploads/Routes.scala
@@ -64,16 +64,20 @@ trait UploadRoutes extends Authentication
 
   def createUpload: Route = authenticate { user =>
     entity(as[Upload.Create]) { newUpload =>
-      onSuccess(write[Upload](Uploads.insertUpload(newUpload, user))) { upload =>
-        complete(upload)
+      authorize(user.isInRootOrSameOrganizationAs(newUpload)) {
+        onSuccess(write[Upload](Uploads.insertUpload(newUpload, user))) { upload =>
+          complete(upload)
+        }
       }
     }
   }
 
   def updateUpload(uploadId: UUID): Route = authenticate { user =>
     entity(as[Upload]) { updateUpload =>
-      onSuccess(update(Uploads.updateUpload(updateUpload, uploadId, user))) { count =>
-        complete(StatusCodes.NoContent)
+      authorize(user.isInRootOrSameOrganizationAs(updateUpload)) {
+        onSuccess(update(Uploads.updateUpload(updateUpload, uploadId, user))) { count =>
+          complete(StatusCodes.NoContent)
+        }
       }
     }
   }

--- a/app-backend/api/src/test/scala/thumbnail/ThumbnailSpec.scala
+++ b/app-backend/api/src/test/scala/thumbnail/ThumbnailSpec.scala
@@ -55,49 +55,6 @@ class ThumbnailSpec extends WordSpec
   // Alias to baseRoutes to be explicit
   val baseRoutes = routes
 
-  "Creating a row" should {
-    "add a row to the table" ignore {
-      val result = Thumbnails.insertThumbnail(baseThumbnailRow)
-      assert(result === Success)
-    }
-  }
-
-  "Getting a row" should {
-    "return the expected row" ignore {
-      assert(Thumbnails.getThumbnail(uuid) === baseThumbnailRow)
-    }
-  }
-
-  "Updating a row" should {
-    "change the expected values" ignore {
-      val newThumbnailsRow = Thumbnail(
-        uuid,
-        new Timestamp(1234687268),
-        new Timestamp(1234687268),
-        uuid,
-        256,
-        128,
-        uuid,
-        "https://website.com",
-        ThumbnailSize.Large
-      )
-      val result = Thumbnails.updateThumbnail(newThumbnailsRow, uuid)
-      assert(result === 1)
-      Thumbnails.getThumbnail(uuid) map {
-        case Some(resp) => assert(resp.widthPx === 256)
-        case _ => Failure(new Exception("Field not updated successfully"))
-      }
-    }
-  }
-
-  "Deleting a row" should {
-    "remove a row from the table" ignore {
-      val result = Thumbnails.deleteThumbnail(uuid)
-      assert(result === 1)
-    }
-  }
-
-
   "/api/thumbnails/{uuid}" should {
     "return a 404 for non-existent thumbnail" ignore {
       Get(s"${baseThumbnail}${publicOrgId}") ~> Route.seal(baseRoutes) ~> check {

--- a/app-backend/database/src/main/scala/com/azavea/rf/database/fields/OrganizationFkFields.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/fields/OrganizationFkFields.scala
@@ -3,7 +3,7 @@ package com.azavea.rf.database.fields
 import com.azavea.rf.database.ExtendedPostgresDriver.api._
 import com.azavea.rf.database.query.OrgQueryParameters
 import com.azavea.rf.database.tables.Organizations
-import com.azavea.rf.datamodel.Organization
+import com.azavea.rf.datamodel.{Organization, User}
 import slick.lifted.ForeignKeyQuery
 
 trait OrganizationFkFields  { self: Table[_] =>
@@ -18,6 +18,14 @@ object OrganizationFkFields {
         that.filter { rec =>
           rec.organizationId inSet orgParams.organizations.toSet
         }
+      } else {
+        that
+      }
+    }
+
+    def filterToSharedOrganizationIfNotInRoot(user: User) = {
+      if (!user.isInRootOrganization) {
+        that.filter(_.organizationId === user.organizationId)
       } else {
         that
       }

--- a/app-backend/database/src/main/scala/com/azavea/rf/database/fields/UserFkFields.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/fields/UserFkFields.scala
@@ -31,5 +31,13 @@ object UserFkFields {
     def filterToOwner(user: User) = {
       that.filter(_.createdBy === user.id)
     }
+
+    def filterToOwnerIfNotInRootOrganization(user: User) = {
+      if (!user.isInRootOrganization) {
+        that.filter(_.createdBy === user.id)
+      } else {
+        that
+      }
+    }
   }
 }

--- a/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Datasources.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Datasources.scala
@@ -92,16 +92,25 @@ object Datasources extends TableQuery(tag => new Datasources(tag)) with LazyLogg
   /** Given a datasource ID, attempt to retrieve it from the database
     *
     * @param datasourceId UUID ID of datasource to get from database
+    * @param user         Results will be limited to user's organization
     */
-  def getDatasource(datasourceId: UUID) =
-    Datasources.filter(_.id === datasourceId).result.headOption
+  def getDatasource(datasourceId: UUID, user: User) =
+    Datasources
+      .filterToSharedOrganizationIfNotInRoot(user)
+      .filter(_.id === datasourceId)
+      .result
+      .headOption
 
   /** Given a datasource ID, attempt to remove it from the database
     *
     * @param datasourceId UUID ID of datasource to remove
+    * @param user         Results will be limited to user's organization
     */
-  def deleteDatasource(datasourceId: UUID) =
-    Datasources.filter(_.id === datasourceId).delete
+  def deleteDatasource(datasourceId: UUID, user: User) =
+    Datasources
+      .filterToSharedOrganizationIfNotInRoot(user)
+      .filter(_.id === datasourceId)
+      .delete
 
 /** Update a datasource @param datasource Datasource to use for update
     * @param datasourceId UUID of datasource to update

--- a/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Datasources.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Datasources.scala
@@ -61,12 +61,13 @@ object Datasources extends TableQuery(tag => new Datasources(tag)) with LazyLogg
     *
     * @param pageRequest PageRequest information about sorting and page size
     */
-  def listDatasources(offset: Int, limit: Int, datasourceParams: DatasourceQueryParameters) = {
+  def listDatasources(offset: Int, limit: Int, datasourceParams: DatasourceQueryParameters, user: User) = {
 
     val dropRecords = limit * offset
+    val accessibleDatasources = Datasources.filterToSharedOrganizationIfNotInRoot(user)
     val datasourceFilterQuery = datasourceParams.name match {
-      case Some(n) => Datasources.filter(_.name === n)
-      case _ => Datasources
+      case Some(n) => accessibleDatasources.filter(_.name === n)
+      case _ => accessibleDatasources
     }
 
     ListQueryResult[Datasource](

--- a/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Datasources.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Datasources.scala
@@ -121,7 +121,9 @@ object Datasources extends TableQuery(tag => new Datasources(tag)) with LazyLogg
     val updateTime = new Timestamp((new java.util.Date).getTime)
 
     val updateDatasourceQuery = for {
-      updateDatasource <- Datasources.filter(_.id === datasourceId)
+      updateDatasource <- Datasources
+                            .filterToSharedOrganizationIfNotInRoot(user)
+                            .filter(_.id === datasourceId)
     } yield (
       updateDatasource.modifiedAt,
       updateDatasource.modifiedBy,

--- a/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Images.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Images.scala
@@ -189,7 +189,9 @@ object Images extends TableQuery(tag => new Images(tag)) with LazyLogging {
     val bands = image.bands
 
     val updateImageQuery = for {
-      updateImage <- Images.filter(_.id === imageId)
+      updateImage <- Images
+                       .filterToSharedOrganizationIfNotInRoot(user)
+                       .filter(_.id === imageId)
     } yield (
       updateImage.modifiedAt, updateImage.modifiedBy, updateImage.rawDataBytes,
       updateImage.visibility, updateImage.filename, updateImage.sourceuri,

--- a/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Projects.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Projects.scala
@@ -228,7 +228,9 @@ object Projects extends TableQuery(tag => new Projects(tag)) with LazyLogging {
     val updateTime = new Timestamp((new Date).getTime)
 
     val updateProjectQuery = for {
-      updateProject <- Projects.filter(_.id === projectId)
+      updateProject <- Projects
+                         .filterToSharedOrganizationIfNotInRoot(user)
+                         .filter(_.id === projectId)
     } yield (
       updateProject.modifiedAt, updateProject.modifiedBy, updateProject.name, updateProject.description,
       updateProject.visibility, updateProject.tileVisibility, updateProject.tags

--- a/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Projects.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Projects.scala
@@ -146,12 +146,17 @@ object Projects extends TableQuery(tag => new Projects(tag)) with LazyLogging {
   /** Get project given a projectId
     *
     * @param projectId UUID primary key of project to retrieve
+    * @user user       Results will be limited to user's organization
     */
-  def getProject(projectId: UUID)
+  def getProject(projectId: UUID, user: User)
                (implicit database: DB): Future[Option[Project]] = {
 
     database.db.run {
-      Projects.filter(_.id === projectId).result.headOption
+      Projects
+        .filterToSharedOrganizationIfNotInRoot(user)
+        .filter(_.id === projectId)
+        .result
+        .headOption
     }
   }
 
@@ -191,11 +196,15 @@ object Projects extends TableQuery(tag => new Projects(tag)) with LazyLogging {
   /** Delete a given project from the database
     *
     * @param projectId UUID primary key of project to delete
+    * @param user      Results will be limited to user's organization
     */
-  def deleteProject(projectId: UUID)(implicit database: DB): Future[Int] = {
+  def deleteProject(projectId: UUID, user: User)(implicit database: DB): Future[Int] = {
 
     database.db.run {
-      Projects.filter(_.id === projectId).delete
+      Projects
+        .filterToSharedOrganizationIfNotInRoot(user)
+        .filter(_.id === projectId)
+        .delete
     }
   }
 

--- a/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Projects.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Projects.scala
@@ -143,10 +143,26 @@ object Projects extends TableQuery(tag => new Projects(tag)) with LazyLogging {
     }.map(Scene.WithRelated.fromRecords)
   }
 
-  /** Get project given a projectId
+  /** Get public project given a projectId
     *
     * @param projectId UUID primary key of project to retrieve
-    * @user user       Results will be limited to user's organization
+    */
+  def getPublicProject(projectId: UUID)
+                      (implicit database: DB): Future[Option[Project]] = {
+
+    database.db.run {
+      Projects
+        .filter(_.tileVisibility === Visibility.fromString("PUBLIC"))
+        .filter(_.id === projectId)
+        .result
+        .headOption
+    }
+  }
+
+  /** Get project given a projectId and user
+    *
+    * @param projectId UUID primary key of project to retrieve
+    * @param user      Results will be limited to user's organization
     */
   def getProject(projectId: UUID, user: User)
                (implicit database: DB): Future[Option[Project]] = {

--- a/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Scenes.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Scenes.scala
@@ -255,6 +255,24 @@ object Scenes extends TableQuery(tag => new Scenes(tag)) with LazyLogging {
     }
   }
 
+  /** Retrieve single scene from database for caching purposes
+    * This does not filter by user and should not be used by standard routes.
+    *
+    * @param sceneId java.util.UUID ID of scene to query with
+    */
+  def getSceneForCaching(sceneId: UUID)
+                        (implicit database: DB): Future[Option[Scene.WithRelated]] = {
+
+    database.db.run {
+      Scenes
+        .filter(_.id === sceneId)
+        .joinWithRelated
+        .result
+    } map { result =>
+      Scene.WithRelated.fromRecords(result).headOption
+    }
+  }
+
   /** Filter scenes based on scene query parameters
     *
     * For reuse in other tables that need to filter scenes, e.g., projects

--- a/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Scenes.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Scenes.scala
@@ -237,12 +237,14 @@ object Scenes extends TableQuery(tag => new Scenes(tag)) with LazyLogging {
   /** Retrieve a single scene from the database
     *
     * @param sceneId java.util.UUID ID of scene to query with
+    * @param user    Results will be limited to user's organization
     */
-  def getScene(sceneId: UUID)
+  def getScene(sceneId: UUID, user: User)
               (implicit database: DB): Future[Option[Scene.WithRelated]] = {
 
     database.db.run {
       val action = Scenes
+        .filterToSharedOrganizationIfNotInRoot(user)
         .filter(_.id === sceneId)
         .joinWithRelated
         .result
@@ -361,10 +363,14 @@ object Scenes extends TableQuery(tag => new Scenes(tag)) with LazyLogging {
   /** Delete a scene from the database
     *
     * @param sceneId java.util.UUID ID of scene to delete
+    * @param user    Results will be limited to user's organization
     */
-  def deleteScene(sceneId: UUID)(implicit database: DB): Future[Int] = {
+  def deleteScene(sceneId: UUID, user: User)(implicit database: DB): Future[Int] = {
     database.db.run {
-      Scenes.filter(_.id === sceneId).delete
+      Scenes
+        .filterToSharedOrganizationIfNotInRoot(user)
+        .filter(_.id === sceneId)
+        .delete
     }
   }
 

--- a/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Thumbnails.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Thumbnails.scala
@@ -140,13 +140,15 @@ object Thumbnails extends TableQuery(tag => new Thumbnails(tag)) with LazyLoggin
     * @param thumbnail Thumbnail scene to use to update the database
     * @param thumbnailId UUID ID of scene to update
     */
-  def updateThumbnail(thumbnail: Thumbnail, thumbnailId: UUID)
+  def updateThumbnail(thumbnail: Thumbnail, thumbnailId: UUID, user: User)
                      (implicit database: DB): Future[Int] = {
 
     val updateTime = new Timestamp((new java.util.Date).getTime)
 
     val updateThumbnailQuery = for {
-      updateThumbnail <- Thumbnails.filter(_.id === thumbnailId)
+      updateThumbnail <- Thumbnails
+                           .filterToSharedOrganizationIfNotInRoot(user)
+                           .filter(_.id === thumbnailId)
     } yield (
       updateThumbnail.modifiedAt, updateThumbnail.widthPx, updateThumbnail.heightPx,
       updateThumbnail.thumbnailSize, updateThumbnail.scene, updateThumbnail.url

--- a/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Thumbnails.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Thumbnails.scala
@@ -84,10 +84,12 @@ object Thumbnails extends TableQuery(tag => new Thumbnails(tag)) with LazyLoggin
     }
   }
 
-  def listThumbnails(pageRequest: PageRequest, queryParams: ThumbnailQueryParameters)
+  def listThumbnails(pageRequest: PageRequest, queryParams: ThumbnailQueryParameters, user: User)
                     (implicit database: DB): Future[PaginatedResponse[Thumbnail]] = {
 
-    val thumbnails = Thumbnails.filterBySceneParams(queryParams)
+    val thumbnails = Thumbnails
+                       .filterToSharedOrganizationIfNotInRoot(user)
+                       .filterBySceneParams(queryParams)
 
     val paginatedThumbnails = database.db.run {
       val action = thumbnails.page(pageRequest).result

--- a/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Thumbnails.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Thumbnails.scala
@@ -69,11 +69,15 @@ object Thumbnails extends TableQuery(tag => new Thumbnails(tag)) with LazyLoggin
   /** Retrieve a single thumbnail from the database
     *
     * @param thumbnailId UUID ID Of thumbnail to query with
+    * @param user        Results will be limited to user's organization
     */
-  def getThumbnail(thumbnailId: UUID)
+  def getThumbnail(thumbnailId: UUID, user: User)
                   (implicit database: DB): Future[Option[Thumbnail]] = {
 
-    val action = Thumbnails.filter(_.id === thumbnailId).result
+    val action = Thumbnails
+                   .filterToSharedOrganizationIfNotInRoot(user)
+                   .filter(_.id === thumbnailId)
+                   .result
     logger.debug(s"Retrieving thumbnail with: ${action.statements.headOption}")
     database.db.run {
       action.headOption
@@ -107,11 +111,15 @@ object Thumbnails extends TableQuery(tag => new Thumbnails(tag)) with LazyLoggin
   /** Delete a scene from the database
     *
     * @param thumbnailId UUID ID of scene to delete
+    * @param user        Results will be limited to user's organization
     */
-  def deleteThumbnail(thumbnailId: UUID)
+  def deleteThumbnail(thumbnailId: UUID, user: User)
                      (implicit database: DB): Future[Int] = {
 
-    val action = Thumbnails.filter(_.id === thumbnailId).delete
+    val action = Thumbnails
+                   .filterToSharedOrganizationIfNotInRoot(user)
+                   .filter(_.id === thumbnailId)
+                   .delete
     logger.debug(s"Deleting thumbnail with: ${action.statements.headOption}")
     database.db.run {
       action.map {

--- a/app-backend/database/src/main/scala/com/azavea/rf/database/tables/ToolRuns.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/tables/ToolRuns.scala
@@ -50,8 +50,12 @@ object ToolRuns extends TableQuery(tag => new ToolRuns(tag)) with LazyLogging {
   def insertToolRun(tr: ToolRun.Create, userId: String): DBIO[ToolRun] =
     (ToolRuns returning ToolRuns).forceInsert(tr.toToolRun(userId))
 
-  def getToolRun(id: UUID): DBIO[Option[ToolRun]] =
-    ToolRuns.filter(_.id === id).result.headOption
+  def getToolRun(id: UUID, user: User): DBIO[Option[ToolRun]] =
+    ToolRuns
+      .filterToSharedOrganizationIfNotInRoot(user)
+      .filter(_.id === id)
+      .result
+      .headOption
 
   def listToolRuns(offset: Int, limit: Int,
                    toolRunParams: CombinedToolRunQueryParameters): ListQueryResult[ToolRun] = {
@@ -87,8 +91,11 @@ object ToolRuns extends TableQuery(tag => new ToolRuns(tag)) with LazyLogging {
     )
   }
 
-  def deleteToolRun(id: UUID): DBIO[Int] =
-    ToolRuns.filter(_.id === id).delete
+  def deleteToolRun(id: UUID, user: User): DBIO[Int] =
+    ToolRuns
+      .filterToSharedOrganizationIfNotInRoot(user)
+      .filter(_.id === id)
+      .delete
 }
 
 class ToolRunDefaultQuery[M, U, C[_]](toolruns: ToolRuns.TableQuery) {

--- a/app-backend/database/src/main/scala/com/azavea/rf/database/tables/ToolRuns.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/tables/ToolRuns.scala
@@ -16,6 +16,8 @@ import com.azavea.rf.database.query._
 import io.circe.Json
 
 class ToolRuns(_TableTag: Tag) extends Table[ToolRun](_TableTag, "tool_runs")
+    with UserFkVisibleFields
+    with OrganizationFkFields
     with TimestampFields {
   def * = (id, createdAt, createdBy, modifiedAt, modifiedBy, visibility,
            organizationId, projectId, toolId, execution_parameters) <> (ToolRun.tupled, ToolRun.unapply _)
@@ -33,7 +35,7 @@ class ToolRuns(_TableTag: Tag) extends Table[ToolRun](_TableTag, "tool_runs")
 
   lazy val createdByUserFK = foreignKey("tool_runs_created_by_fkey", createdBy, Users)(r => r.id, onUpdate=ForeignKeyAction.NoAction, onDelete=ForeignKeyAction.NoAction)
   lazy val modifiedByUserFK = foreignKey("tool_runs_modified_by_fkey", modifiedBy, Users)(r => r.id, onUpdate=ForeignKeyAction.NoAction, onDelete=ForeignKeyAction.NoAction)
-  lazy val organizationFK = foreignKey("tool_runs_organization_fkey", organizationId, Organizations)(r => r.id, onUpdate=ForeignKeyAction.NoAction, onDelete=ForeignKeyAction.NoAction)
+  lazy val organizationsFk = foreignKey("tool_runs_organization_fkey", organizationId, Organizations)(r => r.id, onUpdate=ForeignKeyAction.NoAction, onDelete=ForeignKeyAction.NoAction)
   lazy val projectFK = foreignKey("tool_runs_project_fkey", projectId, Projects)(r => r.id, onUpdate=ForeignKeyAction.NoAction, onDelete=ForeignKeyAction.NoAction)
   lazy val toolFK = foreignKey("tool_runs_tool_fkey", toolId, Tools)(r => r.id, onUpdate=ForeignKeyAction.NoAction, onDelete=ForeignKeyAction.NoAction)
 

--- a/app-backend/database/src/main/scala/com/azavea/rf/database/tables/ToolRuns.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/tables/ToolRuns.scala
@@ -58,9 +58,10 @@ object ToolRuns extends TableQuery(tag => new ToolRuns(tag)) with LazyLogging {
       .headOption
 
   def listToolRuns(offset: Int, limit: Int,
-                   toolRunParams: CombinedToolRunQueryParameters): ListQueryResult[ToolRun] = {
+                   toolRunParams: CombinedToolRunQueryParameters, user: User): ListQueryResult[ToolRun] = {
     val dropRecords = limit * offset
-    val toolRunFilterQuery = ToolRuns
+    val accessibleToolRuns = ToolRuns.filterToSharedOrganizationIfNotInRoot(user)
+    val toolRunFilterQuery = accessibleToolRuns
       .filterByTimestamp(toolRunParams.timestampParams)
       .filterByToolRunParams(toolRunParams.toolRunParams)
 
@@ -69,7 +70,7 @@ object ToolRuns extends TableQuery(tag => new ToolRuns(tag)) with LazyLogging {
          .drop(dropRecords)
          .take(limit)
          .result):DBIO[Seq[ToolRun]],
-      ToolRuns.length.result
+      accessibleToolRuns.length.result
     )
   }
 

--- a/app-backend/database/src/main/scala/com/azavea/rf/database/tables/ToolRuns.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/tables/ToolRuns.scala
@@ -78,7 +78,9 @@ object ToolRuns extends TableQuery(tag => new ToolRuns(tag)) with LazyLogging {
     val updateTime = new Timestamp((new java.util.Date).getTime)
 
     val updateToolRunQuery = for {
-      updateToolRun <- ToolRuns.filter(_.id === id)
+      updateToolRun <- ToolRuns
+                         .filterToSharedOrganizationIfNotInRoot(user)
+                         .filter(_.id === id)
     } yield (
       updateToolRun.modifiedAt,
       updateToolRun.modifiedBy,

--- a/app-backend/database/src/main/scala/com/azavea/rf/database/tables/ToolTags.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/tables/ToolTags.scala
@@ -115,9 +115,14 @@ object ToolTags extends TableQuery(tag => new ToolTags(tag)) with LazyLogging {
   /** Given a tool tag ID, attempt to retrieve it from the database
     *
     * @param toolTagId UUID ID of tool tag to get from database
+    * @param user      Results will be limited to user's organization
     */
-  def getToolTag(toolTagId: UUID)(implicit database: DB): Future[Option[ToolTag]] = {
-    val fetchAction = ToolTags.filter(_.id === toolTagId).result.headOption
+  def getToolTag(toolTagId: UUID, user: User)(implicit database: DB): Future[Option[ToolTag]] = {
+    val fetchAction = ToolTags
+                        .filterToSharedOrganizationIfNotInRoot(user)
+                        .filter(_.id === toolTagId)
+                        .result
+                        .headOption
 
     database.db.run {
       fetchAction
@@ -127,10 +132,14 @@ object ToolTags extends TableQuery(tag => new ToolTags(tag)) with LazyLogging {
   /** Delete a given tool tag
     *
     * @param toolTagId UUID ID of tool tag to delete
+    * @param user      Results will be limited to user's organization
     */
-  def deleteToolTag(toolTagId: UUID)(implicit database: DB): Future[Int] = {
+  def deleteToolTag(toolTagId: UUID, user: User)(implicit database: DB): Future[Int] = {
     database.db.run {
-      ToolTags.filter(_.id === toolTagId).delete
+      ToolTags
+        .filterToSharedOrganizationIfNotInRoot(user)
+        .filter(_.id === toolTagId)
+        .delete
     }
   }
 

--- a/app-backend/database/src/main/scala/com/azavea/rf/database/tables/ToolTags.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/tables/ToolTags.scala
@@ -157,7 +157,9 @@ object ToolTags extends TableQuery(tag => new ToolTags(tag)) with LazyLogging {
     val updateTime = new Timestamp((new java.util.Date).getTime)
 
     val updateToolTagQuery = for {
-      updateToolTag <- ToolTags.filter(_.id === toolTagId)
+      updateToolTag <- ToolTags
+                         .filterToSharedOrganizationIfNotInRoot(user)
+                         .filter(_.id === toolTagId)
     } yield (updateToolTag.modifiedAt, updateToolTag.modifiedBy, updateToolTag.tag)
 
     database.db.run {

--- a/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Tools.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Tools.scala
@@ -260,7 +260,9 @@ object Tools extends TableQuery(tag => new Tools(tag)) with LazyLogging {
     val updateTime = new Timestamp((new java.util.Date).getTime)
 
     val updateToolQuery = for {
-      updateTool <- Tools.filter(_.id === toolId)
+      updateTool <- Tools
+                      .filterToSharedOrganizationIfNotInRoot(user)
+                      .filter(_.id === toolId)
     } yield (
       updateTool.modifiedAt, updateTool.modifiedBy, updateTool.title,
       updateTool.description, updateTool.requirements, updateTool.license,

--- a/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Uploads.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Uploads.scala
@@ -120,7 +120,9 @@ object Uploads extends TableQuery(tag => new Uploads(tag)) with LazyLogging {
     val updateTime = new Timestamp((new java.util.Date).getTime)
 
     val updateUploadQuery = for {
-      updateUpload <- Uploads.filter(_.id === uploadId)
+      updateUpload <- Uploads
+                        .filterToSharedOrganizationIfNotInRoot(user)
+                        .filter(_.id === uploadId)
     } yield (
       updateUpload.modifiedAt,
       updateUpload.modifiedBy,

--- a/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Uploads.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Uploads.scala
@@ -64,16 +64,17 @@ object Uploads extends TableQuery(tag => new Uploads(tag)) with LazyLogging {
     * @param limit Int limit of objects per page
     * @param queryParams UploadQueryparameters query parameters for request
     */
-  def listUploads(offset: Int, limit: Int, queryParams: UploadQueryParameters) = {
+  def listUploads(offset: Int, limit: Int, queryParams: UploadQueryParameters, user: User) = {
 
     val dropRecords = limit * offset
+    val accessibleUploads = Uploads.filterToSharedOrganizationIfNotInRoot(user)
     ListQueryResult[Upload](
-      (Uploads
+      (accessibleUploads
          .filterByUploadParams(queryParams)
          .drop(dropRecords)
          .take(limit)
          .result):DBIO[Seq[Upload]],
-      Uploads.length.result
+      accessibleUploads.length.result
     )
   }
 

--- a/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Uploads.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Uploads.scala
@@ -91,16 +91,25 @@ object Uploads extends TableQuery(tag => new Uploads(tag)) with LazyLogging {
   /** Given a upload ID, attempt to retrieve it from the database
     *
     * @param uploadId UUID ID of upload to get from database
+    * @param user     Results will be limited to user's organization
     */
-  def getUpload(uploadId: UUID) =
-    Uploads.filter(_.id === uploadId).result.headOption
+  def getUpload(uploadId: UUID, user: User) =
+    Uploads
+      .filterToSharedOrganizationIfNotInRoot(user)
+      .filter(_.id === uploadId)
+      .result
+      .headOption
 
   /** Given a upload ID, attempt to remove it from the database
     *
     * @param uploadId UUID ID of upload to remove
+    * @param user     Results will be limited to user's organization
     */
-  def deleteUpload(uploadId: UUID) =
-    Uploads.filter(_.id === uploadId).delete
+  def deleteUpload(uploadId: UUID, user: User) =
+    Uploads
+      .filterToSharedOrganizationIfNotInRoot(user)
+      .filter(_.id === uploadId)
+      .delete
 
 /** Update a upload @param upload Upload to use for update
     * @param uploadId UUID of upload to update

--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/User.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/User.scala
@@ -23,7 +23,17 @@ case class User(
   role: UserRole,
   createdAt: Timestamp,
   modifiedAt: Timestamp
-)
+) {
+  private val rootOrganizationId = UUID.fromString("9e2bef18-3f46-426b-a5bd-9913ee1ff840")
+
+  def isInRootOrganization: Boolean = {
+    this.organizationId == rootOrganizationId
+  }
+
+  def isInRootOrSameOrganizationAs(target: { def organizationId: UUID }): Boolean = {
+    this.isInRootOrganization || this.organizationId == target.organizationId
+  }
+}
 
 object User {
 

--- a/app-backend/tile/src/main/scala/LayerCache.scala
+++ b/app-backend/tile/src/main/scala/LayerCache.scala
@@ -58,7 +58,7 @@ object LayerCache extends Config with LazyLogging {
 
   def layerUri(layerId: UUID)(implicit ec: ExecutionContext): OptionT[Future, String] = {
     layerUriCache.get(layerId, _ => blocking {
-      OptionT(Scenes.getScene(layerId).map(_.flatMap(_.ingestLocation)))
+      OptionT(Scenes.getSceneForCaching(layerId).map(_.flatMap(_.ingestLocation)))
     })
   }
 

--- a/app-backend/tile/src/main/scala/directives/TileAuthentication.scala
+++ b/app-backend/tile/src/main/scala/directives/TileAuthentication.scala
@@ -39,8 +39,8 @@ trait TileAuthentication extends Authentication
   }
 
   def isProjectPublic(id: UUID): Directive1[Boolean] =
-    onSuccess(Projects.getProject(id)).flatMap {
-      case Some(project) => provide(project.tileVisibility == Visibility.Public)
+    onSuccess(Projects.getPublicProject(id)).flatMap {
+      case Some(_) => provide(true)
       case _ => provide(false)
     }
 


### PR DESCRIPTION
## Overview

Any user that is a member of the [root organization](https://github.com/azavea/raster-foundry/blob/13ac14022fc9d9ce07c096968d2be57d440ef20d/app-backend/migrations/src_migrations/main/scala/2.scala#L13) is a _super user_. Super users have access to everything and can make all API calls. Regular users can only access datasources, images, maptokens, projects, scenes, tags, thumbnails, toolruns, tools, and uploads that belong to the same organization as the users themselves.

The `User` class has been augmented with two methods: `isInRootOrganization` and `isInRootOrSameOrganizationAs(target)`. The first returns true for super users, and the second for super users as well as members of `target`'s organization.

All _create_ and _update_ routes have been decorated with AKKA HTTP's `authorize` directive, which uses `user.isInRootOrSameOrganizationAs(payload)` to determine if the authenticated user is allowed to create or update the payload which they are supplying. In case of inaccessible resources, the API would return a 403 instead of a 201 or 200. In addition, we also check during update if the resource is in the same organization as the user, so a user cannot maliciously update another organization's resource by specifying their own in the payload.

All _list_, _get_ and _delete_ routes have been modified to take the `user` in addition to the resource `id`. The results are filtered to the `user`'s organization if they are not a super user. In case of inaccessible resources, the API would return a 404 instead of a 200 or 204.

Map tokens are personal items, and thus are accessible only to owners and super users.

There were a couple spots that needed refactoring to accommodate these changes:

 * `ThumbnailSpec` performed some tests on the database functions themselves, unlike all other specs which only test the API routes. These tests were no longer working since the spec could not instantiate a user. These tests have been removed.
 * `isProjectPublic` directive for tile access fetched a project from the database and then checked its tile visibility. Since fetching projects from the database now requires a user, but that should by definition not be needed for public projects, a new method `getPublicProject` was added to the Projects table for this purpose.
 * `getScene` is used when caching layers. Since we cannot expect a `user` to be available at that stage, we make a new method `getSceneForCaching` which allows fetching scenes without specifying a user.

The `/organizations` and `/users` endpoints have not had these authorization directives added to them. It is possible we might want to restrict accessing and modifying these to those in the root organization only, but since currently there are no users in the root organization I didn't want to lock us out from staging. I have created #1364 for this.

### Checklist

- ~~Styleguide updated, if necessary~~
- ~~Swagger specification updated, if necessary~~
- ~~Symlinks from new migrations present or corrected for any new migrations~~

## Testing Instructions

 * Create a project. Ensure you can access the project as you.

    ```http
    POST /api/projects HTTP/1.1
    Authorization: Bearer eyJ...
    {
        "description": "",
        "extent": null,
        "manualOrder": true,
        "name": "1297 Authorization Test 1",
        "organizationId": "dfac6307-b5ef-43f7-beda-b9f208bb7726",
        "slugLabel": "1297 Authorization Test 1",
        "tags": [],
        "tileVisibility": "PRIVATE",
        "visibility": "PRIVATE"
    }

    HTTP/1.1 201 Created
    {
        "createdAt": "2017-03-30T18:23:19.157Z",
        "createdBy": "google-oauth2|116017798712183358036",
        "description": "",
        "extent": null,
        "id": "72faa7cf-a6ef-4d8a-8d0e-5163d84086a9",
        "manualOrder": true,
        "modifiedAt": "2017-03-30T18:23:19.157Z",
        "modifiedBy": "google-oauth2|116017798712183358036",
        "name": "1297 Authorization Test 1",
        "organizationId": "dfac6307-b5ef-43f7-beda-b9f208bb7726",
        "slugLabel": "1297 Authorization Test 1",
        "tags": [],
        "tileVisibility": "PRIVATE",
        "visibility": "PRIVATE"
    }
    ```

    ```http
    GET /api/projects/72faa7cf-a6ef-4d8a-8d0e-5163d84086a9 HTTP/1.1
    Authorization: Bearer eyJ...

    HTTP/1.1 200 OK
    {
        "createdAt": "2017-03-30T18:23:19.157Z",
        "createdBy": "google-oauth2|116017798712183358036",
        "description": "",
        "extent": null,
        "id": "72faa7cf-a6ef-4d8a-8d0e-5163d84086a9",
        "manualOrder": true,
        "modifiedAt": "2017-03-30T18:23:19.157Z",
        "modifiedBy": "google-oauth2|116017798712183358036",
        "name": "1297 Authorization Test 1",
        "organizationId": "dfac6307-b5ef-43f7-beda-b9f208bb7726",
        "slugLabel": "1297 Authorization Test 1",
        "tags": [],
        "tileVisibility": "PRIVATE",
        "visibility": "PRIVATE"
    }
    ```

 * Create a new organization.

    ```http
    POST /api/organizations HTTP/1.1
    Authorization: Bearer eyJ...
    {
        "name": "Other"
    }

    HTTP/1.1 201 Created
    {
        "createdAt": "2017-03-30T18:18:33.649Z",
        "id": "746110fe-3129-42cc-8ae7-35c36f9102f4",
        "modifiedAt": "2017-03-30T18:18:33.649Z",
        "name": "Other"
    }
    ```

 * Update the project to belong to this new organization (which is different from your organization)

    ```http
    PUT /api/projects/72faa7cf-a6ef-4d8a-8d0e-5163d84086a9 HTTP/1.1
    Authorization: Bearer eyJ...
    {
        "createdAt": "2017-03-30T18:23:19.157Z",
        "createdBy": "google-oauth2|116017798712183358036",
        "description": "",
        "extent": null,
        "id": "72faa7cf-a6ef-4d8a-8d0e-5163d84086a9",
        "manualOrder": true,
        "modifiedAt": "2017-03-30T18:23:19.157Z",
        "modifiedBy": "google-oauth2|116017798712183358036",
        "name": "1297 Authorization Test 1",
        "organizationId": "746110fe-3129-42cc-8ae7-35c36f9102f4",
        "slugLabel": "1297 Authorization Test 1",
        "tags": [],
        "tileVisibility": "PRIVATE",
        "visibility": "PRIVATE"
    }

    HTTP/1.1 403 Forbidden
    The supplied authentication is not authorized to access this resource
    ```

    You will have to do it via the database

    ```sql
    UPDATE projects
       SET organization_id = '746110fe-3129-42cc-8ae7-35c36f9102f4'
     WHERE id = '72faa7cf-a6ef-4d8a-8d0e-5163d84086a9';
    ```

 * Try accessing the project now. Ensure that you get a 404 on get or delete, and a 400 on update.

    ```http
    GET /api/projects/72faa7cf-a6ef-4d8a-8d0e-5163d84086a9 HTTP/1.1
    Authorization: Bearer eyJ...

    HTTP/1.1 404 Not Found
    The requested resource could not be found.
    ```

    ```http
    PUT /api/projects/72faa7cf-a6ef-4d8a-8d0e-5163d84086a9 HTTP/1.1
    Authorization: Bearer eyJ...
    {
        "createdAt": "2017-03-30T18:23:19.157Z",
        "createdBy": "google-oauth2|116017798712183358036",
        "description": "",
        "extent": null,
        "id": "72faa7cf-a6ef-4d8a-8d0e-5163d84086a9",
        "manualOrder": true,
        "modifiedAt": "2017-03-30T18:23:19.157Z",
        "modifiedBy": "google-oauth2|116017798712183358036",
        "name": "1297 Authorization Test 1",
        "organizationId": "dfac6307-b5ef-43f7-beda-b9f208bb7726",
        "slugLabel": "1297 Authorization Test 1",
        "tags": [],
        "tileVisibility": "PRIVATE",
        "visibility": "PRIVATE"
    }

    HTTP/1.1 400 Bad Request
    Error updating project: update result expected to be 1, was 0
    ```

 * Try creating a new project with `organizationId` set to that of the new organization (which is different from your organization). Ensure you get a 403.

    ```http
    POST /api/projects HTTP/1.1
    Authorization: Bearer eyJ...
    {
        "description": "",
        "extent": null,
        "manualOrder": true,
        "name": "1297 Authorization Test 2",
        "organizationId": "746110fe-3129-42cc-8ae7-35c36f9102f4",
        "slugLabel": "1297 Authorization Test 2",
        "tags": [],
        "tileVisibility": "PRIVATE",
        "visibility": "PRIVATE"
    }

    HTTP/1.1 403 Forbidden
    The supplied authentication is not authorized to access this resource
    ```

 * Try listing all projects. This last one will show up since users can see all public projects, and all projects created by them. Since you created this project, even though it is in another organization, it is visible to you.

    ```http
    GET /api/projects HTTP/1.1
    Authorization: Bearer eyJ...

    HTTP/1.1 200 OK
    {
        "count": 2,
        "hasNext": false,
        "hasPrevious": false,
        "page": 0,
        "pageSize": 30,
        "results": [
            {
                "createdAt": "2017-03-10T20:56:16.935Z",
                "createdBy": "google-oauth2|116017798712183358036",
                "description": "",
                "extent": {
                    "coordinates": [
                        [
                            [
                                -13.207230000000001,
                                26.372459999999997
                            ],
                            [
                                -13.207230000000001,
                                28.478300000000004
                            ],
                            [
                                -10.89195,
                                28.478300000000004
                            ],
                            [
                                -10.89195,
                                26.372459999999997
                            ],
                            [
                                -13.207230000000001,
                                26.372459999999997
                            ]
                        ]
                    ],
                    "type": "Polygon"
                },
                "id": "27fe6068-a7b6-45ff-b339-7ae185b797dc",
                "manualOrder": true,
                "modifiedAt": "2017-03-10T20:56:16.935Z",
                "modifiedBy": "google-oauth2|116017798712183358036",
                "name": "Map Token Test",
                "organizationId": "dfac6307-b5ef-43f7-beda-b9f208bb7726",
                "slugLabel": "Map Token Test",
                "tags": [],
                "tileVisibility": "PRIVATE",
                "visibility": "PRIVATE"
            },
            {
                "createdAt": "2017-03-30T18:23:19.157Z",
                "createdBy": "google-oauth2|116017798712183358036",
                "description": "",
                "extent": null,
                "id": "72faa7cf-a6ef-4d8a-8d0e-5163d84086a9",
                "manualOrder": true,
                "modifiedAt": "2017-03-30T18:23:19.157Z",
                "modifiedBy": "google-oauth2|116017798712183358036",
                "name": "1297 Authorization Test 1",
                "organizationId": "746110fe-3129-42cc-8ae7-35c36f9102f4",
                "slugLabel": "1297 Authorization Test 1",
                "tags": [],
                "tileVisibility": "PRIVATE",
                "visibility": "PRIVATE"
            }
        ]
    }
    ```

    But if this wasn't the case

    ```sql
    UPDATE projects
       SET created_by = 'default'
     WHERE id = '72faa7cf-a6ef-4d8a-8d0e-5163d84086a9';
    ```

    it wouldn't show up anymore

    ```http
    GET /api/projects HTTP/1.1
    Authorization: Bearer eyJ...

    HTTP/1.1 200 OK
    {
        "count": 1,
        "hasNext": false,
        "hasPrevious": false,
        "page": 0,
        "pageSize": 30,
        "results": [
            {
                "createdAt": "2017-03-10T20:56:16.935Z",
                "createdBy": "google-oauth2|116017798712183358036",
                "description": "",
                "extent": {
                    "coordinates": [
                        [
                            [
                                -13.207230000000001,
                                26.372459999999997
                            ],
                            [
                                -13.207230000000001,
                                28.478300000000004
                            ],
                            [
                                -10.89195,
                                28.478300000000004
                            ],
                            [
                                -10.89195,
                                26.372459999999997
                            ],
                            [
                                -13.207230000000001,
                                26.372459999999997
                            ]
                        ]
                    ],
                    "type": "Polygon"
                },
                "id": "27fe6068-a7b6-45ff-b339-7ae185b797dc",
                "manualOrder": true,
                "modifiedAt": "2017-03-10T20:56:16.935Z",
                "modifiedBy": "google-oauth2|116017798712183358036",
                "name": "Map Token Test",
                "organizationId": "dfac6307-b5ef-43f7-beda-b9f208bb7726",
                "slugLabel": "Map Token Test",
                "tags": [],
                "tileVisibility": "PRIVATE",
                "visibility": "PRIVATE"
            }
        ]
    }
    ```

 * Update your user to belong to the root organization.

    ```sql
    UPDATE users
       SET organization_id = '746110fe-3129-42cc-8ae7-35c36f9102f4' 
     WHERE id = 'google-oauth2|116017798712183358036';
    ```

 * Try accessing the project now. Ensure that you should be able to list, get, update, and delete the new project.

    ```http
    GET /api/projects/72faa7cf-a6ef-4d8a-8d0e-5163d84086a9 HTTP/1.1
    Authorization: Bearer eyJ...

    HTTP/1.1 200 OK
    {
        "createdAt": "2017-03-30T18:23:19.157Z",
        "createdBy": "default",
        "description": "",
        "extent": null,
        "id": "72faa7cf-a6ef-4d8a-8d0e-5163d84086a9",
        "manualOrder": true,
        "modifiedAt": "2017-03-30T18:23:19.157Z",
        "modifiedBy": "google-oauth2|116017798712183358036",
        "name": "1297 Authorization Test 1",
        "organizationId": "746110fe-3129-42cc-8ae7-35c36f9102f4",
        "slugLabel": "1297 Authorization Test 1",
        "tags": [],
        "tileVisibility": "PRIVATE",
        "visibility": "PRIVATE"
    }
    ```
 
 * Try anything else you can think of.

Connects #1297 
Connects #1298 
