### PR TITLE
Project export modal

### DIFF
--- a/app-frontend/src/app/components/exportModal/exportModal.component.js
+++ b/app-frontend/src/app/components/exportModal/exportModal.component.js
@@ -7,7 +7,8 @@ const rfexportModal = {
         dismiss: '&',
         modalInstance: '<',
         resolve: '<'
-    }
+    },
+    controller: 'ExportModalController'
 };
 
 export default rfexportModal;

--- a/app-frontend/src/app/components/exportModal/exportModal.component.js
+++ b/app-frontend/src/app/components/exportModal/exportModal.component.js
@@ -1,0 +1,13 @@
+import exportModalTpl from './exportModal.html';
+
+const rfexportModal = {
+    templateUrl: exportModalTpl,
+    bindings: {
+        close: '&',
+        dismiss: '&',
+        modalInstance: '<',
+        resolve: '<'
+    }
+};
+
+export default rfexportModal;

--- a/app-frontend/src/app/components/exportModal/exportModal.controller.js
+++ b/app-frontend/src/app/components/exportModal/exportModal.controller.js
@@ -1,5 +1,41 @@
 export default class ExportModalController {
-    constructor() {
+    constructor(projectService) {
         'ngInject';
+        this.projectService = projectService;
+    }
+
+    $onInit() {
+        this.minZoom = 1;
+        this.maxZoom = 22;
+        this.projectId = this.resolve.project.id;
+        this.zoom = this.resolve.zoom;
+        this.exportSuccess = false;
+        this.exportFailure = false;
+        this.zoomSlider = {
+            options: {
+                floor: 1,
+                ceil: 22,
+                step: 1,
+                precision: 1
+            }
+        };
+    }
+
+    exportNotStarted() {
+        return !this.exportSuccess && !this.exportFailure;
+    }
+
+    createExport() {
+        this.projectService
+            .export(this.projectId, this.zoom)
+            .then(
+                () => {
+                    // @TODO: should we do something with the export object that we get back here?
+                    this.exportSuccess = true;
+                },
+                () => {
+                    this.exportFailure = true;
+                }
+            );
     }
 }

--- a/app-frontend/src/app/components/exportModal/exportModal.controller.js
+++ b/app-frontend/src/app/components/exportModal/exportModal.controller.js
@@ -1,0 +1,5 @@
+export default class ExportModalController {
+    constructor() {
+        'ngInject';
+    }
+}

--- a/app-frontend/src/app/components/exportModal/exportModal.html
+++ b/app-frontend/src/app/components/exportModal/exportModal.html
@@ -1,0 +1,77 @@
+<div class="modal-header">
+	<button type="button" class="close" aria-label="Close"
+          ng-click="$ctrl.dismiss()">
+    <span aria-hidden="true">&times;</span>
+  </button>
+  <span class="badge"><i class="icon-download"></i></span>
+  <h4 class="modal-title">
+    Download scenes
+  </h4>
+</div>
+<div class="modal-body">
+  <div class="list-group" ng-repeat=" downloadSet in $ctrl.resolve.downloads">
+    <div class="list-group-item">
+      <div class="list-group-overflow">
+        <strong class="color-dark">{{downloadSet.label}}</strong>
+      </div>
+    </div>
+    <div ng-init="show = false">
+      <div class="list-group-item selectable"
+           ng-click="show = !show">
+        <span class="badge color-dark selectable"><i class="icon-plus"></i></span>
+        <strong class="color-dark">Images</strong>
+        <ng-pluralize count="downloadSet.images.length"
+                      when="{'0': 'No images',
+                            'one': 'One image',
+                            'other': '{} images'}">
+        </ng-pluralize>
+        available
+      </div>
+      <div ng-show="show"
+           class="list-group-subitem"
+           ng-repeat-start="image in downloadSet.images"
+           ng-init="showImageDownloads = false">
+        <a class="color-dark" ng-attr-href="{{image.uri}}" download>
+          <span class="badge"><i class="icon-download"></i></span>
+        </a>
+        <div class="list-group-overflow">
+          <a ng-attr-href="{{image.uri}}" download>{{image.filename}}</a>
+        </div>
+      </div>
+      <div ng-repeat-end
+           ng-show="show"
+           class="list-group-subitem download"
+           ng-repeat="file in image.metadata">
+        <a class="color-dark" ng-attr-href="{{file}}" download>
+          <span class="badge"><i class="icon-download"></i></span>
+        </a>
+        <a class="color-dark" ng-attr-href="{{file}}" download>
+          {{file}}
+        </a>
+      </div>
+    </div>
+    <div ng-init="show = false" ng-if="downloadSet.metadata.length">
+      <div class="list-group-item selectable"
+           ng-click="show = !show">
+        <span class="badge color-dark selectable"><i class="icon-plus"></i></span>
+        <strong class="color-dark">Metadata</strong>
+        <ng-pluralize count="downloadSet.metadata.length"
+                      when="{'0': 'No metadata files',
+                            'one': 'One metadata file',
+                            'other': '{} metadata files'}">
+        </ng-pluralize>
+        available
+      </div>
+      <div ng-show="show"
+           class="list-group-subitem"
+           ng-repeat="download in downloadSet.metadata">
+        <a class="color-dark" ng-attr-href="{{download}}" download>
+          <span class="badge"><i class="icon-download"></i></span>
+        </a>
+        <div class="list-group-overflow">
+          <a ng-attr-href="{{download}}" download>{{download}}</a>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app-frontend/src/app/components/exportModal/exportModal.html
+++ b/app-frontend/src/app/components/exportModal/exportModal.html
@@ -1,77 +1,69 @@
-<div class="modal-header">
-	<button type="button" class="close" aria-label="Close"
-          ng-click="$ctrl.dismiss()">
-    <span aria-hidden="true">&times;</span>
-  </button>
-  <span class="badge"><i class="icon-download"></i></span>
-  <h4 class="modal-title">
-    Download scenes
-  </h4>
-</div>
-<div class="modal-body">
-  <div class="list-group" ng-repeat=" downloadSet in $ctrl.resolve.downloads">
-    <div class="list-group-item">
-      <div class="list-group-overflow">
-        <strong class="color-dark">{{downloadSet.label}}</strong>
-      </div>
-    </div>
-    <div ng-init="show = false">
-      <div class="list-group-item selectable"
-           ng-click="show = !show">
-        <span class="badge color-dark selectable"><i class="icon-plus"></i></span>
-        <strong class="color-dark">Images</strong>
-        <ng-pluralize count="downloadSet.images.length"
-                      when="{'0': 'No images',
-                            'one': 'One image',
-                            'other': '{} images'}">
-        </ng-pluralize>
-        available
-      </div>
-      <div ng-show="show"
-           class="list-group-subitem"
-           ng-repeat-start="image in downloadSet.images"
-           ng-init="showImageDownloads = false">
-        <a class="color-dark" ng-attr-href="{{image.uri}}" download>
-          <span class="badge"><i class="icon-download"></i></span>
-        </a>
-        <div class="list-group-overflow">
-          <a ng-attr-href="{{image.uri}}" download>{{image.filename}}</a>
-        </div>
-      </div>
-      <div ng-repeat-end
-           ng-show="show"
-           class="list-group-subitem download"
-           ng-repeat="file in image.metadata">
-        <a class="color-dark" ng-attr-href="{{file}}" download>
-          <span class="badge"><i class="icon-download"></i></span>
-        </a>
-        <a class="color-dark" ng-attr-href="{{file}}" download>
-          {{file}}
-        </a>
-      </div>
-    </div>
-    <div ng-init="show = false" ng-if="downloadSet.metadata.length">
-      <div class="list-group-item selectable"
-           ng-click="show = !show">
-        <span class="badge color-dark selectable"><i class="icon-plus"></i></span>
-        <strong class="color-dark">Metadata</strong>
-        <ng-pluralize count="downloadSet.metadata.length"
-                      when="{'0': 'No metadata files',
-                            'one': 'One metadata file',
-                            'other': '{} metadata files'}">
-        </ng-pluralize>
-        available
-      </div>
-      <div ng-show="show"
-           class="list-group-subitem"
-           ng-repeat="download in downloadSet.metadata">
-        <a class="color-dark" ng-attr-href="{{download}}" download>
-          <span class="badge"><i class="icon-download"></i></span>
-        </a>
-        <div class="list-group-overflow">
-          <a ng-attr-href="{{download}}" download>{{download}}</a>
+<div class="modal-scrollable-body modal-sidebar-header">
+  <div class="modal-header">
+    <button type="button" class="close" aria-label="Close" ng-click="$ctrl.dismiss()">
+      <span aria-hidden="true">&times;</span>
+    </button>
+    <h4 class="modal-title">
+      Export Project
+    </h4>
+    <p>
+      {{$ctrl.resolve.project.name}}
+    </p>
+  </div>
+
+  <!-- Body for export start -->
+  <div class="modal-body" ng-if="$ctrl.exportNotStarted()">
+    <div class="content">
+      <h4 class="modal-content-header">Export zoom level</h4>
+      <div class="form-group">
+        <div>
+          <p>
+            Select the zoom level at which you'd like to generate your project export.
+            Valid zoom levels range from 1 to 22.
+            Higher zoom levels will create larger files and take longer to process.
+          </p>
+          <div class="form-group">
+            <label>Zoom level</label>
+            <label for="zoom-level" class="sr-only">Export zoom level</label>
+            <rzslider id="export-zoom-level"
+                      class="light"
+                      rz-slider-model="$ctrl.zoom"
+                      rz-slider-options="$ctrl.zoomSlider.options">
+            </rzslider>
+          </div>
         </div>
       </div>
     </div>
+  </div>
+
+  <!-- Body for export success -->
+  <div class="modal-body" ng-if="$ctrl.exportSuccess">
+    <div class="content">
+      <h4 class="modal-content-header">Your project export has started</h4>
+      <p>You'll be notified when the export process has completed and your files are ready</p>
+    </div>
+  </div>
+
+  <!-- Body for export failure -->
+  <div class="modal-body" ng-if="$ctrl.exportFailure">
+    <div class="content">
+      <h3>There was a problem starting the export.</h3>
+    </div>
+  </div>
+
+  <div class="modal-footer">
+    <button type="button" class="btn pull-left"
+            ng-click="$ctrl.dismiss()"
+            ng-if="$ctrl.exportNotStarted()">
+      Cancel
+    </button>
+    <button class="btn btn-primary"
+            ng-click="$ctrl.createExport()"
+            ng-if="$ctrl.exportNotStarted()">
+      Start project export
+    </button>
+    <button class="btn btn-primary" ng-click="$ctrl.dismiss()" ng-if="!$ctrl.exportNotStarted()">
+      Done
+    </button>
   </div>
 </div>

--- a/app-frontend/src/app/components/exportModal/exportModal.module.js
+++ b/app-frontend/src/app/components/exportModal/exportModal.module.js
@@ -1,0 +1,15 @@
+import angular from 'angular';
+import ExportModalComponent from './ExportModal.component.js';
+import ExportModalController from './ExportModal.controller.js';
+require('../../../assets/font/fontello/css/fontello.css');
+
+const ExportModalModule = angular.module('components.ExportModal', []);
+
+ExportModalModule.controller(
+    'ExportModalController', ExportModalController
+);
+ExportModalModule.component(
+    'rfExportModal', ExportModalComponent
+);
+
+export default ExportModalModule;

--- a/app-frontend/src/app/components/exportModal/exportModal.module.js
+++ b/app-frontend/src/app/components/exportModal/exportModal.module.js
@@ -1,6 +1,6 @@
 import angular from 'angular';
-import ExportModalComponent from './ExportModal.component.js';
-import ExportModalController from './ExportModal.controller.js';
+import ExportModalComponent from './exportModal.component.js';
+import ExportModalController from './exportModal.controller.js';
 require('../../../assets/font/fontello/css/fontello.css');
 
 const ExportModalModule = angular.module('components.ExportModal', []);

--- a/app-frontend/src/app/components/exportModal/exportModal.module.js
+++ b/app-frontend/src/app/components/exportModal/exportModal.module.js
@@ -3,7 +3,7 @@ import ExportModalComponent from './exportModal.component.js';
 import ExportModalController from './exportModal.controller.js';
 require('../../../assets/font/fontello/css/fontello.css');
 
-const ExportModalModule = angular.module('components.ExportModal', []);
+const ExportModalModule = angular.module('components.exportModal', []);
 
 ExportModalModule.controller(
     'ExportModalController', ExportModalController

--- a/app-frontend/src/app/components/sceneItem/sceneItem.component.js
+++ b/app-frontend/src/app/components/sceneItem/sceneItem.component.js
@@ -8,15 +8,7 @@ const rfSceneItem = {
     bindings: {
         scene: '<',
         selected: '&',
-<<<<<<< HEAD
-<<<<<<< HEAD
         isDisabled: '<',
-=======
-        isInProject: '<',
->>>>>>> Disallow adding scenes already added to project
-=======
-        isDisabled: '<',
->>>>>>> Cleanup
         onSelect: '&',
         onAction: '&',
         onView: '&',

--- a/app-frontend/src/app/components/sceneItem/sceneItem.component.js
+++ b/app-frontend/src/app/components/sceneItem/sceneItem.component.js
@@ -9,10 +9,14 @@ const rfSceneItem = {
         scene: '<',
         selected: '&',
 <<<<<<< HEAD
+<<<<<<< HEAD
         isDisabled: '<',
 =======
         isInProject: '<',
 >>>>>>> Disallow adding scenes already added to project
+=======
+        isDisabled: '<',
+>>>>>>> Cleanup
         onSelect: '&',
         onAction: '&',
         onView: '&',

--- a/app-frontend/src/app/components/sceneItem/sceneItem.component.js
+++ b/app-frontend/src/app/components/sceneItem/sceneItem.component.js
@@ -8,7 +8,11 @@ const rfSceneItem = {
     bindings: {
         scene: '<',
         selected: '&',
+<<<<<<< HEAD
         isDisabled: '<',
+=======
+        isInProject: '<',
+>>>>>>> Disallow adding scenes already added to project
         onSelect: '&',
         onAction: '&',
         onView: '&',

--- a/app-frontend/src/app/core/services/project.service.js
+++ b/app-frontend/src/app/core/services/project.service.js
@@ -62,6 +62,10 @@ export default (app) => {
                         params: {
                             projectId: '@projectId'
                         }
+                    },
+                    export: {
+                        method: 'POST',
+                        url: '/api/exports/'
                     }
                 }
             );
@@ -73,6 +77,26 @@ export default (app) => {
 
         get(id) {
             return this.Project.get({id}).$promise;
+        }
+
+        export(projectId, zoom) {
+            return this.userService.getCurrentUser().then(
+                (user) => {
+                    return this.Project.export({
+                        organizationId: user.organizationId,
+                        projectId: projectId,
+                        exportStatus: 'TOBEEXPORTED',
+                        exportType: 'S3',
+                        visibility: 'PRIVATE',
+                        exportOptions: {
+                            rasterSize: zoom
+                        }
+                    }).$promise;
+                },
+                (error) => {
+                    return error;
+                }
+            );
         }
 
         createProject(name) {

--- a/app-frontend/src/app/core/services/project.service.js
+++ b/app-frontend/src/app/core/services/project.service.js
@@ -89,7 +89,7 @@ export default (app) => {
                         exportType: 'S3',
                         visibility: 'PRIVATE',
                         exportOptions: {
-                            rasterSize: zoom
+                            resolution: zoom
                         }
                     }).$promise;
                 },

--- a/app-frontend/src/app/index.components.js
+++ b/app-frontend/src/app/index.components.js
@@ -30,5 +30,6 @@ export default angular.module('index.components', [
     require('./components/selectProjectModal/selectProjectModal.module.js').name,
     require('./components/importModal/importModal.module.js').name,
     require('./components/staticMap/staticMap.module.js').name,
-    require('./components/sceneDetailModal/sceneDetailModal.module.js').name
+    require('./components/sceneDetailModal/sceneDetailModal.module.js').name,
+    require('./components/exportModal/exportModal.module.js').name
 ]);

--- a/app-frontend/src/app/pages/projects/edit/edit.controller.js
+++ b/app-frontend/src/app/pages/projects/edit/edit.controller.js
@@ -3,7 +3,7 @@ const Map = require('es6-map');
 export default class ProjectsEditController {
     constructor( // eslint-disable-line max-params
         $log, $q, $state, $scope, projectService, mapService, mapUtilsService, layerService,
-        datasourceService
+        datasourceService, $uibModal
     ) {
         'ngInject';
         this.$log = $log;
@@ -14,6 +14,7 @@ export default class ProjectsEditController {
         this.mapUtilsService = mapUtilsService;
         this.layerService = layerService;
         this.datasourceService = datasourceService;
+        this.$uibModal = $uibModal;
 
         this.getMap = () => mapService.getMap('edit');
     }
@@ -144,5 +145,23 @@ export default class ProjectsEditController {
                 return ao;
             }, {});
         }, composites[0]);
+    }
+
+    openExportModal() {
+        if (this.activeModal) {
+            this.activeModal.dismiss();
+        }
+
+        this.getMap().then(m => {
+            return m.map.getZoom();
+        }).then(zoom => {
+            this.activeModal = this.$uibModal.open({
+                component: 'rfExportModal',
+                resolve: {
+                    project: () => this.project,
+                    zoom: () => zoom
+                }
+            });
+        });
     }
 }

--- a/app-frontend/src/app/pages/projects/edit/edit.html
+++ b/app-frontend/src/app/pages/projects/edit/edit.html
@@ -42,7 +42,8 @@
         <li>
           <span class="label">Export</span>
           <button class="btn btn-light fixedwidth"
-                  type="button">
+                  type="button"
+                  ng-click="$ctrl.openExportModal()">
             Export project
           </button>
           <i class="icon-info"></i>

--- a/docs/swagger/spec.yml
+++ b/docs/swagger/spec.yml
@@ -3022,7 +3022,7 @@ definitions:
     properties:
       exportStatus:
         type: string
-        description: Status of upload
+        description: Status of export
         enum:
           - NOTEXPORTED
           - TOBEEXPORTED

--- a/docs/swagger/spec.yml
+++ b/docs/swagger/spec.yml
@@ -3024,14 +3024,11 @@ definitions:
         type: string
         description: Status of upload
         enum:
-          - CREATED
+          - NOTEXPORTED
+          - TOBEEXPORTED
           - EXPORTING
           - EXPORTED
-          - QUEUED
-          - PROCESSING
-          - COMPLETE
           - FAILED
-          - ABORTED
       input:
         $ref: '#/definitions/InputExportDefinition'
       output:


### PR DESCRIPTION
## Overview

This PR adds an export modal that allows the user to select the zoom level at which they would like to export a selected project.

This uses a slider to select the zoom level as it seems like the most clear way to indicate min/max zoom levels and removes the need for more complex validation logic.

### Checklist

~- [ ] Styleguide updated, if necessary~
- [x] Swagger specification updated, if necessary
~- [ ] Symlinks from new migrations present or corrected for any new migrations~

### Demo

<img width="837" alt="screen shot 2017-04-23 at 11 38 24 pm" src="https://cloud.githubusercontent.com/assets/2442245/25340592/3f190de6-28d4-11e7-8779-96c6a5169992.png">
<img width="839" alt="screen shot 2017-04-23 at 11 38 33 pm" src="https://cloud.githubusercontent.com/assets/2442245/25340593/3f1c22ec-28d4-11e7-951a-f82a8be85f1b.png">

### Notes

The swagger spec in regards to the export statuses seemed to not match what the endpoint was actually expecting, so I updated it to match.

We want to specify zoom level, but it's not clear how we expect that to be provided in the request. `rasterSize` seemed like the closest option.

This hardcodes some assumed defaults for now:
 - visibility of `PRIVATE`
- export type of `S3`
- zoom range of 1 - 22

## Testing Instructions

 * Open a project in the editor, and click the 'Export Project' button
 * Make sure the modal opens
 * Check that the default zoom level is the current zoom level of the editor map
 * Create an export or three and make sure that the exports are being posted properly and that you get an export object back -- make sure the zoom level is being updated and posted as expected

Closes #1534
