### PR TITLE
Remove Client Error Notifications from Rollbar

### DIFF
--- a/app-backend/common/src/main/scala/UserErrorHandler.scala
+++ b/app-backend/common/src/main/scala/UserErrorHandler.scala
@@ -16,15 +16,12 @@ trait UserErrorHandler extends Directives
       complete(StatusCodes.ClientError(409)("Duplicate Key", ""))
     case e: IllegalArgumentException =>
       logger.error(RfStackTrace(e))
-      sendError(e)
       complete(StatusCodes.ClientError(400)("Bad Argument", e.getMessage))
     case e: IllegalStateException =>
       logger.error(RfStackTrace(e))
-      sendError(e)
       complete(StatusCodes.ClientError(400)("Bad Request", e.getMessage))
     case e: InvalidParameterException =>
       logger.error(RfStackTrace(e))
-      sendError(e)
       complete(StatusCodes.ClientError(400)("Bad Request", e.getMessage))
     case e: Exception =>
       sendError(e)

--- a/app-backend/common/src/main/scala/UserErrorHandler.scala
+++ b/app-backend/common/src/main/scala/UserErrorHandler.scala
@@ -1,10 +1,9 @@
 package com.azavea.rf.common
 
-import akka.http.scaladsl.server.{Route, ExceptionHandler, Directives}
-import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.server.{ExceptionHandler, Directives}
+import akka.http.scaladsl.model.{IllegalRequestException, StatusCodes}
 import com.typesafe.scalalogging.LazyLogging
 import java.security.InvalidParameterException
-import com.typesafe.scalalogging.LazyLogging
 import org.postgresql.util.PSQLException
 
 
@@ -23,6 +22,10 @@ trait UserErrorHandler extends Directives
     case e: InvalidParameterException =>
       logger.error(RfStackTrace(e))
       complete(StatusCodes.ClientError(400)("Bad Request", e.getMessage))
+    case e: IllegalRequestException =>
+      logger.error(RfStackTrace(e))
+      // Status code and error message are expected to be contained within
+      complete(e)
     case e: Exception =>
       sendError(e)
       complete(StatusCodes.ServerError(501)("An unknown error occurred", ""))

--- a/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Projects.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Projects.scala
@@ -18,6 +18,7 @@ import io.circe.optics.JsonPath._
 import java.util.UUID
 import java.util.Date
 import java.sql.Timestamp
+import akka.http.scaladsl.model.{IllegalRequestException, StatusCodes}
 import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
 
@@ -298,7 +299,7 @@ object Projects extends TableQuery(tag => new Projects(tag)) with LazyLogging {
                     updateProjectExtentQuery.update(newProjectExtentGeometry)
                   }
                 }
-                case _ => throw new IllegalStateException("Error updating project: no project matching id found")
+                case _ => throw IllegalRequestException(StatusCodes.ClientError(404)("Not Found", "Error updating project: no project matching id found"))
               }
             }
 
@@ -355,8 +356,8 @@ object Projects extends TableQuery(tag => new Projects(tag)) with LazyLogging {
           }
 
         }
-        case (0, _) => throw new IllegalStateException("Error updating project: not authorized to modify this project")
-        case (_, _) => throw new IllegalStateException("Error updating project: not authorized to use one or more of these scenes")
+        case (0, _) => throw IllegalRequestException(StatusCodes.ClientError(403)("Forbidden", "Error updating project: not authorized to modify this project"))
+        case (_, _) => throw IllegalRequestException(StatusCodes.ClientError(403)("Forbidden", "Error updating project: not authorized to use one or more of these scenes"))
       }
     }
   }

--- a/app-backend/tile/src/main/scala/directives/TileErrorHandler.scala
+++ b/app-backend/tile/src/main/scala/directives/TileErrorHandler.scala
@@ -15,7 +15,6 @@ trait TileErrorHandler extends Directives
   val tileExceptionHandler = ExceptionHandler {
     case e: IllegalArgumentException =>
       logger.error(RfStackTrace(e))
-      sendError(e)
       complete(StatusCodes.ClientError(400)("Bad Argument", e.getMessage))
     case e: IllegalStateException =>
       logger.error(RfStackTrace(e))
@@ -23,15 +22,12 @@ trait TileErrorHandler extends Directives
       complete(StatusCodes.ClientError(400)("Bad Request", e.getMessage))
     case e: DeserializationException =>
       logger.error(RfStackTrace(e))
-      sendError(e)
       complete(StatusCodes.ClientError(400)("Decoding Error", e.getMessage))
     case e: SerializationException =>
       logger.error(RfStackTrace(e))
-      sendError(e)
       complete(StatusCodes.ServerError(500)("Encoding Error", e.getMessage))
     case e: LayerIOError =>
       logger.error(RfStackTrace(e))
-      sendError(e)
       complete(StatusCodes.ClientError(404)("Scene or Scene tile data not found", e.getMessage))
     case e: Exception =>
       sendError(e)


### PR DESCRIPTION
## Overview

This attempts to reduce the noise in Rollbar by not notifying client errors. These errors will still be logged for development purposes.

Of the individual errors mentioned in #1233, there are three categories:

 * `InvalidParameterExceptions` like https://rollbar.com/Azavea/RasterFoundry/items/152/. We fix this by not reporting any client exceptions, with the exception of `IllegalStateException` and the catch all `Exception`.
 * Authentication errors like https://rollbar.com/Azavea/RasterFoundry/items/109/ and https://rollbar.com/Azavea/RasterFoundry/items/110/. These were internally raised as `IllegalStateException`s. We fix them by raising the appropriate `403` or `404` `ClientError` in a new `IllegalRequestException`, which is handled by passing through the status code and error message through to the client.
 * Genuine errors like https://rollbar.com/Azavea/RasterFoundry/items/45/occurrences/22362291670/. While this reads like an API error, it is possibly a data issue somewhere, since this error is raised from within GeoTrellis https://rollbar.com/Azavea/RasterFoundry/items/45/occurrences/22362291670/. Notifications for these will continue.

The new `IllegalRequestException` may also be used for fixing #1365 in the cases when errors are reported from within the database code.

### Checklist

- ~Styleguide updated, if necessary~
- ~Swagger specification updated, if necessary~
- ~Symlinks from new migrations present or corrected for any new migrations~

### Demo

###### When trying to add scenes to a project that you don't have permissions for

```http
POST /api/projects/ff9429d9-dc39-4c06-a664-c5cdc268b8c2/scenes HTTP/1.1
Accept: application/json, */*
Accept-Encoding: gzip, deflate
Authorization: Bearer eyJ...
Connection: keep-alive
Content-Length: 41
Content-Type: application/json
Host: localhost:9100
User-Agent: HTTPie/0.9.8

[
    "4f62f002-fcdf-4a47-8eb2-48890532aadf"
]
```

Before:

```http
HTTP/1.1 400 Bad Request
Connection: keep-alive
Content-Length: 61
Content-Type: text/plain; charset=UTF-8
Date: Fri, 31 Mar 2017 18:48:03 GMT
Server: nginx
Strict-Transport-Security: max-age=15552000; preload
X-Content-Type-Options: nosniff
X-Frame-Options: SAMEORIGIN
X-XSS-Protection: 1; mode=block

Error updating project: not authorized to modify this project
```

After:

```http
HTTP/1.1 403 Forbidden
Connection: keep-alive
Content-Length: 61
Content-Type: text/plain; charset=UTF-8
Date: Fri, 31 Mar 2017 17:38:40 GMT
Server: nginx
Strict-Transport-Security: max-age=15552000; preload
X-Content-Type-Options: nosniff
X-Frame-Options: SAMEORIGIN
X-XSS-Protection: 1; mode=block

Error updating project: not authorized to modify this project
```

### Notes

I felt a little weird bringing in API considerations (such as status codes) into our database code: I think it can cause [coupling](https://en.wikipedia.org/wiki/Coupling_(computer_programming)) and violate the [Single Responsibility Principle](https://en.wikipedia.org/wiki/Single_responsibility_principle) down the line if we're not careful. However, since there are many exit points in many of our database methods, this kind of error handling _must_ be done within. We may have to refactor this out, to really only run queries in the database functions, and handle all transformations outside.

## Testing Instructions

 * Try to add scenes to a project that you don't own on `develop`. Ensure the "Last Seen" reference is updated: https://rollbar.com/Azavea/RasterFoundry/items/157/

    ![image](https://cloud.githubusercontent.com/assets/1430060/24565073/a9e24216-1621-11e7-85b0-b62323bee86e.png)

    and also in the error list here: https://rollbar.com/Azavea/RasterFoundry/items/
 * Try to add scenes to a project you don't own on this branch. Ensure you get a `403` instead of a `400`. Ensure there is no error in https://rollbar.com/Azavea/RasterFoundry/items/
 * Try to add scenes to a project that doesn't exist. Ensure you get a `404` instead of a `400`. Ensure there is no error in https://rollbar.com/Azavea/RasterFoundry/items/

Connects #1233 
