### PR TITLE
Fix shapeless EMR error

### DIFF
--- a/app-backend/build.sbt
+++ b/app-backend/build.sbt
@@ -175,6 +175,10 @@ lazy val batch = Project("batch", file("batch"))
       Dependencies.scopt
     )
   })
+  .settings(assemblyShadeRules in assembly := Seq(
+      ShadeRule.rename("shapeless.**" -> "com.azavea.shaded.shapeless.@1").inAll
+    )
+  )
 
 import io.gatling.sbt.GatlingPlugin
 lazy val tile = Project("tile", file("tile"))

--- a/app-backend/project/Version.scala
+++ b/app-backend/project/Version.scala
@@ -20,7 +20,7 @@ object Version {
   val akkaHttpCors       = "0.1.11"
   val akkaSlf4j          = "2.4.11"
   val ammoniteOps        = "0.7.0"
-  val spark              = "2.0.0"
+  val spark              = "2.1.0"
   val commonsIO          = "2.5"
   val scopt              = "3.5.0"
   val scaffeine          = "2.0.0"

--- a/app-backend/project/build.properties
+++ b/app-backend/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.13
+sbt.version=0.13.15

--- a/app-backend/project/plugins.sbt
+++ b/app-backend/project/plugins.sbt
@@ -9,7 +9,7 @@ addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0")
 
 addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.1.10")
 
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.3")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.4")
 
 addSbtPlugin("io.spray" % "sbt-revolver" % "0.8.0")
 


### PR DESCRIPTION
## Overview

This PR does two things:
 1. Fixes a problem with using our shapeless dependency which seemed to be overridden in the class path without shading. I'm not sure if there is a definite way to determine that, but [this](http://stackoverflow.com/a/42658876) SO post suggests a similar problem.
 2. Updates our scala dependency to 2.1.0 -- this wasn't included in our assembly jar, but helps ensure we are compiling against the version we are running in.

### Checklist

- ~[ ] Styleguide updated, if necessary~
- ~[ ] Swagger specification updated, if necessary~
- ~[ ] Symlinks from new migrations present or corrected for any new migrations~

### Demo
![completed](https://cloud.githubusercontent.com/assets/898060/25255995/ca55463a-25fb-11e7-9173-f40c57b5ce0a.png)

## Testing Instructions

 * On this branch, run `./scripts/console api-server "./sbt batch/assembly"` to create a new assembly jar
 * Upload assembly to S3 and give it your own unique name in the `s3://rasterfoundry-global-artifacts-us-east-1/batch/` S3 bucket/prefix:
![upload-jar](https://cloud.githubusercontent.com/assets/898060/25256116/6c68e166-25fc-11e7-9bb0-94a0b0651e14.png)

 * Clone the successful job and add your newly uploaded jar in place of `rf-batch-cbrown.jar` and watch for errors

Closes #1566
