### PR TITLE
Don't enforce strict url matching

### DIFF
--- a/app-frontend/src/app/index.routes.js
+++ b/app-frontend/src/app/index.routes.js
@@ -371,8 +371,10 @@ function importStates($stateProvider) {
         });
 }
 
-function routeConfig($urlRouterProvider, $stateProvider) {
+function routeConfig($urlRouterProvider, $stateProvider, $urlMatcherFactoryProvider) {
     'ngInject';
+
+    $urlMatcherFactoryProvider.strictMode(false);
 
     $stateProvider.state('root', {
         templateUrl: rootTpl


### PR DESCRIPTION
## Overview

Trailing slashes cause routes not to match

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~

## Testing Instructions

* Navigate to a non-home view with a `/` at the end of the url.
* Verify that it does not redirect to the home view and preserves the trailing slash

Connects #1373 
