### PR TITLE
Service-layer implementation of organization overrides for feature flags

### DIFF
--- a/app-backend/api/src/main/scala/config/Routes.scala
+++ b/app-backend/api/src/main/scala/config/Routes.scala
@@ -2,20 +2,39 @@ package com.azavea.rf.api.config
 
 import akka.http.scaladsl.server.Route
 
-import com.azavea.rf.common.Authentication
+import com.azavea.rf.common.{Authentication}
 import com.azavea.rf.database.Database
 import io.circe._
+import com.azavea.rf.database.tables.OrgFeatureFlags
+import io.circe.generic.auto._
 import de.heikoseeberger.akkahttpcirce.CirceSupport._
-
 
 trait ConfigRoutes extends Authentication {
   implicit def database: Database
 
-  def configRoutes: Route = {
+  val configRoutes: Route = {
     pathEndOrSingleSlash {
       get {
         complete {
           AngularConfigService.getConfig()
+        }
+      }
+    } ~
+    pathPrefix("organization") {
+      pathEndOrSingleSlash {
+        get {
+          complete {
+            AngularConfigService.getConfig()
+          }
+        }
+      } ~
+      path(JavaUUID) { orgId =>
+        pathEndOrSingleSlash {
+          get {
+            complete {
+              OrgFeatureFlags.getFeatures(orgId)
+            }
+          }
         }
       }
     }

--- a/app-backend/database/src/main/scala/com/azavea/rf/database/tables/OrgFeatureFlags.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/tables/OrgFeatureFlags.scala
@@ -1,0 +1,41 @@
+package com.azavea.rf.database.tables
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import com.typesafe.scalalogging.LazyLogging
+import java.util.UUID
+
+import com.azavea.rf.database.ExtendedPostgresDriver.api._
+import com.azavea.rf.database.{Database => DB}
+import com.azavea.rf.datamodel.FeatureFlag
+import com.azavea.rf.datamodel.OrgFeatures
+
+import scala.concurrent.Future
+
+class OrgFeatureFlags(_tableTag: Tag) extends Table[OrgFeatures](_tableTag, "organization_features") {
+  def * = (organization, featureFlag, active) <> (OrgFeatures.tupled, OrgFeatures.unapply)
+
+  val organization: Rep[UUID] = column[UUID]("organization")
+  val featureFlag: Rep[UUID] = column[UUID]("feature_flag")
+  val active: Rep[Boolean] = column[Boolean]("active")
+
+  val pk = primaryKey("organization_features_pkey", (organization, featureFlag))
+
+  lazy val orgFk = foreignKey("organization_features_org_fkey", organization, Organizations)(r => r.id, onUpdate=ForeignKeyAction.NoAction, onDelete=ForeignKeyAction.Cascade)
+  lazy val flagFk = foreignKey("organization_features_flag_fkey", featureFlag, FeatureFlags)(r => r.id, onUpdate=ForeignKeyAction.NoAction, onDelete=ForeignKeyAction.Cascade)
+}
+
+object OrgFeatureFlags extends TableQuery(tag => new OrgFeatureFlags(tag)) with LazyLogging {
+  def getFeatures(orgId: UUID)(implicit database: DB): Future[Seq[FeatureFlag]] = {
+    val dbAction =
+      for {
+        orgFfs <- OrgFeatureFlags.filter(o => o.organization === orgId)
+        ffs <- FeatureFlags if (orgFfs.featureFlag === ffs.id)
+      } yield (ffs, orgFfs.active)
+
+    database.db.run(dbAction.result) map (results =>
+      results map {
+        case (ff: FeatureFlag, orgOverride: Boolean) => ff.copy(active = orgOverride)
+        case _ => throw new IllegalArgumentException("Invalid arguments for constructor FeatureFlag")
+      })
+  }
+}

--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/OrgFeatureFlags.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/OrgFeatureFlags.scala
@@ -1,0 +1,13 @@
+package com.azavea.rf.datamodel
+
+import java.util.UUID
+
+case class OrgFeatures(
+  organization: UUID,
+  featureFlag: UUID,
+  active: Boolean
+)
+
+object OrgFeatures {
+  def tupled = (OrgFeatures.apply _).tupled
+}


### PR DESCRIPTION
## Overview

This PR implements the service-layer changes needed to support organization-level feature overrides.

### Checklist

~~- [ ] Styleguide updated, if necessary~~
~~- [ ] Swagger specification updated, if necessary~~
~~- [ ] Symlinks from new migrations present or corrected for any new migrations~~

### Notes

To facilitate testing, I added a route at `config/organization/{UUID}`. This may be removed or re- purposed as part of #1410.


## Testing Instructions

* add a record to `organization_features`, e.g.
```
insert into organization_features (organization, feature_flag, active)
VALUES ('9e2bef18-3f46-426b-a5bd-9913ee1ff840','68144a5a-bf71-4925-b2f6-94893333c88d',FALSE);
```
* `GET` `http://localhost:9000/config/organization/9e2bef18-3f46-426b-a5bd-9913ee1ff840` and check that the response agrees with the added record(s)
* `GET http://localhost:9000/config/organization/{bogus organization ID}` and check that the response is empty
* `GET http://localhost:9000/config` and check that the behavior is unchanged

Closes #1409
