### PR TITLE
Use bulk color-correction endpoint

### DIFF
--- a/app-frontend/src/app/components/colorCorrectPane/colorCorrectPane.controller.js
+++ b/app-frontend/src/app/components/colorCorrectPane/colorCorrectPane.controller.js
@@ -1,12 +1,14 @@
 export default class ColorCorrectPaneController {
     constructor( // eslint-disable-line max-params
-        $log, $scope, $q, projectService, $state, featureFlags, sceneService, mapService
+        $log, $scope, $q, projectService, $state, featureFlags,
+        sceneService, mapService, colorCorrectService
     ) {
         'ngInject';
         this.$parent = $scope.$parent.$ctrl;
         this.projectService = projectService;
         this.sceneService = sceneService;
         this.featureFlags = featureFlags;
+        this.colorCorrectService = colorCorrectService;
         this.$state = $state;
         this.$q = $q;
         this.getMap = () => mapService.getMap('project');
@@ -68,10 +70,15 @@ export default class ColorCorrectPaneController {
      */
     onCorrectionChange(newCorrection) {
         let promises = [];
+        const sceneIds = Array.from(this.selectedScenes.keys());
         if (newCorrection) {
-            for (let layer of this.selectedLayers.values()) {
-                promises.push(layer.updateColorCorrection(newCorrection));
-            }
+            promises.push(
+                this.colorCorrectService.bulkUpdate(
+                    this.projectService.currentProject.id,
+                    sceneIds,
+                    newCorrection
+                )
+            );
 
             if (this.featureFlags.isOn('display-histogram')) {
                 this.fetchHistograms();
@@ -79,6 +86,8 @@ export default class ColorCorrectPaneController {
             this.redrawMosaic(promises, newCorrection);
         }
     }
+
+
 
     redrawMosaic(promises, newCorrection) {
         if (!promises.length) {

--- a/app-frontend/src/app/components/colorCorrectPane/colorCorrectPane.controller.js
+++ b/app-frontend/src/app/components/colorCorrectPane/colorCorrectPane.controller.js
@@ -46,14 +46,18 @@ export default class ColorCorrectPaneController {
     }
 
     resetCorrection() {
-        let promises = [];
-        for (let layer of this.selectedLayers.values()) {
-            promises.push(layer.resetTiles());
+        const sceneIds = Array.from(this.selectedScenes.keys());
+        const promise = this.colorCorrectService.bulkUpdate(
+            this.projectService.currentProject.id,
+            sceneIds
+        );
+        const defaultCorrection = this.colorCorrectService.getDefaultColorCorrection();
+
+        if (this.featureFlags.isOn('display-histogram')) {
+            this.fetchHistograms();
         }
-        this.firstLayer.getColorCorrection().then((correction) => {
-            this.setCorrection(correction);
-            this.redrawMosaic(promises, correction);
-        });
+        this.setCorrection(defaultCorrection);
+        this.redrawMosaic(promise, defaultCorrection);
     }
 
     setCorrection(correction) {
@@ -69,31 +73,23 @@ export default class ColorCorrectPaneController {
      * @returns {null} null
      */
     onCorrectionChange(newCorrection) {
-        let promises = [];
         const sceneIds = Array.from(this.selectedScenes.keys());
         if (newCorrection) {
-            promises.push(
-                this.colorCorrectService.bulkUpdate(
-                    this.projectService.currentProject.id,
-                    sceneIds,
-                    newCorrection
-                )
+            const promise = this.colorCorrectService.bulkUpdate(
+                this.projectService.currentProject.id,
+                sceneIds,
+                newCorrection
             );
 
             if (this.featureFlags.isOn('display-histogram')) {
                 this.fetchHistograms();
             }
-            this.redrawMosaic(promises, newCorrection);
+            this.redrawMosaic(promise, newCorrection);
         }
     }
 
-
-
-    redrawMosaic(promises, newCorrection) {
-        if (!promises.length) {
-            return;
-        }
-        this.$q.all(promises).then(() => {
+    redrawMosaic(promise, newCorrection) {
+        promise.then(() => {
             this.mosaic.getMosaicTileLayer().then((tiles) => {
                 let newParams = this.mosaic.paramsFromObject(newCorrection);
                 this.mosaic.getMosaicLayerURL(newParams).then((url) => {

--- a/app-frontend/src/app/core/services/colorCorrect.service.js
+++ b/app-frontend/src/app/core/services/colorCorrect.service.js
@@ -24,6 +24,17 @@ export default (app) => {
                     }
                 }
             );
+
+            this.bulkColorCorrect = $resource(
+                '/api/projects/:projectId/mosaic/bulk-update-color-corrections/', {}, {
+                    create: {
+                        method: 'POST',
+                        params: {
+                            id: '@projectId'
+                        }
+                    }
+                }
+            );
         }
 
         /** Function to return default color correction
@@ -85,6 +96,26 @@ export default (app) => {
             ).$promise.then(() => {
                 return data;
             });
+        }
+
+        /** Function to update or create color correction for multiple scenes
+         *
+         * @param {string} projectId id of current project
+         * @param {string[]} sceneIds array of scenes to set color correction for
+         * @param {object} data color-correction params to set for each scene
+         * @return {Promise} response with data
+         */
+        bulkUpdate(projectId, sceneIds, data) {
+            const bulkData = sceneIds.map(s => {
+                return {
+                    sceneId: s,
+                    params: data
+                }
+            });
+            return this.bulkColorCorrect.create(
+                { projectId: projectId },
+                { items: bulkData }
+            ).$promise;
         }
 
     }

--- a/app-frontend/src/app/core/services/colorCorrect.service.js
+++ b/app-frontend/src/app/core/services/colorCorrect.service.js
@@ -102,15 +102,17 @@ export default (app) => {
          *
          * @param {string} projectId id of current project
          * @param {string[]} sceneIds array of scenes to set color correction for
-         * @param {object} data color-correction params to set for each scene
+         * @param {object} data color-correction params to set for each scene.
+         * If not provided, color corrections are returned to their defaults
          * @return {Promise} response with data
          */
         bulkUpdate(projectId, sceneIds, data) {
+            const resolvedColorCorrection = data || this.getDefaultColorCorrection();
             const bulkData = sceneIds.map(s => {
                 return {
                     sceneId: s,
-                    params: data
-                }
+                    params: resolvedColorCorrection
+                };
             });
             return this.bulkColorCorrect.create(
                 { projectId: projectId },


### PR DESCRIPTION
## Overview

This PR updates the color correction logic to use the new bulk color-correction endpoint.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~

### Notes

We probably should look into either removing the 'Reset Changes' option or making it work in an expected manner, because as it is now, the button sets the color-correction to an arbitrary set of corrections that don't make sense.


## Testing Instructions

 * Go into color correction for a project with multiple ingested scenes
 * Select multiple scenes, monitor network traffic and see that there is a single request for color-correction changes
* Make sure single scene correction works correctly

Closes #1355
