### PR TITLE
Split Tileserver

### DIFF
--- a/app-backend/api/src/main/resources/application.conf
+++ b/app-backend/api/src/main/resources/application.conf
@@ -70,3 +70,8 @@ intercom {
   appId = ""
   appId = ${?INTERCOM_APP_ID}
 }
+
+tileServer {
+  location = ""
+  location = ${?TILE_SERVER_LOCATION}
+}

--- a/app-backend/api/src/main/scala/config/Config.scala
+++ b/app-backend/api/src/main/scala/config/Config.scala
@@ -14,11 +14,15 @@ case class AngularConfig(
   auth0Domain: String,
   rollbarClientToken: String,
   intercomAppId: String,
-  featureFlags: Seq[FeatureFlag]
+  featureFlags: Seq[FeatureFlag],
+  tileServerLocation: String
 )
 
 object AngularConfigService extends AkkaSystem.LoggerExecutor with Config {
   def getConfig()(implicit database: Database) = for {
     features:Seq[FeatureFlag] <- FeatureFlags.listFeatureFlags()
-  } yield AngularConfig(auth0ClientId, clientEnvironment, auth0Domain, rollbarClientToken, intercomAppId, features)
+  } yield AngularConfig(
+    auth0ClientId, clientEnvironment, auth0Domain, rollbarClientToken,
+    intercomAppId, features, tileServerLocation
+  )
 }

--- a/app-backend/api/src/main/scala/utils/Config.scala
+++ b/app-backend/api/src/main/scala/utils/Config.scala
@@ -10,6 +10,7 @@ trait Config {
   private val intercomConfig = config.getConfig("intercom")
   private val rollbarConfig = config.getConfig("rollbar")
   private val s3Config = config.getConfig("s3")
+  private val tileServerConfig = config.getConfig("tileServer")
 
   val httpHost = httpConfig.getString("interface")
   val httpPort = httpConfig.getInt("port")
@@ -30,4 +31,6 @@ trait Config {
   val region = s3Config.getString("region")
   val dataBucket = s3Config.getString("dataBucket")
   val thumbnailBucket = s3Config.getString("thumbnailBucket")
+
+  val tileServerLocation = tileServerConfig.getString("location")
 }

--- a/app-frontend/src/app/core/services/layer.service.js
+++ b/app-frontend/src/app/core/services/layer.service.js
@@ -12,6 +12,7 @@ export default (app) => {
          * @param {object} authService service for auth, used to get token for layers
          * @param {object} colorCorrectService color correction service
          * @param {object} projectService project service
+         * @param {object} APP_CONFIG config of application
          * @param {object} scene response from the API, optional
          * @param {object} projectId project that layer is in
          * @param {boolean} projectMosaic flag to enable requesting layers from mosaic tile server
@@ -21,8 +22,8 @@ export default (app) => {
          * @param {object} bands keys = band type, values = band number
          */
         constructor( // eslint-disable-line max-params
-            $http, $q, authService, colorCorrectService, projectService, scene, projectId,
-            projectMosaic = true, gammaCorrect = true, sigmoidCorrect = true,
+            $http, $q, authService, colorCorrectService, projectService, APP_CONFIG,
+            scene, projectId, projectMosaic = true, gammaCorrect = true, sigmoidCorrect = true,
             colorClipCorrect = true, bands = {red: 3, green: 2, blue: 1}
         ) {
             this.$http = $http;
@@ -40,6 +41,8 @@ export default (app) => {
             this._sceneTiles = null;
             this._mosaicTiles = null;
             this._correction = null;
+
+            this.tileServer = `${APP_CONFIG.tileServerLocation}`;
         }
 
         /** Function to return bounds from either the project or the scene
@@ -123,19 +126,21 @@ export default (app) => {
          * @returns {string} URL for this tile layer
          */
         getSceneLayerURL() {
-            return `/tiles/${this.scene.id}/rgb/{z}/{x}/{y}/?${this.formatColorParams()}`;
+            return `${this.tileServer}/${this.scene.id}/rgb/` +
+                `{z}/{x}/{y}/?${this.formatColorParams()}`;
         }
 
         getMosaicLayerURL(params = {}) {
             params.token = this.authService.token();
             let formattedParams = L.Util.getParamString(params);
             return this.$q((resolve) => {
-                resolve(`/tiles/${this.projectId}/{z}/{x}/{y}/${formattedParams}`);
+                resolve(`${this.tileServer}/${this.projectId}/{z}/{x}/{y}/${formattedParams}`);
             });
         }
 
         getNDVIURL(bands) {
-            return `/tiles/${this.scene.id}/ndvi/{z}/{x}/{y}/?bands=${bands[0]},${bands[1]}`;
+            return `${this.tileServer}/${this.scene.id}/` +
+                `ndvi/{z}/{x}/{y}/?bands=${bands[0]},${bands[1]}`;
         }
 
         /**
@@ -143,7 +148,7 @@ export default (app) => {
          * @returns {string} URL for the histogram
          */
         getHistogramURL() {
-            return `/tiles/${this.scene.id}/rgb/histogram/?${this.formatColorParams()}`;
+            return `${this.tileServer}/${this.scene.id}/rgb/histogram/?${this.formatColorParams()}`;
         }
 
         /**
@@ -262,13 +267,14 @@ export default (app) => {
     }
 
     class LayerService {
-        constructor($http, $q, authService, colorCorrectService, projectService) {
+        constructor($http, $q, authService, colorCorrectService, projectService, APP_CONFIG) {
             'ngInject';
             this.$http = $http;
             this.$q = $q;
             this.authService = authService;
             this.colorCorrectService = colorCorrectService;
             this.projectService = projectService;
+            this.APP_CONFIG = APP_CONFIG;
         }
 
         /**
@@ -280,7 +286,7 @@ export default (app) => {
          */
         layerFromScene(scene, projectId, projectMosaic = false) {
             return new Layer(this.$http, this.$q, this.authService,
-                this.colorCorrectService, this.projectService,
+                this.colorCorrectService, this.projectService, this.APP_CONFIG,
                 scene, projectId, projectMosaic);
         }
     }

--- a/app-frontend/src/app/core/services/project.service.js
+++ b/app-frontend/src/app/core/services/project.service.js
@@ -2,7 +2,7 @@
 
 export default (app) => {
     class ProjectService {
-        constructor($resource, $location, tokenService, userService, $http, $q) {
+        constructor($resource, $location, tokenService, userService, $http, $q, APP_CONFIG) {
             'ngInject';
 
             this.tokenService = tokenService;
@@ -12,6 +12,8 @@ export default (app) => {
             this.$q = $q;
 
             this.currentProject = null;
+
+            this.tileServer = `${APP_CONFIG.tileServerLocation}`;
 
             this.Project = $resource(
                 '/api/projects/:id/', {
@@ -226,8 +228,7 @@ export default (app) => {
 
             let formattedParams = L.Util.getParamString(params);
 
-            return this.getBaseURL() +
-                `/tiles/${project.id}/{z}/{x}/{y}/${formattedParams}`;
+            return `${this.tileServer}/${project.id}/{z}/{x}/{y}/${formattedParams}`;
         }
 
         getProjectShareURL(project) {

--- a/nginx/etc/nginx/conf.d/api.conf
+++ b/nginx/etc/nginx/conf.d/api.conf
@@ -8,10 +8,6 @@ upstream api-server-upstream {
     server api-server:9000;
 }
 
-upstream tile-server-upstream {
-    server tile-server:9900;
-}
-
 server {
     listen 443 default_server;
     server_name app.staging.rasterfoundry.com app.rasterfoundry.com localhost;
@@ -24,14 +20,6 @@ server {
         proxy_redirect off;
 
         proxy_pass http://api-server-upstream;
-    }
-
-    location /tiles {
-        proxy_set_header Host $http_host;
-        proxy_set_header X-Forwarded-For $remote_addr;
-        proxy_redirect off;
-
-        proxy_pass http://tile-server-upstream;
     }
 
     location /thumbnails {
@@ -50,7 +38,6 @@ server {
         proxy_pass http://api-server-upstream;
     }
 
-
     # Angular config
     location = /config {
         proxy_set_header Host $http_host;
@@ -66,5 +53,4 @@ server {
         index index.json index.html;
         try_files $uri $uri/ /index.html =404;
     }
-
 }

--- a/nginx/etc/nginx/conf.d/tiler.conf
+++ b/nginx/etc/nginx/conf.d/tiler.conf
@@ -1,0 +1,24 @@
+server {
+    listen 80;
+    server_name tiles.staging.rasterfoundry.com tiles.rasterfoundry.com;
+    return 301 https://$host$request_uri;
+}
+
+upstream tile-server-upstream {
+    server tile-server:9900;
+}
+
+server {
+    listen 443;
+    server_name tiles.staging.rasterfoundry.com tiles.rasterfoundry.com;
+
+    include /etc/nginx/includes/security-headers.conf;
+
+    location / {
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Forwarded-For $remote_addr;
+        proxy_redirect off;
+
+        proxy_pass http://tile-server-upstream;
+    }
+}


### PR DESCRIPTION
## Overview

This commit adds support for splitting the tile server from the api server on both the backend and frontend. On the backend, the tile server location is injected via an environment variable that is returned via the `/config` endpoint.

On the frontend, the response in `/config` is used when constructing tile requests.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~

### Demo
Config response
![config-response](https://cloud.githubusercontent.com/assets/898060/24861764/d6f47514-1dc7-11e7-8d10-3f26a6268bf2.png)

Publish URLs
![publish-urls-correct](https://cloud.githubusercontent.com/assets/898060/24861770/d951205a-1dc7-11e7-815a-779def2524af.png)

Tiles Load Correctly
![still-correct](https://cloud.githubusercontent.com/assets/898060/24861761/d3aee33a-1dc7-11e7-86c8-1fcdae0cb510.png)

## Testing Instructions

 - Download most recent `.env` file and start server
 - Start development frontend server
 - Go to `/config` and verify tile server location is returned
 - Open a project that has been ingested, ensure that tiles load
 - Verify that tile URL is correct for share screen

Closes #1422 
Closes #1423
