### PR TITLE
Add batch jar to airflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,3 +119,4 @@ app-tasks/usr/local/airflow/logs/
 /app-tasks/usr/local/airflow/unittests.cfg
 .idea
 .ensime_cache
+/app-tasks/jars/rf-batch.jar

--- a/app-tasks/Dockerfile
+++ b/app-tasks/Dockerfile
@@ -41,3 +41,4 @@ WORKDIR ${AIRFLOW_HOME}
 
 COPY usr/local/airflow/airflow.cfg ${AIRFLOW_HOME}/airflow.cfg
 COPY dags/ /opt/raster-foundry/app-tasks/dags/
+COPY jars/ /opt/raster-foundry/jars/

--- a/docker-compose.airflow.yml
+++ b/docker-compose.airflow.yml
@@ -97,6 +97,7 @@ services:
       - ./app-tasks/dags/:/opt/raster-foundry/app-tasks/dags/
       - ./app-tasks/rf/:/opt/raster-foundry/app-tasks/rf/
       - ./app-tasks/rf/src/rf/:/usr/local/bin/rf/
+      - ./app-backend/batch/target/scala-2.11/rf-batch.jar:/opt/raster-foundry/jars/rf-batch.jar
       - $HOME/.aws:/var/lib/airflow/.aws:ro
     build:
       context: ./app-tasks

--- a/scripts/cibuild
+++ b/scripts/cibuild
@@ -40,6 +40,15 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
             -f "${DIR}/../docker-compose.test.yml" \
             run --rm app-frontend run build
 
+        echo "Building batch JAR"
+        docker-compose \
+            run --rm --no-deps api-server batch/clean
+        docker-compose \
+            run --rm --no-deps api-server batch/assembly
+
+        cp "${DIR}/../app-backend/batch/target/scala-2.11/rf-batch.jar" \
+           "${DIR}/../app-tasks/jars/rf-batch.jar"
+
         echo "Building Airflow container image"
         GIT_COMMIT="${GIT_COMMIT}" docker-compose \
                   -f "${DIR}/../docker-compose.yml" \

--- a/scripts/cipublish
+++ b/scripts/cipublish
@@ -33,21 +33,11 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
                       -f "${DIR}/../docker-compose.test.yml"\
                       build app-migrations
 
-            echo "Building batch JAR"
-            docker-compose \
-                run --rm --no-deps api-server batch/clean
-            docker-compose \
-                run --rm --no-deps api-server batch/assembly
-
             echo "Building application JAR"
-            docker-compose \
-                run --rm --no-deps api-server api/clean
             docker-compose \
                 run --rm --no-deps api-server api/assembly
 
             echo "Building tile server JAR"
-            docker-compose \
-                run --rm --no-deps tile-server tile/clean
             docker-compose \
                 run --rm --no-deps tile-server tile/assembly
 


### PR DESCRIPTION
## Overview

Adding the batch jar to our airflow worker is necessary so that
we can run `java -jar` (non-spark) jobs to do various batch tasks within an
airflow worker

### Checklist

- ~[ ] Styleguide updated, if necessary~
- ~[ ] Swagger specification updated, if necessary~
- ~[ ] Symlinks from new migrations present or corrected for any new migrations~

## Testing Instructions

 * Create an assembly jar of the batch project:
```bash
./scripts/console api-server "./sbt batch/assembly"
```
 * Get a console in an `airflow-worker` and check that the assembly jar is added
```bash
./scripts/console airflow-worker "ls -lah /opt/raster-foundry/jars"
```
 * Build a new airflow docker container and verify that the jar has been added to the built container
```bash
GIT_COMMIT=batch docker-compose -f docker-compose.test.yml build airflow
docker run -it raster-foundry-airflow:batch ls -lah /opt/raster-foundry/jars
```

Closes #1543 
