### PR TITLE
Allow import from project creation

### DIFF
--- a/app-frontend/src/app/components/createProjectModal/createProjectModal.controller.js
+++ b/app-frontend/src/app/components/createProjectModal/createProjectModal.controller.js
@@ -99,9 +99,7 @@ export default class CreateProjectModalController {
             }
         });
 
-        this.activeModal.result.then(() => {
-
-        });
+        this.dismiss();
 
         return this.activeModal;
     }

--- a/app-frontend/src/app/components/importModal/importModal.html
+++ b/app-frontend/src/app/components/importModal/importModal.html
@@ -59,25 +59,21 @@
           <rf-box-select-item
           class="small"
           ng-class="{selected: $ctrl.importType === 'local'}"
-          ng-click="$ctrl.setProjectAttribute('importType', 'local')"
         >
           <div class="text-center"><strong>Local Files</strong></div>
         </rf-box-select-item>
         <rf-box-select-item
           class="small disabled"
-          ng-click="$ctrl.setProjectAttribute('importType', 'uri')"
         >
           <div class="text-center"><strong>URI</strong></div>
         </rf-box-select-item>
         <rf-box-select-item
           class="small disabled"
-          ng-click="$ctrl.setProjectAttribute('importType', 's3')"
         >
           <div class="text-center"><strong>AWS S3</strong></div>
         </rf-box-select-item>
         <rf-box-select-item
           class="small disabled"
-          ng-click="$ctrl.setProjectAttribute('importType', 'dropbox')"
         >
           <div class="text-center"><strong>DropBox</strong></div>
         </rf-box-select-item>

--- a/app-frontend/src/app/components/importModal/importModal.html
+++ b/app-frontend/src/app/components/importModal/importModal.html
@@ -9,6 +9,44 @@
     <p>Import your imagery from various sources</p>
   </div>
 
+  <!-- Body for DATASOURCE_SELECT-->
+  <div class="modal-body" ng-if="$ctrl.currentStepIs('DATASOURCE_SELECT')">
+    <div class="content">
+      <div class="list-group">
+        <div class="form-group all-in-one">
+          <label for="search"><i class="icon-search"></i></label>
+          <input id="search" type="text" class="form-control"
+                placeholder="Search Datasources" ng-model="$ctrl.searchString">
+        </div>
+        <div class="list-group-item" ng-repeat="datasource in $ctrl.datasources.results | filter: {name: $ctrl.searchString}">
+          <div class="list-group-overflow">
+            <strong class="color-dark">{{datasource.name}}</strong><br>
+          </div>
+          <div class="list-group-right">
+            <button class="btn btn-square" ng-click="$ctrl.handleDatasourceSelect(datasource)">
+              Select
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <!-- Datasource pagination, show only when item count exceeds page size-->
+      <div class="list-group text-center"
+          ng-show="$ctrl.shouldShowPagination()">
+        <ul uib-pagination
+            items-per-page="$ctrl.pageSize"
+            total-items="$ctrl.datasources.count"
+            ng-model="$ctrl.currentPage"
+            max-size="4"
+            rotate="true"
+            boundary-link-numbers="true"
+            force-ellipses="true"
+            ng-change="$ctrl.loadDatasources($ctrl.currentPage)">
+        </ul>
+      </div>
+    </div>
+  </div>
+
   <!--Body for IMPORT-->
   <div class="modal-body" ng-if="$ctrl.currentStepIs('IMPORT')">
     <div class="content">
@@ -46,6 +84,8 @@
       </div>
     </div>
   </div>
+
+  <!-- Body for LOCAL_UPLOAD -->
   <div class="modal-body" ng-if="$ctrl.currentStepIs('LOCAL_UPLOAD')"
     ngf-multiple=true
     ngf-pattern="'*.tif'"
@@ -152,7 +192,7 @@
 
   <!--Default Footer-->
   <div
-    ng-if="$ctrl.currentStepIsNot(['UPLOAD_PROGRESS', 'IMPORT_SUCCESS'])"
+    ng-if="$ctrl.currentStepIsNot(['UPLOAD_PROGRESS', 'IMPORT_SUCCESS', 'DATASOURCE_SELECT'])"
     class="modal-footer"
   >
     <button type="button" class="btn pull-left"
@@ -174,6 +214,14 @@
 
   <!--Footer for UPLOAD_PROGRESS-->
   <div ng-if="$ctrl.currentStepIs(['UPLOAD_PROGRESS'])" class="modal-footer">
+  </div>
+
+  <!--Footer for DATASOURCE_SELECT-->
+  <div ng-if="$ctrl.currentStepIs(['DATASOURCE_SELECT'])" class="modal-footer">
+    <button type="button" class="btn pull-left"
+            ng-click="$ctrl.closeWithData(1)">
+      Cancel
+    </button>
   </div>
 
   <!--Footer for SUCCESS-->


### PR DESCRIPTION
## Overview

This PR fixes the project creation process to allow for doing an upload right after project creation.

Between the project creation process and the standard import process it adds a datasource selection step. The datasource selection is built into the import modal, so that anytime the modal is opened but a datasource isn't specified, the selection step is presented.

This also adjusts the code to set the `files` of an upload to a list of fully qualified s3 resource URIs rather than just filenames. This addresses #1446.


### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~

### Notes

This does not actually link the upload to the project, as that connection does not yet exist.

## Testing Instructions

 * Create a project and make sure you can complete an upload within the same flow.
 * Create an import from a datasource page and make sure you are not presented with the datasource selection step of the import process.
 * Check the PUT request sent to the upload and see that the list of files are full URIs rather than just a filename

Connects #1399
