### PR TITLE
Add a custom rejection handler for malformed requests

### DIFF
--- a/app-backend/api/src/main/scala/Main.scala
+++ b/app-backend/api/src/main/scala/Main.scala
@@ -6,6 +6,7 @@ import akka.http.scaladsl.Http
 import akka.stream.ActorMaterializer
 
 import com.azavea.rf.api.utils.Config
+import com.azavea.rf.common.RFRejectionHandler._
 import com.azavea.rf.database.Database
 
 object AkkaSystem {
@@ -17,7 +18,10 @@ object AkkaSystem {
   }
 }
 
-object Main extends App with Config with Router with AkkaSystem.LoggerExecutor {
+object Main extends App
+    with Config
+    with Router
+    with AkkaSystem.LoggerExecutor {
   implicit lazy val database = Database.DEFAULT
   implicit val system = AkkaSystem.system
   implicit val materializer = AkkaSystem.materializer

--- a/app-backend/common/src/main/scala/MalformedContentRejectionHandler.scala
+++ b/app-backend/common/src/main/scala/MalformedContentRejectionHandler.scala
@@ -1,0 +1,23 @@
+package com.azavea.rf.common
+
+import akka.http.scaladsl.server._
+import akka.http.scaladsl.model._
+import StatusCodes._
+import Directives._
+
+import scala.util.matching.Regex
+
+object RFRejectionHandler {
+  implicit val rfRejectionHandler:RejectionHandler = RejectionHandler.newBuilder()
+    .handle {
+    case e: MalformedRequestContentRejection => {
+      val missingFieldPattern = """(?:DownField\()(.*)(?:\))""".r
+      missingFieldPattern findFirstMatchIn e.message match {
+        case Some(matchedGroup) =>
+          complete(ClientError(400)("Bad Request", s"Missing field ${matchedGroup.group(1)}"))
+        case _ => complete(ClientError(400)("Bad Request", e.message))
+      }
+    }
+  }
+  .result()
+}

--- a/app-backend/common/src/main/scala/MalformedContentRejectionHandler.scala
+++ b/app-backend/common/src/main/scala/MalformedContentRejectionHandler.scala
@@ -14,7 +14,7 @@ object RFRejectionHandler {
       val missingFieldPattern = """(.*decode value.*)(?:DownField\()(.*)(?:\))""".r
       val badTypePattern = """(?:.*DownField\()(.*)(?:\))""".r
       e.getCause.getMessage match {
-        case missingFieldPattern(missing: Any, field) =>
+        case missingFieldPattern(missing, field) =>
           complete(ClientError(400)("Bad Request", s"Missing field: $field"))
         case badTypePattern(field) =>
           complete(ClientError(400)("Bad Request", s"Field cannot be parsed to expected type: $field"))


### PR DESCRIPTION
## Overview

This PR transforms the messages associated with `MalformedRequestContentRejection`s from ugly and not user-friendly to pretty and user-friendly.

### Checklist

- [x] ~Styleguide updated, if necessary~
- [x] ~Swagger specification updated, if necessary~
- [x] ~Symlinks from new migrations present or corrected for any new migrations~

### Demo

If you're a cool kid with `httpie`, set an `RF_TOKEN` env variable, and:

```
http :9000/api/scenes/ Authorization: $RF_TOKEN foo=bar
http :9000/api/projects/ Authorization: $RF_TOKEN foo=bar
http :9000/api/thumbnails/ Authorization: $RF_TOKEN foo=bar
```

### Notes

##### 1

Setting up an implicit `RejectionHandler` where `bindAndHandle` is called is the [recommended way to implement custom rejection handling](http://doc.akka.io/docs/akka-http/10.0.1/scala/http/routing-dsl/rejections.html). I'm pretty sure we could do the same thing with the `UserErrorHandler` and not have to extend it in every `FooRoutes` trait.

If we do that, I think we throw both custom handlers into an `RfClientErrorHandler` as implicits and just import `RfClientErrorHandler._` in `Main.scala`. We'll get to delete more code! :smile: 

##### 2

I'm not sure how to list _all_ of the fields that are missing. Presumably people will be using our fancy and very informative docs site, so they should only make a few mistakes, but I can imagine going a little insane trying to brute force my way to a legal request, and we don't list all the fields right now anyway.

## Testing Instructions

 * `./scripts/server` (or `./scripts/console api-server ./sbt`, then `api/run` if you're impatient)
 * Send some bad json to any endpoint you choose
 * Verify that the error message tells you what's wrong instead of mysteriously complaining about decoding and `DownField(something-or-other)`s

Closes #1398
