### PR TITLE
Refactor Ingest Definition Creation

### DIFF
--- a/app-backend/database/src/main/scala/com/azavea/rf/database/fields/UserFkVisibleFields.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/fields/UserFkVisibleFields.scala
@@ -13,7 +13,7 @@ object UserFkVisibleFields {
   implicit class DefaultQuery[M <: UserFkVisibleFields, U, C[_]](that: Query[M, U, Seq]) {
     def filterUserVisibility(user: User) = {
       that.filter { rec => {
-        rec.visibility === Visibility.fromString("PUBLIC") || rec.createdBy === user.id
+        rec.visibility === Visibility.fromString("PUBLIC") || rec.createdBy === user.id ||  user.isInRootOrganization
       }
       }
     }

--- a/app-tasks/rf/src/rf/ingest/__init__.py
+++ b/app-tasks/rf/src/rf/ingest/__init__.py
@@ -1,1 +1,2 @@
 from .landsat8_ingest import create_landsat8_ingest
+from .geotiff_ingest import create_ingest_definition

--- a/app-tasks/rf/src/rf/ingest/geotiff_ingest.py
+++ b/app-tasks/rf/src/rf/ingest/geotiff_ingest.py
@@ -1,0 +1,77 @@
+import os
+from urlparse import urlparse, ParseResult
+from urllib import quote
+
+from .models import Ingest, Source, Layer
+
+
+layer_s3_bucket = os.getenv('TILE_SERVER_BUCKET')
+
+
+def get_safe_uri(uri):
+    """Parse URI and ensure the path is escaped properly
+
+    Fixes a case where the URIs with the `|` are not escaped properly and break
+    ingests
+
+    Args:
+        uri (str): uri to check for validity
+
+    Returns:
+        str
+    """
+    parsed = urlparse(uri)
+    safe = ParseResult(parsed.scheme, parsed.netloc,
+                       quote(parsed.path), parsed.params,
+                       parsed.query, parsed.fragment)
+    return safe.geturl()
+
+
+def get_source_definition(image, extent, crs=None):
+    """Create source definition from an image
+
+    Args:
+        image (Image): image to get source definition from
+        extent (List[float]): extent of scene
+        crs (str): optional crs of image
+
+    Return:
+        Source
+    """
+
+    uri = get_safe_uri(image.sourceUri)
+    band_maps = [{'source': band.number, 'target': band.number} for band in image.bands]
+    cell_size = {'width': image.resolutionMeters, 'height': image.resolutionMeters}
+    extent_crs = 'epsg:4326'
+    return Source(uri, extent, band_maps, cell_size, crs, extent_crs)
+
+
+def get_ingest_layer(scene):
+    """Create a layer definition for ingest
+
+    Args:
+        scene (Scene): scene to extract layer from
+
+    Return:
+        Layer
+    """
+    extent = scene.get_extent()
+    sources = [get_source_definition(image, extent) for image in scene.images]
+    highest_resolution_meters = min([image.resolutionMeters for image in scene.images])
+    cell_size = {'width': highest_resolution_meters, 'height': highest_resolution_meters}
+    output_uri = 's3://{}/layers'.format(layer_s3_bucket)
+    return Layer(scene.id, output_uri, sources, cell_size)
+
+
+def create_ingest_definition(scene):
+    """Create ingest definition for a multiband geotiff
+
+    Args:
+         scene (Scene): scene to create an ingest definition for
+
+    Return:
+        Ingest
+    """
+    layer = get_ingest_layer(scene)
+    id = scene.id
+    return Ingest(id, [layer])

--- a/app-tasks/rf/src/rf/ingest/models/source.py
+++ b/app-tasks/rf/src/rf/ingest/models/source.py
@@ -3,7 +3,7 @@
 
 class Source(object):
     def __init__(self, uri, extent, band_maps, cell_size,
-                 source_crs, extent_crs):
+                  extent_crs, source_crs=None):
 
         """
             Create a new ingest Source
@@ -13,8 +13,8 @@ class Source(object):
                 extent (List[float]): extent of the source
                 starting_target_band (int): index of first target band
                 band_maps (List[dict]): list of mappings for each band within the image
-                crs (str): CRS of the Source
                 extent_crs (str): CRS of the extent
+                crs (str): Optional CRS of the Source
         """
         self.uri = uri
         self.cell_size = cell_size
@@ -35,7 +35,7 @@ class Source(object):
         )
 
     def to_dict(self):
-        return {
+        d = {
             'crs': self.source_crs,
             'extentCrs': self.extent_crs,
             'cellSize': self.cell_size,
@@ -43,3 +43,8 @@ class Source(object):
             'extent': self.extent,
             'bandMaps': self.band_maps
         }
+
+        if self.source_crs:
+            d['crs'] = self.source_crs
+
+        return d

--- a/app-tasks/rf/src/rf/uploads/geotiff/create_thumbnails.py
+++ b/app-tasks/rf/src/rf/uploads/geotiff/create_thumbnails.py
@@ -43,15 +43,21 @@ def create_thumbnails(tif_path, scene_id, organization_id):
     dim_large = (int(dim[0] * scale_large), int(dim[1] * scale_large))
     dim_small = (int(dim[0] * scale_small), int(dim[1] * scale_small))
 
+    tempdir = os.path.dirname(tif_path)
+
     # Create paths for each size thumb
-    path_large = '{}-LARGE.png'.format(scene_id)
-    path_small = '{}-SMALL.png'.format(scene_id)
+    path_large = os.path.join(tempdir, '{}-LARGE.png'.format(scene_id))
+    path_small = os.path.join(tempdir, '{}-SMALL.png'.format(scene_id))
+
+    # Color Corrected
+    path_cc_large = os.path.join(tempdir, '{}-CC-LARGE.png'.format(scene_id))
+    path_cc_small = os.path.join(tempdir, '{}-CC-SMALL.png'.format(scene_id))
 
     # Create urls for each size Thumbnail
-    url_large = '/thumbnails/{}'.format(path_large)
-    url_small = '/thumbnails/{}'.format(path_small)
+    url_large = '/thumbnails/{}'.format(os.path.basename(path_cc_large))
+    url_small = '/thumbnails/{}'.format(os.path.basename(path_cc_small))
 
-    try_to_remove_files([r_tif_path, rp_tif_path, path_large, path_small])
+    try_to_remove_files([r_tif_path, rp_tif_path, path_large, path_small, path_cc_large, path_cc_small])
 
     if os.path.isfile(tif_path):
         try:
@@ -99,15 +105,12 @@ def create_thumbnails(tif_path, scene_id, organization_id):
             # If any subprocess calls fail, we need to clean up before exiting
             try_to_remove_files([r_tif_path, rp_tif_path, path_large, path_small])
             raise
-
         if os.path.isfile(path_large) and os.path.isfile(path_small):
             s3_bucket_name = os.getenv('THUMBNAIL_BUCKET')
             s3_bucket = boto3.resource('s3').Bucket(s3_bucket_name)
-            s3_bucket.upload_file(path_large, path_large, {'ContentType': 'image/png'})
-            s3_bucket.upload_file(path_small, path_small, {'ContentType': 'image/png'})
-
+            s3_bucket.upload_file(path_cc_large, os.path.basename(path_cc_large), {'ContentType': 'image/png'})
+            s3_bucket.upload_file(path_cc_small, os.path.basename(path_cc_small), {'ContentType': 'image/png'})
         try_to_remove_files([r_tif_path, rp_tif_path, path_large, path_small])
-
     else:
         return
 

--- a/app-tasks/rf/src/rf/uploads/geotiff/create_thumbnails.py
+++ b/app-tasks/rf/src/rf/uploads/geotiff/create_thumbnails.py
@@ -101,6 +101,23 @@ def create_thumbnails(tif_path, scene_id, organization_id):
                 '-of', 'PNG',
                 '-q',
             ], env=mod_env)
+
+            # Do basic histogram normalization to improve thumbnails
+            subprocess.check_call([
+                'convert',
+                path_small,
+                '-normalize',
+                path_cc_small
+            ])
+
+            # Do basic histogram normalization to improve thumbnails
+            subprocess.check_call([
+                'convert',
+                path_large,
+                '-normalize',
+                path_cc_large
+            ])
+
         except:
             # If any subprocess calls fail, we need to clean up before exiting
             try_to_remove_files([r_tif_path, rp_tif_path, path_large, path_small])


### PR DESCRIPTION
## Overview

Updates ingest definition creation to support more than Landsat data. Any multiband geotiff should work from the import to ingest and succeed on the whole pipeline.

Additional problems uncovered during testing are fixed here as well:
 - Use rasterio's built in dataset mask functionality for footprints
 - Add convert command to do basic balancing of thumbnails
 - Disables user FK visibility filter for admin org
 - Encode URIs for tiff location

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~

### Demo

![test-pr-results](https://cloud.githubusercontent.com/assets/898060/24862436/8ff2de28-1dca-11e7-918a-03823af632a9.png)

![batch-success](https://cloud.githubusercontent.com/assets/898060/24862439/946e0090-1dca-11e7-9091-29c9a3390fc6.png)

## Notes

Opened https://github.com/azavea/raster-foundry/issues/1462 because this PR uncovered an issue where users cannot view scenes that they imported.

## Testing Instructions

 - Obtain test tiff to import
 - Start server with airflow running
 - Go through import process in UI and upload test tif
 - Update users to be part of root organization (`./scripts/psql`)
   `update users set organization_id = '9e2bef18-3f46-426b-a5bd-9913ee1ff840';`
 - Check that scene is imported successfully in browse UI
 - Check that scene is ingested successfully in AWS Batch console

Closes #1303 
