### PR TITLE
Use per-user feature flags on the frontend

### DIFF
--- a/app-frontend/src/app/core/services/featureFlags.provider.js
+++ b/app-frontend/src/app/core/services/featureFlags.provider.js
@@ -1,5 +1,6 @@
 function updateFlagsAndGetAll(newFlags) {
-    Object.values(newFlags).forEach(flag => {
+    let flagsList = angular.isArray(newFlags) ? newFlags : Object.values(newFlags);
+    flagsList.forEach(flag => {
         this.serverFlagCache[flag.key] = flag.active;
         flag.active = this.isOn(flag.key);
     });
@@ -20,6 +21,7 @@ export default app => {
             this.serverFlagCache = {};
             this.flags = [];
             this.initialFlags = initialFlags ? initialFlags : [];
+            this.perUserFlags = {};
             this.featureFlagOverrides = featureFlagOverrides;
             if (this.initialFlags.length) {
                 this.set(initialFlags);
@@ -70,6 +72,18 @@ export default app => {
 
     }
 
+    class PerUserFeatureFlagService {
+        constructor($resource) {
+            'ngInject';
+
+            this.PerUserFeatureFlag = $resource('/feature-flags/');
+        }
+
+        load() {
+            return this.PerUserFeatureFlag.query().$promise;
+        }
+    }
+
     class FeatureFlagsProvider {
         constructor() {
             this.initialFlags = [];
@@ -85,5 +99,6 @@ export default app => {
         }
     }
 
+    app.service('perUserFeatureFlags', PerUserFeatureFlagService);
     app.provider('featureFlags', FeatureFlagsProvider);
 };

--- a/app-frontend/src/app/index.run.js
+++ b/app-frontend/src/app/index.run.js
@@ -1,37 +1,63 @@
 function runBlock(
     $rootScope, jwtHelper, $state, $location, APP_CONFIG,
-    authService, localStorage, rollbarWrapperService, intercomService
+    authService, localStorage, rollbarWrapperService, intercomService,
+    featureFlags, perUserFeatureFlags
 ) {
     'ngInject';
+    let flagsPromise;
+
+    if (authService.verifyAuthCache()) {
+        flagsPromise = perUserFeatureFlags.load();
+        featureFlags.set(flagsPromise);
+    }
 
     $rootScope.$on('$stateChangeStart', function (e, toState) {
-        if (APP_CONFIG.error && toState.name !== 'error') {
-            e.preventDefault();
-            $state.go('error');
-        } else if (toState.name !== 'login' && !authService.verifyAuthCache()) {
-            e.preventDefault();
-            rollbarWrapperService.init();
-            intercomService.shutdown();
-            $state.go('login');
-        } else if (toState.name !== 'login') {
-            rollbarWrapperService.init(authService.profile());
-            intercomService.bootWithUser(authService.profile());
+        function setupState() {
+            if (APP_CONFIG.error && toState.name !== 'error') {
+                e.preventDefault();
+                $state.go('error');
+            } else if (toState.name !== 'login' && !authService.verifyAuthCache()) {
+                e.preventDefault();
+                rollbarWrapperService.init();
+                intercomService.shutdown();
+                $state.go('login');
+            } else if (toState.name !== 'login') {
+                rollbarWrapperService.init(authService.profile());
+                intercomService.bootWithUser(authService.profile());
+            }
+        }
+        // TODO: I'm not sure exactly where this lies on the continuum between awful and the worst
+        // thing ever, but it's pretty bad. We should either refactor our app initialization so this
+        // is easier, or refactor FeatureFlags to deal in promises.
+        // Note that on initial login, the feature flags get populated in the AuthService.
+        if (flagsPromise) {
+            flagsPromise.then(setupState);
+        } else {
+            setupState();
         }
     });
 
     $rootScope.$on('$locationChangeStart', function () {
-        let token = localStorage.get('id_token');
-        if (token) {
-            if (!authService.verifyAuthCache()) {
+        function setupState() {
+            let token = localStorage.get('id_token');
+            if (token) {
+                if (!authService.verifyAuthCache()) {
+                    rollbarWrapperService.init();
+                    authService.login(token);
+                }
+            } else {
+                intercomService.shutdown();
                 rollbarWrapperService.init();
-                authService.login(token);
+                $state.go('login');
             }
+        }
+        if (flagsPromise) {
+            flagsPromise.then(setupState);
         } else {
-            intercomService.shutdown();
-            rollbarWrapperService.init();
-            $state.go('login');
+            setupState();
         }
     });
+
 }
 
 export default runBlock;

--- a/nginx/etc/nginx/conf.d/api.conf
+++ b/nginx/etc/nginx/conf.d/api.conf
@@ -47,6 +47,15 @@ server {
         proxy_pass http://api-server-upstream;
     }
 
+    # Angular per-user feature flags
+    location = /feature-flags {
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Forwarded-For $remote_addr;
+        proxy_redirect off;
+
+        proxy_pass http://api-server-upstream;
+    }
+
     # Static Assets
     location / {
         root /srv/dist;


### PR DESCRIPTION
## Overview

This modifies the front-end to use the new authenticated `/feature-flags` endpoint to allow per-user feature flag determination (though on the backend it is only per-organization at the moment).

### Checklist

- [ ] ~Styleguide updated, if necessary~
- [ ] ~Swagger specification updated, if necessary~
- [ ] ~Symlinks from new migrations present or corrected for any new migrations~

### Notes

This was more complicated than it needed to be due to the way our application is initialized and because the existing feature flags service doesn't return promises. The core issue is that there is no single point after we confirm that the user is authenticated (either via login or page reload) where we can block the rest of the application's initialization while we wait for the per-user feature-flags to be populated. The need for this could be alleviated by making the feature-flags service return promises, but that would have been a much bigger refactor than this card anticipated. I've put in a hack that I think works in most situations although I think it _may_ still introduce a race condition on initial login. However, I don't think it's a workable long-term solution, so this should probably be revisited -- I'm interested in hearing thoughts after people have had a chance to read through the PR, and I'll break out any conclusions into a separate issue before merging this.

## Testing Instructions

 * Rebuild the nginx container with `docker-compose -f docker-compose.yml build nginx`
 * Open up `./scripts/psql` and disable the `tools-ui` flag with: `insert into organization_features (organization, feature_flag, active) values ('dfac6307-b5ef-43f7-beda-b9f208bb7726', 'a75d427f-576d-4850-96c3-895bbf384098', FALSE);`
 * Load the UI and confirm that the Tools UI elements don't appear, both on reload and initial login.
 * Run `delete from organization_features;` and confirm the Tools UI comes back.

Closes #1411 
