### PR TITLE
Use uploads API for scene imports

### DIFF
--- a/app-backend/database/src/main/scala/com/azavea/rf/database/QueryParameters.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/QueryParameters.scala
@@ -204,6 +204,7 @@ case class CombinedMapTokenQueryParameters(
   mapTokenParams: MapTokenQueryParameters = MapTokenQueryParameters()
 )
 
+// TODO add uploadStatus
 case class UploadQueryParameters(
   organization: Option[UUID] = None,
   datasource: Option[UUID] = None

--- a/app-tasks/dags/geotiff/find_geotiff_scenes.py
+++ b/app-tasks/dags/geotiff/find_geotiff_scenes.py
@@ -30,18 +30,8 @@ dag = DAG(
     dag_id='find_geotiff_scenes',
     default_args=args,
     schedule_interval=timedelta(minutes=2),
-    concurrency=int(os.getenv('AIRFLOW_DAG_CONCURRENCY', 24))
+    concurrency=1
 )
-
-
-def chunkify(lst, n):
-    """Helper function to split a list into roughly n chunks
-
-    Args:
-        lst (List): list of things to split
-        n (Int): number of chunks to split into
-    """
-    return [lst[i::n] for i in xrange(n)]
 
 
 @wrap_rollbar
@@ -52,6 +42,8 @@ def find_geotiffs(*args, **kwargs):
     logger.info("Finding geotiff scenes...")
 
     conf = kwargs['dag_run'].conf if kwargs['dag_run'] else {}
+    if conf is None:
+        conf = {}
 
     try:
         upload_ids = Upload.get_importable_uploads()
@@ -68,11 +60,15 @@ def find_geotiffs(*args, **kwargs):
         )
         logger.info('Kicking off new scene import: %s', run_id)
         upload = Upload.from_id(upload_id)
-        upload.update_upload_status('Queued')
-        conf['upload_id'] = upload_id
-        confjson = json.dumps(conf)
-        dag_args = DagArgs(dag_id=dag_id, conf=confjson, run_id=run_id)
-        trigger_dag(dag_args)
+        # We already tried to check this above but the uploads endpoint doesn't currently
+        # support an uploadStatus filter so we have to check again to avoid trying to
+        # kick off imports and setting the status a second time
+        if upload.uploadStatus.upper() == 'UPLOADED':
+            upload.update_upload_status('Queued')
+            conf['upload_id'] = upload_id
+            confjson = json.dumps(conf)
+            dag_args = DagArgs(dag_id=dag_id, conf=confjson, run_id=run_id)
+            trigger_dag(dag_args)
 
     logger.info('Finished kicking off new uploaded scene dags')
 

--- a/app-tasks/dags/geotiff/find_geotiff_scenes.py
+++ b/app-tasks/dags/geotiff/find_geotiff_scenes.py
@@ -63,12 +63,16 @@ def find_geotiffs(*args, **kwargs):
         # We already tried to check this above but the uploads endpoint doesn't currently
         # support an uploadStatus filter so we have to check again to avoid trying to
         # kick off imports and setting the status a second time
-        if upload.uploadStatus.upper() == 'UPLOADED':
-            upload.update_upload_status('Queued')
-            conf['upload_id'] = upload_id
-            confjson = json.dumps(conf)
-            dag_args = DagArgs(dag_id=dag_id, conf=confjson, run_id=run_id)
-            trigger_dag(dag_args)
+        try:
+            if upload.uploadStatus.upper() == 'UPLOADED':
+                upload.update_upload_status('Queued')
+                conf['upload_id'] = upload_id
+                confjson = json.dumps(conf)
+                dag_args = DagArgs(dag_id=dag_id, conf=confjson, run_id=run_id)
+                trigger_dag(dag_args)
+        except:
+            upload.update_upload_status('Failed')
+            raise
 
     logger.info('Finished kicking off new uploaded scene dags')
 

--- a/app-tasks/rf/src/rf/models/base.py
+++ b/app-tasks/rf/src/rf/models/base.py
@@ -54,12 +54,12 @@ class BaseModel(object):
         return self.from_dict(response.json())
 
     def update(self):
-        url = '{HOST}{URL_PATH}{id}'.format(HOST=self.HOST, URL_PATH=self.URL_PATH, id=self.id)
+        url = '{HOST}{URL_PATH}{id}/'.format(HOST=self.HOST, URL_PATH=self.URL_PATH, id=self.id)
         session = get_session()
         response = session.put(url, json=self.to_dict())
         try:
             response.raise_for_status()
         except:
-            logger.exception('Unable to update scene: %s', response.text)
+            logger.exception('Unable to update: %s', response.text)
             raise
         return response

--- a/app-tasks/rf/src/rf/uploads/geotiff/__init__.py
+++ b/app-tasks/rf/src/rf/uploads/geotiff/__init__.py
@@ -1,4 +1,5 @@
 from .create_thumbnails import create_thumbnails
-from .create_scenes import create_geotiff_scene, GeoTiffS3SceneFactory
+from .create_scenes import create_geotiff_scene
+from .factories import GeoTiffS3SceneFactory
 from .create_images import create_geotiff_image
 from .create_footprints import extract_footprints

--- a/app-tasks/rf/src/rf/uploads/geotiff/create_bands.py
+++ b/app-tasks/rf/src/rf/uploads/geotiff/create_bands.py
@@ -1,7 +1,11 @@
+import logging
+
 import rasterio
 from rasterio.enums import ColorInterp
 
 from rf.models import Band
+
+logger = logging.getLogger(__name__)
 
 # TODO: This module as it currently stands is specific to the UltraCam Falcon, which is just one of
 # several imaging systems used by manned and unmanned aerial imagery providers, so this doesn't
@@ -43,7 +47,12 @@ def create_geotiff_bands(tif_path):
             colorinterp = src.colorinterp(band)
             if colorinterp == ColorInterp.undefined:
                 band_data = band_data_lookup['nir']
-            else:
+            elif colorinterp.name in band_data_lookup:
                 band_data = band_data_lookup[colorinterp.name]
+            else:
+                # If we get a name for a layer that we can't map to anything, log
+                # and ignore it.
+                logger.warning('Could not map layer with name %s', colorinterp.name)
+                continue
             bands.append(Band(band_data[0], band, band_data[1]))
     return bands

--- a/app-tasks/rf/src/rf/uploads/geotiff/create_footprints.py
+++ b/app-tasks/rf/src/rf/uploads/geotiff/create_footprints.py
@@ -77,9 +77,11 @@ def transform_polygon_coordinates(feature, src_crs, target_crs):
         dict
     """
     copied_feature = feature.copy()
+    coords_array = copied_feature['coordinates']
     for index, coords in enumerate(copied_feature['coordinates']):
         reproj_coords = coord_transform(coords, src_crs, target_crs)
-        feature['coordinates'][index] = reproj_coords
+        coords_array[index] = reproj_coords
+    feature['coordinates'] = [coords_array]
     return feature
 
 
@@ -103,11 +105,11 @@ def extract_polygon(mask_tif_path):
 
     footprint, value = geoms.next()
 
-    assert value == 1.0, 'Geometry should be of value 1'
+    assert value == 1.0, 'Geometry should be of value 1, got %r' % value
 
     target_crs = Proj(init='epsg:4326')
     feature = transform_polygon_coordinates(footprint, src_crs, target_crs)
-    return {'type': 'MultiPolygon', 'coordinates': [feature['coordinates']]}
+    return feature['coordinates']
 
 
 def extract_footprints(organization_id, tif_path):

--- a/app-tasks/rf/src/rf/uploads/geotiff/factories.py
+++ b/app-tasks/rf/src/rf/uploads/geotiff/factories.py
@@ -1,0 +1,90 @@
+# Factories to create scenes from different geotiff upload destinations
+import os
+import tempfile
+
+import boto3
+
+from .create_thumbnails import create_thumbnails
+from .create_images import create_geotiff_image
+from .create_scenes import create_geotiff_scene
+
+from .io import s3_url, s3_bucket_and_key_from_url
+from rf.utils.io import Visibility
+
+class GeoTiffS3SceneFactory(object):
+    """A convenience class for creating Scenes from an S3 folder of multiband GeoTiffs.
+
+    Example usage:
+    ```
+        from rf.utils.io import Visibility
+
+        captureDate = datetime.date(YYYY, MM, DD)
+
+        factory = GeoTiffS3SceneFactory('<Organization ID Here>', Visibility.PRIVATE,
+                                        '<data source name here', captureDate,
+                                        '<bucket name here>',
+                                        '<folder prefix here, e.g. imagery-provider-name/philly>')
+        for scene in factory.generate_scenes():
+            # do something with the created scenes
+            # Note that this will download GeoTIFFs locally, so it is best run somewhere with a fast
+            # connection to S3
+    ```
+    """
+    def __init__(self, upload):
+#        organizationId, visibility, datasource, acquisitionDate,
+#                 bucket_name, files_prefix, tags=[]):
+        """Args:
+            upload (Upload): instance of upload model to create scenes for
+        """
+        self._upload = upload
+        self.files = self._upload.files
+        self.organizationId = self._upload.organizationId
+        self.visibility = Visibility.PRIVATE
+        self.datasource = self._upload.datasource
+        self.acquisitionDate = self._upload.metadata.get('acquisitionDate')
+        self.tags = self._upload.metadata.get('tags') or ['']
+
+    def generate_scenes(self):
+        """Create a Scene and associated Image for each GeoTiff in self.s3_path
+        Returns:
+            Generator of Scenes
+        """
+        s3 = boto3.resource('s3')
+        for infile in self.files:
+            # We can't use the temp file as a context manager because it'll be opened/closed multiple
+            # times and by default is deleted when it's closed. So we use try/finally to ensure that
+            # it gets cleaned up.
+            local_tif = tempfile.NamedTemporaryFile(delete=False)
+            try:
+                bucket_name, key = s3_bucket_and_key_from_url(infile)
+                bucket = s3.Bucket(bucket_name)
+                bucket.download_file(key, local_tif.name)
+                # We need to override the autodetected filename because we're loading into temp
+                # files which don't preserve the file name that is on S3.
+                filename = os.path.basename(key)
+                scene = self.create_geotiff_scene(local_tif.name, os.path.splitext(filename)[0])
+                image = self.create_geotiff_image(local_tif.name, infile,
+                                                  scene, filename)
+
+                # TODO: thumbnails aren't currently created in a way that matches serialization
+                # in the API
+                scene.thumbnails = [] # create_thumbnails(local_tif.name, scene.id, self.organizationId)
+                scene.images = [image]
+            finally:
+                os.remove(local_tif.name)
+            yield scene
+
+    def create_geotiff_image(self, tif_path, source_uri, scene, filename):
+        return create_geotiff_image(self.organizationId, tif_path, source_uri, scene=scene.id,
+                                    filename=filename, visibility=self.visibility)
+
+    def create_geotiff_scene(self, tif_path, name):
+        return create_geotiff_scene(
+            tif_path,
+            self.organizationId,
+            self.datasource,
+            visibility=self.visibility,
+            tags=self.tags,
+            acquisitionDate=self.acquisitionDate,
+            name=name
+        )

--- a/app-tasks/rf/src/rf/uploads/geotiff/factories.py
+++ b/app-tasks/rf/src/rf/uploads/geotiff/factories.py
@@ -20,10 +20,7 @@ class GeoTiffS3SceneFactory(object):
 
         captureDate = datetime.date(YYYY, MM, DD)
 
-        factory = GeoTiffS3SceneFactory('<Organization ID Here>', Visibility.PRIVATE,
-                                        '<data source name here', captureDate,
-                                        '<bucket name here>',
-                                        '<folder prefix here, e.g. imagery-provider-name/philly>')
+        factory = GeoTiffS3SceneFactory('<Upload Here>')
         for scene in factory.generate_scenes():
             # do something with the created scenes
             # Note that this will download GeoTIFFs locally, so it is best run somewhere with a fast
@@ -31,8 +28,6 @@ class GeoTiffS3SceneFactory(object):
     ```
     """
     def __init__(self, upload):
-#        organizationId, visibility, datasource, acquisitionDate,
-#                 bucket_name, files_prefix, tags=[]):
         """Args:
             upload (Upload): instance of upload model to create scenes for
         """

--- a/app-tasks/rf/src/rf/uploads/geotiff/io.py
+++ b/app-tasks/rf/src/rf/uploads/geotiff/io.py
@@ -1,5 +1,6 @@
 import os
 import rasterio
+import urlparse
 
 
 def get_geotiff_metadata(tif_path):
@@ -55,6 +56,12 @@ def get_geotiff_size_bytes(tif_path):
 
 def s3_url(bucket, key):
     return 's3://{bucket}/{key}'.format(bucket=bucket, key=key)
+
+
+def s3_bucket_and_key_from_url(s3_url):
+    parts = urlparse.urlparse(s3_url) 
+    # parts.path[1:] drops the leading slash that urlparse includes
+    return (parts.netloc, parts.path[1:])
 
 
 def get_geotiff_dimensions(tif_path):


### PR DESCRIPTION
## Overview

Brief description of what this PR does, and why it is needed.

### Checklist

- [x] ~Styleguide updated, if necessary~
- [x] ~Swagger specification updated, if necessary~
- [x] ~Symlinks from new migrations present or corrected for any new migrations~

### Notes

This added two TODOs, captured as #1386 and #1387

## Testing Instructions

- You may want to reset your airflow db before you do this. To do that, `./scripts/console airflow-worker bash`, then `airflow resetdb`, `airflow initdb` (as long as the scheduler isn't up no tasks should start)
- From the api project's console, create the same upload from #1371, but add a file (`:paste` this):

```scala
/** Prepare a bunch of values */
val user = Await.result(Users.getUserById("default"), 3 seconds).get
val orgId = Await.result(database.db.run(Organizations.take(1).result), 3 seconds).head.id
val datasourceId = Await.result(database.db.run(Datasources.filter(_.visibility === (Visibility.Public:Rep[Visibility])).take(1).result), 3 seconds).head.id
val uploadStatus = UploadStatus.fromString("uploaded")
val fileType = FileType.fromString("geotiff")
val uploadType = UploadType.fromString("s3")
val files = List("s3://rasterfoundry-staging-data-us-east-1/airflow-test-tif/sample-data.tif")
val metadata = ().asJson
/** Actually create the Upload */
val uploadCreate = Upload.Create(orgId, uploadStatus, fileType, uploadType, files, datasourceId, metadata)
Await.result(database.db.run(Uploads.insertUpload(uploadCreate, user)), 3 seconds)
/** :tada: */
```

- I used three terminals to do the following:

  1. `./scripts/server/`
  2. `watch` a `GET` to the healtcheck endpoint
  3. When 2 succeeds, `docker-compose -f docker-compose.airflow.yml up`

- Navigate to your airflow UI, `Browse / task instances`, then keep refreshing until an `import_geotiff_scenes` task appears -- it should succeed

Connects #1302