### PR TITLE
Add batch color-correction endpoint

### DIFF
--- a/app-backend/api/src/main/scala/project/Routes.scala
+++ b/app-backend/api/src/main/scala/project/Routes.scala
@@ -62,6 +62,11 @@ trait ProjectRoutes extends Authentication
         pathPrefix(JavaUUID) { sceneId =>
           get { getProjectSceneColorCorrectParams(projectId, sceneId) } ~
           put { setProjectSceneColorCorrectParams(projectId, sceneId) }
+        } ~
+        pathPrefix("bulk-update-color-corrections") {
+          pathEndOrSingleSlash {
+            post { setProjectScenesColorCorrectParams(projectId) }
+          }
         }
       } ~
       pathPrefix("order") {
@@ -159,6 +164,15 @@ trait ProjectRoutes extends Authentication
   def setProjectSceneColorCorrectParams(projectId: UUID, sceneId: UUID) = authenticate { user =>
     entity(as[ColorCorrect.Params]) { ccParams =>
       onSuccess(ScenesToProjects.setColorCorrectParams(projectId, sceneId, ccParams)) { sceneToProject =>
+        complete(StatusCodes.NoContent)
+      }
+    }
+  }
+
+  /** Set color correction parameters for a list of scenes */
+  def setProjectScenesColorCorrectParams(projectId: UUID) = authenticate { user =>
+    entity(as[BatchParams]) { params =>
+      onSuccess(ScenesToProjects.setColorCorrectParamsBatch(projectId, params)) { scenesToProject =>
         complete(StatusCodes.NoContent)
       }
     }

--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/SceneToProject.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/SceneToProject.scala
@@ -9,3 +9,6 @@ case class SceneToProject(
   sceneOrder: Option[Int] = None,
   colorCorrectParams: Option[ColorCorrect.Params] = None
 )
+
+case class SceneCorrectionParams(sceneId: UUID, params: ColorCorrect.Params)
+case class BatchParams(items: List[SceneCorrectionParams])


### PR DESCRIPTION
## Overview

This PR adds an endpoint at `/projects/{uuid}/mosaic/bulk-update-color-corrections/` that adds color-correction parameters to project/scene combinations in bulk, which either succeed or fail together. It is intended to fix a bug that resulted in inconsistent application of parameters to tiles.

### Checklist

~~- [ ] Styleguide updated, if necessary~~
~~- [ ] Swagger specification updated, if necessary~~
~~- [ ] Symlinks from new migrations present or corrected for any new migrations~~

### Notes

## Testing Instructions

* revise `ScenesToProjects.scala` to introduce random failures; I used this -->
```
  def setColorCorrectParams(projectId: UUID, sceneId: UUID, colorCorrectParams: ColorCorrect.Params)(implicit database: DB) = {
    val r = new Random()
    val draw = r.nextInt(4)
    println(draw)
    draw match {
      case 1 =>
        throw new IllegalStateException(
            s"Error updating scene's color correction"
          )
      case _ =>
        val sceneToProject = SceneToProject(sceneId, projectId, None, Some(colorCorrectParams))
        database.db.run {
          ScenesToProjects.insertOrUpdate(
            sceneToProject
          )
        }.map {
          case 1 => sceneToProject
          case count => throw new IllegalStateException(
            s"Error updating scene's color correction: update result expected to be 1, was $count"
          )
        }
    }
  }
```
* bring up the server and app
* create a project and add scenes, then go to the editor
* using Postman or something similar, `POST` a few sets of parameters to `http://localhost:9091/api/projects/[...]/mosaic/bulk-update-color-corrections/`; when the API randomly fails, the request should report an error, otherwise it should return a `204` status
* make a `GET` request to the `/tiles/[...]` endpoint after each `POST` to check that when the update fails, the tiles returned reflect the prior correction state, but when it succeeds the tiles show the appropriate corrections

Connects #1354
