### PR TITLE
Ensure thumbnail creation works for raw geotiff import

### DIFF
--- a/app-tasks/rf/src/rf/models/upload.py
+++ b/app-tasks/rf/src/rf/models/upload.py
@@ -5,8 +5,8 @@ class Upload(BaseModel):
     URL_PATH = '/api/uploads/'
 
     def __init__(self, organizationId, uploadStatus, fileType, uploadType, files,
-                 datasource, metadata, id=None, createdAt=None, createdBy=None,
-                 modifiedAt=None, modifiedBy=None):
+                 datasource, metadata, visibility, id=None, createdAt=None,
+                 createdBy=None, modifiedAt=None, modifiedBy=None):
         self.id = id
         self.createdAt = createdAt
         self.createdBy = createdBy
@@ -19,6 +19,7 @@ class Upload(BaseModel):
         self.files = files
         self.datasource = datasource
         self.metadata = metadata
+        self.visibility = visibility
 
     def to_dict(self):
         return dict(
@@ -34,6 +35,7 @@ class Upload(BaseModel):
             files=self.files,
             datasource=self.datasource,
             metadata=self.metadata,
+            visibility=self.visibility
         )
 
     def update_upload_status(self, status):
@@ -50,6 +52,7 @@ class Upload(BaseModel):
             d.get('files'),
             d.get('datasource'),
             d.get('metadata'),
+            d.get('visibility'),
             d.get('id'),
             d.get('createdAt'),
             d.get('createdBy'),

--- a/app-tasks/rf/src/rf/uploads/geotiff/create_thumbnails.py
+++ b/app-tasks/rf/src/rf/uploads/geotiff/create_thumbnails.py
@@ -40,8 +40,8 @@ def create_thumbnails(tif_path, scene_id, organization_id):
     scale_large = size_large / max_dim
     scale_small = size_small / max_dim
 
-    dim_large = (dim[0] * scale_large, dim[1] * scale_large)
-    dim_small = (dim[0] * scale_small, dim[1] * scale_small)
+    dim_large = (int(dim[0] * scale_large), int(dim[1] * scale_large))
+    dim_small = (int(dim[0] * scale_small), int(dim[1] * scale_small))
 
     # Create paths for each size thumb
     path_large = '{}-LARGE.png'.format(scene_id)

--- a/app-tasks/rf/src/rf/uploads/geotiff/factories.py
+++ b/app-tasks/rf/src/rf/uploads/geotiff/factories.py
@@ -63,7 +63,7 @@ class GeoTiffS3SceneFactory(object):
 
                 # TODO: thumbnails aren't currently created in a way that matches serialization
                 # in the API
-                scene.thumbnails = [] # create_thumbnails(local_tif.name, scene.id, self.organizationId)
+                scene.thumbnails = create_thumbnails(local_tif.name, scene.id, self.organizationId)
                 scene.images = [image]
             finally:
                 os.remove(local_tif.name)


### PR DESCRIPTION
## Overview

This PR adds `visibility` to the python `Upload` model and coerces footprint dimensions for scenes from raw geotiffs to `int`. With raw geotiffs, it's possible that the scale factor * the starting dimensions results in a float value, which circe reasonably refuses to decode as an int (ain't type safety grand).

### Checklist

- [x] ~Styleguide updated, if necessary~
- [x] ~Swagger specification updated, if necessary~
- [x] ~Symlinks from new migrations present or corrected for any new migrations~

### Notes

It isn't obvious to me whether this should be `int(...)` or `ceil(...)`, but that's a future 0 point change if this introduces 1px seams.

Also, I figured out how to turn (non-nested, though nesting isn't too tricky to imagine with recursion and a little extra formatting) python dicts into potentially decodable circe `JsonObject`s. I found this useful for testing without having to go through http requests all the time.

```python
def asJson(x):
    if isinstance(x, basestring):
        return '"{}".asJson'.format(x)
    else:
        return '{}.asJson'.format(x)

', '.join(['"{}" -> {}'.format(k, asJson(v)) for k, v in some_dict.iteritems()])
```

Then in the `api/console`, you can do:

```scala
val jsMap = Map[String, Json](<paste the output from above here>)
val jsObj = JsonObject.fromMap(jsMap)
Decoder[Foo].decodeJson(jsObj.asJson)
```

## Testing Instructions

 * `mg update`, `mg apply` (just because you might not have done that yet and this depends on a recent migration)
 * Create an upload: (same as #1388 , but with visibility now)

```scala
/** Prepare a bunch of values */
val user = Await.result(Users.getUserById("default"), 3 seconds).get
val orgId = Await.result(database.db.run(Organizations.take(1).result), 3 seconds).head.id
val datasourceId = Await.result(database.db.run(Datasources.filter(_.visibility === (Visibility.Public:Rep[Visibility])).take(1).result), 3 seconds).head.id
val uploadStatus = UploadStatus.fromString("uploaded")
val fileType = FileType.fromString("geotiff")
val uploadType = UploadType.fromString("s3")
val files = List("s3://rasterfoundry-staging-data-us-east-1/airflow-test-tif/sample-data.tif")
val metadata = ().asJson
/** Actually create the Upload */
val uploadCreate = Upload.Create(orgId, uploadStatus, fileType, uploadType, files, datasourceId, metadata, Visibility.Public)
Await.result(database.db.run(Uploads.insertUpload(uploadCreate, user)), 3 seconds)
/** :tada: */
```

 * I used three terminals to do the following:

   1. ./scripts/server/
   2. watch a GET to the healtcheck endpoint
   3. When 2 succeeds, docker-compose -f docker-compose.airflow.yml up

 * Navigate to your airflow UI, `Browse / Task Instances`, keep refreshing until you see a task for `import_geotiff_scenes`. It should succeed.

Connects #1387
