### PR TITLE
Feature/lk/fix map memoryleak

### DIFF
--- a/app-frontend/src/app/core/services/gridLayer.service.js
+++ b/app-frontend/src/app/core/services/gridLayer.service.js
@@ -270,11 +270,21 @@ export default (app) => {
                         stage.add(layer);
                         done(null, tile);
                     });
+                    tile.konvaContexts = [
+                        stage, text, textRect, layer, topLeft, topRight,
+                        bottomLeft, bottomRight
+                    ];
+
                     return tile;
                 }
             });
 
-            return new GridLayer();
+            let gridLayer = new GridLayer();
+            gridLayer.on('tileunload', (event) => {
+                event.tile.konvaContexts.forEach((context) => context.destroy());
+            });
+
+            return gridLayer;
         }
     }
 

--- a/app-frontend/src/app/core/services/imageOverlay.service.js
+++ b/app-frontend/src/app/core/services/imageOverlay.service.js
@@ -56,7 +56,7 @@ export default (app) => {
                     let points = _.flatten(result);
 
 
-                    let stage = new Konva.Stage({
+                    let stage = this.stage = new Konva.Stage({
                         container: tile,
                         width: size.x,
                         height: size.y
@@ -92,6 +92,15 @@ export default (app) => {
                         this.layer.draw();
                     };
                     stage.add(layer);
+                },
+                onRemove: function () {
+                    L.DomUtil.remove(this._image);
+                    if (this.options.interactive) {
+                        this.removeInteractiveTarget(this._image);
+                    }
+                    this.stage.destroy();
+                    this.layer.destroy();
+                    this.lineImage.destroy();
                 }
 
             });


### PR DESCRIPTION
## Overview

Fix memory leaks that resulted from not cleaning up Konva objects when destroying leaflet tiles and layers

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~

### Note

There is still some minor memory growth when panning around the map in the scene browse mode, but it's hard to tell at this point if it's just temporary caching or an actual leak.

## Testing Instructions

 * Using the chrome task manager, verify that mousing over scenes in the browse view no longer causes massive memory growth. Before, after about 30 seconds of mousing over scenes, I could reach > 1.5 gigs of ram usage
* Using the chrome task manager, verify that panning around the browse view results in only minor memory growth and spikes. There may be other memory leaks in this view, but the gridlayer was the primary source.

Closes #1475 
