### PR TITLE
Add java dependency back to airflow

### DIFF
--- a/app-tasks/Dockerfile
+++ b/app-tasks/Dockerfile
@@ -14,13 +14,19 @@ RUN set -ex \
     && buildDeps=' \
        python-dev \
     ' \
+    && javaDeps=' \
+       openjdk-8-jre \
+    ' \
     && gdal=' \
        gdal-bin \
        libgdal1h \
        libgdal-dev \
     ' \
     && echo "deb http://ftp.debian.org/debian jessie-backports main" > /etc/apt/sources.list.d/backports.list \
-    && apt-get update && apt-get install -y --no-install-recommends ${buildDeps} ${gdal} \
+    && apt-get update \
+    && apt-get -t jessie-backports install -y --no-install-recommends ca-certificates-java \
+    && apt-get install -y --no-install-recommends ${buildDeps} ${gdal} ${javaDeps} \
+    && update-java-alternatives -s java-1.8.0-openjdk-amd64 \
     && pip install --no-cache-dir \
            numpy==$(grep "numpy" /tmp/requirements.txt | cut -d= -f3) \
     && pip install --no-cache-dir -r /tmp/requirements.txt \


### PR DESCRIPTION
## Overview

Effectively reverts `a15ced` and adds java back

See https://github.com/azavea/raster-foundry/commit/a15ced453f9cb45aece5a1c1c08c7a8c8f04a5d3

Still a WIP - haven't had a chance to test fully.

### Checklist

- ~[ ] Styleguide updated, if necessary~
- ~[ ] Swagger specification updated, if necessary~
- ~[ ] Symlinks from new migrations present or corrected for any new migrations~

## Testing Instructions

 * Build airflow worker: `docker-compose -f docker-compose.airflow.yml  build airflow-worker`
 * Get a shell in docker container: `./scripts/console airflow-worker bash`
 * Check java version: `java -version`

Closes #1447 
