### PR TITLE
Add API endpoint for organization feature overrides

### DIFF
--- a/app-backend/api/src/main/scala/Router.scala
+++ b/app-backend/api/src/main/scala/Router.scala
@@ -24,6 +24,7 @@ import com.azavea.rf.api.feed.FeedRoutes
 import com.azavea.rf.api.uploads.UploadRoutes
 import com.azavea.rf.api.exports.ExportRoutes
 import com.azavea.rf.api.utils.Config
+import com.azavea.rf.api.featureflags.FeatureFlagRoutes
 
 /**
   * Contains all routes for Raster Foundry API/Healthcheck endpoints.
@@ -50,7 +51,8 @@ trait Router extends HealthCheckRoutes
     with FeedRoutes
     with UploadRoutes
     with ExportRoutes
-    with Config {
+    with Config
+    with FeatureFlagRoutes {
 
   val corsSettings = CorsSettings.defaultSettings
 
@@ -79,6 +81,9 @@ trait Router extends HealthCheckRoutes
     } ~
     pathPrefix("config") {
       configRoutes
+    } ~
+    pathPrefix("feature-flags") {
+      featureFlagRoutes
     } ~
     pathPrefix("thumbnails") {
       thumbnailImageRoutes

--- a/app-backend/api/src/main/scala/config/Routes.scala
+++ b/app-backend/api/src/main/scala/config/Routes.scala
@@ -19,24 +19,6 @@ trait ConfigRoutes extends Authentication {
           AngularConfigService.getConfig()
         }
       }
-    } ~
-    pathPrefix("organization") {
-      pathEndOrSingleSlash {
-        get {
-          complete {
-            AngularConfigService.getConfig()
-          }
-        }
-      } ~
-      path(JavaUUID) { orgId =>
-        pathEndOrSingleSlash {
-          get {
-            complete {
-              OrgFeatureFlags.getFeatures(orgId)
-            }
-          }
-        }
-      }
     }
   }
 }

--- a/app-backend/api/src/main/scala/featureflags/Routes.scala
+++ b/app-backend/api/src/main/scala/featureflags/Routes.scala
@@ -1,0 +1,36 @@
+package com.azavea.rf.api.featureflags
+
+import akka.http.scaladsl.server.Route
+import com.azavea.rf.common.{Authentication, CommonHandlers, UserErrorHandler}
+import com.azavea.rf.database.Database
+import com.azavea.rf.database.tables.{OrgFeatureFlags}
+import com.azavea.rf.datamodel._
+
+import akka.http.scaladsl.server.Route
+import com.lonelyplanet.akka.http.extensions.PaginationDirectives
+import io.circe._
+import de.heikoseeberger.akkahttpcirce.CirceSupport._
+
+import java.util.UUID
+
+
+/**
+  * Routes for FeatureFlag overrides
+  */
+trait FeatureFlagRoutes extends Authentication
+  with PaginationDirectives
+  with CommonHandlers
+  with UserErrorHandler {
+
+  implicit def database: Database
+
+  val featureFlagRoutes: Route = handleExceptions(userExceptionHandler) {
+    pathEndOrSingleSlash {
+      get { getFeatureFlags }
+    }
+  }
+
+  def getFeatureFlags: Route = authenticate { user =>
+    complete(OrgFeatureFlags.getFeatures(user.organizationId))
+  }
+}

--- a/app-backend/api/src/main/scala/featureflags/package.scala
+++ b/app-backend/api/src/main/scala/featureflags/package.scala
@@ -1,0 +1,5 @@
+package com.azavea.rf.api
+
+import com.azavea.rf.datamodel._
+
+package object featureflags


### PR DESCRIPTION
## Overview

This PR adds an API endpoint at `/organizations/{ID|/ff-overrides/` that lists all feature overrides for a specified organization.

### Checklist

~~- [ ] Styleguide updated, if necessary~~
- [x] Swagger specification updated, if necessary
~~- [ ] Symlinks from new migrations present or corrected for any new migrations~~


## Testing Instructions
* add a record to organization_features, e.g.
```
insert into organization_features (organization, feature_flag, active)
VALUES ('{organization ID}','{feature_flag ID}',TRUE);
```

* GET http://localhost:9000/feature-flags and check that the response agrees with the added record(s)

Closes #1410
