### PR TITLE
Add feature flag for displaying Tools

### DIFF
--- a/app-backend/api/src/main/resources/application.conf
+++ b/app-backend/api/src/main/resources/application.conf
@@ -84,6 +84,12 @@ featureFlags {
       name = "Display Histogram"
       description = "Display and fetch histograms for color correction"
     }
+    {
+      key = "tools-ui"
+      active = true
+      name = "Enable Tools UI"
+      description = "Enable UI elements providing access to Tools functionality"
+    }
 
   ]
 }

--- a/app-frontend/src/app/components/navBar/navBar.html
+++ b/app-frontend/src/app/components/navBar/navBar.html
@@ -21,7 +21,7 @@
       </div>
       <a href ui-sref="library.projects.list" ui-sref-active="active">Projects</a>
       <a href ui-sref="imports" ui-sref-active="active">Imports</a>
-      <a href ui-sref="market.search"
+      <a href feature-flag="tools-ui" ui-sref="market.search"
          ng-class="{
                    active: $ctrl.$state.$current.name.includes('market')
                    }">Tools</a>

--- a/app-frontend/src/app/pages/home/home.html
+++ b/app-frontend/src/app/pages/home/home.html
@@ -21,7 +21,7 @@
           </rf-call-to-action-item>
         </div>
         <div class="cta-row">
-          <rf-call-to-action-item title="Tools">
+          <rf-call-to-action-item title="Tools" feature-flag="tools-ui">
             <div class="cta-flex-text">
               Use the Raster Foundry Tools to build custom processing tasks and get the most out of your imagery.
             </div>


### PR DESCRIPTION
## Overview

Puts the Tools interfaces behind a feature flag so that we can turn them on and off as needed.

### Checklist

- [ ] ~Styleguide updated, if necessary~
- [ ] ~Swagger specification updated, if necessary~
- [ ] ~Symlinks from new migrations present or corrected for any new migrations~

### Notes

- This is currently set to `true` so that the interface continues to show up in staging. #1305 will need to be closed before we can toggle this independently in staging and production.

## Testing Instructions

 * Edit `app-backend/api/src/main/resources/application.conf` and set `active = false` for the `tools-ui` feature flag.
 * Restart the server and confirm that the Tools interface elements disappear.

Closes #1290 