### PR TITLE
Initialize `registerClick` flag in browse

### DIFF
--- a/app-frontend/src/app/pages/projects/edit/browse/browse.controller.js
+++ b/app-frontend/src/app/pages/projects/edit/browse/browse.controller.js
@@ -26,6 +26,7 @@ export default class ProjectAddScenesBrowseController {
 
     $onInit() {
         this.allSelected = false;
+        this.registerClick = true;
         this.scenes = {
             count: 0,
             results: []


### PR DESCRIPTION
## Overview

Fixes bug where scene grid is not always interact-able via click.

The `registerClick` variable is used to disable canvas interactions when drag-panning.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~

## Testing Instructions

*Before checking out this branch (bug reproduction):*
- open a project with ingested scenes within the scene browser (where the grid is visible)
- reload the window
- navigate back to the scene list via the '< Scenes' button, then return to the scene add page using the 'Browse Scenes to Add` button
- notice that the grid doesn't respond to click until you trigger a map move event of some sort (pan, zoom)

*Testing this fix:*
- do the same thing as above, except you should now be able to click the grid right away

Closes #1523
