### PR TITLE
Saturation slider

### DIFF
--- a/app-frontend/src/app/pages/projects/edit/advancedcolor/adjust/adjust.controller.js
+++ b/app-frontend/src/app/pages/projects/edit/advancedcolor/adjust/adjust.controller.js
@@ -17,6 +17,14 @@ export default class ProjectsColorAdjustController {
             precision: 2
         };
 
+        let baseSaturationOptions = {
+            floor: 0,
+            ceil: 2,
+            step: 0.01,
+            showTicks: 0.25,
+            precision: 2
+        };
+
         let baseFilterOptions = {
             floor: -60,
             ceil: 60,
@@ -74,6 +82,13 @@ export default class ProjectsColorAdjustController {
             }
         }, baseGammaOptions);
 
+        this.saturationOptions = Object.assign({
+            id: 'saturation',
+            onEnd: (id, val) => {
+                this.onFilterChange(id, val, baseSaturationOptions);
+            }
+        }, baseSaturationOptions);
+
         this.alphaOptions = Object.assign({
             id: 'alpha',
             onEnd: (id, val) => this.onFilterChange(id, val, this.alphaOptions)
@@ -102,10 +117,11 @@ export default class ProjectsColorAdjustController {
 
         this.gammaLinkToggle = true;
 
-        this.gammaToggle = {value: true};
-        this.sigToggle = {value: true};
-        this.bcToggle = {value: true};
-        this.minMaxToggle = {value: true};
+        this.gammaToggle = { value: true };
+        this.sigToggle = { value: true };
+        this.bcToggle = { value: true };
+        this.minMaxToggle = { value: true };
+        this.saturationToggle = { value: true };
 
         this.sliderCorrection = {min: minMaxOptions.floor, max: minMaxOptions.ceil};
     }
@@ -142,6 +158,10 @@ export default class ProjectsColorAdjustController {
                 this.greenGammaOptions.disabled = false;
                 this.blueGammaOptions.disabled = false;
                 this.gammaToggle.value = true;
+            }
+
+            if (this.correction.saturation === null) {
+                this.saturationToggle.value = false;
             }
 
             if (this.correction.alpha === null &&
@@ -204,6 +224,7 @@ export default class ProjectsColorAdjustController {
             redGamma: 0.5,
             greenGamma: 0.5,
             blueGamma: 0.5,
+            saturation: 0.5,
             brightness: -6,
             contrast: 0,
             alpha: 0.2,
@@ -221,6 +242,12 @@ export default class ProjectsColorAdjustController {
             }
             if (correction.blueGamma === null) {
                 correction.blueGamma = defaults.blueGamma;
+            }
+        }
+
+        if (this.saturationToggle.value) {
+            if (correction.saturation === null) {
+                correction.saturation = defaults.saturation;
             }
         }
 
@@ -307,6 +334,15 @@ export default class ProjectsColorAdjustController {
             this.correction.redGamma = null;
             this.correction.greenGamma = null;
             this.correction.blueGamma = null;
+        }
+        this.setDefaultsForEnabled();
+        this.onFilterChange();
+    }
+
+    saturationToggled(value) {
+        this.saturationOptions.disabled = !value;
+        if (!value) {
+            this.correction.saturation = null;
         }
         this.setDefaultsForEnabled();
         this.onFilterChange();

--- a/app-frontend/src/app/pages/projects/edit/advancedcolor/adjust/adjust.html
+++ b/app-frontend/src/app/pages/projects/edit/advancedcolor/adjust/adjust.html
@@ -141,6 +141,29 @@
           </div>
         </div>
 
+        <!-- Saturation correction -->
+        <div class="filter-group">
+          <div class="filter-group-header">
+            <rf-toggle data-model="$ctrl.saturationToggle.value"
+                       on-change="$ctrl.saturationToggled(value)"></rf-toggle>
+            <h5 class="h5">Saturation</h5>
+          </div>
+          <div class="filter-group-body" ng-show="$ctrl.saturationToggle.value">
+            <div class="filter">
+              <label>Saturation</label>
+              <rzslider class="dark"
+                        rz-slider-model="$ctrl.sliderCorrection.saturation"
+                        rz-slider-options="$ctrl.saturationOptions"></rzslider>
+              <input class="filter-adjust-input"
+                     type="number"
+                     step="1"
+                     ng-model="$ctrl.sliderCorrection.saturation"
+                     ng-model-options="{ debounce: 250 }"
+                     ng-change="$ctrl.onFilterChange('saturation', $ctrl.sliderCorrection.saturation)">
+            </div>
+          </div>
+        </div>
+
         <div class="filter-group">
           <div class="filter-group-header">
             <rf-toggle data-model="$ctrl.minMaxToggle.value"


### PR DESCRIPTION
## Overview

This PR adds a saturation slider to the advanced color correct panel.

Intended to ease the debugging of backend saturation filter development.

This PR is based on a non-merged PR (#1578) so it should not be merged before that one.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~

### Demo

(The values here were from different adjustments, they do match in actual usage)

<img width="363" alt="screen shot 2017-04-26 at 8 26 55 am" src="https://cloud.githubusercontent.com/assets/2442245/25434404/31e70358-2a5a-11e7-9341-58f266af8098.png">
<img width="452" alt="screen shot 2017-04-26 at 8 27 05 am" src="https://cloud.githubusercontent.com/assets/2442245/25434403/31e6d1b2-2a5a-11e7-9aa4-0206afe6b8f6.png">

### Notes

We'll need to decide on a default value.


## Testing Instructions

 WIP

Closes #1527
