### PR TITLE
Request previous day's landsat scenes

### DIFF
--- a/app-tasks/dags/landsat8/import_landsat8_scenes.py
+++ b/app-tasks/dags/landsat8/import_landsat8_scenes.py
@@ -1,6 +1,6 @@
 """Task for scheduled finding new Landsat 8 scenes to ingest"""
 
-from datetime import datetime
+from datetime import datetime, timedelta
 import logging
 import os
 
@@ -43,7 +43,7 @@ def import_landsat8_scenes(*args, **kwargs):
     Uses the execution date from the Airflow context to determine what day
     to check for imports.
     """
-    execution_date = kwargs['execution_date']
+    execution_date = kwargs['execution_date'] - timedelta(days=1)
     logging.info('Finding Landsat 8 scenes for date: %s', execution_date)
 
     csv_rows = find_landsat8_scenes(execution_date.year, execution_date.month,


### PR DESCRIPTION
## Overview

This PR requests scenes from the day prior to the task execution date. This will prevent the task from failing when trying to get scenes for the current day.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~


## Testing Instructions

 * Manually kick of the `find_landsat8_scenes` task in the airflow UI and set the execution date for the current day
 * Check the task instances and see your new task in the list, verify the execution date is today
 * View the task logs, and see that the logs indicate the task is searching for scenes from the previous day

Closes #1227
