### PR TITLE
Add status-filter for Uploads

### DIFF
--- a/app-backend/api/src/main/scala/uploads/QueryParameters.scala
+++ b/app-backend/api/src/main/scala/uploads/QueryParameters.scala
@@ -4,13 +4,13 @@ import java.util.UUID
 
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.directives.ParameterDirectives.parameters
-
 import com.azavea.rf.database.query._
 import com.azavea.rf.api.utils.queryparams._
 
 trait UploadQueryParameterDirective extends QueryParametersCommon {
   val uploadQueryParams = parameters((
     'datasource.as[UUID].?,
-    'organization.as[UUID].?
+    'organization.as[UUID].?,
+    'uploadStatus.as[String].?
   )).as(UploadQueryParameters.apply _)
 }

--- a/app-backend/database/src/main/scala/com/azavea/rf/database/QueryParameters.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/QueryParameters.scala
@@ -231,5 +231,6 @@ case class CombinedMapTokenQueryParameters(
 @JsonCodec
 case class UploadQueryParameters(
   organization: Option[UUID] = None,
-  datasource: Option[UUID] = None
+  datasource: Option[UUID] = None,
+  uploadStatus: Option[String] = None
 )

--- a/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Uploads.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Uploads.scala
@@ -158,9 +158,14 @@ class UploadTableQuery[M, U, C[_]](uploads: Uploads.TableQuery) {
       case _ => uploads
     }
 
-    queryParams.datasource match {
+    val filteredBySource = queryParams.datasource match {
       case Some(ds) => filteredByOrg.filter(_.datasource === ds)
       case _ => filteredByOrg
+    }
+
+    queryParams.uploadStatus match {
+      case Some(st) => filteredBySource.filter(_.uploadStatus === UploadStatus.fromString(st))
+      case _ => filteredBySource
     }
   }
 

--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/UploadStatus.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/UploadStatus.scala
@@ -26,6 +26,7 @@ object UploadStatus {
     case "COMPLETE" => Complete
     case "FAILED" => Failed
     case "ABORTED" => Aborted
+    case _ => throw new IllegalArgumentException(s"Argument $s cannot be mapped to UploadStatus")
   }
 
   implicit val uploadStatusEncoder: Encoder[UploadStatus] =

--- a/docs/swagger/spec.yml
+++ b/docs/swagger/spec.yml
@@ -260,6 +260,7 @@ paths:
         - $ref: '#/parameters/page'
         - $ref: '#/parameters/organization'
         - $ref: '#/parameters/datasource'
+        - $ref: '#/parameters/uploadStatus'
       responses:
         200:
           description: Paginated list of uploads
@@ -1435,6 +1436,21 @@ parameters:
     items:
       type: string
       format: uuid
+  uploadStatus:
+    name: uploadStatus
+    description: Status of upload
+    in: query
+    type: string
+    required: false
+    enum:
+      - CREATED
+      - UPLOADING
+      - UPLOADED
+      - QUEUED
+      - PROCESSING
+      - COMPLETE
+      - FAILED
+      - ABORTED
   month:
     name: month
     description: Only return results from this month


### PR DESCRIPTION
## Overview

This PR implement a status filter for Uploads.

### Checklist

~~- [ ] Styleguide updated, if necessary~~
- [x] Swagger specification updated, if necessary
~~- [ ] Symlinks from new migrations present or corrected for any new migrations~~


## Testing Instructions

* (assuming there are `upload` records)
* send a `GET` request to `api/uploads?uploadStatus=BOGUS` endpoint and check that an error is returned
*  `GET` `/api/uploads?uploadStatus=[status with some records]` such that the `uploadStatus` argument should return something, check that the results are expected
* `GET /api/uploads?uploadStatus=[status with no records]` such that no results are expected, check that the result is a `200` response with an empty `results` field
* check the swagger docs for accuracy of the added query parameter

Closes #1386
