### PR TITLE
Minimize Airflow container rebuilds; upgrade Spark container images

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,17 +11,12 @@ node {
     env.RF_ARTIFACTS_BUCKET = 'rasterfoundry-global-artifacts-us-east-1'
     env.RF_DOCS_BUCKET = 'rasterfoundry-staging-docs-site-us-east-1'
 
-    if (env.BRANCH_NAME.startsWith('release/')){
-      env.RF_DOCS_BUCKET = 'rasterfoundry-production-docs-site-us-east-1'
-    }
-
     // Execute `cibuild` wrapped within a plugin that translates
     // ANSI color codes to something that renders inside the Jenkins
     // console.
     stage('cibuild') {
-
-      // Override Settings bucket for testing
       env.RF_SETTINGS_BUCKET = 'rasterfoundry-testing-config-us-east-1'
+
       wrap([$class: 'AnsiColorBuildWrapper']) {
         sh 'scripts/cibuild'
       }
@@ -30,6 +25,11 @@ node {
     env.RF_SETTINGS_BUCKET = 'rasterfoundry-staging-config-us-east-1'
 
     if (env.BRANCH_NAME == 'develop' || env.BRANCH_NAME.startsWith('release/')) {
+      // When a release branch is used, override `env.RF_DOCS_BUCKET`
+      // so that the production documentation site is published by `cipublish`.
+      if (env.BRANCH_NAME.startsWith('release/')){
+        env.RF_DOCS_BUCKET = 'rasterfoundry-production-docs-site-us-east-1'
+      }
 
       // Publish container images built and tested during `cibuild`
       // to the private Amazon Container Registry tagged with the

--- a/app-backend/export/Dockerfile
+++ b/app-backend/export/Dockerfile
@@ -1,19 +1,10 @@
-FROM quay.io/azavea/spark:2.0.1
+FROM quay.io/azavea/spark:2.1-hadoop2.7
 
 USER root
 
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 642AC823
-
-ENV SBT_VERSION 0.13.12
-
-RUN echo 'deb http://dl.bintray.com/sbt/debian /' > /etc/apt/sources.list.d/sbt.list
-
 RUN \
       mkdir -p /spark-state \
-      && chown spark:spark -R /spark-state \
-      && apt-get update && apt-get install -y --no-install-recommends \
-              sbt=$SBT_VERSION \
-      && rm -rf /var/lib/apt/lists/*
+      && chown spark:spark -R /spark-state
 
 COPY ./target/scala-2.11/rf-export.jar /opt/rf/jars/
 

--- a/app-backend/ingest/Dockerfile
+++ b/app-backend/ingest/Dockerfile
@@ -1,19 +1,10 @@
-FROM quay.io/azavea/spark:2.0.1
+FROM quay.io/azavea/spark:2.1-hadoop2.7
 
 USER root
 
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 642AC823
-
-ENV SBT_VERSION 0.13.12
-
-RUN echo 'deb http://dl.bintray.com/sbt/debian /' > /etc/apt/sources.list.d/sbt.list
-
 RUN \
       mkdir -p /spark-state \
-      && chown spark:spark -R /spark-state \
-      && apt-get update && apt-get install -y --no-install-recommends \
-              sbt=$SBT_VERSION \
-      && rm -rf /var/lib/apt/lists/*
+      && chown spark:spark -R /spark-state
 
 COPY ./target/scala-2.11/rf-ingest.jar /opt/rf/jars/
 

--- a/app-tasks/.dockerignore
+++ b/app-tasks/.dockerignore
@@ -1,64 +1,6 @@
-*.py[cod]
-
-# C extensions
-*.so
-
-# Packages
+**/*.pyc
 *.egg
 *.egg-info
-dist
-build
 eggs
 .eggs
-parts
-bin
-var
-sdist
-wheelhouse
-develop-eggs
-.installed.cfg
-lib
-lib64
-venv*/
-pyvenv*/
-
-# Installer logs
-pip-log.txt
-
-# Unit test / coverage reports
-.coverage
-.tox
-.coverage.*
-nosetests.xml
-coverage.xml
-htmlcov
-
-# Translations
-*.mo
-
-# Mr Developer
-.mr.developer.cfg
-.project
-.pydevproject
-.idea
-*.iml
-*.komodoproject
-
-# Complexity
-output/*.html
-output/*/index.html
-
-# Sphinx
-docs/_build
-
-.DS_Store
-*~
-.*.sw[po]
-.build
-.ve
-.env
-.cache
-.pytest
-.bootstrap
-.appveyor.token
-*.bak
+__pycache__

--- a/app-tasks/Dockerfile
+++ b/app-tasks/Dockerfile
@@ -3,8 +3,6 @@ FROM python:2.7
 ENV AIRFLOW_HOME /usr/local/airflow
 
 COPY requirements.txt /tmp/
-COPY rf/ /tmp/rf
-
 RUN set -ex \
     addgroup --system airflow \
     && adduser --disabled-password --system --group \
@@ -26,9 +24,11 @@ RUN set -ex \
     && pip install --no-cache-dir \
            numpy==$(grep "numpy" /tmp/requirements.txt | cut -d= -f3) \
     && pip install --no-cache-dir -r /tmp/requirements.txt \
-    && (cd /tmp/rf && python setup.py install) \
     && apt-get purge -y --auto-remove ${buildDeps} \
     && rm -rf /var/lib/apt/lists/*
+
+COPY rf/ /tmp/rf
+RUN (cd /tmp/rf && python setup.py install)
 
 USER airflow
 WORKDIR ${AIRFLOW_HOME}

--- a/scripts/cipublish
+++ b/scripts/cipublish
@@ -70,7 +70,7 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
             docker tag "raster-foundry-nginx:${GIT_COMMIT}" \
                    "${AWS_ECR_ENDPOINT}/raster-foundry-nginx:${GIT_COMMIT}"
             docker tag "raster-foundry-spark-ingest:${GIT_COMMIT}" \
-                   "${AWS_ECR_ENDPOINT}/raster-foundry-spark-ingest:${GIT_COMMIT}"            
+                   "${AWS_ECR_ENDPOINT}/raster-foundry-spark-ingest:${GIT_COMMIT}"
             docker tag "raster-foundry-api-server:${GIT_COMMIT}" \
                    "${AWS_ECR_ENDPOINT}/raster-foundry-api-server:${GIT_COMMIT}"
             docker tag "raster-foundry-tile-server:${GIT_COMMIT}" \
@@ -81,7 +81,7 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
                    "${AWS_ECR_ENDPOINT}/raster-foundry-migrations:${GIT_COMMIT}"
 
             docker push "${AWS_ECR_ENDPOINT}/raster-foundry-nginx:${GIT_COMMIT}"
-            docker push "${AWS_ECR_ENDPOINT}/raster-foundry-spark-ingest:${GIT_COMMIT}"            
+            docker push "${AWS_ECR_ENDPOINT}/raster-foundry-spark-ingest:${GIT_COMMIT}"
             docker push "${AWS_ECR_ENDPOINT}/raster-foundry-api-server:${GIT_COMMIT}"
             docker push "${AWS_ECR_ENDPOINT}/raster-foundry-tile-server:${GIT_COMMIT}"
             docker push "${AWS_ECR_ENDPOINT}/raster-foundry-airflow:${GIT_COMMIT}"

--- a/worker-tasks/Dockerfile
+++ b/worker-tasks/Dockerfile
@@ -1,18 +1,9 @@
-FROM quay.io/azavea/spark:2.0.1
+FROM quay.io/azavea/spark:2.1-hadoop2.7
 
 USER root
 
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 642AC823
-
-ENV SBT_VERSION 0.13.12
-
-RUN echo 'deb http://dl.bintray.com/sbt/debian /' > /etc/apt/sources.list.d/sbt.list
-
 RUN \
       mkdir -p /spark-state \
-      && chown spark:spark -R /spark-state \
-      && apt-get update && apt-get install -y --no-install-recommends \
-              sbt=$SBT_VERSION \
-      && rm -rf /var/lib/apt/lists/*
+      && chown spark:spark -R /spark-state
 
 USER spark


### PR DESCRIPTION
## Overview

Try not to reinstall all dependencies if changes are detected by the `Dockerfile` step that copies module source code into the container image. Instead, make it so that dependency reinstallation only occurs when the contents of `requirements.txt` changes.

Also, upgrade Spark container images so that 2.1.x is used.

Part of https://github.com/azavea/raster-foundry/issues/1347

## Testing Instructions

Build Airflow container image, execute the test suite (creates a bunch of files we don't necessarily care about), and build container image again. The second time, it should skip over all of the dependency installation steps.

```bash
$ docker-compose -f docker-compose.airflow.yml -f docker-compose.test.yml \
    build airflow
$ docker-compose -f docker-compose.airflow.yml -f docker-compose.test.yml \
    run --rm --entrypoint python --user root --workdir /opt/raster-foundry/app-tasks/rf \
    airflow setup.py test
$ docker-compose -f docker-compose.airflow.yml -f docker-compose.test.yml \
    build airflow