### PR TITLE
Fix long compile times caused by circe auto derivation

### DIFF
--- a/app-backend/api/build.sbt
+++ b/app-backend/api/build.sbt
@@ -8,7 +8,6 @@ initialCommands in console := """
   |import com.azavea.rf.database.ExtendedPostgresDriver.api._
   |import com.azavea.rf.database.tables._
   |import io.circe._
-  |import io.circe.generic.auto._
   |import io.circe.syntax._
   |import java.util.UUID
   |import java.sql.Timestamp

--- a/app-backend/api/src/main/scala/Codec.scala
+++ b/app-backend/api/src/main/scala/Codec.scala
@@ -3,7 +3,6 @@ package com.azavea.rf.api
 import com.azavea.rf.api.healthcheck.HealthCheckStatus
 
 import io.circe._
-import io.circe.generic.auto._
 
 object Codec {
   implicit val healthcheckEncoder: Encoder[HealthCheckStatus.Status] =

--- a/app-backend/api/src/main/scala/categories/QueryParameters.scala
+++ b/app-backend/api/src/main/scala/categories/QueryParameters.scala
@@ -10,10 +10,10 @@ import com.azavea.rf.api.utils.queryparams._
 trait ToolCategoryQueryParametersDirective extends QueryParametersCommon {
   val toolCategorySpecificQueryParams = parameters((
     'search.as[String].?
-  )).as(ToolCategoryQueryParameters)
+  )).as(ToolCategoryQueryParameters.apply _)
 
   val toolCategoryQueryParameters = (
     timestampQueryParameters &
     toolCategorySpecificQueryParams
-  ).as(CombinedToolCategoryQueryParams)
+  ).as(CombinedToolCategoryQueryParams.apply _)
 }

--- a/app-backend/api/src/main/scala/categories/Routes.scala
+++ b/app-backend/api/src/main/scala/categories/Routes.scala
@@ -9,7 +9,6 @@ import com.azavea.rf.database.tables.ToolCategories
 import com.azavea.rf.datamodel._
 import com.lonelyplanet.akka.http.extensions.PaginationDirectives
 import io.circe._
-import io.circe.generic.auto._
 import de.heikoseeberger.akkahttpcirce.CirceSupport._
 
 

--- a/app-backend/api/src/main/scala/config/Config.scala
+++ b/app-backend/api/src/main/scala/config/Config.scala
@@ -8,6 +8,9 @@ import com.azavea.rf.datamodel.FeatureFlag
 import com.azavea.rf.database.Database
 import com.azavea.rf.database.tables.FeatureFlags
 
+import io.circe.generic.JsonCodec
+
+@JsonCodec
 case class AngularConfig(
   clientId: String,
   clientEnvironment: String,

--- a/app-backend/api/src/main/scala/config/Routes.scala
+++ b/app-backend/api/src/main/scala/config/Routes.scala
@@ -5,7 +5,6 @@ import akka.http.scaladsl.server.Route
 import com.azavea.rf.common.Authentication
 import com.azavea.rf.database.Database
 import io.circe._
-import io.circe.generic.auto._
 import de.heikoseeberger.akkahttpcirce.CirceSupport._
 
 

--- a/app-backend/api/src/main/scala/datasource/QueryParameters.scala
+++ b/app-backend/api/src/main/scala/datasource/QueryParameters.scala
@@ -11,5 +11,5 @@ import com.azavea.rf.api.utils.queryparams._
 trait DatasourceQueryParameterDirective extends QueryParametersCommon {
   val datasourceQueryParams = parameters((
     'name.as[String].?
-  )).as(DatasourceQueryParameters)
+  )).as(DatasourceQueryParameters.apply _)
 }

--- a/app-backend/api/src/main/scala/datasource/Routes.scala
+++ b/app-backend/api/src/main/scala/datasource/Routes.scala
@@ -15,7 +15,6 @@ import com.azavea.rf.database.query._
 import com.azavea.rf.database.{Database, ActionRunner}
 import com.azavea.rf.datamodel._
 import io.circe._
-import io.circe.generic.auto._
 import de.heikoseeberger.akkahttpcirce.CirceSupport._
 
 trait DatasourceRoutes extends Authentication

--- a/app-backend/api/src/main/scala/grid/QueryParameters.scala
+++ b/app-backend/api/src/main/scala/grid/QueryParameters.scala
@@ -27,12 +27,12 @@ trait GridQueryParameterDirective extends QueryParametersCommon
     'maxSunElevation.as[Float].?,
     'minSunElevation.as[Float].?,
     'ingested.as[Boolean].?
-  )).as(GridQueryParameters)
+  )).as(GridQueryParameters.apply _)
 
   val gridQueryParameters = (orgQueryParams &
     userQueryParameters &
     timestampQueryParameters &
     gridSpecificQueryParams &
     imageSpecificQueryParams
-  ).as(CombinedGridQueryParams)
+  ).as(CombinedGridQueryParams.apply _)
 }

--- a/app-backend/api/src/main/scala/grid/Routes.scala
+++ b/app-backend/api/src/main/scala/grid/Routes.scala
@@ -14,7 +14,6 @@ import com.azavea.rf.database.Database
 import com.azavea.rf.database._
 import com.typesafe.scalalogging.LazyLogging
 import io.circe._
-import io.circe.generic.auto._
 import de.heikoseeberger.akkahttpcirce.CirceSupport._
 
 trait GridRoutes extends Authentication

--- a/app-backend/api/src/main/scala/healthcheck/Healthcheck.scala
+++ b/app-backend/api/src/main/scala/healthcheck/Healthcheck.scala
@@ -4,10 +4,10 @@ import com.azavea.rf.database.tables.Users
 import com.azavea.rf.database.Database
 import com.azavea.rf.api.AkkaSystem
 import com.azavea.rf.api.Codec._
+
 import scala.concurrent.ExecutionContext.Implicits.global
 import io.circe._
-import io.circe.generic.auto._
-import io.circe.syntax._
+import io.circe.generic.JsonCodec
 import de.heikoseeberger.akkahttpcirce.CirceSupport._
 
 /**
@@ -23,16 +23,6 @@ object HealthCheckStatus extends Enumeration {
   }
 }
 
-
-/**
-  * Individual service check for a component (database, cache, etc.)
-  *
-  * @param service name of service that check is for
-  * @param status status of service (e.g. OK, UNHEALTHY)
-  */
-case class ServiceCheck(service: String, status: HealthCheckStatus.Status)
-
-
 /**
   * Overall healthcheck for Raster Foundry
   *
@@ -40,8 +30,17 @@ case class ServiceCheck(service: String, status: HealthCheckStatus.Status)
   * @param services list of individual service checks
   *
   */
+@JsonCodec
 case class HealthCheck(status: HealthCheckStatus.Status, services: Seq[ServiceCheck])
 
+/**
+  * Individual service check for a component (database, cache, etc.)
+  *
+  * @param service name of service that check is for
+  * @param status status of service (e.g. OK, UNHEALTHY)
+  */
+@JsonCodec
+case class ServiceCheck(service: String, status: HealthCheckStatus.Status)
 
 /**
   * Exception for database errors
@@ -49,7 +48,6 @@ case class HealthCheck(status: HealthCheckStatus.Status, services: Seq[ServiceCh
   * @param description description of error
   */
 case class DatabaseException(description:String) extends Exception
-
 
 object HealthCheckService extends AkkaSystem.LoggerExecutor {
 

--- a/app-backend/api/src/main/scala/healthcheck/Routes.scala
+++ b/app-backend/api/src/main/scala/healthcheck/Routes.scala
@@ -9,7 +9,6 @@ import com.azavea.rf.api.Codec._
 import com.azavea.rf.common.{Authentication, RollbarNotifier}
 import com.azavea.rf.database.Database
 import io.circe._
-import io.circe.generic.auto._
 import de.heikoseeberger.akkahttpcirce.CirceSupport._
 
 

--- a/app-backend/api/src/main/scala/image/QueryParams.scala
+++ b/app-backend/api/src/main/scala/image/QueryParams.scala
@@ -17,11 +17,11 @@ trait ImageQueryParametersDirective extends QueryParametersCommon {
     'minResolution.as[Float].?,
     'maxResolution.as[Float].?,
     'scene.as[UUID].*
-  ).as(ImageQueryParameters)
+  ).as(ImageQueryParameters.apply _)
 
   val imageQueryParameters = (orgQueryParams &
     timestampQueryParameters &
     imageSpecificQueryParams
-  ).as(CombinedImageQueryParams)
+  ).as(CombinedImageQueryParams.apply _)
 
 }

--- a/app-backend/api/src/main/scala/image/Routes.scala
+++ b/app-backend/api/src/main/scala/image/Routes.scala
@@ -9,13 +9,11 @@ import akka.http.scaladsl.server.Route
 import akka.http.scaladsl.model.StatusCodes
 import com.lonelyplanet.akka.http.extensions.PaginationDirectives
 import io.circe._
-import io.circe.generic.auto._
 import de.heikoseeberger.akkahttpcirce.CirceSupport
 
 import java.util.UUID
 
 import io.circe._
-import io.circe.generic.auto._
 
 import de.heikoseeberger.akkahttpcirce.CirceSupport
 

--- a/app-backend/api/src/main/scala/maptoken/QueryParams.scala
+++ b/app-backend/api/src/main/scala/maptoken/QueryParams.scala
@@ -13,11 +13,11 @@ trait MapTokensQueryParameterDirective extends QueryParametersCommon {
   val mapTokenSpecificQueryParams = parameters(
     'name.as[String].?,
     'project.as[UUID].?
-  ).as(MapTokenQueryParameters)
+  ).as(MapTokenQueryParameters.apply _)
 
   val mapTokenQueryParams = (
     orgQueryParams &
     userQueryParameters &
     mapTokenSpecificQueryParams
-    ).as(CombinedMapTokenQueryParameters)
+    ).as(CombinedMapTokenQueryParameters.apply _)
 }

--- a/app-backend/api/src/main/scala/maptoken/Routes.scala
+++ b/app-backend/api/src/main/scala/maptoken/Routes.scala
@@ -10,7 +10,6 @@ import com.azavea.rf.database.tables.{Images, MapTokens}
 import com.azavea.rf.database.{ActionRunner, Database}
 import com.azavea.rf.datamodel._
 import io.circe._
-import io.circe.generic.auto._
 import de.heikoseeberger.akkahttpcirce.CirceSupport._
 
 

--- a/app-backend/api/src/main/scala/organization/Routes.scala
+++ b/app-backend/api/src/main/scala/organization/Routes.scala
@@ -9,7 +9,6 @@ import akka.http.scaladsl.server.Route
 import akka.http.scaladsl.model.StatusCodes
 import com.lonelyplanet.akka.http.extensions.PaginationDirectives
 import io.circe._
-import io.circe.generic.auto._
 import de.heikoseeberger.akkahttpcirce.CirceSupport._
 
 import java.util.UUID

--- a/app-backend/api/src/main/scala/project/Routes.scala
+++ b/app-backend/api/src/main/scala/project/Routes.scala
@@ -14,7 +14,6 @@ import com.azavea.rf.api.scene._
 import com.azavea.rf.api.utils.queryparams.QueryParametersCommon
 
 import io.circe._
-import io.circe.generic.auto._
 import io.circe.parser._
 import io.circe.syntax._
 import de.heikoseeberger.akkahttpcirce.CirceSupport._

--- a/app-backend/api/src/main/scala/scene/QueryParameters.scala
+++ b/app-backend/api/src/main/scala/scene/QueryParameters.scala
@@ -31,12 +31,12 @@ trait SceneQueryParameterDirective extends QueryParametersCommon
     'project.as[UUID].?,
     'ingested.as[Boolean].?,
     'ingestStatus.as[String].*
-  )).as(SceneQueryParameters)
+  )).as(SceneQueryParameters.apply _)
 
   val sceneQueryParameters = (orgQueryParams &
     userQueryParameters &
     timestampQueryParameters &
     sceneSpecificQueryParams &
     imageSpecificQueryParams
-  ).as(CombinedSceneQueryParams)
+  ).as(CombinedSceneQueryParams.apply _)
 }

--- a/app-backend/api/src/main/scala/scene/Routes.scala
+++ b/app-backend/api/src/main/scala/scene/Routes.scala
@@ -12,7 +12,6 @@ import akka.http.scaladsl.server.Route
 import io.circe._
 import io.circe.syntax._
 import io.circe.parser._
-import io.circe.generic.auto._
 
 import de.heikoseeberger.akkahttpcirce.CirceSupport._
 

--- a/app-backend/api/src/main/scala/tags/Routes.scala
+++ b/app-backend/api/src/main/scala/tags/Routes.scala
@@ -9,7 +9,6 @@ import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.server.Route
 import com.lonelyplanet.akka.http.extensions.PaginationDirectives
 import io.circe._
-import io.circe.generic.auto._
 import de.heikoseeberger.akkahttpcirce.CirceSupport._
 
 import scala.util.{Success, Failure}

--- a/app-backend/api/src/main/scala/thumbnail/QueryParameters.scala
+++ b/app-backend/api/src/main/scala/thumbnail/QueryParameters.scala
@@ -15,5 +15,5 @@ trait ThumbnailQueryParameterDirective extends QueryParametersCommon {
 
   val thumbnailSpecificQueryParameters = parameters(
     'sceneId.as[UUID].?
-  ).as(ThumbnailQueryParameters)
+  ).as(ThumbnailQueryParameters.apply _)
 }

--- a/app-backend/api/src/main/scala/thumbnail/Routes.scala
+++ b/app-backend/api/src/main/scala/thumbnail/Routes.scala
@@ -8,17 +8,11 @@ import com.azavea.rf.api.utils.Config
 
 import akka.http.scaladsl.server.Route
 import akka.http.scaladsl.model.{StatusCodes, ContentType, HttpEntity, HttpResponse, MediaType, MediaTypes}
-import akka.http.scaladsl.model.MediaType.Binary
-import org.apache.commons.io.IOUtils
 import com.lonelyplanet.akka.http.extensions.PaginationDirectives
-import io.circe._
-import io.circe.generic.auto._
 import de.heikoseeberger.akkahttpcirce.CirceSupport._
 
 import java.util.UUID
 import java.net.URI
-import scala.util.{Success, Failure, Try}
-
 
 trait ThumbnailRoutes extends Authentication
     with ThumbnailQueryParameterDirective

--- a/app-backend/api/src/main/scala/token/Routes.scala
+++ b/app-backend/api/src/main/scala/token/Routes.scala
@@ -5,7 +5,6 @@ import com.azavea.rf.api.utils.{Auth0ErrorHandler}
 
 import akka.http.scaladsl.server.Route
 import io.circe._
-import io.circe.generic.auto._
 import de.heikoseeberger.akkahttpcirce.CirceSupport._
 
 

--- a/app-backend/api/src/main/scala/token/Token.scala
+++ b/app-backend/api/src/main/scala/token/Token.scala
@@ -16,13 +16,15 @@ import com.azavea.rf.datamodel.User
 import com.azavea.rf.api.utils.Config
 import com.azavea.rf.api.utils.{Auth0Exception, ManagementBearerToken}
 
-import io.circe._
-import io.circe.generic.auto._
 import de.heikoseeberger.akkahttpcirce.CirceSupport._
+import io.circe.generic.JsonCodec
 
 // TODO: this sort of case class definition should live in datamodel
+@JsonCodec
 case class RefreshToken(refresh_token: String)
+@JsonCodec
 case class DeviceCredential(id: String, device_name: String)
+@JsonCodec
 case class AuthorizedToken(id_token: String, expires_in: Int, token_type: String)
 
 object TokenService extends Config {

--- a/app-backend/api/src/main/scala/toolrun/QueryParameters.scala
+++ b/app-backend/api/src/main/scala/toolrun/QueryParameters.scala
@@ -14,10 +14,10 @@ trait ToolRunQueryParametersDirective extends QueryParametersCommon {
     'createdBy.as[String].?,
     'projectId.as[UUID].?,
     'toolId.as[UUID].?
-  )).as(ToolRunQueryParameters)
+  )).as(ToolRunQueryParameters.apply _)
 
   val toolRunQueryParameters = (
     toolRunSpecificQueryParams &
     timestampQueryParameters
-  ).as(CombinedToolRunQueryParameters)
+  ).as(CombinedToolRunQueryParameters.apply _)
 }

--- a/app-backend/api/src/main/scala/toolrun/Routes.scala
+++ b/app-backend/api/src/main/scala/toolrun/Routes.scala
@@ -9,7 +9,6 @@ import com.lonelyplanet.akka.http.extensions.PaginationDirectives
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.server.Route
 import io.circe._
-import io.circe.generic.auto._
 import de.heikoseeberger.akkahttpcirce.CirceSupport._
 
 import scala.concurrent.ExecutionContext.Implicits.global

--- a/app-backend/api/src/main/scala/tools/Routes.scala
+++ b/app-backend/api/src/main/scala/tools/Routes.scala
@@ -9,7 +9,6 @@ import com.lonelyplanet.akka.http.extensions.PaginationDirectives
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.server.Route
 import io.circe._
-import io.circe.generic.auto._
 import de.heikoseeberger.akkahttpcirce.CirceSupport._
 
 import scala.util.{Success, Failure}

--- a/app-backend/api/src/main/scala/uploads/Credentials.scala
+++ b/app-backend/api/src/main/scala/uploads/Credentials.scala
@@ -5,25 +5,22 @@ import java.util.{Date, UUID}
 
 import com.azavea.rf.api.utils.{Auth0Exception, Config}
 import com.azavea.rf.datamodel.User
-
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.unmarshalling.Unmarshal
-
 import com.amazonaws.auth.{AWSCredentials, AWSSessionCredentials, AWSStaticCredentialsProvider}
 import com.amazonaws.services.s3.AmazonS3ClientBuilder
-
 import com.typesafe.scalalogging.LazyLogging
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
-
-import io.circe.generic.auto._
+import io.circe.generic.JsonCodec
 import io.circe.optics.JsonPath._
 import io.circe.Json
 import de.heikoseeberger.akkahttpcirce.CirceSupport._
 
 
+@JsonCodec
 case class Credentials (
   AccessKeyId: String,
   Expiration: String,
@@ -35,6 +32,7 @@ case class Credentials (
   override def getSessionToken = this.SessionToken
 }
 
+@JsonCodec
 case class CredentialsWithBucketPath (
   credentials: Credentials,
   bucketPath: String

--- a/app-backend/api/src/main/scala/uploads/QueryParameters.scala
+++ b/app-backend/api/src/main/scala/uploads/QueryParameters.scala
@@ -12,5 +12,5 @@ trait UploadQueryParameterDirective extends QueryParametersCommon {
   val uploadQueryParams = parameters((
     'datasource.as[UUID].?,
     'organization.as[UUID].?
-  )).as(UploadQueryParameters)
+  )).as(UploadQueryParameters.apply _)
 }

--- a/app-backend/api/src/main/scala/uploads/Routes.scala
+++ b/app-backend/api/src/main/scala/uploads/Routes.scala
@@ -15,7 +15,6 @@ import com.azavea.rf.database.query._
 import com.azavea.rf.database.{Database, ActionRunner}
 import com.azavea.rf.datamodel._
 import io.circe._
-import io.circe.generic.auto._
 import de.heikoseeberger.akkahttpcirce.CirceSupport._
 
 trait UploadRoutes extends Authentication

--- a/app-backend/api/src/main/scala/user/Auth0User.scala
+++ b/app-backend/api/src/main/scala/user/Auth0User.scala
@@ -2,8 +2,7 @@ package com.azavea.rf.api.user
 
 import com.azavea.rf.datamodel.User
 import com.azavea.rf.api.utils.Config
-import com.azavea.rf.api.utils.{ManagementBearerToken, Auth0Exception}
-
+import com.azavea.rf.api.utils.{Auth0Exception, ManagementBearerToken}
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.model.HttpMethods._
 import akka.http.scaladsl.model._
@@ -14,7 +13,7 @@ import com.github.blemale.scaffeine.{AsyncLoadingCache, Scaffeine}
 import com.typesafe.scalalogging.LazyLogging
 import io.circe._
 import io.circe.syntax._
-import io.circe.generic.auto._
+import io.circe.generic.JsonCodec
 import de.heikoseeberger.akkahttpcirce.CirceSupport._
 
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -24,6 +23,7 @@ import com.azavea.rf.database.{Database => DB}
 import com.azavea.rf.database.tables.Users
 import com.typesafe.scalalogging.LazyLogging
 
+@JsonCodec
 case class Auth0User(
   email: Option[String], email_verified: Option[Boolean],
   username: Option[String],
@@ -45,11 +45,13 @@ case class Auth0User(
   family_name: Option[String]
 )
 
+@JsonCodec
 case class UserWithOAuth(
   user: User,
   oauth: Auth0User
 )
 
+@JsonCodec
 case class Auth0UserUpdate(
   email: Option[String],
   phone_number: Option[String],
@@ -57,6 +59,7 @@ case class Auth0UserUpdate(
   username: Option[String]
 )
 
+@JsonCodec
 case class UserWithOAuthUpdate(
   user: User.Create,
   oauth: Auth0UserUpdate

--- a/app-backend/api/src/main/scala/user/Routes.scala
+++ b/app-backend/api/src/main/scala/user/Routes.scala
@@ -12,7 +12,6 @@ import com.azavea.rf.database.Database
 import com.azavea.rf.database.tables.Users
 import com.azavea.rf.datamodel._
 import io.circe._
-import io.circe.generic.auto._
 import de.heikoseeberger.akkahttpcirce.CirceSupport._
 
 

--- a/app-backend/api/src/main/scala/utils/Auth0Util.scala
+++ b/app-backend/api/src/main/scala/utils/Auth0Util.scala
@@ -1,6 +1,6 @@
 package com.azavea.rf.api.utils
 
-import io.circe._
-import io.circe.generic.auto._
+import io.circe.generic.JsonCodec
 
+@JsonCodec
 case class ManagementBearerToken(access_token: String, expires_in: Int, token_type: String, scope: String)

--- a/app-backend/api/src/main/scala/utils/QueryParameters.scala
+++ b/app-backend/api/src/main/scala/utils/QueryParameters.scala
@@ -26,18 +26,18 @@ trait QueryParameterDeserializers {
 trait QueryParametersCommon extends QueryParameterDeserializers {
   def projectQueryParameters = (
     orgQueryParams & userQueryParameters & timestampQueryParameters
-  ).as(ProjectQueryParameters)
+  ).as(ProjectQueryParameters.apply _)
 
   def orgQueryParams = parameters(
     'organization.as(deserializerUUID).*
-  ).as(OrgQueryParameters)
+  ).as(OrgQueryParameters.apply _)
 
   def userQueryParameters = parameters(
     (
     'createdBy.as[String].?,
     'modifiedBy.as[String].?
     )
-  ).as(UserQueryParameters)
+  ).as(UserQueryParameters.apply _)
 
   def timestampQueryParameters = parameters(
     (
@@ -46,5 +46,5 @@ trait QueryParametersCommon extends QueryParameterDeserializers {
       'minModifiedDatetime.as(deserializerTimestamp).?,
       'maxModifiedDatetime.as(deserializerTimestamp).?
     )
-  ).as(TimestampQueryParameters)
+  ).as(TimestampQueryParameters.apply _)
 }

--- a/app-backend/api/src/test/scala/auth/AuthSpec.scala
+++ b/app-backend/api/src/test/scala/auth/AuthSpec.scala
@@ -14,7 +14,6 @@ import com.azavea.rf.api.utils.Config
 import com.azavea.rf.api.{AuthUtils, DBSpec, Router}
 
 import io.circe._
-import io.circe.generic.auto._
 import de.heikoseeberger.akkahttpcirce.CirceSupport._
 
 class AuthSpec extends WordSpec

--- a/app-backend/api/src/test/scala/datasource/DatasourceSpec.scala
+++ b/app-backend/api/src/test/scala/datasource/DatasourceSpec.scala
@@ -18,7 +18,6 @@ import java.time.Instant
 
 import io.circe._
 import io.circe.syntax._
-import io.circe.generic.auto._
 import de.heikoseeberger.akkahttpcirce.CirceSupport._
 
 class DatasourceSpec extends WordSpec

--- a/app-backend/api/src/test/scala/healthcheck/HealthCheckSpec.scala
+++ b/app-backend/api/src/test/scala/healthcheck/HealthCheckSpec.scala
@@ -10,7 +10,6 @@ import com.azavea.rf.api.{DBSpec, Router}
 import com.azavea.rf.api.Codec._
 
 import io.circe._
-import io.circe.generic.auto._
 import de.heikoseeberger.akkahttpcirce.CirceSupport._
 
 class HealthCheckSpec extends WordSpec

--- a/app-backend/api/src/test/scala/image/ImageSpec.scala
+++ b/app-backend/api/src/test/scala/image/ImageSpec.scala
@@ -18,7 +18,6 @@ import java.sql.Timestamp
 import java.time.Instant
 
 import io.circe._
-import io.circe.generic.auto._
 import io.circe.syntax._
 import de.heikoseeberger.akkahttpcirce.CirceSupport._
 

--- a/app-backend/api/src/test/scala/organization/OrganizationSpec.scala
+++ b/app-backend/api/src/test/scala/organization/OrganizationSpec.scala
@@ -14,7 +14,6 @@ import com.azavea.rf.api.{DBSpec, Router}
 import com.azavea.rf.api.AuthUtils
 
 import io.circe._
-import io.circe.generic.auto._
 import io.circe.syntax._
 import de.heikoseeberger.akkahttpcirce.CirceSupport._
 

--- a/app-backend/api/src/test/scala/project/ProjectSceneSpec.scala
+++ b/app-backend/api/src/test/scala/project/ProjectSceneSpec.scala
@@ -14,7 +14,6 @@ import com.azavea.rf.api.utils.Config
 import com.azavea.rf.api.{AuthUtils, DBSpec, Router}
 
 import io.circe._
-import io.circe.generic.auto._
 import io.circe.parser._
 import io.circe.syntax._
 import de.heikoseeberger.akkahttpcirce.CirceSupport._

--- a/app-backend/api/src/test/scala/project/ProjectSpec.scala
+++ b/app-backend/api/src/test/scala/project/ProjectSpec.scala
@@ -13,7 +13,6 @@ import com.azavea.rf.api.utils.Config
 import com.azavea.rf.api.{DBSpec, Router, AuthUtils}
 
 import io.circe._
-import io.circe.generic.auto._
 import io.circe.syntax._
 import de.heikoseeberger.akkahttpcirce.CirceSupport._
 

--- a/app-backend/api/src/test/scala/scene/SceneSpec.scala
+++ b/app-backend/api/src/test/scala/scene/SceneSpec.scala
@@ -21,7 +21,6 @@ import geotrellis.slick.Projected
 
 import io.circe._
 import io.circe.syntax._
-import io.circe.generic.auto._
 import de.heikoseeberger.akkahttpcirce.CirceSupport._
 
 class SceneSpec extends WordSpec

--- a/app-backend/api/src/test/scala/tags/ToolTagSpec.scala
+++ b/app-backend/api/src/test/scala/tags/ToolTagSpec.scala
@@ -15,7 +15,6 @@ import com.azavea.rf.api.utils.Config
 import com.azavea.rf.api.{AuthUtils, DBSpec, Router}
 
 import io.circe._
-import io.circe.generic.auto._
 import io.circe.syntax._
 import de.heikoseeberger.akkahttpcirce.CirceSupport._
 

--- a/app-backend/api/src/test/scala/thumbnail/ThumbnailSpec.scala
+++ b/app-backend/api/src/test/scala/thumbnail/ThumbnailSpec.scala
@@ -20,7 +20,6 @@ import com.azavea.rf.api.utils.Config
 import com.azavea.rf.api.{DBSpec, Router}
 
 import io.circe._
-import io.circe.generic.auto._
 import io.circe.syntax._
 import de.heikoseeberger.akkahttpcirce.CirceSupport._
 

--- a/app-backend/api/src/test/scala/thumbnail/ThumbnailsHelper.scala
+++ b/app-backend/api/src/test/scala/thumbnail/ThumbnailsHelper.scala
@@ -7,7 +7,6 @@ import java.sql.Timestamp
 import java.time.Instant
 
 import io.circe._
-import io.circe.generic.auto._
 import io.circe.syntax._
 
 trait ThumbnailSpecHelper {

--- a/app-backend/api/src/test/scala/toolruns/ToolRunSpec.scala
+++ b/app-backend/api/src/test/scala/toolruns/ToolRunSpec.scala
@@ -13,7 +13,6 @@ import concurrent.duration._
 import org.scalatest.{Matchers, WordSpec}
 
 import io.circe._
-import io.circe.generic.auto._
 import io.circe.syntax._
 import de.heikoseeberger.akkahttpcirce.CirceSupport._
 
@@ -97,4 +96,3 @@ class ToolRunSpec extends WordSpec
     }
   }
 }
-

--- a/app-backend/api/src/test/scala/tools/ToolSpec.scala
+++ b/app-backend/api/src/test/scala/tools/ToolSpec.scala
@@ -16,7 +16,6 @@ import com.azavea.rf.api.{AuthUtils, DBSpec, Router}
 import concurrent.duration._
 
 import io.circe._
-import io.circe.generic.auto._
 import io.circe.syntax._
 import de.heikoseeberger.akkahttpcirce.CirceSupport._
 

--- a/app-backend/api/src/test/scala/user/UserSpec.scala
+++ b/app-backend/api/src/test/scala/user/UserSpec.scala
@@ -11,7 +11,6 @@ import com.azavea.rf.api.{DBSpec, Router}
 import com.azavea.rf.api.AuthUtils
 
 import io.circe._
-import io.circe.generic.auto._
 import de.heikoseeberger.akkahttpcirce.CirceSupport._
 
 class UserSpec extends WordSpec

--- a/app-backend/build.sbt
+++ b/app-backend/build.sbt
@@ -25,7 +25,8 @@ lazy val commonSettings = Seq(
   ),
   resolvers += Resolver.sonatypeRepo("snapshots"),
   resolvers += Resolver.bintrayRepo("lonelyplanet", "maven"),
-  shellPrompt := { s => Project.extract(s).currentProject.id + " > " }
+  shellPrompt := { s => Project.extract(s).currentProject.id + " > " },
+  addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full)
 )
 
 lazy val apiSettings = commonSettings ++ Seq(

--- a/app-backend/database/src/main/scala/com/azavea/rf/database/ExtendedPostgresDriver.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/ExtendedPostgresDriver.scala
@@ -7,9 +7,6 @@ import geotrellis.slick.PostGisProjectionSupport
 import com.github.tminglei.slickpg._
 import io.circe._
 import io.circe.syntax._
-import io.circe.generic.auto._
-
-import scala.collection.immutable.Map
 
 /** Custom Postgres driver that adds custom column types and implicit conversions
   *

--- a/app-backend/database/src/main/scala/com/azavea/rf/database/QueryParameters.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/QueryParameters.scala
@@ -4,16 +4,20 @@ import java.util.UUID
 import java.sql.Timestamp
 import java.time.Instant
 
+import com.azavea.rf.datamodel._
+import io.circe.generic.JsonCodec
 import geotrellis.proj4._
 import geotrellis.slick.Projected
-import geotrellis.vector.{Point, Polygon, Extent}
+import geotrellis.vector.{Extent, Point, Polygon}
 
 /** Case class representing all /thumbnail query parameters */
+@JsonCodec
 case class ThumbnailQueryParameters(
   sceneId: Option[UUID] = None
 )
 
 /** Case class for combined params for images */
+@JsonCodec
 case class CombinedImageQueryParams(
   orgParams: OrgQueryParameters = OrgQueryParameters(),
   timestampParams: TimestampQueryParameters = TimestampQueryParameters(),
@@ -21,6 +25,7 @@ case class CombinedImageQueryParams(
 )
 
 /** Query parameters specific to image files */
+@JsonCodec
 case class ImageQueryParameters(
   minRawDataBytes: Option[Int] = None,
   maxRawDataBytes: Option[Int] = None,
@@ -30,6 +35,7 @@ case class ImageQueryParameters(
 )
 
 /** Case class representing all possible query parameters */
+@JsonCodec
 case class SceneQueryParameters(
   maxCloudCover: Option[Float] = None,
   minCloudCover: Option[Float] = None,
@@ -79,6 +85,7 @@ case class SceneQueryParameters(
 }
 
 /** Case class for Grid query parameters */
+@JsonCodec
 case class GridQueryParameters(
   maxCloudCover: Option[Float] = None,
   minCloudCover: Option[Float] = None,
@@ -96,6 +103,7 @@ case class GridQueryParameters(
 )
 
 /** Combined all query parameters */
+@JsonCodec
 case class CombinedSceneQueryParams(
   orgParams: OrgQueryParameters = OrgQueryParameters(),
   userParams: UserQueryParameters = UserQueryParameters(),
@@ -105,6 +113,7 @@ case class CombinedSceneQueryParams(
 )
 
 /** Combined all query parameters for grids */
+@JsonCodec
 case class CombinedGridQueryParams(
   orgParams: OrgQueryParameters = OrgQueryParameters(),
   userParams: UserQueryParameters = UserQueryParameters(),
@@ -113,8 +122,8 @@ case class CombinedGridQueryParams(
   imageParams: ImageQueryParameters = ImageQueryParameters()
 )
 
-
 /** Case class for project query parameters */
+@JsonCodec
 case class ProjectQueryParameters(
   orgParams: OrgQueryParameters = OrgQueryParameters(),
   userParams: UserQueryParameters = UserQueryParameters(),
@@ -122,6 +131,7 @@ case class ProjectQueryParameters(
 )
 
 /** Query parameters specific to tools */
+@JsonCodec
 case class ToolQueryParameters(
   minRating: Option[Double] = None,
   maxRating: Option[Double] = None,
@@ -131,6 +141,7 @@ case class ToolQueryParameters(
 )
 
 /** Combined tool query parameters */
+@JsonCodec
 case class CombinedToolQueryParameters(
   orgParams: OrgQueryParameters = OrgQueryParameters(),
   userParams: UserQueryParameters = UserQueryParameters(),
@@ -138,12 +149,14 @@ case class CombinedToolQueryParameters(
   toolParams: ToolQueryParameters = ToolQueryParameters()
 )
 
+@JsonCodec
 case class FootprintQueryParameters(
   x: Option[Double] = None,
   y: Option[Double] = None,
   bbox: Option[String] = None
 )
 
+@JsonCodec
 case class CombinedFootprintQueryParams(
   orgParams: OrgQueryParameters = OrgQueryParameters(),
   timestampParams: TimestampQueryParameters = TimestampQueryParameters(),
@@ -151,17 +164,20 @@ case class CombinedFootprintQueryParams(
 )
 
 /** Common query parameters for models that have organization attributes */
+@JsonCodec
 case class OrgQueryParameters(
   organizations: Iterable[UUID] = Seq[UUID]()
 )
 
 /** Query parameters to filter by users */
+@JsonCodec
 case class UserQueryParameters(
   createdBy: Option[String] = None,
   modifiedBy: Option[String] = None
 )
 
 /** Query parameters to filter by modified/created times */
+@JsonCodec
 case class TimestampQueryParameters(
   minCreateDatetime: Option[Timestamp] = None,
   maxCreateDatetime: Option[Timestamp] = None,
@@ -169,35 +185,42 @@ case class TimestampQueryParameters(
   maxModifiedDatetime: Option[Timestamp] = None
 )
 
+@JsonCodec
 case class ToolCategoryQueryParameters(
   search: Option[String] = None
 )
 
+@JsonCodec
 case class ToolRunQueryParameters(
   createdBy: Option[String] = None,
   projectId: Option[UUID] = None,
   toolId: Option[UUID] = None
 )
 
+@JsonCodec
 case class CombinedToolRunQueryParameters(
   toolRunParams: ToolRunQueryParameters = ToolRunQueryParameters(),
   timestampParams: TimestampQueryParameters = TimestampQueryParameters()
 )
 
+@JsonCodec
 case class CombinedToolCategoryQueryParams(
   timestampParams: TimestampQueryParameters = TimestampQueryParameters(),
   toolCategoryParams: ToolCategoryQueryParameters = ToolCategoryQueryParameters()
 )
 
+@JsonCodec
 case class DatasourceQueryParameters(
   name: Option[String] = None
 )
 
+@JsonCodec
 case class MapTokenQueryParameters(
   name: Option[String] = None,
   projectId: Option[UUID] = None
 )
 
+@JsonCodec
 case class CombinedMapTokenQueryParameters(
   orgParams: OrgQueryParameters = OrgQueryParameters(),
   userParams: UserQueryParameters = UserQueryParameters(),
@@ -205,6 +228,7 @@ case class CombinedMapTokenQueryParameters(
 )
 
 // TODO add uploadStatus
+@JsonCodec
 case class UploadQueryParameters(
   organization: Option[UUID] = None,
   datasource: Option[UUID] = None

--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/Band.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/Band.scala
@@ -3,6 +3,10 @@ package com.azavea.rf.datamodel
 import akka.http.scaladsl.unmarshalling._
 import java.util.UUID
 
+import io.circe._
+import io.circe.generic.JsonCodec
+
+@JsonCodec
 case class Band(
   id: UUID,
   image: UUID,
@@ -12,11 +16,11 @@ case class Band(
 )
 
 object Band {//extends RangeUnmarshaler{
-
   def create = Create.apply _
 
   def tupled = (Band.apply _).tupled
 
+  @JsonCodec
   case class Create(
     name: String,
     number: Int,
@@ -34,8 +38,7 @@ object Band {//extends RangeUnmarshaler{
     }
   }
 
-  object Create
-
+  @JsonCodec
   case class Identified(
     id: Option[UUID],
     imageId: UUID,

--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/ColorCorrect.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/ColorCorrect.scala
@@ -2,6 +2,8 @@ package com.azavea.rf.datamodel
 
 import io.circe._
 import io.circe.syntax._
+import io.circe.generic.JsonCodec
+
 import geotrellis.raster._
 import geotrellis.raster.equalization.HistogramEqualization
 import geotrellis.raster.histogram.Histogram
@@ -10,6 +12,8 @@ import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server._
 
 object ColorCorrect {
+
+  @JsonCodec
   case class Params(
     redBand: Int, greenBand: Int, blueBand: Int,
     redGamma: Option[Double], greenGamma: Option[Double], blueGamma: Option[Double],
@@ -28,7 +32,6 @@ object ColorCorrect {
   }
 
   object Params {
-
     def colorCorrectParams: Directive1[Params] =
       parameters(
         'redBand.as[Int].?(0), 'greenBand.as[Int].?(1), 'blueBand.as[Int].?(2),

--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/Datasource.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/Datasource.scala
@@ -1,10 +1,12 @@
 package com.azavea.rf.datamodel
 
 import io.circe._
-
 import java.util.UUID
 import java.sql.Timestamp
 
+import io.circe.generic.JsonCodec
+
+@JsonCodec
 case class Datasource(
   id: UUID,
   createdAt: java.sql.Timestamp,
@@ -26,6 +28,7 @@ object Datasource {
   def create = Create.apply _
 
 
+  @JsonCodec
   case class Create(
     organizationId: UUID,
     name: String,
@@ -52,5 +55,4 @@ object Datasource {
       )
     }
   }
-
 }

--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/FeatureFlag.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/FeatureFlag.scala
@@ -1,7 +1,10 @@
 package com.azavea.rf.datamodel
 
+import io.circe.generic.JsonCodec
+
 import java.util.UUID
 
+@JsonCodec
 case class FeatureFlag(
   id: UUID,
   key: String,

--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/Image.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/Image.scala
@@ -3,8 +3,10 @@ package com.azavea.rf.datamodel
 import java.util.UUID
 import java.sql.Timestamp
 
-import io.circe.Json
+import io.circe._
+import io.circe.generic.JsonCodec
 
+@JsonCodec
 case class Image(
   id: UUID,
   createdAt: Timestamp,
@@ -46,6 +48,7 @@ object Image {
 
   def tupled = (Image.apply _).tupled
 
+  @JsonCodec
   case class Create(
     organizationId: UUID,
     rawDataBytes: Int,
@@ -80,6 +83,7 @@ object Image {
   }
 
   /** Image class when posted with bands */
+  @JsonCodec
   case class Banded(
     organizationId: UUID,
     rawDataBytes: Int,
@@ -107,6 +111,7 @@ object Image {
     }
   }
 
+  @JsonCodec
   case class WithRelated(
     id: UUID,
     createdAt: Timestamp,

--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/MapToken.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/MapToken.scala
@@ -1,12 +1,15 @@
 package com.azavea.rf.datamodel
 
 import java.util.UUID
-
 import java.sql.Timestamp
+
+import io.circe.generic.JsonCodec
 
 /**
   * Created by cbrown on 3/11/17.
   */
+
+@JsonCodec
 case class MapToken(
   id: UUID,
   createdAt: Timestamp,
@@ -24,6 +27,7 @@ object MapToken {
 
   def create = Create.apply _
 
+  @JsonCodec
   case class Create(
     organizationId: UUID,
     name: String,

--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/MosaicDefinition.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/MosaicDefinition.scala
@@ -2,6 +2,10 @@ package com.azavea.rf.datamodel
 
 import java.util.UUID
 
+import io.circe._
+import io.circe.generic.JsonCodec
+
+@JsonCodec
 case class MosaicDefinition(sceneId: UUID, colorCorrections: Option[ColorCorrect.Params])
 
 object MosaicDefinition {

--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/Organization.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/Organization.scala
@@ -3,7 +3,10 @@ package com.azavea.rf.datamodel
 import java.util.UUID
 import java.sql.Timestamp
 
+import io.circe._
+import io.circe.generic.JsonCodec
 
+@JsonCodec
 case class Organization(
   id: UUID,
   createdAt: Timestamp,
@@ -12,11 +15,11 @@ case class Organization(
 )
 
 object Organization {
-
   def tupled = (Organization.apply _).tupled
 
   def create = Create.apply _
 
+  @JsonCodec
   case class Create(name: String) {
     def toOrganization(): Organization = {
       val id = java.util.UUID.randomUUID()

--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/PaginatedResponse.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/PaginatedResponse.scala
@@ -1,5 +1,7 @@
 package com.azavea.rf.datamodel
 
+import io.circe.generic.JsonCodec
+
 /**
  * Case class for paginated results
  *
@@ -10,6 +12,7 @@ package com.azavea.rf.datamodel
  * @param pageSize number of results per page
  * @param results sequence of results for a page
  */
+@JsonCodec
 case class PaginatedResponse[A](
   count: Int,
   hasPrevious: Boolean,

--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/Project.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/Project.scala
@@ -1,12 +1,14 @@
 package com.azavea.rf.datamodel
 
 import geotrellis.vector.io.json.GeoJsonSupport
-import geotrellis.vector.{Geometry, Point}
+import geotrellis.vector.Geometry
 import geotrellis.slick.Projected
+import io.circe.generic.JsonCodec
 
 import java.util.UUID
 import java.sql.Timestamp
 
+@JsonCodec
 case class Project(
   id: UUID,
   createdAt: Timestamp,
@@ -26,7 +28,6 @@ case class Project(
 
 /** Case class for project creation */
 object Project extends GeoJsonSupport {
-
   def tupled = (Project.apply _).tupled
 
   def create = Create.apply _
@@ -41,6 +42,7 @@ object Project extends GeoJsonSupport {
         .toLowerCase)
   }
 
+  @JsonCodec
   case class Create(
     organizationId: UUID,
     name: String,

--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/Scene.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/Scene.scala
@@ -6,11 +6,10 @@ import java.util.UUID
 import geotrellis.vector.Geometry
 import geotrellis.slick.Projected
 
-import slick.collection.heterogeneous.{HList, HNil}
-import slick.collection.heterogeneous.syntax._
+import io.circe._
+import io.circe.generic.JsonCodec
 
-import io.circe.Json
-
+@JsonCodec
 case class SceneFilterFields(
   cloudCover: Option[Float] = None,
   acquisitionDate: Option[java.sql.Timestamp] = None,
@@ -29,6 +28,7 @@ object SceneFilterFields {
   )
 }
 
+@JsonCodec
 case class SceneStatusFields(
   thumbnailStatus: JobStatus,
   boundaryStatus: JobStatus,
@@ -45,6 +45,7 @@ object SceneStatusFields {
   )
 }
 
+@JsonCodec
 case class Scene(
   id: UUID,
   createdAt: java.sql.Timestamp,
@@ -96,8 +97,8 @@ case class Scene(
 
 
 object Scene {
-
   /** Case class extracted from a POST request */
+  @JsonCodec
   case class Create(
     id: Option[UUID],
     organizationId: UUID,
@@ -141,6 +142,7 @@ object Scene {
     }
   }
 
+  @JsonCodec
   case class WithRelated(
     id: UUID,
     createdAt: Timestamp,

--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/SceneToProject.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/SceneToProject.scala
@@ -1,7 +1,8 @@
 package com.azavea.rf.datamodel
 
 import java.util.UUID
-import java.sql.Timestamp
+
+import io.circe.generic.JsonCodec
 
 case class SceneToProject(
   sceneId: UUID,
@@ -10,5 +11,7 @@ case class SceneToProject(
   colorCorrectParams: Option[ColorCorrect.Params] = None
 )
 
+@JsonCodec
 case class SceneCorrectionParams(sceneId: UUID, params: ColorCorrect.Params)
+@JsonCodec
 case class BatchParams(items: List[SceneCorrectionParams])

--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/Thumbnail.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/Thumbnail.scala
@@ -3,6 +3,10 @@ package com.azavea.rf.datamodel
 import java.util.UUID
 import java.sql.Timestamp
 
+import io.circe._
+import io.circe.generic.JsonCodec
+
+@JsonCodec
 case class Thumbnail(
   id: UUID,
   createdAt: Timestamp,
@@ -18,7 +22,6 @@ case class Thumbnail(
 }
 
 object Thumbnail {
-
   def tupled = (Thumbnail.apply _).tupled
 
   def create = Create.apply _
@@ -26,6 +29,7 @@ object Thumbnail {
   def identified = Identified.apply _
 
   /** Thumbnail class prior to ID assignment */
+  @JsonCodec
   case class Create(
     organizationId: UUID,
     thumbnailSize: ThumbnailSize,
@@ -51,6 +55,7 @@ object Thumbnail {
   }
 
   /** Thumbnail class when posted with an ID */
+  @JsonCodec
   case class Identified(
     id: Option[UUID],
     organizationId: UUID,

--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/ThumbnailSize.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/ThumbnailSize.scala
@@ -1,5 +1,7 @@
 package com.azavea.rf.datamodel
 
+import io.circe.{Decoder, Encoder}
+import cats.syntax.either._
 
 /** The possible sizes of thumbnail */
 sealed abstract class ThumbnailSize(val repr: String) {
@@ -7,6 +9,13 @@ sealed abstract class ThumbnailSize(val repr: String) {
 }
 
 object ThumbnailSize {
+  implicit val thumbnailSizeEncoder: Encoder[ThumbnailSize] =
+    Encoder.encodeString.contramap[ThumbnailSize](_.toString)
+  implicit val thumbnailSizeDecoder: Decoder[ThumbnailSize] =
+    Decoder.decodeString.emap { str =>
+      Either.catchNonFatal(ThumbnailSize.fromString(str)).leftMap(_ => "ThumbnailSize")
+    }
+
   case object Small extends ThumbnailSize("SMALL")
   case object Large extends ThumbnailSize("LARGE")
   case object Square extends ThumbnailSize("SQUARE")

--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/Tool.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/Tool.scala
@@ -5,7 +5,10 @@ import io.circe._
 import java.util.UUID
 import java.sql.Timestamp
 
+import io.circe.generic.JsonCodec
+
 /** Model Lab Tool */
+@JsonCodec
 case class Tool(
   id: UUID,
   createdAt: Timestamp,
@@ -65,11 +68,11 @@ case class Tool(
 
 /** Case class for tool creation */
 object Tool {
-
   def create = Create.apply _
 
   def tupled = (Tool.apply _).tupled
 
+  @JsonCodec
   case class Create(
     organizationId: UUID,
     title: String,
@@ -112,6 +115,7 @@ object Tool {
   }
 
   // join of tool/tag/category
+  @JsonCodec
   case class ToolRelationshipJoin(tool: Tool, toolTag: Option[ToolTag], toolCategory: Option[ToolCategory], organization: Option[Organization])
 
   object ToolRelationshipJoin {
@@ -119,6 +123,7 @@ object Tool {
   }
 
   /** Tool class when posted with category and tag ids */
+  @JsonCodec
   case class WithRelated(
     id: UUID,
     createdAt: Timestamp,
@@ -158,6 +163,7 @@ object Tool {
     }
   }
 
+  @JsonCodec
   case class WithRelatedUUIDs(
     id: UUID,
     createdAt: Timestamp,
@@ -177,4 +183,3 @@ object Tool {
     categories: Seq[String]
   )
 }
-

--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/ToolCategory.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/ToolCategory.scala
@@ -1,7 +1,8 @@
 package com.azavea.rf.datamodel
 
-import java.util.UUID
 import java.sql.Timestamp
+
+import io.circe.generic.JsonCodec
 
 /** A user generate category to track tools in the Raster Foundry lab
   *
@@ -12,6 +13,7 @@ import java.sql.Timestamp
   * @param modifiedBy String User ID that last modified category
   * @param category String Category that is displayed to user
   */
+@JsonCodec
 case class ToolCategory(
     slugLabel: String,
     createdAt: Timestamp,
@@ -27,6 +29,7 @@ object ToolCategory {
 
   def tupled = (ToolCategory.apply _).tupled
 
+  @JsonCodec
   case class Create(
       category: String
   ) {

--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/ToolCategoryToTool.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/ToolCategoryToTool.scala
@@ -1,6 +1,5 @@
 package com.azavea.rf.datamodel
 
 import java.util.UUID
-import java.sql.Timestamp
 
 case class ToolCategoryToTool(toolCategorySlug: String, toolId: UUID)

--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/ToolRun.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/ToolRun.scala
@@ -3,8 +3,10 @@ package com.azavea.rf.datamodel
 import java.util.UUID
 import java.sql.Timestamp
 
-import io.circe.Json
+import io.circe._
+import io.circe.generic.JsonCodec
 
+@JsonCodec
 case class ToolRun(
   id: UUID,
   createdAt: Timestamp,
@@ -22,6 +24,7 @@ object ToolRun {
   def create = Create.apply _
   def tupled = (ToolRun.apply _).tupled
 
+  @JsonCodec
   case class Create(
     visibility: Visibility,
     organizationId: UUID,

--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/ToolTag.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/ToolTag.scala
@@ -3,6 +3,9 @@ package com.azavea.rf.datamodel
 import java.util.UUID
 import java.sql.Timestamp
 
+import io.circe._
+import io.circe.generic.JsonCodec
+
 /** A user generate tag to track tools in the Raster Foundry lab
   *
   * @param id UUID Unique identifier for Tool Tag
@@ -13,18 +16,18 @@ import java.sql.Timestamp
   * @param modifiedBy String User ID that last modified tag
   * @param tag String Tag that is displayed to user
   */
+@JsonCodec
 case class ToolTag(
-    id: UUID,
-    createdAt: Timestamp,
-    modifiedAt: Timestamp,
-    organizationId: UUID,
-    createdBy: String,
-    modifiedBy: String,
-    tag: String
+  id: UUID,
+  createdAt: Timestamp,
+  modifiedAt: Timestamp,
+  organizationId: UUID,
+  createdBy: String,
+  modifiedBy: String,
+  tag: String
 )
 
 object ToolTag {
-
   def create = Create.apply _
 
   def tupled = (ToolTag.apply _).tupled
@@ -34,10 +37,8 @@ object ToolTag {
     * @param organizationId UUID organization to create tag for
     * @param tag String user supplied string to use for tag
     */
-  case class Create(
-      organizationId: UUID,
-      tag: String
-  ) {
+  @JsonCodec
+  case class Create(organizationId: UUID, tag: String) {
 
     def toToolTag(userId: String): ToolTag = {
       val now = new Timestamp((new java.util.Date()).getTime())
@@ -52,6 +53,4 @@ object ToolTag {
       )
     }
   }
-
-  object Create
 }

--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/ToolTagToTool.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/ToolTagToTool.scala
@@ -1,6 +1,5 @@
 package com.azavea.rf.datamodel
 
 import java.util.UUID
-import java.sql.Timestamp
 
 case class ToolTagToTool(toolTagId: UUID, toolId: UUID)

--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/Upload.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/Upload.scala
@@ -1,10 +1,12 @@
 package com.azavea.rf.datamodel
 
 import io.circe._
-
 import java.util.UUID
 import java.sql.Timestamp
 
+import io.circe.generic.JsonCodec
+
+@JsonCodec
 case class Upload(
   id: UUID,
   createdAt: Timestamp,
@@ -27,6 +29,7 @@ object Upload {
 
   def create = Upload.apply _
 
+  @JsonCodec
   case class Create(
     organizationId: UUID,
     uploadStatus: UploadStatus,

--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/package.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/package.scala
@@ -34,21 +34,14 @@ package object datamodel {
     Encoder.encodeString.contramap[Timestamp](_.toInstant.toString)
   implicit val timestampDecoder: Decoder[Timestamp] =
     Decoder.decodeString.emap { str =>
-      Either.catchNonFatal(Timestamp.from(Instant.parse(str))).leftMap(t => "Timestamp")
-    }
-
-  implicit val thumbnailSizeEncoder: Encoder[ThumbnailSize] =
-    Encoder.encodeString.contramap[ThumbnailSize](_.toString)
-  implicit val thumbnailSizeDecoder: Decoder[ThumbnailSize] =
-    Decoder.decodeString.emap { str =>
-      Either.catchNonFatal(ThumbnailSize.fromString(str)).leftMap(t => "ThumbnailSize")
+      Either.catchNonFatal(Timestamp.from(Instant.parse(str))).leftMap(_ => "Timestamp")
     }
 
   implicit val uuidEncoder: Encoder[UUID] =
     Encoder.encodeString.contramap[UUID](_.toString)
   implicit val uuidDecoder: Decoder[UUID] =
     Decoder.decodeString.emap { str =>
-    Either.catchNonFatal(UUID.fromString(str)).leftMap(t => "UUID")
+    Either.catchNonFatal(UUID.fromString(str)).leftMap(_ => "UUID")
   }
 
   implicit val projectedGeometryEncoder: Encoder[Projected[Geometry]] =
@@ -75,11 +68,4 @@ package object datamodel {
   implicit val projectedGeometryDecoder: Decoder[Projected[Geometry]] = Decoder[Json] map { js =>
     Projected(js.spaces4.parseGeoJson[Geometry], 4326).reproject(CRS.fromEpsgCode(4326), CRS.fromEpsgCode(3857))(3857)
   }
-
-  implicit val userRoleEncoder: Encoder[UserRole] =
-    Encoder.encodeString.contramap[UserRole](_.toString)
-  implicit val userRoleDecoder: Decoder[UserRole] =
-    Decoder.decodeString.emap { str =>
-      Either.catchNonFatal(UserRole.fromString(str)).leftMap(r => "UserRole")
-    }
 }

--- a/app-backend/tile/src/it/scala/ApiUtils.scala
+++ b/app-backend/tile/src/it/scala/ApiUtils.scala
@@ -1,25 +1,14 @@
 package com.azavea.rf.tile
 
 import io.circe._
-import io.circe.syntax._
 import io.circe.parser._
-import io.circe.generic.auto._
 import scalaj.http._
-import io.gatling.core.Predef._
-import io.gatling.http.Predef._
-import io.gatling.http.request.builder.HttpRequestBuilder
 import cats.syntax.either._
-import com.typesafe.config.ConfigFactory
 import geotrellis.vector._
-import geotrellis.proj4._
 import geotrellis.slick._
-import geotrellis.vector.io._
 
-import scala.concurrent.duration._
-import scala.collection.JavaConverters._
 import scala.util._
 import java.util.UUID
-import java.lang.IllegalStateException
 
 object ApiUtils {
 

--- a/app-backend/tool/src/main/scala/ast/ClassBreaks.scala
+++ b/app-backend/tool/src/main/scala/ast/ClassBreaks.scala
@@ -2,6 +2,8 @@ package com.azavea.rf.tool.ast
 
 import geotrellis.raster.render._
 
+import io.circe.generic.JsonCodec
 
+@JsonCodec
 case class ClassBreaks(classMap: Map[Double, Double], boundaryType: ClassBoundaryType = LessThanOrEqualTo)
 

--- a/app-backend/tool/src/main/scala/ast/MapAlgebraAST.scala
+++ b/app-backend/tool/src/main/scala/ast/MapAlgebraAST.scala
@@ -2,6 +2,7 @@ package com.azavea.rf.tool.ast
 
 import java.util.UUID
 
+import io.circe.generic.JsonCodec
 
 /** The ur-type for a recursive representation of MapAlgebra operations */
 sealed trait MapAlgebraAST extends Product with Serializable {
@@ -22,21 +23,27 @@ object MapAlgebraAST {
       }).distinct
   }
 
+  @JsonCodec
   case class Addition(args: List[MapAlgebraAST], id: UUID, label: Option[String])
       extends Operation("+")
 
+  @JsonCodec
   case class Subtraction(args: List[MapAlgebraAST], id: UUID, label: Option[String])
       extends Operation("-")
 
+  @JsonCodec
   case class Multiplication(args: List[MapAlgebraAST], id: UUID, label: Option[String])
       extends Operation("*")
 
+  @JsonCodec
   case class Division(args: List[MapAlgebraAST], id: UUID, label: Option[String])
       extends Operation("/")
 
+  @JsonCodec
   case class Masking(args: List[MapAlgebraAST], id: UUID, label: Option[String])
       extends Operation("mask")
 
+  @JsonCodec
   case class Reclassification(args: List[MapAlgebraAST], id: UUID, label: Option[String], classBreaks: ClassBreaks)
       extends Operation("reclassify")
 
@@ -49,6 +56,7 @@ object MapAlgebraAST {
     def unbound: List[MapAlgebraAST] = if (evaluable) List.empty else List(this)
   }
 
+  @JsonCodec
   case class RFMLRasterSource(id: UUID, label: Option[String], value: Option[RFMLRaster])
       extends Source[RFMLRaster]("raster")
 

--- a/app-backend/tool/src/main/scala/ast/RFMLRaster.scala
+++ b/app-backend/tool/src/main/scala/ast/RFMLRaster.scala
@@ -2,18 +2,21 @@ package com.azavea.rf.tool.ast
 
 import io.circe._
 import io.circe.syntax._
-import io.circe.generic.auto._
-
 import java.util.UUID
 import java.security.InvalidParameterException
 
+import io.circe.generic.JsonCodec
 
 sealed abstract class RFMLRaster(val `type`: String) {
   def id: UUID
 }
+@JsonCodec
 case class SceneRaster(id: UUID, band: Option[Int]) extends RFMLRaster("scene")
+@JsonCodec
 case class ProjectRaster(id: UUID, band: Option[Int]) extends RFMLRaster("project")
+@JsonCodec
 case class MLToolRaster(id: UUID, node: Option[UUID]) extends RFMLRaster("tool")
+@JsonCodec
 case class RasterReference(id: UUID) extends RFMLRaster("reference")
 
 object RFMLRaster {

--- a/app-backend/tool/src/main/scala/ast/codec/MapAlgebraCodec.scala
+++ b/app-backend/tool/src/main/scala/ast/codec/MapAlgebraCodec.scala
@@ -4,11 +4,8 @@ import com.azavea.rf.tool.ast._
 
 import io.circe._
 import io.circe.syntax._
-import io.circe.generic.auto._
-import io.circe.optics.JsonPath._
 
 import java.security.InvalidParameterException
-
 
 trait MapAlgebraCodec
     extends MapAlgebraSourceCodecs

--- a/app-backend/tool/src/main/scala/ast/codec/MapAlgebraOperationCodecs.scala
+++ b/app-backend/tool/src/main/scala/ast/codec/MapAlgebraOperationCodecs.scala
@@ -6,7 +6,6 @@ import geotrellis.raster.render._
 import io.circe._
 import io.circe.optics.JsonPath._
 import io.circe.syntax._
-import io.circe.generic.auto._
 
 import scala.util.Try
 import java.security.InvalidParameterException

--- a/app-backend/tool/src/main/scala/ast/codec/MapAlgebraSourceCodecs.scala
+++ b/app-backend/tool/src/main/scala/ast/codec/MapAlgebraSourceCodecs.scala
@@ -2,13 +2,9 @@ package com.azavea.rf.tool.ast.codec
 
 import com.azavea.rf.tool.ast._
 
-import geotrellis.raster.render._
 import io.circe._
-import io.circe.optics.JsonPath._
 import io.circe.syntax._
-import io.circe.generic.auto._
 
-import scala.util.Try
 import java.security.InvalidParameterException
 
 

--- a/app-backend/tool/src/main/scala/ast/codec/MapAlgebraUtilityCodecs.scala
+++ b/app-backend/tool/src/main/scala/ast/codec/MapAlgebraUtilityCodecs.scala
@@ -3,16 +3,10 @@ package com.azavea.rf.tool.ast.codec
 import com.azavea.rf.tool.ast._
 
 import geotrellis.raster.render._
-import cats.syntax.either._
 import io.circe._
-import io.circe.syntax._
-import io.circe.generic.auto._
-import io.circe.optics.JsonPath._
-import io.circe.parser._
 
 import scala.util.Try
 import java.security.InvalidParameterException
-
 
 trait MapAlgebraUtilityCodecs {
   implicit def mapAlgebraDecoder: Decoder[MapAlgebraAST]


### PR DESCRIPTION
This reintroduces a bit of boilerplate (`@JsonCodec` usages), but an arguably acceptable amount. ~~This could be further reduced if we use @JsonCodec instead.~~

~~Note: Not all uses of full auto derivation were removed, only those which were causing problems.~~

Closes #1347 
Closes #1390
Supersedes #1481 
