### PR TITLE
Add gamma correction linking

### DIFF
--- a/app-frontend/src/app/components/colorCorrectAdjust/colorCorrectAdjust.controller.js
+++ b/app-frontend/src/app/components/colorCorrectAdjust/colorCorrectAdjust.controller.js
@@ -38,17 +38,31 @@ export default class ColorCorrectAdjustController {
             step: 10
         };
 
+        let allGamma = ['redGamma', 'greenGamma', 'blueGamma'];
+
         this.redGammaOptions = Object.assign({
             id: 'redGamma',
-            onEnd: (id, val) => this.onFilterChange(id, val, this.redGammaOptions)
+            onEnd: (id, val) => {
+                this.onFilterChange(
+                    this.gammaLinkToggle ? allGamma : 'redGamma', val, this.redGammaOptions
+                );
+            }
         }, baseGammaOptions);
         this.greenGammaOptions = Object.assign({
             id: 'greenGamma',
-            onEnd: (id, val) => this.onFilterChange(id, val, this.greenGammaOptions)
+            onEnd: (id, val) => {
+                this.onFilterChange(
+                    this.gammaLinkToggle ? allGamma : 'greenGamma', val, this.greenGammaOptions
+                );
+            }
         }, baseGammaOptions);
         this.blueGammaOptions = Object.assign({
             id: 'blueGamma',
-            onEnd: (id, val) => this.onFilterChange(id, val, this.blueGammaOptions)
+            onEnd: (id, val) => {
+                this.onFilterChange(
+                    this.gammaLinkToggle ? allGamma : 'blueGamma', val, this.blueGammaOptions
+                );
+            }
         }, baseGammaOptions);
 
         this.alphaOptions = Object.assign({
@@ -77,6 +91,8 @@ export default class ColorCorrectAdjustController {
             }
         }, minMaxOptions);
 
+        this.gammaLinkToggle = true;
+
         this.gammaToggle = {value: true};
         this.sigToggle = {value: true};
         this.bcToggle = {value: true};
@@ -91,6 +107,9 @@ export default class ColorCorrectAdjustController {
     $onChanges(changes) {
         if ('correction' in changes && changes.correction.currentValue) {
             this.correction = changes.correction.currentValue;
+
+            this.gammaLinkToggle = this.correction.redGamma === this.correction.blueGamma &&
+                this.correction.blueGamma === this.correction.greenGamma;
 
             if (this.correction.redGamma === null &&
                 this.correction.greenGamma === null &&
@@ -217,13 +236,30 @@ export default class ColorCorrectAdjustController {
      * @returns {null} null
      */
     onFilterChange(id, val, options) {
-        if (id && !options.disabled) {
+        if (Array.isArray(id)) {
+            id.forEach((key) => {
+                if (!options.disabled) {
+                    this.correction[key] = val;
+                } else {
+                    this.correction[key] = null;
+                }
+            });
+        } else if (id && !options.disabled) {
             this.correction[id] = val;
         } else if (id) {
             this.correction[id] = null;
         }
         this.sliderCorrection = Object.assign({}, this.correction);
         this.onCorrectionChange({newCorrection: Object.assign({}, this.correction)});
+    }
+
+    gammaLinkToggled() {
+        this.gammaLinkToggle = !this.gammaLinkToggle;
+        if (this.gammaLinkToggle) {
+            this.onFilterChange(
+                ['redGamma', 'greenGamma', 'blueGamma'],
+                this.correction.redGamma, this.redGammaOptions);
+        }
     }
 
     gammaToggled(value) {

--- a/app-frontend/src/app/components/colorCorrectAdjust/colorCorrectAdjust.html
+++ b/app-frontend/src/app/components/colorCorrectAdjust/colorCorrectAdjust.html
@@ -18,6 +18,14 @@
                     rz-slider-options="$ctrl.redGammaOptions"
           ></rzslider>
         </div>
+        <div class="filter-separator offset">
+          <button type="button"
+                  ng-click="$ctrl.gammaLinkToggled()"
+                  ng-class="{'active': $ctrl.gammaLinkToggle}"
+                  class="btn btn-default btn-square">
+            <i class="icon-mosaic"></i>
+          </button>
+        </div>
         <div class="filter">
           <label>Green</label>
           <div class="filter-item slider-filter">
@@ -26,6 +34,14 @@
           <rzslider rz-slider-model="$ctrl.sliderCorrection.greenGamma"
                     rz-slider-options="$ctrl.greenGammaOptions"
           ></rzslider>
+        </div>
+        <div class="filter-separator offset">
+          <button type="button"
+                  ng-click="$ctrl.gammaLinkToggled()"
+                  ng-class="{'active': $ctrl.gammaLinkToggle}"
+                  class="btn btn-default btn-square">
+            <i class="icon-mosaic"></i>
+          </button>
         </div>
         <div class="filter">
           <label>Blue</label>
@@ -36,6 +52,7 @@
                     rz-slider-options="$ctrl.blueGammaOptions"
           ></rzslider>
         </div>
+        <div class="filter-separator"></div>
       </div>
     </div>
 
@@ -55,6 +72,7 @@
                     rz-slider-options="$ctrl.alphaOptions"
           ></rzslider>
         </div>
+        <div class="filter-separator"></div>
         <div class="filter">
           <label>Beta</label>
           <div class="filter-item slider-filter">
@@ -64,6 +82,7 @@
                     rz-slider-options="$ctrl.betaOptions"
           ></rzslider>
         </div>
+        <div class="filter-separator"></div>
       </div>
     </div>
 
@@ -79,6 +98,7 @@
           <rzslider rz-slider-model="$ctrl.sliderCorrection.brightness"
                     rz-slider-options="$ctrl.brightnessOptions"></rzslider>
         </div>
+        <div class="filter-separator"></div>
         <div class="filter">
           <label>Contrast</label>
           <div class="filter-item slider-filter">
@@ -87,6 +107,7 @@
           <rzslider rz-slider-model="$ctrl.sliderCorrection.contrast"
                     rz-slider-options="$ctrl.contrastOptions"></rzslider>
         </div>
+        <div class="filter-separator"></div>
       </div>
     </div>
     <div class="filter-group">

--- a/app-frontend/src/assets/styles/sass/_shame.scss
+++ b/app-frontend/src/assets/styles/sass/_shame.scss
@@ -253,3 +253,32 @@ ob-daterangepicker {
     }
   }
 }
+
+.color-correct-pane {
+
+  .content {
+    padding-top: 1rem;
+  }
+
+  .filter {
+    padding-top: 1rem;
+    padding-bottom: 1rem;
+  }
+
+  .filter-separator {
+    &.offset {
+      margin-right: 5rem;
+    }
+    border-bottom: 1px solid $shade-dark;
+    button {
+      transform: translateY(-50%) translateX(5.1rem);
+      float: right;
+      &.active {
+        background: $shade-dark;
+      }
+    }
+    &:last-of-type {
+      margin-bottom: 2rem;
+    }
+  }
+}

--- a/app-frontend/src/assets/styles/sass/components/_filter.scss
+++ b/app-frontend/src/assets/styles/sass/components/_filter.scss
@@ -1,7 +1,6 @@
 .filter {
   padding-top: 2rem;
   padding-bottom: 2rem;
-  border-bottom: 1px solid $shade-dark;
 
   &:first-child {
     padding-top: 0;
@@ -21,7 +20,7 @@
 .month-filter {
   display: flex;
   flex-wrap: wrap;
-  
+
   .btn {
     flex-basis: 24%;
     margin: .5%;


### PR DESCRIPTION
## Overview

Add toggleable linking of gamma sliders

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~

### Demo

![image](https://cloud.githubusercontent.com/assets/4392704/24713415/9550db84-19f3-11e7-8238-325733415ab0.png)

### Notes

@designmatty Made a slight style edit - the filter separator (formerly a border-bottom on the filter) is now a separate div element, so it can be adjusted to allow for items on the actual divider such as buttons. New styles have been placed in `_shame.scss` as usual.

To test with greyscale tiles, set the color correction of a scene to have the green, red, and blue band set to the same value

## Testing Instructions

* Go to the color correction pane in a project
* Verify that the linking starts out enabled if gamma values are loaded as the same
* Verify that linked gamma values move together
* Verify that unlinking by clicking the button allows changing values independently
* Verify that linking independent values sets them all to the same value immediately

Connects #1317 
