### PR TITLE
Scene detail modal

### DIFF
--- a/app-frontend/src/app/components/sceneDetailModal/sceneDetailModal.component.js
+++ b/app-frontend/src/app/components/sceneDetailModal/sceneDetailModal.component.js
@@ -1,0 +1,14 @@
+import sceneDetailModalTpl from './sceneDetailModal.html';
+
+const rfSceneDetailModal = {
+    templateUrl: sceneDetailModalTpl,
+    bindings: {
+        close: '&',
+        dismiss: '&',
+        modalInstance: '<',
+        resolve: '<'
+    },
+    controller: 'SceneDetailModalController'
+};
+
+export default rfSceneDetailModal;

--- a/app-frontend/src/app/components/sceneDetailModal/sceneDetailModal.controller.js
+++ b/app-frontend/src/app/components/sceneDetailModal/sceneDetailModal.controller.js
@@ -1,0 +1,61 @@
+/* global L */
+
+export default class SceneDetailModalController {
+    constructor(
+        $state, sceneService, datasourceService, mapService, $uibModal
+    ) {
+        'ngInject';
+        this.$state = $state;
+        this.sceneService = sceneService;
+        this.datasourceService = datasourceService;
+        this.$uibModal = $uibModal;
+        this.scene = this.resolve.scene;
+        this.getMap = () => mapService.getMap('scene-preview-map');
+    }
+
+    $onInit() {
+        this.datasourceLoaded = false;
+        this.getMap().then(mapWrapper => {
+            mapWrapper.setThumbnail(this.scene, false, true);
+            mapWrapper.map.fitBounds(this.getSceneBounds());
+        });
+        this.datasourceService.get(this.scene.datasource).then(d => {
+            this.datasourceLoaded = true;
+            this.datasource = d;
+        });
+    }
+
+    openDownloadModal() {
+        const images = this.scene.images.map(i => Object({
+            filename: i.filename,
+            uri: i.sourceUri,
+            metadata: i.metadataFiles || []
+        }));
+
+        const downloadSets = [{
+            label: this.scene.name,
+            metadata: this.scene.metadataFiles || [],
+            images: images
+        }];
+
+        this.activeModal = this.$uibModal.open({
+            component: 'rfDownloadModal',
+            resolve: {
+                downloads: () => downloadSets
+            }
+        });
+
+        this.dismiss();
+
+        return this.activeModal;
+    }
+
+    getSceneBounds() {
+        const bounds = L.geoJSON(this.scene.dataFootprint).getBounds();
+        return bounds;
+    }
+
+    closeWithData(data) {
+        this.close({$value: data});
+    }
+}

--- a/app-frontend/src/app/components/sceneDetailModal/sceneDetailModal.html
+++ b/app-frontend/src/app/components/sceneDetailModal/sceneDetailModal.html
@@ -1,0 +1,58 @@
+<div class="scene-detail-modal-body">
+  <div class="content-row">
+    <div class="scene-metadata text-left">
+      <div class="scene-metadata-fixed">
+        <button type="button" class="close" aria-label="Close" ng-click="$ctrl.dismiss()">
+          <span aria-hidden="true">&times;</span>
+        </button>
+        <p>
+        <strong class="color-dark">{{$ctrl.scene.name}}</strong><br>
+          {{$ctrl.datasourceLoaded ? $ctrl.datasource.name : 'Loading datasource'}}
+        </p>
+      </div>
+      <div class="scene-metadata-scrollable">
+        <h5 class="color-dark">Scene properties</h5>
+        <dl class="meta-list">
+          <dt ng-repeat-start="(field, value) in $ctrl.scene.filterFields">
+            {{field}}
+          </dt>
+          <dd ng-repeat-end>{{value}}</dd>
+          <dt ng-if-start="$ctrl.scene.createdAt">Created Date</dt>
+          <dd ng-if-end>{{$ctrl.scene.createdAt | date}}</dd>
+          <dt ng-if-start="$ctrl.scene.modifiedAt">Modified Date</dt>
+          <dd ng-if-end>{{$ctrl.scene.modifiedAt | date}}</dd>
+          <dt ng-if-start="$ctrl.scene.datasource">Datasource</dt>
+          <dd ng-if-end>{{$ctrl.scene.datasource}}</dd>
+          <dt>Visiblity</dt>
+          <dd>{{$ctrl.scene.visibility}}</dd>
+          <dt ng-repeat-start="(field, value) in $ctrl.scene.statusFields">
+            {{field}}
+          </dt>
+          <dd ng-repeat-end>{{value}}</dd>
+        </dl>
+        <h5 class="color-dark">Scene metadata</h5>
+        <dl class="meta-list">
+          <dt ng-repeat-start="(metaKey, metaVal) in $ctrl.scene.sceneMetadata">
+            {{metaKey}}
+          </dt>
+          <dd ng-repeat-end>{{metaVal}}</dd>
+        </dl>
+      </div>
+    </div>
+    <div class="scene-preview-container">
+      <rf-map-container map-id="scene-preview-map">
+      </rf-map-container>
+    </div>
+  </div>
+
+  <div class="modal-footer">
+    <button type="button" class="btn pull-left"
+            ng-click="$ctrl.closeWithData(1)">
+      Done
+    </button>
+    <button type="button" class="btn btn-default pull-right"
+            ng-click="$ctrl.openDownloadModal()">
+      <i class="icon-download"></i> Download
+    </button>
+  </div>
+</div>

--- a/app-frontend/src/app/components/sceneDetailModal/sceneDetailModal.module.js
+++ b/app-frontend/src/app/components/sceneDetailModal/sceneDetailModal.module.js
@@ -1,0 +1,10 @@
+import angular from 'angular';
+import SceneDetailModalComponent from './sceneDetailModal.component.js';
+import SceneDetailModalController from './sceneDetailModal.controller.js';
+
+const SceneDetailModalModule = angular.module('components.sceneDetailModal', []);
+
+SceneDetailModalModule.controller('SceneDetailModalController', SceneDetailModalController);
+SceneDetailModalModule.component('rfSceneDetailModal', SceneDetailModalComponent);
+
+export default SceneDetailModalModule;

--- a/app-frontend/src/app/components/sceneItem/sceneItem.html
+++ b/app-frontend/src/app/components/sceneItem/sceneItem.html
@@ -1,4 +1,4 @@
-<div class="list-group-item">
+<div class="list-group-item has-action">
   <div ng-if="$ctrl.isDraggable" ui-tree-handle>
     <i class="icon-gripper"></i>
   </div>

--- a/app-frontend/src/app/index.components.js
+++ b/app-frontend/src/app/index.components.js
@@ -29,5 +29,6 @@ export default angular.module('index.components', [
     require('./components/datasourceItem/datasourceItem.module.js').name,
     require('./components/selectProjectModal/selectProjectModal.module.js').name,
     require('./components/importModal/importModal.module.js').name,
-    require('./components/staticMap/staticMap.module.js').name
+    require('./components/staticMap/staticMap.module.js').name,
+    require('./components/sceneDetailModal/sceneDetailModal.module.js').name
 ]);

--- a/app-frontend/src/app/pages/projects/detail/detail.controller.js
+++ b/app-frontend/src/app/pages/projects/detail/detail.controller.js
@@ -232,6 +232,19 @@ export default class ProjectsDetailController {
         );
     }
 
+    openSceneDetailModal(scene) {
+        if (this.activeModal) {
+            this.activeModal.dismiss();
+        }
+
+        this.activeModal = this.$uibModal.open({
+            component: 'rfSceneDetailModal',
+            resolve: {
+                scene: () => scene
+            }
+        });
+    }
+
     cancelProjectNameEdit() {
         this.isEditingProjectName = false;
         this.editedProjectName = this.project.name;

--- a/app-frontend/src/app/pages/projects/detail/detail.html
+++ b/app-frontend/src/app/pages/projects/detail/detail.html
@@ -2,7 +2,7 @@
     <rf-static-map map-id="{{$ctrl.project.id}}-big-preview" ng-if="$ctrl.project" class="project-preview-map"></rf-static-map>
   </div>
   <div class="row content stack-sm max-width">
-    <div class="column-8" ng-if="!$ctrl.loading">
+    <div class="column-10" ng-if="!$ctrl.loading">
       <div class="library-header">
         <h1 class="h3 page-title">
           <a ui-sref="projects.list"><i class="icon-caret-left"></i> Projects</a><br>
@@ -62,7 +62,8 @@
       <div class="list-group">
         <rf-scene-item
             scene="scene"
-            ng-repeat="scene in $ctrl.sceneList track by scene.id">
+            ng-repeat="scene in $ctrl.sceneList track by scene.id"
+            ng-click="$ctrl.openSceneDetailModal(scene)">
           <a href class="link-danger" ng-click="$ctrl.removeScene(scene)">Remove from Project</a>
         </rf-scene-item>
       </div>

--- a/app-frontend/src/assets/styles/sass/_shame.scss
+++ b/app-frontend/src/assets/styles/sass/_shame.scss
@@ -399,3 +399,10 @@ ob-daterangepicker {
   justify-content: space-between;
   align-items: flex-end;
 }
+
+.list-group-item.has-action {
+  cursor: pointer;
+  &:hover {
+    background: #fafafa;
+  }
+}

--- a/app-frontend/src/assets/styles/sass/components/_modal.scss
+++ b/app-frontend/src/assets/styles/sass/components/_modal.scss
@@ -279,6 +279,7 @@
   .content-row {
     display: flex;
     flex-direction: column;
+    min-height: 0;
     @include respond-to('md-up') {
       flex-direction: row;
     }

--- a/app-frontend/src/assets/styles/sass/components/_modal.scss
+++ b/app-frontend/src/assets/styles/sass/components/_modal.scss
@@ -237,8 +237,8 @@
     flex: 1;
     overflow: auto;
   }
-  
-  /* 
+
+  /*
     Modal with a sidebar instead up top header
    */
   @include respond-to('md-up') {
@@ -269,3 +269,39 @@
   }
 }
 
+.scene-detail-modal-body {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  @include respond-to('md-up') {
+    max-height: calc(100vh - 100px);
+  }
+  .content-row {
+    display: flex;
+    flex-direction: column;
+    @include respond-to('md-up') {
+      flex-direction: row;
+    }
+  }
+  .scene-metadata {
+    max-width: 350px;
+    display: flex;
+    flex-direction: column;
+    border-right: 1px solid #ddd;
+    background-color: #fff;
+    & > div {
+      padding: 1.5rem;
+    }
+    .scene-metadata-fixed {
+      border-bottom: 1px solid #ddd;
+    }
+    .scene-metadata-scrollable {
+      overflow-y: auto;
+      overflow-x: hidden;
+    }
+  }
+  .scene-preview-container {
+    flex: 1;
+    padding: 0;
+  }
+}


### PR DESCRIPTION
## Overview
This PR adds a scene detail modal to replace our previous scene detail implmentation (side-panel + overlay).

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~

### Demo

<img width="935" alt="screen shot 2017-04-19 at 11 23 47 am" src="https://cloud.githubusercontent.com/assets/2442245/25189925/ae256c96-24f8-11e7-9a70-3abeb115b110.png">

### Notes

The modal width is not ideal.


## Testing Instructions

 * Go to a projects detail page and click on a scene; see that the modal opens
 * Click the download button and check that this works as expected

Closes #1454
