### PR TITLE
Make migration link relative

### DIFF
--- a/app-backend/migrations/src/main/scala/migrations/50.scala
+++ b/app-backend/migrations/src/main/scala/migrations/50.scala
@@ -1,1 +1,1 @@
-/opt/raster-foundry/app-backend/./migrations/src_migrations/main/scala/50.scala
+../../../../src_migrations/main/scala/50.scala


### PR DESCRIPTION
## Overview

I broke the build by forgetting to make my new migration's symlink relative :man_facepalming: . This PR undoes my previous evils.

### Checklist

- [x] ~Styleguide updated, if necessary~
- [x] ~Swagger specification updated, if necessary~
- [x] Symlinks from new migrations present _and_ corrected for any new migrations

## Testing Instructions

 * don't
 * this was dumb
 * i am ashamed
 * :man_facepalming: 


