### PR TITLE
Add stub dags for area of interest monitoring

### DIFF
--- a/app-tasks/dags/aoi-monitoring/find_aoi_projects_to_update.py
+++ b/app-tasks/dags/aoi-monitoring/find_aoi_projects_to_update.py
@@ -1,0 +1,109 @@
+from collections import namedtuple
+import datetime
+import logging
+import json
+import subprocess
+
+from airflow.bin.cli import trigger_dag
+from airflow.models import DAG
+from airflow.operators.python_operator import PythonOperator
+
+from rf.utils.exception_reporting import wrap_rollbar
+
+rf_logger = logging.getLogger('rf')
+ch = logging.StreamHandler()
+ch.setLevel(logging.INFO)
+formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+ch.setFormatter(formatter)
+rf_logger.addHandler(ch)
+
+logger = logging.getLogger(__name__)
+
+default_args = {
+    'owner': 'raster-foundry',
+    'start_date': datetime.datetime(2017, 4, 7)
+}
+
+DagArgs = namedtuple('DagArgs', 'dag_id, conf, run_id')
+
+# TODO: update this schedule to something more reasonable/carefully chosen
+dag = DAG(
+    dag_id='find_aoi_projects_to_update',
+    default_args=default_args,
+    schedule_interval=datetime.timedelta(hours=6),
+    concurrency=1
+)
+
+#############
+# Constants #
+#############
+
+FIND_TASK_ID = 'find_aoi_projects_to_update'
+KICKOFF_TASK_ID = 'kickoff_aoi_project_update_checks'
+UPDATE_DAG_ID = 'update_aoi_projects'
+
+#################################
+# Callables for PythonOperators #
+#################################
+
+@wrap_rollbar
+def find_aoi_projects_to_update():
+    """Find AOI projects to check for updates and push their IDs to xcoms"""
+    logger.info('Finding AOI projects to check for updates')
+    # This is check_output to mock shelling out to some scala command
+    # and returning a sequence of UUIDs
+    projects = subprocess.check_output([
+        'echo', 'some-project, ids, here, maybe, many, of-them'
+    ])
+    return {'project_ids': projects.strip().split(', ')}
+
+
+@wrap_rollbar
+def kickoff_aoi_project_update_checks(**context):
+    xcom = context['task_instance'].xcom_pull(task_ids=FIND_TASK_ID)
+    project_ids = xcom['project_ids']
+    logger.info('Found projects to check for updates: %s', project_ids)
+    execution_date = context['execution_date']
+    # TODO: remove this
+    # so we can keep kicking off jobs with the same bogus ids from the 
+    def add_random_text(s):
+        """Add random text to a string s"""
+        import random
+        from string import ascii_lowercase
+        letters = [random.choice(ascii_lowercase) for _ in xrange(25)]
+        return s + ''.join(letters)
+
+    for project_id in project_ids:
+        # Run ID goes out to seconds because users may have really high frequency cadences
+        # Maybe we shouldn't allow cadences below a certain value?
+        run_id = (
+            'aoi_project_update_{project_id}_{year}_{month}_{day}_{hour}_{minute}_{second}'
+        ).format(
+            project_id=project_id,
+            year=execution_date.year,
+            month=execution_date.month,
+            day=execution_date.day,
+            hour=execution_date.hour,
+            minute=execution_date.minute,
+            second=execution_date.second
+        )
+        run_id = add_random_text(run_id)
+        conf = json.dumps({'project_id': project_id})
+        dag_args = DagArgs(dag_id=UPDATE_DAG_ID, conf=conf, run_id=run_id)
+        trigger_dag(dag_args)
+
+
+find_operator = PythonOperator(
+    task_id=FIND_TASK_ID,
+    provide_context=False,
+    python_callable=find_aoi_projects_to_update,
+    dag=dag
+)
+
+kickoff_operator = PythonOperator(
+    task_id=KICKOFF_TASK_ID,
+    provide_context=True,
+    python_callable=kickoff_aoi_project_update_checks,
+    dag=dag
+)
+kickoff_operator.set_upstream(find_operator)

--- a/app-tasks/dags/aoi-monitoring/find_aoi_projects_to_update.py
+++ b/app-tasks/dags/aoi-monitoring/find_aoi_projects_to_update.py
@@ -30,7 +30,7 @@ DagArgs = namedtuple('DagArgs', 'dag_id, conf, run_id')
 dag = DAG(
     dag_id='find_aoi_projects_to_update',
     default_args=default_args,
-    schedule_interval=datetime.timedelta(hours=6),
+    schedule_interval=None,
     concurrency=1
 )
 

--- a/app-tasks/dags/aoi-monitoring/update_aoi_projects.py
+++ b/app-tasks/dags/aoi-monitoring/update_aoi_projects.py
@@ -51,5 +51,6 @@ PythonOperator(
     task_id='update_aoi_project',
     provide_context=True,
     python_callable=update_aoi_project,
+    sla=datetime.timedelta(minutes=3),
     dag=dag
 )

--- a/app-tasks/dags/aoi-monitoring/update_aoi_projects.py
+++ b/app-tasks/dags/aoi-monitoring/update_aoi_projects.py
@@ -51,6 +51,6 @@ PythonOperator(
     task_id='update_aoi_project',
     provide_context=True,
     python_callable=update_aoi_project,
-    sla=datetime.timedelta(minutes=3),
+    execution_timeout=datetime.timedelta(seconds=60),
     dag=dag
 )

--- a/app-tasks/dags/aoi-monitoring/update_aoi_projects.py
+++ b/app-tasks/dags/aoi-monitoring/update_aoi_projects.py
@@ -1,0 +1,99 @@
+import datetime
+import logging
+import os
+
+from airflow.models import DAG
+from airflow.operators import PythonOperator, BranchPythonOperator
+
+from rf.utils.exception_reporting import wrap_rollbar
+
+rf_logger = logging.getLogger('rf')
+ch = logging.StreamHandler()
+ch.setLevel(logging.INFO)
+formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+ch.setFormatter(formatter)
+rf_logger.addHandler(ch)
+
+logger = logging.getLogger(__name__)
+
+default_args = {
+    'owner': 'raster-foundry',
+    'start_date': datetime.datetime(2017, 4, 1)
+}
+
+dag = DAG(
+    dag_id='update_aoi_projects',
+    default_args=default_args,
+    schedule_interval=None,
+    concurrency=os.getenv('AIRFLOW_DAG_CONCURRENCY', 24)
+)
+
+
+def check_whether_update_available(**context):
+    # check whether a project needs to update
+
+    conf = context['dag_run'].conf
+    project_id = conf.get('project_id')
+    logger.info('Checking whether %s has updated scenes available', project_id)
+
+    task_id = 'dont_update_project'
+    # this would be replaced by a subprocess call to some jar that determines
+    # whether the project needs to be updated
+    import random
+    update_available = random.random() > 0.5
+    if update_available:
+        logger.info('AOI project %s has an update available', project_id)
+        task_id = 'update_project'
+
+    return task_id
+
+
+def update_project(**context):
+    conf = context['dag_run'].conf
+    project_id = conf.get('project_id')
+    logger.info('Updating AOI project %s', project_id)
+
+
+def dont_update_project(**context):
+    conf = context['dag_run'].conf
+    project_id = conf.get('project_id')
+    logger.info('Not updating AOI project %s, no need', project_id)
+
+
+def mark_project_update_time(**context):
+    conf = context['dag_run'].conf
+    project_id = conf.get('project_id')
+    logger.info('Updating AOI project %s\'s last update time', project_id)
+
+
+check_operator = BranchPythonOperator(
+    task_id='check_project_update_available',
+    provide_context=True,
+    python_callable=check_whether_update_available,
+    dag=dag
+)
+
+update_operator = PythonOperator(
+    task_id='update_project',
+    provide_context=True,
+    python_callable=update_project,
+    dag=dag
+)
+update_operator.set_upstream(check_operator)
+
+dont_update_operator = PythonOperator(
+    task_id='dont_update_project',
+    provide_context=True,
+    python_callable=dont_update_project,
+    dag=dag
+)
+dont_update_operator.set_upstream(check_operator)
+
+finish_operator = PythonOperator(
+    task_id='mark_project_updated',
+    provide_context=True,
+    python_callable=mark_project_update_time,
+    dag=dag,
+    trigger_rule='one_success'
+)
+finish_operator.set_upstream([update_operator, dont_update_operator])


### PR DESCRIPTION
## Overview

This PR adds stubbed DAGs for area of interest monitoring. The stubbing is based on stubs in #1042.

### Checklist

- ~Styleguide updated, if necessary~
- ~Swagger specification updated, if necessary~
- ~Symlinks from new migrations present or corrected for any new migrations~

### Notes

1. Because we don't have a schedule frequency determined or a minimum value for cadences (AFAIK), the `run_id`s for the `DAG` that does all the work includes time data down to seconds. We could relax this with a minimum cadence or if we knew what the schedule was going to be.

2. I _think_ the last update time should be updated independent of whether there are scenes to update. This creates a race condition though, where:
    1. The project is found as a project that needs to update
    2. The DAG to update the project gets scheduled
    3. The DAG to find projects that need to run starts again on its schedule before the DAG to update that project is executed

I _think_ that we can solve this by creating a [LatestOnlyOperator](https://airflow.incubator.apache.org/concepts.html#latest-run-only) as the upstream of [`check_operator`](https://github.com/azavea/raster-foundry/blob/2e8a3688e9d29bd6617d13050d3dc891ccb2ec30/app-tasks/dags/aoi-monitoring/update_aoi_projects.py#L69) and not tracking AOI monitoring state on `Projects` or in the database. I didn't figure out how to test whether this would defeat the race condition locally.

## Testing Instructions

 * `watch http :9000/healthcheck/`
 * `./scripts/server`
 * after the healthcheck is up, `docker-compose -f docker-compose.airflow.yml up | grep airflow-worker`
 * go to your airflow ui at `localhost:8080` and turn off everything except the two AOI DAGs (do this really soon after it boots up to keep other DAGs from filling up your queue)
 * wait a bit (a few minutes, for some reason)
 * go to your `task_instances` view under `Browse` in the airflow UI
 * add a filter: `task_id` contains `update_project`
 * make sure all of the states are `success` or `skipped`
 * click some `logs` and make sure the IDs match the IDs sent forward from `find_aoi_projects_to_update`

Closes #1418
