### PR TITLE
Use date range picker instead of year / month filters

### DIFF
--- a/app-frontend/config/webpack/global.js
+++ b/app-frontend/config/webpack/global.js
@@ -137,7 +137,12 @@ module.exports = function (_path) {
                 loaders: [
                     'expose?joint'
                 ]
-            },{
+            }, {
+                test: require.resolve('moment'),
+                loaders: [
+                    'expose?moment'
+                ]
+            }, {
                 test: /node_modules[\\\/]auth0-lock[\\\/].*\.js$/,
                 loaders: ['transform-loader/cacheable?brfs',
                           'transform-loader/cacheable?packageify']

--- a/app-frontend/package.json
+++ b/app-frontend/package.json
@@ -49,9 +49,11 @@
     "leaflet": "~1.0.0",
     "leaflet-draw": "~0.4.7",
     "lodash": "~4.5.0",
+    "moment": "^2.18.1",
     "ng-infinite-scroll": "~1.3.0",
     "ng-rollbar": "^1.9.2",
     "nvd3": "~1.8.4",
+    "ob-daterangepicker": "^0.10.3",
     "svg-pan-zoom": "ariutta/svg-pan-zoom",
     "webpack-fail-plugin": "^1.0.6"
   },

--- a/app-frontend/src/app/components/filterPane/filterPane.controller.js
+++ b/app-frontend/src/app/components/filterPane/filterPane.controller.js
@@ -1,4 +1,5 @@
 import _ from 'lodash';
+import moment from 'moment';
 export default class FilterPaneController {
     constructor(datasourceService, authService, $scope, $rootScope, $timeout) {
         'ngInject';
@@ -11,6 +12,7 @@ export default class FilterPaneController {
 
     $onInit() {
         this.toggleDrag = {toggle: false, enabled: false};
+        this.initDatefilter();
         this.$scope.$watch(() => this.authService.isLoggedIn, (isLoggedIn) => {
             if (isLoggedIn) {
                 this.initFilters();
@@ -26,47 +28,71 @@ export default class FilterPaneController {
         }
     }
 
+    initDatefilter() {
+        this.datefilter = {
+            start: moment().subtract(100, 'years'),
+            end: moment()
+        };
+        this.dateranges = [
+            {
+                name: 'Today',
+                start: moment(),
+                end: moment()
+            },
+            {
+                name: 'The Last Month',
+                start: moment().subtract(1, 'months'),
+                end: moment()
+            },
+            {
+                name: 'The Last Year',
+                start: moment().subtract(1, 'years'),
+                end: moment()
+            },
+            {
+                name: 'All',
+                start: moment().subtract(100, 'years'),
+                end: moment()
+            }
+        ];
+
+        if (this.filters.minAcquisitionDatetime && this.filters.maxAcquisitionDatetime) {
+            this.datefilter.start = moment(this.filters.minAcquisitionDatetime);
+            this.datefilter.end = moment(this.filters.maxAcquisitionDatetime);
+        }
+
+        if (!this.filters.minAcquisitionDatetime || !this.filters.maxAcquisitionDatetime) {
+            this.clearDateFilter();
+        } else {
+            this.dateFilterToggle = {value: true};
+        }
+    }
+
+    clearDateFilter() {
+        delete this.filters.minAcquisitionDatetime;
+        delete this.filters.maxAcquisitionDatetime;
+        this.dateFilterToggle = {value: false};
+    }
+
+    setDateRange(start, end) {
+        this.dateFilterToggle.value = true;
+        this.filters.minAcquisitionDatetime = start.toISOString();
+        this.filters.maxAcquisitionDatetime = end.toISOString();
+        this.cacheYearFilters();
+    }
+
+    onDateFilterToggle(value) {
+        if (value) {
+            this.filters.minAcquisitionDatetime = this.datefilter.start.toISOString();
+            this.filters.maxAcquisitionDatetime = this.datefilter.end.toISOString();
+        } else {
+            delete this.filters.minAcquisitionDatetime;
+            delete this.filters.maxAcquisitionDatetime;
+        }
+    }
+
     close() {
         this.opened = false;
-    }
-
-    onYearFiltersChange(id, minModel, maxModel) {
-        if (minModel && maxModel) {
-            if (minModel === this.yearRange.min) {
-                delete this.filters.minAcquisitionDatetime;
-            } else {
-                this.filters.minAcquisitionDatetime =
-                    (new Date(minModel, 0, 1))
-                    .toISOString();
-            }
-
-            if (maxModel === this.yearRange.max) {
-                delete this.filters.maxAcquisitionDatetime;
-            } else {
-                this.filters.maxAcquisitionDatetime =
-                    (new Date(maxModel, 11, 31))
-                    .toISOString();
-            }
-        } else if (minModel) {
-            this.filters.minAcquisitionDatetime =
-                (new Date(minModel, 0, 1)).toISOString();
-            this.filters.maxAcquisitionDatetime =
-                (new Date(minModel, 11, 31)).toISOString();
-        }
-    }
-
-    onDayOfMonthFiltersChange(id, minModel, maxModel) {
-        if (minModel === this.dayOfMonthRange.min) {
-            delete this.filters.minDayOfMonth;
-        } else {
-            this.filters.minDayOfMonth = minModel;
-        }
-
-        if (maxModel === this.dayOfMonthRange.max) {
-            delete this.filters.maxDayOfMonth;
-        } else {
-            this.filters.maxDayOfMonth = maxModel;
-        }
     }
 
     onCloudCoverFiltersChange(id, minModel, maxModel) {
@@ -113,57 +139,6 @@ export default class FilterPaneController {
 
     initFilters() {
         this.cachedFilters = {};
-
-        let thisMonth = new Date().getMonth();
-        let thisYear = new Date().getFullYear();
-
-        // Changing from a 0-based to a 1-based indexing of months
-        let monthValues = [thisMonth + 1, thisMonth, thisMonth - 1].map(m => {
-            return m <= 0 ? 12 + m : m;
-        });
-
-        this.initMonthFilters({
-            defaults: {
-                values: monthValues
-            }
-        });
-
-        if (thisMonth > 1) {
-            this.initYearFilters({
-                defaults: {
-                    min: thisYear,
-                    max: thisYear
-                }
-            });
-        } else {
-            this.initYearFilters({
-                defaults: {
-                    min: thisYear - 1,
-                    max: thisYear
-                }
-            });
-        }
-
-        this.dayOfMonthRange = {min: 1, max: 31};
-        let minDayOfMonth = this.filters.minDayOfMonth ||
-            this.dayOfMonthRange.min;
-        let maxDayOfMonth = this.filters.maxDayOfMonth ||
-            this.dayOfMonthRange.max;
-        this.dayOfMonthFilters = {
-            minModel: minDayOfMonth,
-            maxModel: maxDayOfMonth,
-            options: {
-                floor: this.dayOfMonthRange.min,
-                ceil: this.dayOfMonthRange.max,
-                minRange: 1,
-                showTicks: 2,
-                step: 1,
-                showTicksValues: true,
-                pushRange: true,
-                draggableRange: true,
-                onEnd: this.onDayOfMonthFiltersChange.bind(this)
-            }
-        };
 
         this.cloudCoverRange = {min: 0, max: 100};
         let minCloudCover = parseInt(this.filters.minCloudCover, 10) ||
@@ -252,102 +227,6 @@ export default class FilterPaneController {
         }
     }
 
-    initYearFilters(options) {
-        let defaults = options.defaults || {};
-
-        this.yearRange = {min: 2010, max: new Date().getFullYear()};
-
-        let minAcquisitionYear =
-            (new Date(this.filters.minAcquisitionDatetime || NaN)).getFullYear() ||
-            defaults.min ||
-            this.yearRange.min;
-
-        let maxAcquisitionYear =
-            (new Date(this.filters.maxAcquisitionDatetime || NaN)).getFullYear() ||
-            defaults.max ||
-            this.yearRange.max;
-
-        this.filters.minAcquisitionDatetime =
-            this.filters.minAcquisitionDatetime ||
-            this.yearToYearStart(minAcquisitionYear).toISOString();
-
-        this.filters.maxAcquisitionDatetime =
-            this.filters.maxAcquisitionDatetime ||
-            this.yearToYearEnd(maxAcquisitionYear).toISOString();
-
-        this.yearFilterMode =
-            minAcquisitionYear === maxAcquisitionYear ? 'single' : 'range';
-
-        this.singleYearFilter = {
-            value: maxAcquisitionYear,
-            options: {
-                floor: this.yearRange.min,
-                ceil: this.yearRange.max,
-                showTicks: 1,
-                showTicksValues: true,
-                onEnd: this.onYearFiltersChange.bind(this)
-            }
-        };
-
-        this.yearRangeFilters = {
-            minModel: minAcquisitionYear,
-            maxModel: maxAcquisitionYear,
-            options: {
-                floor: this.yearRange.min,
-                ceil: this.yearRange.max,
-                minRange: 1,
-                showTicks: 1,
-                showTicksValues: true,
-                pushRange: true,
-                draggableRange: true,
-                onEnd: this.onYearFiltersChange.bind(this)
-            }
-        };
-    }
-
-    initMonthFilters(options) {
-        let defaults = options.defaults || {};
-
-        this.monthFilters = {
-            1: {label: 'Jan', enabled: false},
-            2: {label: 'Feb', enabled: false},
-            3: {label: 'Mar', enabled: false},
-            4: {label: 'Apr', enabled: false},
-            5: {label: 'May', enabled: false},
-            6: {label: 'Jun', enabled: false},
-            7: {label: 'Jul', enabled: false},
-            8: {label: 'Aug', enabled: false},
-            9: {label: 'Sep', enabled: false},
-            10: {label: 'Oct', enabled: false},
-            11: {label: 'Nov', enabled: false},
-            12: {label: 'Dec', enabled: false}
-        };
-
-        if (this.filters.month) {
-            if (!isNaN(this.filters.month)) {
-                this.monthFilters[parseInt(this.filters.month, 10)].enabled = true;
-            } else if (
-                Object.prototype.toString.call(this.filters.month)
-                    === '[object Array]'
-            ) {
-                this.monthFilters = _.mapValues(
-                    this.monthFilters,
-                    (val, key) => {
-                        val.enabled = this.filters.month.indexOf(key) !== -1;
-                        return val;
-                    }
-                );
-            } else {
-                this.filters.month = null;
-            }
-        } else if (defaults.values) {
-            this.filters.month = defaults.values;
-            defaults.values.forEach(v => {
-                this.monthFilters[v].enabled = true;
-            });
-        }
-    }
-
     initSourceFilters() {
         this.datasourceService.query().then(d => {
             this.datasources = d.results;
@@ -403,17 +282,7 @@ export default class FilterPaneController {
     }
 
     resetAllFilters() {
-        this.yearRangeFilters.minModel = this.yearRange.min;
-        this.yearRangeFilters.maxModel = this.yearRange.max;
-        delete this.filters.minAcquisitionDatetime;
-        delete this.filters.maxAcquisitionDatetime;
-        this.yearFilterMode = 'range';
-
-        this.monthFilters = _.mapValues(this.monthFilters, (val) => {
-            val.enabled = false;
-            return val;
-        });
-        delete this.filters.month;
+        this.clearDateFilter();
 
         this.cloudCoverFilters.minModel = this.cloudCoverRange.min;
         this.cloudCoverFilters.maxModel = this.cloudCoverRange.max;
@@ -447,29 +316,6 @@ export default class FilterPaneController {
         delete this.filters.datasource;
     }
 
-    onMonthFilterChange(newVal) {
-        if (!newVal || !this.filters) {
-            return;
-        }
-
-        let enabledMonths = Object.keys(newVal).filter((key) => {
-            return newVal[key].enabled;
-        }).map((key) => {
-            let month = {};
-            month[key] = newVal[key];
-            return month;
-        });
-
-        if (enabledMonths.length === 0) {
-            delete this.filters.month;
-        } else {
-            this.filters.month = [];
-            enabledMonths.forEach((monthAttr) => {
-                this.filters.month.push(Object.keys(monthAttr)[0]);
-            });
-        }
-    }
-
     setIngestFilter(mode) {
         this.ingestFilter = mode;
         this.onIngestFilterChange();
@@ -485,105 +331,10 @@ export default class FilterPaneController {
         }
     }
 
-    setYearFilterMode(mode) {
-        if (mode === this.yearFilterMode) {
-            return;
-        }
-
-        this.yearFilterMode = mode;
-
-        if (mode === 'single') {
-            this.cacheYearFilters();
-            // if we move from range to single, we use the range's max
-            let tmpDate;
-
-            if (this.filters.maxAcquisitionDatetime) {
-                tmpDate = new Date(this.filters.maxAcquisitionDatetime);
-                this.filters.maxAcquisitionDatetime = this.dateToYearEnd(tmpDate).toISOString();
-            } else {
-                tmpDate = this.dateToYearEnd();
-                this.filters.maxAcquisitionDatetime = tmpDate.toISOString();
-            }
-
-            this.filters.minAcquisitionDatetime = this.dateToYearStart(tmpDate).toISOString();
-            this.singleYearFilter.value = tmpDate.getFullYear();
-        } else {
-            // if moving from single to range
-
-            let cmin = new Date(this.cachedFilters.minAcquisitionDatetime).getFullYear();
-            let actual = new Date(this.filters.minAcquisitionDatetime).getFullYear();
-
-            if (cmin && cmin < actual) {
-                this.filters.minAcquisitionDatetime = this.cachedFilters.minAcquisitionDatetime;
-            } else {
-                let c = cmin || actual;
-                if (c > this.yearRange.min) {
-                    this.filters.minAcquisitionDatetime =
-                        this.yearToYearStart(actual - 1).toISOString();
-                } else {
-                    this.filters.minAcquisitionDatetime =
-                        this.yearToYearStart(this.yearRange.min).toISOString();
-
-                    this.filters.maxAcquisitionDatetime =
-                        this.yearToYearEnd(this.yearRange.min + 1).toISOString();
-                }
-            }
-            this.yearRangeFilters.minModel =
-                new Date(this.filters.minAcquisitionDatetime).getFullYear();
-
-            this.yearRangeFilters.maxModel =
-                new Date(this.filters.maxAcquisitionDatetime).getFullYear();
-        }
-    }
 
     cacheYearFilters() {
         this.cachedFilters.minAcquisitionDatetime = this.filters.minAcquisitionDatetime;
         this.cachedFilters.maxAcquisitionDatetime = this.filters.maxAcquisitionDatetime;
-    }
-
-    yearToYearEnd(fullYear) {
-        let d = new Date();
-        d.setFullYear(fullYear);
-        return this.dateToYearEnd(d);
-    }
-
-    yearToYearStart(fullYear) {
-        let d = new Date();
-        d.setFullYear(fullYear);
-        return this.dateToYearStart(d);
-    }
-
-    dateToYearEnd(dateObject) {
-        let d = dateObject || new Date();
-        let newDate = new Date(d.getTime());
-        newDate.setMonth(11);
-        newDate.setDate(31);
-        return newDate;
-    }
-
-    dateToYearStart(dateObject) {
-        let d = dateObject || new Date();
-        let newDate = new Date(d.getTime());
-        newDate.setMonth(0);
-        newDate.setDate(1);
-        return newDate;
-    }
-
-    setMonthFilter(month, enabled) {
-        this.monthFilters[month].enabled = enabled;
-        this.onMonthFilterChange(this.monthFilters);
-    }
-
-    onMonthFilterMousedown(filter, filterAttrs) {
-        this.toggleDrag.toggle = true;
-        this.toggleDrag.enabled = !filterAttrs.enabled;
-        this.setMonthFilter(filter, this.toggleDrag.enabled);
-    }
-
-    onMonthFilterMouseover(filter) {
-        if (this.toggleDrag.toggle) {
-            this.setMonthFilter(filter, this.toggleDrag.enabled);
-        }
     }
 
     onSourceFilterChange() {

--- a/app-frontend/src/app/components/filterPane/filterPane.html
+++ b/app-frontend/src/app/components/filterPane/filterPane.html
@@ -12,56 +12,21 @@
       <a href ng-click="$ctrl.resetAllFilters()" class="btn btn-toggle btn-small btn-block">Clear all filters</a>
     </div>
     <div class="filter">
-      <label>Year</label>
-      <div class="filter-item">
-        <div id="year_slider"></div>
+      <label>Date Range: </label>
+      <div>
+        <ob-daterangepicker
+            class="right"
+            range="$ctrl.datefilter"
+            ranges="$ctrl.dateranges"
+            calendars-always-on="true"
+            on-apply="$ctrl.setDateRange(start, end)"
+            ng-class="{'active': $ctrl.dateFilterToggle.value}"
+        ></ob-daterangepicker>
+        <rf-toggle data-model="$ctrl.dateFilterToggle"
+                   on-change="$ctrl.onDateFilterToggle(value)"
+                   style="float: right;"
+        ></rf-toggle>
       </div>
-      <div class="btn-group">
-        <button type="button"
-                class="btn btn-toggle btn-small"
-                ng-class="{'active': $ctrl.yearFilterMode === 'range'}"
-                ng-click="$ctrl.setYearFilterMode('range')">
-          Year Range
-        </button>
-        <button type="button"
-                class="btn btn-toggle btn-small"
-                ng-class="{'active': $ctrl.yearFilterMode === 'single'}"
-                ng-click="$ctrl.setYearFilterMode('single')">
-          Single year
-        </button>
-      </div>
-      <br/>
-        <rzslider rz-slider-model="$ctrl.yearRangeFilters.minModel"
-                  rz-slider-high="$ctrl.yearRangeFilters.maxModel"
-                  rz-slider-options="$ctrl.yearRangeFilters.options"
-                  ng-show="$ctrl.yearFilterMode === 'range'"
-        ></rzslider>
-        <rzslider rz-slider-model="$ctrl.singleYearFilter.value"
-                  rz-slider-options="$ctrl.singleYearFilter.options"
-                  ng-show="$ctrl.yearFilterMode === 'single'"
-        ></rzslider>
-    </div>
-    <div class="filter"
-         ng-mouseup="$ctrl.toggleDrag.toggle = false"
-         ng-mouseleave="$ctrl.toggleDrag.toggle = false">
-      <label>Month</label>
-      <div class="filter-item month-filter">
-        <button type="button"
-                class="btn btn-toggle btn-small"
-                autocomplete="off"
-                ng-class="{'active': monthAttrs.enabled}"
-                ng-mousedown="$ctrl.onMonthFilterMousedown(month, monthAttrs)"
-                ng-mouseover="$ctrl.onMonthFilterMouseover(month)"
-                ng-repeat="(month, monthAttrs) in $ctrl.monthFilters track by month">
-          {{monthAttrs.label}}
-        </button>
-      </div>
-    </div>
-    <div class="filter">
-      <label>Day of Month</label>
-      <rzslider rz-slider-model="$ctrl.dayOfMonthFilters.minModel"
-                rz-slider-high="$ctrl.dayOfMonthFilters.maxModel"
-                rz-slider-options="$ctrl.dayOfMonthFilters.options"></rzslider>
     </div>
     <div class="filter">
       <label>Cloud cover</label>

--- a/app-frontend/src/app/index.module.js
+++ b/app-frontend/src/app/index.module.js
@@ -12,6 +12,7 @@ const App = angular.module(
         // plugins
         require('angular-ui-router'),
         require('angular-nvd3'),
+        'obDateRangePicker',
         'angular-jwt',
         'angular-clipboard',
         'auth0.lock',

--- a/app-frontend/src/app/index.vendor.js
+++ b/app-frontend/src/app/index.vendor.js
@@ -1,8 +1,11 @@
 'use strict';
+require('../../node_modules/ob-daterangepicker/dist/styles/ob-daterangepicker.css');
 
 // node_modules
 import 'jquery';
+import 'moment';
 import 'angular';
+import 'ob-daterangepicker';
 import 'd3';
 import 'nvd3';
 import 'angular-nvd3';

--- a/app-frontend/src/assets/styles/sass/_shame.scss
+++ b/app-frontend/src/assets/styles/sass/_shame.scss
@@ -240,3 +240,16 @@ rf-project-editor .leaflet-tile {
 .form-group.all-in-one [readonly] {
   background: none;
 }
+
+ob-daterangepicker {
+  margin-bottom: 2em;
+  .picker-dropdown-container {
+    position: absolute;
+    z-index: 10;
+  }
+  &.active {
+    .picker-dropdown-container {
+      background: $shade-dark;
+    }
+  }
+}

--- a/app-frontend/yarn.lock
+++ b/app-frontend/yarn.lock
@@ -165,6 +165,10 @@ angular@^1.0.8, angular@^1.x, angular@~1.5.8:
   version "1.5.11"
   resolved "https://registry.yarnpkg.com/angular/-/angular-1.5.11.tgz#8c5ba7386f15965c9acf3429f6881553aada30d6"
 
+angular@~1.4.2:
+  version "1.4.14"
+  resolved "https://registry.yarnpkg.com/angular/-/angular-1.4.14.tgz#9d0feaf60ce6e52ce50f49ee328656d1e1875c37"
+
 angularjs-slider@~6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/angularjs-slider/-/angularjs-slider-6.0.0.tgz#c0f430d859d9f4f7c03f092dd289ed2545c582c6"
@@ -4537,6 +4541,14 @@ mkdirp@~0.3.5:
   version "0.3.5"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.3.5.tgz#de3e5f8961c88c787ee1368df849ac4413eca8d7"
 
+moment@^2.18.1:
+  version "2.18.1"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.18.1.tgz#c36193dd3ce1c2eed2adb7c802dbbc77a81b1c0f"
+
+moment@~2.10.6:
+  version "2.10.6"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.10.6.tgz#6cb21967c79cba7b0ca5e66644f173662b3efa77"
+
 ms@0.7.1:
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.1.tgz#9cd13c03adbff25b65effde7ce864ee952017098"
@@ -4795,6 +4807,13 @@ nvd3@^1.7.1, nvd3@~1.8.4:
 oauth-sign@~0.8.1:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.8.2.tgz#46a6ab7f0aead8deae9ec0565780b7d4efeb9d43"
+
+ob-daterangepicker@^0.10.3:
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/ob-daterangepicker/-/ob-daterangepicker-0.10.3.tgz#1cc22b614485b9e67344799f389d343982e089d1"
+  dependencies:
+    angular "~1.4.2"
+    moment "~2.10.6"
 
 object-assign@^2.0.0:
   version "2.1.1"


### PR DESCRIPTION
## Overview
Use a date range picker to filter on date in the browse view

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~

### Demo

![image](https://cloud.githubusercontent.com/assets/4392704/24518940/8892915e-1551-11e7-9212-04a8a9b1816d.png)
![image](https://cloud.githubusercontent.com/assets/4392704/24518972/93cc0744-1551-11e7-94e8-95a75bbeea70.png)
![image](https://cloud.githubusercontent.com/assets/4392704/24518981/9a6fc31a-1551-11e7-9ab2-e5b80a63bebf.png)


### Notes

We don't have a way to create open-ended filters right now

## Testing Instructions

 * Run "yarn" to install the new libraries before starting the frontend with "yarn dev"
* Go to the browse view
* Verify that the date range picker picker works as expected.
* Verify that disabling the picker removes the filter
* Verify that the picker still persists its filter within the same browser session (nav to another view and back)

Connects #996