### PR TITLE
Remove use of NODE_ENV where possible

### DIFF
--- a/app-backend/api/src/main/resources/application.conf
+++ b/app-backend/api/src/main/resources/application.conf
@@ -49,6 +49,11 @@ auth0 {
   managementSecret = ${?AUTH0_MANAGEMENT_SECRET}
 }
 
+client {
+  clientEnvironment = ""
+  clientEnvironment = ${?ENVIRONMENT}
+}
+
 rollbar {
   clientToken = ""
   clientToken = ${?ROLLBAR_CLIENT_TOKEN}

--- a/app-backend/api/src/main/scala/config/Config.scala
+++ b/app-backend/api/src/main/scala/config/Config.scala
@@ -10,6 +10,7 @@ import com.azavea.rf.database.tables.FeatureFlags
 
 case class AngularConfig(
   clientId: String,
+  clientEnvironment: String,
   auth0Domain: String,
   rollbarClientToken: String,
   intercomAppId: String,
@@ -19,5 +20,5 @@ case class AngularConfig(
 object AngularConfigService extends AkkaSystem.LoggerExecutor with Config {
   def getConfig()(implicit database: Database) = for {
     features:Seq[FeatureFlag] <- FeatureFlags.listFeatureFlags()
-  } yield AngularConfig(auth0ClientId, auth0Domain, rollbarClientToken, intercomAppId, features)
+  } yield AngularConfig(auth0ClientId, clientEnvironment, auth0Domain, rollbarClientToken, intercomAppId, features)
 }

--- a/app-backend/api/src/main/scala/utils/Config.scala
+++ b/app-backend/api/src/main/scala/utils/Config.scala
@@ -6,6 +6,7 @@ trait Config {
   val config = ConfigFactory.load()
   private val httpConfig = config.getConfig("http")
   private val auth0Config = config.getConfig("auth0")
+  private val clientConfig = config.getConfig("client")
   private val intercomConfig = config.getConfig("intercom")
   private val rollbarConfig = config.getConfig("rollbar")
   private val s3Config = config.getConfig("s3")
@@ -19,6 +20,8 @@ trait Config {
   val auth0ClientId = auth0Config.getString("clientId")
   val auth0ManagementClientId = auth0Config.getString("managementClientId")
   val auth0ManagementSecret = auth0Config.getString("managementSecret")
+
+  val clientEnvironment = clientConfig.getString("clientEnvironment")
 
 
   val intercomAppId = intercomConfig.getString("appId")

--- a/app-frontend/src/app/core/services/rollbarWrapper.service.js
+++ b/app-frontend/src/app/core/services/rollbarWrapper.service.js
@@ -1,5 +1,3 @@
-/* global process */
-
 export default (app) => {
     class RollbarWrapperService {
         constructor($resource, APP_CONFIG, Rollbar) {

--- a/app-frontend/src/app/core/services/rollbarWrapper.service.js
+++ b/app-frontend/src/app/core/services/rollbarWrapper.service.js
@@ -6,7 +6,7 @@ export default (app) => {
             'ngInject';
             this.Rollbar = Rollbar;
             this.accessToken = APP_CONFIG.rollbarClientToken;
-            this.env = process.env.NODE_ENV || 'production';
+            this.env = APP_CONFIG.clientEnvironment;
         }
 
         init(user = {}) {

--- a/app-frontend/src/app/index.config.js
+++ b/app-frontend/src/app/index.config.js
@@ -39,7 +39,7 @@ function config( // eslint-disable-line max-params
         accessToken: APP_CONFIG.rollbarClientToken,
         captureUncaught: true,
         payload: {
-            environment: process.env.NODE_ENV || 'production'
+            environment: APP_CONFIG.clientEnvironment
         }
     });
 


### PR DESCRIPTION
## Overview

This PR passes through the environment variable `ENVIRONMENT` to the front-end via the `/config` endpoint so that the front-end has a way to determine what environment it is running in aside from the `process.env.NODE_ENV`, which is not reliable for this use.

This should allow Rollbar to properly funnel client-side errors in Staging to the proper Rollbar environment.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~

## Notes

There shouldn't be any changes to the deployment scripts as `ENVIRONMENT` is already set.

## Testing Instructions

This one is a bit difficult to test.

* See that the environment is being provided to the front-end in the `/config` response

Connects #1394 
