### PR TITLE
Reorganize Imports page

### DIFF
--- a/app-frontend/src/app/components/sceneItem/sceneItem.component.js
+++ b/app-frontend/src/app/components/sceneItem/sceneItem.component.js
@@ -9,6 +9,8 @@ const rfSceneItem = {
         selected: '&',
         onSelect: '&',
         onAction: '&',
+        onView: '&',
+        onDownload: '&',
         actionIcon: '<'
     }
 };

--- a/app-frontend/src/app/components/sceneItem/sceneItem.controller.js
+++ b/app-frontend/src/app/components/sceneItem/sceneItem.controller.js
@@ -5,6 +5,7 @@ export default class SceneItemController {
         this.mapService = mapService;
         this.isSelectable = $attrs.hasOwnProperty('selectable');
         this.isDraggable = $attrs.hasOwnProperty('draggable');
+        this.isEditable = $attrs.hasOwnProperty('editable');
         this.datasourceService = datasourceService;
         this.$scope = $scope;
     }
@@ -43,6 +44,16 @@ export default class SceneItemController {
 
     onAction(event) {
         this.onAction({scene: this.scene});
+        event.stopPropagation();
+    }
+
+    onView(event) {
+        this.onView({scene: this.scene});
+        event.stopPropagation();
+    }
+
+    onDownload(event) {
+        this.onDownload({scene: this.scene});
         event.stopPropagation();
     }
 }

--- a/app-frontend/src/app/components/sceneItem/sceneItem.html
+++ b/app-frontend/src/app/components/sceneItem/sceneItem.html
@@ -29,5 +29,25 @@
             ng-if="$ctrl.actionIcon">
       <i ng-class="$ctrl.actionIcon"></i>
     </button>
+    <div ng-if="$ctrl.isEditable">
+      <div class="dropdown btn-group" uib-dropdown>
+        <button class="btn" ng-click="$ctrl.onView()">View</button>
+        <button type="button" class="btn" uib-dropdown-toggle>
+          <i class="icon-caret-down"></i>
+        </button>
+        <ul class="dropdown-menu" uib-dropdown-menu role="menu">
+          <li role="menuitem">
+            <a href ng-click="$ctrl.onDownload()"><i class="icon-download"></i>Download</a>
+          </li>
+          <li role="menuitem">
+            <a><i class="icon-unlocked"></i>Make public</a>
+          </li>
+          <li class="divider"></li>
+          <li role="menuitem">
+            <a href><i class="icon-trash"></i>Delete</a>
+          </li>
+        </ul>
+      </div>
+    </div>
   </div>
 </div>

--- a/app-frontend/src/app/components/sceneList/sceneList.component.js
+++ b/app-frontend/src/app/components/sceneList/sceneList.component.js
@@ -1,0 +1,11 @@
+// Component code
+import sceneListTpl from './sceneList.html';
+
+const rfSceneList = {
+    templateUrl: sceneListTpl,
+    controller: 'SceneListController',
+    bindings: {
+    }
+};
+
+export default rfSceneList;

--- a/app-frontend/src/app/components/sceneList/sceneList.controller.js
+++ b/app-frontend/src/app/components/sceneList/sceneList.controller.js
@@ -1,0 +1,113 @@
+export default class SceneListController {
+    constructor( // eslint-disable-line max-params
+        $log, sceneService, $state, authService, $uibModal
+    ) {
+        'ngInject';
+        this.$log = $log;
+        this.sceneService = sceneService;
+        this.$state = $state;
+        this.authService = authService;
+        this.$uibModal = $uibModal;
+    }
+
+    $onInit() {
+        this.populateSceneList(this.$state.params.page || 1);
+    }
+
+    populateSceneList(page) {
+        if (this.loading) {
+            return;
+        }
+        delete this.errorMsg;
+        this.loading = true;
+        // save off selected scenes so you don't lose them during the refresh
+        this.sceneList = [];
+        this.sceneService.query(
+            {
+                sort: 'createdAt,desc',
+                pageSize: '10',
+                page: page - 1,
+                createdBy: this.authService.profile().user_id
+            }
+        ).then((sceneResult) => {
+            this.lastSceneResult = sceneResult;
+            this.numPaginationButtons = 6 - sceneResult.page % 10;
+            if (this.numPaginationButtons < 3) {
+                this.numPaginationButtons = 3;
+            }
+            this.currentPage = sceneResult.page + 1;
+            let replace = !this.$state.params.page;
+            this.$state.transitionTo(
+                this.$state.$current.name,
+                {page: this.currentPage},
+                {
+                    location: replace ? 'replace' : true,
+                    notify: false
+                }
+            );
+            this.sceneList = this.lastSceneResult.results;
+            this.loading = false;
+        }, () => {
+            this.errorMsg = 'Server error.';
+            this.loading = false;
+        });
+    }
+
+    viewSceneDetail(scene) {
+        this.$state.go(
+            'library.scenes.detail',
+            {
+                scene: scene,
+                id: scene.id
+            }
+        );
+    }
+
+    importModal() {
+        if (this.activeModal) {
+            this.activeModal.dismiss();
+        }
+
+        this.activeModal = this.$uibModal.open({
+            component: 'rfImportModal',
+            resolve: {}
+        });
+    }
+
+    downloadModal(scene) {
+        if (this.activeModal) {
+            this.activeModal.dismiss();
+        }
+
+        let images = scene.images.map((image) => {
+            return {
+                filename: image.filename,
+                uri: image.sourceUri,
+                metadata: image.metadataFiles || []
+            };
+        });
+
+        let downloadSets = [{
+            label: scene.name,
+            metadata: scene.metadataFiles || [],
+            images: images
+        }];
+
+        this.activeModal = this.$uibModal.open({
+            component: 'rfDownloadModal',
+            resolve: {
+                downloads: () => downloadSets
+            }
+        });
+    }
+
+    shouldShowSceneList() {
+        return !this.loading && this.lastSceneResult &&
+            this.lastSceneResult.count > this.lastSceneResult.pageSize && !this.errorMsg;
+    }
+
+    shouldShowImportBox() {
+        return !this.loading && this.lastSceneResult &&
+            this.lastSceneResult.count === 0 && !this.errorMsg;
+    }
+}

--- a/app-frontend/src/app/components/sceneList/sceneList.html
+++ b/app-frontend/src/app/components/sceneList/sceneList.html
@@ -1,0 +1,48 @@
+<div class="list-group" ng-if="$ctrl.loading">
+  <span class="list-placeholder">
+    <i class="icon-load"></i>
+  </span>
+</div>
+<div class="list-group">
+  <rf-scene-item
+      on-view="$ctrl.viewSceneDetail(scene)"
+      on-download="$ctrl.downloadModal(scene)"
+      scene="scene"
+      editable
+      ng-repeat="scene in $ctrl.sceneList track by scene.id">
+  </rf-scene-item>
+</div>
+<div class="list-group text-center"
+     ng-if="$ctrl.shouldShowSceneList()">
+  <ul uib-pagination
+      items-per-page="$ctrl.lastSceneResult.pageSize"
+      total-items="$ctrl.lastSceneResult.count"
+      ng-model="$ctrl.currentPage"
+      max-size="4"
+      rotate="true"
+      boundary-link-numbers="true"
+      force-ellipses="true"
+      ng-change="$ctrl.populateSceneList($ctrl.currentPage)">
+  </ul>
+</div>
+<div ng-if="$ctrl.shouldShowImportBox()" class="list-group">
+    <rf-call-to-action-item title="You haven't imported any scenes">
+      <div class="cta-flex-text">
+        Every scene that you import will be listed here. After you have imported one or more scenes,
+        you can return to this page to view them.
+      </div>
+      <div class="cta-button-row">
+        <a class="btn btn-primary" ng-click="$ctrl.importModal()">Import scenes</a>
+      </div>
+      <div class="cta-text">
+        <a>Getting started with Imports</a>
+      </div>
+    </rf-call-to-action-item>
+</div>
+<div class="list-group" ng-if="$ctrl.errorMsg">
+  <span class="list-placeholder">
+    {{$ctrl.errorMsg}}
+    <a href ng-click="$ctrl.populateSceneList(1)">Try again</a>
+  </span>
+</div>
+

--- a/app-frontend/src/app/components/sceneList/sceneList.module.js
+++ b/app-frontend/src/app/components/sceneList/sceneList.module.js
@@ -1,0 +1,11 @@
+import angular from 'angular';
+import SceneListComponent from './sceneList.component.js';
+import SceneListController from './sceneList.controller.js';
+
+const SceneListModule = angular.module('components.sceneList', []);
+
+SceneListModule.component('rfSceneList', SceneListComponent);
+SceneListModule.controller('SceneListController', SceneListController);
+
+export default SceneListModule;
+

--- a/app-frontend/src/app/index.components.js
+++ b/app-frontend/src/app/index.components.js
@@ -16,6 +16,7 @@ export default angular.module('index.components', [
     require('./components/mosaicMask/mosaicMask.module.js').name,
     require('./components/maskItem/maskItem.module.js').name,
     require('./components/mosaicParameters/mosaicScenesParameters.module.js').name,
+    require('./components/sceneList/sceneList.module.js').name,
     require('./components/sceneItem/sceneItem.module.js').name,
     require('./components/sceneDetail/sceneDetail.module.js').name,
     require('./components/projectItem/projectItem.module.js').name,

--- a/app-frontend/src/app/pages/imports/imports.controller.js
+++ b/app-frontend/src/app/pages/imports/imports.controller.js
@@ -13,21 +13,6 @@ class ImportsController {
 
     }
 
-    openCreateProjectModal() {
-        if (this.activeModal) {
-            this.activeModal.dismiss();
-        }
-
-        this.activeModal = this.$uibModal.open({
-            component: 'rfCreateProjectModal'
-        });
-
-        this.activeModal.result.then(() => {
-
-        });
-
-        return this.activeModal;
-    }
 }
 
 export default ImportsController;

--- a/app-frontend/src/app/pages/imports/imports.html
+++ b/app-frontend/src/app/pages/imports/imports.html
@@ -2,34 +2,25 @@
   <div class="container column-stretch dashboard">
     <div class="main">
       <div class="content stack-sm">
-        <h2>Imports</h2>
+        <h2><i class="icon-imports"></i>Imports</h2>
       </div>
       <div class="row content stack-sm">
-        <div class="column-12">
-          <div class="cta-row">
-            <rf-call-to-action-item title="Datasources">
-              <div class="cta-flex-text">
-                Datasources allow you to connect to various imagery sources and import scenes into Raster Foundry.
-              </div>
-              <div class="cta-button-row">
-                <a class="btn btn-primary" ui-sref="imports.datasources.list">Browse Datasources</a>
-              </div>
-              <div class="cta-text">
-                <a>Getting started with Datasources</a>
-              </div>
-            </rf-call-to-action-item>
-            <rf-call-to-action-item title="Scenes">
-              <div class="cta-flex-text">
-                Raster Foundry creates Scenes from your Datasources.
-              </div>
-              <div class="cta-button-row">
-                <a class="btn btn-primary" ui-sref="settings.tokens">Browse Imported Scenes</a>
-              </div>
-              <div class="cta-text">
-                <a>Getting started with your Scenes</a>
-              </div>
-            </rf-call-to-action-item>
-          </div>
+        <div class="column-8">
+          <rf-scene-list></rf-scene-list>
+        </div>
+        <div class="column"></div>
+        <div class="column-3">
+          <rf-call-to-action-item title="Datasources">
+            <div class="cta-flex-text">
+              Datasources allow you to connect to various imagery sources and import scenes into Raster Foundry.
+            </div>
+            <div class="cta-button-row">
+              <a class="btn btn-primary" ui-sref="imports.datasources.list">Browse Datasources</a>
+            </div>
+            <div class="cta-text">
+              <a>Getting started with Datasources</a>
+            </div>
+          </rf-call-to-action-item>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Overview
Reorganizes the Imports page to better match the latest wireframes

### Checklist

- [ ] ~Styleguide updated, if necessary~
- [ ] ~Swagger specification updated, if necessary~
- [ ] ~Symlinks from new migrations present or corrected for any new migrations~

### Demo

![imports1](https://cloud.githubusercontent.com/assets/447977/24882435/0b61311a-1e0f-11e7-8189-ad4802c23006.png)
![imports2](https://cloud.githubusercontent.com/assets/447977/24882434/0b5fe558-1e0f-11e7-80b9-4707f5cccc47.png)
![imports3](https://cloud.githubusercontent.com/assets/447977/24882437/0b8135c8-1e0f-11e7-9738-f3478e03d8ff.png)


### Notes

- There is some styling that needs to be done on the buttons to solve z-indexing issues (as well as make them match the mockup styling better and add a hamburger icon). @designmatty 
- It's not exactly clear where clicking the "Import Scenes" button should go because right now you need to navigate through the Datasources list in order to start an import. So I've just made it take you to the Datasources list page.
- This adds a `sceneList` component which might be a starting point for a solution to #1468, but doing that full refactor was outside the scope of this card.

## Testing Instructions

 * Load up the front end and click "Imports" in the nav bar. You should see a screen similar to the first screenshot above.
 * Because there's no way to actually create imports at the moment (see #1462), you'll need to use the DB shell to assign yourself some. Open up a SQL shell with `./scripts/psql`. Figure out your user ID (it will be in the query parameters to the `scenes` endpoint when you load the `Imports` page, so that's a good way to check find it) and then substitute it into the following command: `UPDATE scenes SET created_by = '<YOUR ID>' WHERE id IN (SELECT id FROM scenes WHERE organization_id = 'dfac6307-b5ef-43f7-beda-b9f208bb7726' limit 20);`
 * Reload the Imports page and you should see something more like the second screenshot. Make sure that the "View" button, and the "Download" option in the dropdown works.

Closes #1442 
Closes #1443 
