### PR TITLE
Add Saturation parameter to color correction

### DIFF
--- a/app-backend/api/src/test/scala/datasource/DatasourceSpec.scala
+++ b/app-backend/api/src/test/scala/datasource/DatasourceSpec.scala
@@ -47,6 +47,7 @@ class DatasourceSpec extends WordSpec
     beta = Some(13.0),
     min = Some(0),
     max = Some(20000),
+    saturation = Some(1.0),
     equalize = false
   ).asJson
 

--- a/app-backend/api/src/test/scala/project/ProjectSceneSpec.scala
+++ b/app-backend/api/src/test/scala/project/ProjectSceneSpec.scala
@@ -289,6 +289,7 @@ class ProjectSceneSpec extends WordSpec
         Some(10), Some(20),                // Contrast, Brightness
         None, None,                        // Alpha, Beta
         None, None,                        // Min, Max
+        None,                              // Saturation
         false                              // Equalize?
       )
 

--- a/app-backend/batch/src/test/resources/export/localJob.json
+++ b/app-backend/batch/src/test/resources/export/localJob.json
@@ -20,6 +20,7 @@
                     "blueGamma": 3.0,
                     "brightness": 5,
                     "contrast": 4.0,
+                    "saturation": 1.0,
                     "greenGamma": 2.0
                 }
             }

--- a/app-backend/batch/src/test/scala/com/azavea/rf/batch/export/model/ExportDefinitionSpec.scala
+++ b/app-backend/batch/src/test/scala/com/azavea/rf/batch/export/model/ExportDefinitionSpec.scala
@@ -42,6 +42,7 @@ class ExportDefinitionSpec extends FunSpec with Matchers with BatchSpec {
                 beta = Some(7d),
                 min = Some(8),
                 max = Some(9),
+                saturation = Some(1.0),
                 equalize = true
               )
             )

--- a/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Projects.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Projects.scala
@@ -393,6 +393,7 @@ object Projects extends TableQuery(tag => new Projects(tag)) with LazyLogging {
                       None, None,                   // Contrast, Brightness
                       None, None,                   // Alpha, Beta
                       None, None,                   // Min, Max
+                      None,                         // Saturation
                       false                         // Equalize
                     )
                   )

--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/ColorCorrect.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/ColorCorrect.scala
@@ -4,12 +4,112 @@ import io.circe._
 import io.circe.syntax._
 import io.circe.generic.JsonCodec
 
+import spire.syntax.cfor._
+
 import geotrellis.raster._
 import geotrellis.raster.equalization.HistogramEqualization
 import geotrellis.raster.histogram.Histogram
 import geotrellis.raster.sigmoidal.SigmoidalContrast
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server._
+
+
+object SaturationAdjust {
+  def apply(rgbTile: MultibandTile, chromaFactor: Double): MultibandTile = {
+    scaleTileChroma(rgbTile, chromaFactor)
+  }
+
+  /* Convert RGB to Hue, Chroma, Luma https://en.wikipedia.org/wiki/HSL_and_HSV#Lightness */
+  def scaleTileChroma(rgbTile: MultibandTile, chromaFactor: Double): MultibandTile = {
+    val (red, green, blue) = (rgbTile.band(0), rgbTile.band(1), rgbTile.band(2))
+    val (nred, ngreen, nblue) = (
+      ArrayTile.alloc(rgbTile.cellType, rgbTile.cols, rgbTile.rows),
+      ArrayTile.alloc(rgbTile.cellType, rgbTile.cols, rgbTile.rows),
+      ArrayTile.alloc(rgbTile.cellType, rgbTile.cols, rgbTile.rows)
+    )
+    cfor(0)(_ < rgbTile.cols, _ + 1) { col =>
+      cfor(0)(_ < rgbTile.rows, _ + 1) { row =>
+        val (r, g, b) = (red.get(col, row), green.get(col, row), blue.get(col, row))
+        val (hue, chroma, luma) = RGBToHCLuma(r, g, b)
+        val newChroma = scaleChroma(chroma, chromaFactor)
+        val (nr, ng, nb) = HCLumaToRGB(hue, newChroma, luma)
+        nred.set(col, row, nr)
+        ngreen.set(col, row, ng)
+        nblue.set(col, row, nb)
+      }
+    }
+    MultibandTile(nred, ngreen, nblue)
+  }
+
+  // See link for a detailed explanation of what is happening. Basically we are taking the
+  // RGB cube and tilting it on its side so that the black -> white line runs vertically
+  // up the center of the HCL cylinder, then flattening the cube down into a hexagon and then
+  // pretending that that hexagon is actually a cylinder.
+  // https://en.wikipedia.org/wiki/HSL_and_HSV#Lightness
+  def RGBToHCLuma(rByte: Int, gByte: Int, bByte: Int): (Double, Double, Double) = {
+    // RGB come in as unsigned Bytes, but the transformation requires Doubles [0,1]
+    val (r, g, b) = (rByte / 255.0, gByte / 255.0, bByte / 255.0)
+    val colors = List(r, g, b)
+    val max = colors.max
+    val min = colors.min
+    val chroma = max - min
+    val hueSextant = ((chroma, max) match {
+      case (0, _) => 0 // Technically, undefined, but we'll ignore this value in this case.
+      case (_, x) if x == r => ((g - b) / chroma.toDouble) % 6
+      case (_, x) if x == g => ((b - r) / chroma.toDouble) + 2
+      case (_, x) if x == b => ((r - g) / chroma.toDouble) + 4
+    })
+    // Wrap degrees
+    val hue = ((hueSextant * 60.0) % 360) match {
+      case h if h < 0 => h + 360
+      case h if h >= 0 => h
+    }
+    // Perceptually weighted average of "lightness" contribution of sRGB primaries (it's
+    // not clear that we're in sRGB here, but that's the default for most images intended for
+    // display so it's a good guess in the absence of explicit information).
+    val luma = 0.21*r + 0.72*g + 0.07*b
+    (hue, chroma, luma)
+  }
+
+  // Reverse the process above
+  def HCLumaToRGB(hue: Double, chroma: Double, luma: Double): (Int, Int, Int) = {
+    val sextant = hue / 60.0
+    val X = chroma * (1 - Math.abs((sextant % 2) - 1))
+    // Projected color values, i.e., on the flat projection of the RGB cube
+    val (rFlat:Double, gFlat:Double, bFlat:Double) = ((chroma, sextant) match {
+      case (0.0, _) => (0.0, 0.0, 0.0) // Gray (or black / white)
+      case (_, s) if 0 <= s && s < 1 => (chroma, X, 0.0)
+      case (_, s) if 1 <= s && s < 2 => (X, chroma, 0.0)
+      case (_, s) if 2 <= s && s < 3 => (0.0, chroma, X)
+      case (_, s) if 3 <= s && s < 4 => (0.0, X, chroma)
+      case (_, s) if 4 <= s && s < 5 => (X, 0.0, chroma)
+      case (_, s) if 5 <= s && s < 6 => (chroma, 0.0, X)
+    })
+
+    // We can add the same value to each component to move straight up the cylinder from the projected
+    // plane, back to the correct lightness value.
+    val lumaCorrection = luma - (0.21*rFlat + 0.72*gFlat + 0.07*bFlat)
+    val r = clamp8Bit((255 * (rFlat + lumaCorrection)).toInt)
+    val g = clamp8Bit((255 * (gFlat + lumaCorrection)).toInt)
+    val b = clamp8Bit((255 * (bFlat + lumaCorrection)).toInt)
+    (r, g, b)
+  }
+
+  def scaleChroma(chroma: Double, scaleFactor: Double): Double = {
+    // Chroma is a Double in the range [0.0, 1.0]. Scale factor is the same as our other gamma corrections:
+    // a Double in the range [0.0, 2.0].
+    val scaled = math.pow(chroma, 1.0 / scaleFactor)
+    if (scaled < 0.0) 0.0
+    else if (scaled > 1.0) 1.0
+    else scaled
+  }
+
+  @inline def clamp8Bit(z: Int): Int = {
+    if (z < 0) 0
+    else if (z > 255) 255
+    else z
+  }
+}
 
 object ColorCorrect {
 
@@ -20,6 +120,7 @@ object ColorCorrect {
     contrast: Option[Double], brightness: Option[Int],
     alpha: Option[Double], beta: Option[Double],
     min: Option[Int], max: Option[Int],
+    saturation: Option[Double],
     equalize: Boolean
   ) {
     def reorderBands(tile: MultibandTile, hist: Seq[Histogram[Double]]): (MultibandTile, Array[Histogram[Double]]) =
@@ -39,6 +140,7 @@ object ColorCorrect {
         "contrast".as[Double].?, "brightness".as[Int].?,
         'alpha.as[Double].?, 'beta.as[Double].?,
         "min".as[Int].?, "max".as[Int].?,
+        "saturation".as[Double].?,
         'equalize.as[Boolean].?(false)
       ).as(ColorCorrect.Params.apply _)
   }
@@ -84,6 +186,10 @@ object ColorCorrect {
       for (alpha <- params.alpha; beta <- params.beta)
         yield SigmoidalContrast(_: MultibandTile, alpha, beta)
 
+    val maybeAdjustSaturation =
+      for (saturationFactor <- params.saturation)
+        yield SaturationAdjust(_: MultibandTile, saturationFactor)
+
 
     // Sequence of transformations to tile, flatten removes None from the list
     val transformations: List[MultibandTile => MultibandTile] = List(
@@ -92,6 +198,7 @@ object ColorCorrect {
       maybeAdjustBrightness,
       maybeAdjustGamma,
       maybeAdjustContrast,
+      maybeAdjustSaturation,
       maybeSigmoidal
     ).flatten
 

--- a/app-backend/tile/src/main/scala/package.scala
+++ b/app-backend/tile/src/main/scala/package.scala
@@ -16,6 +16,6 @@ package object tile {
         deserializationError("Failed to parse UUID string ${js} to java UUID")
     }
   }
-  implicit val defaultColorCorrectParamsFormat = jsonFormat13(ColorCorrect.Params.apply)
+  implicit val defaultColorCorrectParamsFormat = jsonFormat14(ColorCorrect.Params.apply)
   implicit val defaultMosaicDefinitionFormat = jsonFormat2(MosaicDefinition.apply)
 }

--- a/docs/swagger/spec.yml
+++ b/docs/swagger/spec.yml
@@ -2071,6 +2071,9 @@ definitions:
       max:
         type: number
         format: float
+      saturation:
+        type: number
+        format: float
       equalize:
         type: boolean
       contrast:


### PR DESCRIPTION
## Overview

This adds Saturation correction to the color correct endpoint. The HSV / HSL Wikipedia page has a lot of useful info explaining what's going on: https://en.wikipedia.org/wiki/HSL_and_HSV

### Checklist

- [ ] ~Styleguide updated, if necessary~
- [x] Swagger specification updated, if necessary
- [ ] ~Symlinks from new migrations present or corrected for any new migrations~

### Demo

![saturation](https://cloud.githubusercontent.com/assets/447977/25407808/cf459b90-29d9-11e7-958a-eaf154c7f287.png)

### Notes

- ~This is not ready to merge -- it currently causes rampant out-of-memory errors from `memcached` on my VM when saturation correction is enabled.~
- ~This also seems to exacerbate or separately suffer from a strange and difficult-to-reproduce bug I've encountered previously where the tile server would start returning patches of NoData in certain areas (you can see that in the white patches in the screenshot above). It now happens all the time, which is also a blocker for merging this. Because I've seen the behavior before I suspect that it may be an interaction with some other part of the code that is now occurring more consistently for some reason, but it's also possible that I've independently re-created the same bug.~
- ~Verifying that this behaves correctly is tough without an interface because the debug cycle is really slow; I think it's mostly correct based on inspecting some manually-chosen values, but it would be helpful to have a saturation slider in place when trying to debug the above two issues.~
- This requires a transformation into cylindrical hue-saturation-value space, for which there are numerous different approaches, all of which cause some type of color distortion. I've decided to use a perception-based "luma" approach which attempts to minimize this distortion without adding a ton of computational complexity. However, because this is a perceptual approach, it won't be appropriate for applications that rely on numerical analysis. Because of this, as we move forward, we will likely want to provide users with multiple different transformation methods; pan-sharpening, for example, also relies heavily on HSV transformation, and can use one of several methods: http://www.asprs.org/a/publications/proceedings/sandiego2010/sandiego10/Padwick.pdf . The solution here is probably to rely on the AST for conducting color space transformations.

## Testing Instructions

 * Load up a project with an ingested scene and go into the color correction UI.
 * ~Intercept a POST to `/bulk-update-color-corrections/` and re-send it with a REST client, updating the `saturation` parameter to be between 0 and 2.0.~
 * ~Intercept a tile request and load it in a separate tab in your browser. Set the `tag` query parameter to a value that you haven't used before (starting at `1` and counting up is a good strategy). You should see the saturation of the image increased or decreased depending on whether you passed saturation above or below 1.~
 * Mess with the saturation slider. Confirm that `0.0` results in a grayscale image, `1.0` results in the original image, and `2.0` results in a very saturated image. ~Note that you will need to increment the `tag` parameter each time you POST in order to see any changes.~

Connects #1526 
