### PR TITLE
Add deployment for Swagger spec

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,6 +9,11 @@ node {
 
     env.AWS_DEFAULT_REGION = 'us-east-1'
     env.RF_ARTIFACTS_BUCKET = 'rasterfoundry-global-artifacts-us-east-1'
+    env.RF_DOCS_BUCKET = 'rasterfoundry-staging-docs-site-us-east-1'
+
+    if (env.BRANCH_NAME.startsWith('release/')){
+      env.RF_DOCS_BUCKET = 'rasterfoundry-production-docs-site-us-east-1'
+    }
 
     // Execute `cibuild` wrapped within a plugin that translates
     // ANSI color codes to something that renders inside the Jenkins

--- a/scripts/cibuild
+++ b/scripts/cibuild
@@ -50,5 +50,7 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
         echo "Running tests"
         GIT_COMMIT="${GIT_COMMIT}" ./scripts/test
         echo "All tests pass!"
+
+        ./scripts/deploy-docs --dryrun
     fi
 fi

--- a/scripts/cipublish
+++ b/scripts/cipublish
@@ -85,6 +85,8 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
             aws s3 cp \
                 "${DIR}/../app-backend/ingest/target/scala-2.11/rf-ingest.jar" \
                 "s3://${RF_ARTIFACTS_BUCKET}/ingest/rf-ingest-${GIT_COMMIT}.jar"
+
+            ./scripts/deploy-docs
         else
             echo "ERROR: No AWS_ECR_ENDPOINT variable defined."
             exit 1

--- a/scripts/deploy-docs
+++ b/scripts/deploy-docs
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+set -e
+
+if [[ -n "${RF_DEBUG}" ]]; then
+    set -x
+fi
+
+DIR="$(dirname "$0")"
+
+function usage() {
+    echo -n \
+"Usage: $(basename "$0")
+Deploy Swagger spec to a S3 website bucket.
+"
+}
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+    if [ "${1:-}" = "--help" ]; then
+        usage
+    else
+        if [[ -n "${RF_DOCS_BUCKET}" ]]; then 
+            if [ "${1:-}" = "--dryrun" ]; then
+                echo "Syncing docs to ${RF_DOCS_BUCKET} (dryrun)"
+                aws s3 cp --dryrun \
+                        "${DIR}/../docs/swagger/spec.yml" \
+                        "s3://${RF_DOCS_BUCKET}/spec"
+            else
+                echo "Syncing docs to ${RF_DOCS_BUCKET}"
+                aws s3 cp \
+                        "${DIR}/../docs/swagger/spec.yml" \
+                        "s3://${RF_DOCS_BUCKET}/spec"
+            fi
+        else
+            echo "ERROR: No RF_DOCS_BUCKET found."
+        fi
+
+    fi
+fi


### PR DESCRIPTION
## Overview

This PR adds `scripts/deploy-docs` to sync documentation to an S3 bucket. 

### Checklist

~~- [ ] Styleguide updated, if necessary~~
~~- [ ] Swagger specification updated, if necessary~~
~~- [ ] Symlinks from new migrations present or corrected for any new migrations~~

### Demo

Optional. Screenshots, `curl` examples, etc.

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.


## Testing Instructions
See [spec.staging.rasterfoundry.com](https://spec.staging.rasterfoundry.com) and [Jenkins Output](http://jenkins.staging.rasterfoundry.com/job/raster-foundry/job/raster-foundry/view/change-requests/job/PR-1402/8/)

Connects #1272 , depends on azavea/raster-foundry-deployment#41
