### PR TITLE
[WIP] Cache circe auto derivation codecs

### DIFF
--- a/app-backend/api/src/main/scala/Codec.scala
+++ b/app-backend/api/src/main/scala/Codec.scala
@@ -3,7 +3,7 @@ package com.azavea.rf.api
 import com.azavea.rf.api.healthcheck.HealthCheckStatus
 
 import io.circe._
-import io.circe.generic.auto._
+import com.azavea.rf.common.cache.circe.auto._
 
 object Codec {
   implicit val healthcheckEncoder: Encoder[HealthCheckStatus.Status] =

--- a/app-backend/api/src/main/scala/categories/Routes.scala
+++ b/app-backend/api/src/main/scala/categories/Routes.scala
@@ -9,7 +9,7 @@ import com.azavea.rf.database.tables.ToolCategories
 import com.azavea.rf.datamodel._
 import com.lonelyplanet.akka.http.extensions.PaginationDirectives
 import io.circe._
-import io.circe.generic.auto._
+import com.azavea.rf.common.cache.circe.auto._
 import de.heikoseeberger.akkahttpcirce.CirceSupport._
 
 

--- a/app-backend/api/src/main/scala/config/Routes.scala
+++ b/app-backend/api/src/main/scala/config/Routes.scala
@@ -5,7 +5,7 @@ import akka.http.scaladsl.server.Route
 import com.azavea.rf.common.Authentication
 import com.azavea.rf.database.Database
 import io.circe._
-import io.circe.generic.auto._
+import com.azavea.rf.common.cache.circe.auto._
 import de.heikoseeberger.akkahttpcirce.CirceSupport._
 
 

--- a/app-backend/api/src/main/scala/datasource/Routes.scala
+++ b/app-backend/api/src/main/scala/datasource/Routes.scala
@@ -15,7 +15,7 @@ import com.azavea.rf.database.query._
 import com.azavea.rf.database.{Database, ActionRunner}
 import com.azavea.rf.datamodel._
 import io.circe._
-import io.circe.generic.auto._
+import com.azavea.rf.common.cache.circe.auto._
 import de.heikoseeberger.akkahttpcirce.CirceSupport._
 
 trait DatasourceRoutes extends Authentication

--- a/app-backend/api/src/main/scala/grid/Routes.scala
+++ b/app-backend/api/src/main/scala/grid/Routes.scala
@@ -14,7 +14,7 @@ import com.azavea.rf.database.Database
 import com.azavea.rf.database._
 import com.typesafe.scalalogging.LazyLogging
 import io.circe._
-import io.circe.generic.auto._
+import com.azavea.rf.common.cache.circe.auto._
 import de.heikoseeberger.akkahttpcirce.CirceSupport._
 
 trait GridRoutes extends Authentication

--- a/app-backend/api/src/main/scala/healthcheck/Healthcheck.scala
+++ b/app-backend/api/src/main/scala/healthcheck/Healthcheck.scala
@@ -6,7 +6,7 @@ import com.azavea.rf.api.AkkaSystem
 import com.azavea.rf.api.Codec._
 import scala.concurrent.ExecutionContext.Implicits.global
 import io.circe._
-import io.circe.generic.auto._
+import com.azavea.rf.common.cache.circe.auto._
 import io.circe.syntax._
 import de.heikoseeberger.akkahttpcirce.CirceSupport._
 

--- a/app-backend/api/src/main/scala/healthcheck/Routes.scala
+++ b/app-backend/api/src/main/scala/healthcheck/Routes.scala
@@ -9,7 +9,7 @@ import com.azavea.rf.api.Codec._
 import com.azavea.rf.common.{Authentication, RollbarNotifier}
 import com.azavea.rf.database.Database
 import io.circe._
-import io.circe.generic.auto._
+import com.azavea.rf.common.cache.circe.auto._
 import de.heikoseeberger.akkahttpcirce.CirceSupport._
 
 

--- a/app-backend/api/src/main/scala/image/Routes.scala
+++ b/app-backend/api/src/main/scala/image/Routes.scala
@@ -9,13 +9,13 @@ import akka.http.scaladsl.server.Route
 import akka.http.scaladsl.model.StatusCodes
 import com.lonelyplanet.akka.http.extensions.PaginationDirectives
 import io.circe._
-import io.circe.generic.auto._
+import com.azavea.rf.common.cache.circe.auto._
 import de.heikoseeberger.akkahttpcirce.CirceSupport
 
 import java.util.UUID
 
 import io.circe._
-import io.circe.generic.auto._
+import com.azavea.rf.common.cache.circe.auto._
 
 import de.heikoseeberger.akkahttpcirce.CirceSupport
 

--- a/app-backend/api/src/main/scala/maptoken/Routes.scala
+++ b/app-backend/api/src/main/scala/maptoken/Routes.scala
@@ -10,7 +10,7 @@ import com.azavea.rf.database.tables.{Images, MapTokens}
 import com.azavea.rf.database.{ActionRunner, Database}
 import com.azavea.rf.datamodel._
 import io.circe._
-import io.circe.generic.auto._
+import com.azavea.rf.common.cache.circe.auto._
 import de.heikoseeberger.akkahttpcirce.CirceSupport._
 
 

--- a/app-backend/api/src/main/scala/organization/Routes.scala
+++ b/app-backend/api/src/main/scala/organization/Routes.scala
@@ -9,7 +9,7 @@ import akka.http.scaladsl.server.Route
 import akka.http.scaladsl.model.StatusCodes
 import com.lonelyplanet.akka.http.extensions.PaginationDirectives
 import io.circe._
-import io.circe.generic.auto._
+import com.azavea.rf.common.cache.circe.auto._
 import de.heikoseeberger.akkahttpcirce.CirceSupport._
 
 import java.util.UUID

--- a/app-backend/api/src/main/scala/project/Routes.scala
+++ b/app-backend/api/src/main/scala/project/Routes.scala
@@ -14,7 +14,7 @@ import com.azavea.rf.api.scene._
 import com.azavea.rf.api.utils.queryparams.QueryParametersCommon
 
 import io.circe._
-import io.circe.generic.auto._
+import com.azavea.rf.common.cache.circe.auto._
 import io.circe.parser._
 import io.circe.syntax._
 import de.heikoseeberger.akkahttpcirce.CirceSupport._

--- a/app-backend/api/src/main/scala/scene/Routes.scala
+++ b/app-backend/api/src/main/scala/scene/Routes.scala
@@ -12,7 +12,7 @@ import akka.http.scaladsl.server.Route
 import io.circe._
 import io.circe.syntax._
 import io.circe.parser._
-import io.circe.generic.auto._
+import com.azavea.rf.common.cache.circe.auto._
 
 import de.heikoseeberger.akkahttpcirce.CirceSupport._
 

--- a/app-backend/api/src/main/scala/tags/Routes.scala
+++ b/app-backend/api/src/main/scala/tags/Routes.scala
@@ -9,7 +9,7 @@ import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.server.Route
 import com.lonelyplanet.akka.http.extensions.PaginationDirectives
 import io.circe._
-import io.circe.generic.auto._
+import com.azavea.rf.common.cache.circe.auto._
 import de.heikoseeberger.akkahttpcirce.CirceSupport._
 
 import scala.util.{Success, Failure}

--- a/app-backend/api/src/main/scala/thumbnail/Routes.scala
+++ b/app-backend/api/src/main/scala/thumbnail/Routes.scala
@@ -12,7 +12,7 @@ import akka.http.scaladsl.model.MediaType.Binary
 import org.apache.commons.io.IOUtils
 import com.lonelyplanet.akka.http.extensions.PaginationDirectives
 import io.circe._
-import io.circe.generic.auto._
+import com.azavea.rf.common.cache.circe.auto._
 import de.heikoseeberger.akkahttpcirce.CirceSupport._
 
 import java.util.UUID

--- a/app-backend/api/src/main/scala/token/Routes.scala
+++ b/app-backend/api/src/main/scala/token/Routes.scala
@@ -5,7 +5,7 @@ import com.azavea.rf.api.utils.{Auth0ErrorHandler}
 
 import akka.http.scaladsl.server.Route
 import io.circe._
-import io.circe.generic.auto._
+import com.azavea.rf.common.cache.circe.auto._
 import de.heikoseeberger.akkahttpcirce.CirceSupport._
 
 

--- a/app-backend/api/src/main/scala/token/Token.scala
+++ b/app-backend/api/src/main/scala/token/Token.scala
@@ -17,7 +17,7 @@ import com.azavea.rf.api.utils.Config
 import com.azavea.rf.api.utils.{Auth0Exception, ManagementBearerToken}
 
 import io.circe._
-import io.circe.generic.auto._
+import com.azavea.rf.common.cache.circe.auto._
 import de.heikoseeberger.akkahttpcirce.CirceSupport._
 
 // TODO: this sort of case class definition should live in datamodel

--- a/app-backend/api/src/main/scala/toolrun/Routes.scala
+++ b/app-backend/api/src/main/scala/toolrun/Routes.scala
@@ -9,7 +9,7 @@ import com.lonelyplanet.akka.http.extensions.PaginationDirectives
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.server.Route
 import io.circe._
-import io.circe.generic.auto._
+import com.azavea.rf.common.cache.circe.auto._
 import de.heikoseeberger.akkahttpcirce.CirceSupport._
 
 import scala.concurrent.ExecutionContext.Implicits.global

--- a/app-backend/api/src/main/scala/tools/Routes.scala
+++ b/app-backend/api/src/main/scala/tools/Routes.scala
@@ -9,7 +9,7 @@ import com.lonelyplanet.akka.http.extensions.PaginationDirectives
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.server.Route
 import io.circe._
-import io.circe.generic.auto._
+import com.azavea.rf.common.cache.circe.auto._
 import de.heikoseeberger.akkahttpcirce.CirceSupport._
 
 import scala.util.{Success, Failure}

--- a/app-backend/api/src/main/scala/uploads/Credentials.scala
+++ b/app-backend/api/src/main/scala/uploads/Credentials.scala
@@ -18,7 +18,7 @@ import com.typesafe.scalalogging.LazyLogging
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
-import io.circe.generic.auto._
+import com.azavea.rf.common.cache.circe.auto._
 import io.circe.optics.JsonPath._
 import io.circe.Json
 import de.heikoseeberger.akkahttpcirce.CirceSupport._

--- a/app-backend/api/src/main/scala/uploads/Routes.scala
+++ b/app-backend/api/src/main/scala/uploads/Routes.scala
@@ -15,7 +15,7 @@ import com.azavea.rf.database.query._
 import com.azavea.rf.database.{Database, ActionRunner}
 import com.azavea.rf.datamodel._
 import io.circe._
-import io.circe.generic.auto._
+import com.azavea.rf.common.cache.circe.auto._
 import de.heikoseeberger.akkahttpcirce.CirceSupport._
 
 trait UploadRoutes extends Authentication

--- a/app-backend/api/src/main/scala/user/Auth0User.scala
+++ b/app-backend/api/src/main/scala/user/Auth0User.scala
@@ -14,7 +14,7 @@ import com.github.blemale.scaffeine.{AsyncLoadingCache, Scaffeine}
 import com.typesafe.scalalogging.LazyLogging
 import io.circe._
 import io.circe.syntax._
-import io.circe.generic.auto._
+import com.azavea.rf.common.cache.circe.auto._
 import de.heikoseeberger.akkahttpcirce.CirceSupport._
 
 import scala.concurrent.ExecutionContext.Implicits.global

--- a/app-backend/api/src/main/scala/user/Routes.scala
+++ b/app-backend/api/src/main/scala/user/Routes.scala
@@ -12,7 +12,7 @@ import com.azavea.rf.database.Database
 import com.azavea.rf.database.tables.Users
 import com.azavea.rf.datamodel._
 import io.circe._
-import io.circe.generic.auto._
+import com.azavea.rf.common.cache.circe.auto._
 import de.heikoseeberger.akkahttpcirce.CirceSupport._
 
 

--- a/app-backend/api/src/main/scala/utils/Auth0Util.scala
+++ b/app-backend/api/src/main/scala/utils/Auth0Util.scala
@@ -1,6 +1,6 @@
 package com.azavea.rf.api.utils
 
 import io.circe._
-import io.circe.generic.auto._
+import com.azavea.rf.common.cache.circe.auto._
 
 case class ManagementBearerToken(access_token: String, expires_in: Int, token_type: String, scope: String)

--- a/app-backend/api/src/test/scala/auth/AuthSpec.scala
+++ b/app-backend/api/src/test/scala/auth/AuthSpec.scala
@@ -14,7 +14,7 @@ import com.azavea.rf.api.utils.Config
 import com.azavea.rf.api.{AuthUtils, DBSpec, Router}
 
 import io.circe._
-import io.circe.generic.auto._
+import com.azavea.rf.common.cache.circe.auto._
 import de.heikoseeberger.akkahttpcirce.CirceSupport._
 
 class AuthSpec extends WordSpec

--- a/app-backend/api/src/test/scala/datasource/DatasourceSpec.scala
+++ b/app-backend/api/src/test/scala/datasource/DatasourceSpec.scala
@@ -18,7 +18,7 @@ import java.time.Instant
 
 import io.circe._
 import io.circe.syntax._
-import io.circe.generic.auto._
+import com.azavea.rf.common.cache.circe.auto._
 import de.heikoseeberger.akkahttpcirce.CirceSupport._
 
 class DatasourceSpec extends WordSpec

--- a/app-backend/api/src/test/scala/healthcheck/HealthCheckSpec.scala
+++ b/app-backend/api/src/test/scala/healthcheck/HealthCheckSpec.scala
@@ -10,7 +10,7 @@ import com.azavea.rf.api.{DBSpec, Router}
 import com.azavea.rf.api.Codec._
 
 import io.circe._
-import io.circe.generic.auto._
+import com.azavea.rf.common.cache.circe.auto._
 import de.heikoseeberger.akkahttpcirce.CirceSupport._
 
 class HealthCheckSpec extends WordSpec

--- a/app-backend/api/src/test/scala/image/ImageSpec.scala
+++ b/app-backend/api/src/test/scala/image/ImageSpec.scala
@@ -18,7 +18,7 @@ import java.sql.Timestamp
 import java.time.Instant
 
 import io.circe._
-import io.circe.generic.auto._
+import com.azavea.rf.common.cache.circe.auto._
 import io.circe.syntax._
 import de.heikoseeberger.akkahttpcirce.CirceSupport._
 

--- a/app-backend/api/src/test/scala/organization/OrganizationSpec.scala
+++ b/app-backend/api/src/test/scala/organization/OrganizationSpec.scala
@@ -14,7 +14,7 @@ import com.azavea.rf.api.{DBSpec, Router}
 import com.azavea.rf.api.AuthUtils
 
 import io.circe._
-import io.circe.generic.auto._
+import com.azavea.rf.common.cache.circe.auto._
 import io.circe.syntax._
 import de.heikoseeberger.akkahttpcirce.CirceSupport._
 

--- a/app-backend/api/src/test/scala/project/ProjectSceneSpec.scala
+++ b/app-backend/api/src/test/scala/project/ProjectSceneSpec.scala
@@ -14,7 +14,7 @@ import com.azavea.rf.api.utils.Config
 import com.azavea.rf.api.{AuthUtils, DBSpec, Router}
 
 import io.circe._
-import io.circe.generic.auto._
+import com.azavea.rf.common.cache.circe.auto._
 import io.circe.parser._
 import io.circe.syntax._
 import de.heikoseeberger.akkahttpcirce.CirceSupport._

--- a/app-backend/api/src/test/scala/project/ProjectSpec.scala
+++ b/app-backend/api/src/test/scala/project/ProjectSpec.scala
@@ -13,7 +13,7 @@ import com.azavea.rf.api.utils.Config
 import com.azavea.rf.api.{DBSpec, Router, AuthUtils}
 
 import io.circe._
-import io.circe.generic.auto._
+import com.azavea.rf.common.cache.circe.auto._
 import io.circe.syntax._
 import de.heikoseeberger.akkahttpcirce.CirceSupport._
 

--- a/app-backend/api/src/test/scala/scene/SceneSpec.scala
+++ b/app-backend/api/src/test/scala/scene/SceneSpec.scala
@@ -21,7 +21,7 @@ import geotrellis.slick.Projected
 
 import io.circe._
 import io.circe.syntax._
-import io.circe.generic.auto._
+import com.azavea.rf.common.cache.circe.auto._
 import de.heikoseeberger.akkahttpcirce.CirceSupport._
 
 class SceneSpec extends WordSpec

--- a/app-backend/api/src/test/scala/tags/ToolTagSpec.scala
+++ b/app-backend/api/src/test/scala/tags/ToolTagSpec.scala
@@ -15,7 +15,7 @@ import com.azavea.rf.api.utils.Config
 import com.azavea.rf.api.{AuthUtils, DBSpec, Router}
 
 import io.circe._
-import io.circe.generic.auto._
+import com.azavea.rf.common.cache.circe.auto._
 import io.circe.syntax._
 import de.heikoseeberger.akkahttpcirce.CirceSupport._
 

--- a/app-backend/api/src/test/scala/thumbnail/ThumbnailSpec.scala
+++ b/app-backend/api/src/test/scala/thumbnail/ThumbnailSpec.scala
@@ -20,7 +20,7 @@ import com.azavea.rf.api.utils.Config
 import com.azavea.rf.api.{DBSpec, Router}
 
 import io.circe._
-import io.circe.generic.auto._
+import com.azavea.rf.common.cache.circe.auto._
 import io.circe.syntax._
 import de.heikoseeberger.akkahttpcirce.CirceSupport._
 

--- a/app-backend/api/src/test/scala/thumbnail/ThumbnailsHelper.scala
+++ b/app-backend/api/src/test/scala/thumbnail/ThumbnailsHelper.scala
@@ -7,7 +7,7 @@ import java.sql.Timestamp
 import java.time.Instant
 
 import io.circe._
-import io.circe.generic.auto._
+import com.azavea.rf.common.cache.circe.auto._
 import io.circe.syntax._
 
 trait ThumbnailSpecHelper {

--- a/app-backend/api/src/test/scala/toolruns/ToolRunSpec.scala
+++ b/app-backend/api/src/test/scala/toolruns/ToolRunSpec.scala
@@ -13,7 +13,7 @@ import concurrent.duration._
 import org.scalatest.{Matchers, WordSpec}
 
 import io.circe._
-import io.circe.generic.auto._
+import com.azavea.rf.common.cache.circe.auto._
 import io.circe.syntax._
 import de.heikoseeberger.akkahttpcirce.CirceSupport._
 

--- a/app-backend/api/src/test/scala/tools/ToolSpec.scala
+++ b/app-backend/api/src/test/scala/tools/ToolSpec.scala
@@ -16,7 +16,7 @@ import com.azavea.rf.api.{AuthUtils, DBSpec, Router}
 import concurrent.duration._
 
 import io.circe._
-import io.circe.generic.auto._
+import com.azavea.rf.common.cache.circe.auto._
 import io.circe.syntax._
 import de.heikoseeberger.akkahttpcirce.CirceSupport._
 

--- a/app-backend/api/src/test/scala/user/UserSpec.scala
+++ b/app-backend/api/src/test/scala/user/UserSpec.scala
@@ -11,7 +11,7 @@ import com.azavea.rf.api.{DBSpec, Router}
 import com.azavea.rf.api.AuthUtils
 
 import io.circe._
-import io.circe.generic.auto._
+import com.azavea.rf.common.cache.circe.auto._
 import de.heikoseeberger.akkahttpcirce.CirceSupport._
 
 class UserSpec extends WordSpec

--- a/app-backend/build.sbt
+++ b/app-backend/build.sbt
@@ -125,6 +125,9 @@ lazy val common = Project("common", file("common"))
     Dependencies.chill,
     Dependencies.cats
   )})
+  .settings(
+    addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.patch)
+  )
 
 lazy val migrations = Project("migrations", file("migrations"))
   .dependsOn(datamodel)

--- a/app-backend/common/src/main/scala/cache/circe/CachedAutoDerivation.scala
+++ b/app-backend/common/src/main/scala/cache/circe/CachedAutoDerivation.scala
@@ -1,0 +1,26 @@
+package com.azavea.rf.common.cache.circe
+
+import io.circe.{Decoder, ObjectEncoder}
+import io.circe.export.Exported
+import io.circe.generic.AutoDerivation
+import io.circe.generic.decoding.DerivedDecoder
+import io.circe.generic.encoding.DerivedObjectEncoder
+import io.circe.generic.util.macros.ExportMacros
+
+import scala.language.experimental.macros
+import shapeless.Cached
+
+import scala.language.experimental.macros
+
+object CachedAutoDerivation extends CachedAutoDerivation
+
+trait CachedAutoDerivation {
+  implicit def cachedExportDecoder[A]: Exported[Decoder[A]] = {
+    def decoder: Exported[Decoder[A]] = macro ExportMacros.exportDecoder[DerivedDecoder, A]
+    Cached.implicitly[Exported[Decoder[A]]]
+  }
+  implicit def cachedExportEncoder[A]: Exported[ObjectEncoder[A]] = {
+    def encoder: Exported[ObjectEncoder[A]] = macro ExportMacros.exportEncoder[DerivedObjectEncoder, A]
+    Cached.implicitly[Exported[ObjectEncoder[A]]]
+  }
+}

--- a/app-backend/common/src/main/scala/cache/circe/auto/package.scala
+++ b/app-backend/common/src/main/scala/cache/circe/auto/package.scala
@@ -1,0 +1,3 @@
+package com.azavea.rf.common.cache.circe
+
+package object auto extends CachedAutoDerivation

--- a/scripts/test
+++ b/scripts/test
@@ -42,7 +42,7 @@ then
 
         echo "Executing Scala test suite"
         docker-compose \
-            run --rm api-server test
+            run --rm --entrypoint=/bin/bash api-server ./sbt test:compile && ./sbt test
 
         # TODO: https://github.com/azavea/raster-foundry/issues/435
         # echo "Executing JavaScript test suite"


### PR DESCRIPTION
## Overview

We can optimise `implicits` search by `shapeless.Cache` usage.

### Checklist

- [ ] Probably a separate project `utils` or `core`, as currently i placed it into `commons` and it's not 100% correct
- [ ] Implicits ordering (currently no ordering at all, a good chance to improve the situation)

Closes #1390 
Connects #1347
