### PR TITLE
Directives Follow Up: Limit to Root Members, Single Result

### DIFF
--- a/app-backend/api/src/main/scala/organization/Routes.scala
+++ b/app-backend/api/src/main/scala/organization/Routes.scala
@@ -1,6 +1,6 @@
 package com.azavea.rf.api.organization
 
-import com.azavea.rf.common.{Authentication, UserErrorHandler}
+import com.azavea.rf.common.{Authentication, UserErrorHandler, CommonHandlers}
 import com.azavea.rf.database.Database
 import com.azavea.rf.database.tables.Organizations
 import com.azavea.rf.datamodel._
@@ -18,7 +18,10 @@ import java.util.UUID
 /**
   * Routes for Organizations
   */
-trait OrganizationRoutes extends Authentication with PaginationDirectives with UserErrorHandler {
+trait OrganizationRoutes extends Authentication
+    with PaginationDirectives
+    with CommonHandlers
+    with UserErrorHandler {
 
   implicit def database: Database
 
@@ -66,10 +69,7 @@ trait OrganizationRoutes extends Authentication with PaginationDirectives with U
   def updateOrganization(orgId: UUID): Route = authenticateRootMember { root =>
     entity(as[Organization]) { updatedOrg =>
       onSuccess(Organizations.updateOrganization(updatedOrg, orgId)) {
-        case 1 => complete(StatusCodes.NoContent)
-        case count => throw new IllegalStateException(
-          s"Error updating organization: update result expected to be: 1, was $count"
-        )
+        completeSingleOrNotFound
       }
     }
   }

--- a/app-backend/api/src/main/scala/organization/Routes.scala
+++ b/app-backend/api/src/main/scala/organization/Routes.scala
@@ -37,13 +37,15 @@ trait OrganizationRoutes extends Authentication with PaginationDirectives with U
 
   def listOrganizations: Route = authenticate { user =>
     withPagination { page =>
-      complete {
-        Organizations.listOrganizations(page)
+      if (user.isInRootOrganization) {
+        complete(Organizations.listOrganizations(page))
+      } else {
+        complete(Organizations.listFilteredOrganizations(List(user.organizationId), page))
       }
     }
   }
 
-  def createOrganization: Route = authenticate { user =>
+  def createOrganization: Route = authenticateRootMember { root =>
     entity(as[Organization.Create]) { newOrg =>
       onSuccess(Organizations.createOrganization(newOrg)) { org =>
         complete(StatusCodes.Created, org)
@@ -53,13 +55,15 @@ trait OrganizationRoutes extends Authentication with PaginationDirectives with U
 
   def getOrganization(orgId: UUID): Route = authenticate { user =>
     rejectEmptyResponse {
-      complete {
-        Organizations.getOrganization(orgId)
+      if (user.isInRootOrSameOrganizationAs(new { val organizationId = orgId })) {
+        complete(Organizations.getOrganization(orgId))
+      } else {
+        complete(StatusCodes.NotFound)
       }
     }
   }
 
-  def updateOrganization(orgId: UUID): Route = authenticate { user =>
+  def updateOrganization(orgId: UUID): Route = authenticateRootMember { root =>
     entity(as[Organization]) { updatedOrg =>
       onSuccess(Organizations.updateOrganization(updatedOrg, orgId)) {
         case 1 => complete(StatusCodes.NoContent)

--- a/app-backend/api/src/main/scala/thumbnail/Routes.scala
+++ b/app-backend/api/src/main/scala/thumbnail/Routes.scala
@@ -1,6 +1,6 @@
 package com.azavea.rf.api.thumbnail
 
-import com.azavea.rf.common.{UserErrorHandler, Authentication, S3}
+import com.azavea.rf.common.{UserErrorHandler, Authentication, S3, CommonHandlers}
 import com.azavea.rf.database.tables.Thumbnails
 import com.azavea.rf.database.Database
 import com.azavea.rf.datamodel._
@@ -23,6 +23,7 @@ import scala.util.{Success, Failure, Try}
 trait ThumbnailRoutes extends Authentication
     with ThumbnailQueryParameterDirective
     with PaginationDirectives
+    with CommonHandlers
     with UserErrorHandler
     with Config {
 
@@ -101,11 +102,7 @@ trait ThumbnailRoutes extends Authentication
     entity(as[Thumbnail]) { updatedThumbnail =>
       authorize(user.isInRootOrSameOrganizationAs(updatedThumbnail)) {
         onSuccess(Thumbnails.updateThumbnail(updatedThumbnail, thumbnailId, user)) {
-          case 1 => complete(StatusCodes.NoContent)
-          case 0 => complete(StatusCodes.NotFound)
-          case count => throw new IllegalStateException(
-            s"Error updating thumbnail: update result expected to be 1, was $count"
-          )
+          completeSingleOrNotFound
         }
       }
     }
@@ -113,11 +110,7 @@ trait ThumbnailRoutes extends Authentication
 
   def deleteThumbnail(thumbnailId: UUID): Route = authenticate { user =>
     onSuccess(Thumbnails.deleteThumbnail(thumbnailId, user)) {
-      case 1 => complete(StatusCodes.NoContent)
-      case 0 => complete(StatusCodes.NotFound)
-      case count => throw new IllegalStateException(
-        s"Error deleting thumbnail: delete result expected to be 1, was $count"
-      )
+      completeSingleOrNotFound
     }
   }
 }

--- a/app-backend/api/src/main/scala/user/Routes.scala
+++ b/app-backend/api/src/main/scala/user/Routes.scala
@@ -7,7 +7,7 @@ import akka.http.scaladsl.model.StatusCodes
 
 import com.lonelyplanet.akka.http.extensions.PaginationDirectives
 
-import com.azavea.rf.common.{Authentication, UserErrorHandler}
+import com.azavea.rf.common.{Authentication, UserErrorHandler, CommonHandlers}
 import com.azavea.rf.database.Database
 import com.azavea.rf.database.tables.Users
 import com.azavea.rf.datamodel._
@@ -19,7 +19,10 @@ import de.heikoseeberger.akkahttpcirce.CirceSupport._
 /**
   * Routes for users
   */
-trait UserRoutes extends Authentication with PaginationDirectives with UserErrorHandler {
+trait UserRoutes extends Authentication
+    with PaginationDirectives
+    with CommonHandlers
+    with UserErrorHandler {
 
   implicit def database: Database
 
@@ -91,10 +94,7 @@ trait UserRoutes extends Authentication with PaginationDirectives with UserError
   def updateUserByEncodedAuthId(authIdEncoded: String): Route = authenticateRootMember { root =>
     entity(as[User]) { updatedUser =>
       onSuccess(Users.updateUser(updatedUser, authIdEncoded)) {
-        case 1 => complete(StatusCodes.NoContent)
-        case count => throw new IllegalStateException(
-          s"Error updating user: update result expected to be: 1, was $count"
-        )
+        completeSingleOrNotFound
       }
     }
   }

--- a/app-backend/api/src/test/scala/organization/OrganizationSpec.scala
+++ b/app-backend/api/src/test/scala/organization/OrganizationSpec.scala
@@ -32,6 +32,7 @@ class OrganizationSpec extends WordSpec
   val baseRoutes = routes
 
   val authHeader = AuthUtils.generateAuthHeader("Default")
+
   "/api/organizations" should {
     "require authentication" in {
       Get("/api/organizations") ~> baseRoutes ~> check {
@@ -45,7 +46,7 @@ class OrganizationSpec extends WordSpec
         responseAs[PaginatedResponse[Organization]]
       }
     }
-    "allow creation of new organizations" in {
+    "require authorization for creation of new organizations" in {
       val newOrg = Organization.Create("Test Organization")
       Post("/api/organizations")
         .withHeadersAndEntity(
@@ -55,7 +56,7 @@ class OrganizationSpec extends WordSpec
           newOrg.asJson.noSpaces
         )
       ) ~> baseRoutes ~> check {
-        responseAs[Organization]
+        rejection
       }
     }
   }

--- a/app-backend/api/src/test/scala/user/UserSpec.scala
+++ b/app-backend/api/src/test/scala/user/UserSpec.scala
@@ -30,9 +30,10 @@ class UserSpec extends WordSpec
   val baseRoutes = routes
 
   "/api/users" should {
-    "return a paginated list of users" in {
+    "require authorization for returning a paginated list of users" in {
       Get("/api/users").withHeaders(List(authHeader)) ~> baseRoutes ~> check {
-        responseAs[PaginatedResponse[User]]
+        // responseAs[PaginatedResponse[User]]
+        rejection
       }
     }
 

--- a/app-backend/common/src/main/scala/Authentication.scala
+++ b/app-backend/common/src/main/scala/Authentication.scala
@@ -89,4 +89,14 @@ trait Authentication extends Directives {
       case _ => reject(AuthenticationFailedRejection(CredentialsRejected, challenge))
     }
   }
+
+  /**
+    * Directive that only allows members of root organization
+    */
+  def authenticateRootMember: Directive1[User] = {
+    authenticate.flatMap { user =>
+      if (user.isInRootOrganization) { provide(user) }
+      else { reject(AuthorizationFailedRejection) }
+    }
+  }
 }

--- a/app-backend/common/src/main/scala/CommonHandlers.scala
+++ b/app-backend/common/src/main/scala/CommonHandlers.scala
@@ -1,0 +1,14 @@
+package com.azavea.rf.common
+
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.server.StandardRoute
+import akka.http.scaladsl.server.directives.RouteDirectives
+
+
+trait CommonHandlers extends RouteDirectives {
+  def completeSingleOrNotFound(count: Int): StandardRoute = count match {
+    case 1 => complete(StatusCodes.NoContent)
+    case 0 => complete(StatusCodes.NotFound)
+    case _ => throw new IllegalStateException(s"Result expected to be 1, was $count")
+  }
+}


### PR DESCRIPTION
## Overview

Builds on top of #1358. There are two commits: the first makes it so only members of the root organization can list, create, and update organizations and users. We do not allow deleting organizations or users to anyone. Members of an organization can view their own organization. Users can view themselves, and edit their Auth0 profile.

The second standardizes behavior of all update and delete endpoints, each of which should result in a single record being affected. In this case, we return a `204 No Content`. In case no rows were affected, we return a `404 Not Found`. In all other cases, we raise an exception which eventually returns a `400 Bad Request`.

I've targeted this to #1358 to keep the diff minimal. Will not merge this until that is in, then will rebase on top of `develop` and merge.

### Notes

I tried to make the standardized handling a `Directive`, but a `StandardRoute` works just as well and is no more verbose.

Should we consider collapsing `UserErrorHandler` in to `CommonHandlers` to avoid having to import it separately every time? Seems like they are both always used together.

Should I add some tests for the new authentication functionality?

## Testing Instructions

 * Try creating or editing an organization as a non-root user. Ensure you get a 403.
 * Try creating or editing an organization as a root user. Ensure you are successful.
 * Ensure existing tests pass, and that updating and deleting resources works same as before.
 * Since no functionality has changed for the second commit, simply do a code review.

Connects #1364 
Connects #1365 