### PR TITLE
Implement export workflow

### DIFF
--- a/app-backend/batch/src/main/resources/application.conf
+++ b/app-backend/batch/src/main/resources/application.conf
@@ -43,3 +43,13 @@ landsat8 {
   awsLandsatBase = "http://landsat-pds.s3.amazonaws.com/"
   bucketName     = "landsat-pds"
 }
+
+export-def {
+  awsRegion      = "us-east-1"
+  bucketName     = "export-definitions"
+  awsDataproc    = "dataproc.rasterfoundry.com."
+  sparkJarS3     = "s3://rasterfoundry-global-artifacts-us-east-1/batch"
+  sparkJar       = "rf-batch-b933688.jar"
+  sparkClass     = "com.azavea.rf.batch.export.Export"
+  sparkMemory    = "2G"
+}

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/Main.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/Main.scala
@@ -3,12 +3,16 @@ package com.azavea.rf.batch
 import com.azavea.rf.batch.export.Export
 import com.azavea.rf.batch.ingest.Ingest
 import com.azavea.rf.batch.landsat8.ImportLandsat8
+import com.azavea.rf.batch.airflow.export.CreateExportDef
+
+import cats.implicits._
 
 object Main {
   val modules = Map[String, Array[String] => Unit](
     Export.name         -> (Export.main(_)),
     Ingest.name         -> (Ingest.main(_)),
-    ImportLandsat8.name -> (ImportLandsat8.main(_))
+    ImportLandsat8.name -> (ImportLandsat8.main(_)),
+    CreateExportDef.name -> (CreateExportDef.main(_))
   )
 
   def main(args: Array[String]): Unit = {

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/SparkJob.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/SparkJob.scala
@@ -1,7 +1,6 @@
 package com.azavea.rf.batch
 
 import org.apache.spark._
-
 trait SparkJob {
   // Functions for combine step
   def createTiles[V](value: V): Seq[V]                         = Seq(value)

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/airflow/export/CreateExportDef.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/airflow/export/CreateExportDef.scala
@@ -1,0 +1,146 @@
+package com.azavea.rf.batch.airflow.export
+
+import java.util.UUID
+
+import org.xbill.DNS._
+
+import scala.collection.JavaConverters._
+import scala.concurrent.{Await, Future}
+import scala.concurrent.duration._
+import scala.util._
+
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
+import cats.data._
+import cats.implicits._
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain
+import com.amazonaws.services.elasticmapreduce.{AmazonElasticMapReduceClient, AmazonElasticMapReduceClientBuilder}
+import com.amazonaws.services.elasticmapreduce.model.{AddJobFlowStepsRequest, StepConfig, HadoopJarStepConfig}
+import io.circe.generic.JsonCodec
+import io.circe.syntax._
+
+import com.azavea.rf.batch.Job
+import com.azavea.rf.batch.util._
+import com.azavea.rf.database.{Database => DB}
+import com.azavea.rf.database.tables._
+import com.azavea.rf.datamodel._
+
+case class CreateExportDef(exportId: UUID)(implicit val database: DB) extends Job {
+  val name = "create_export_def"
+    
+  protected def writeExportDefToS3(exportDef: ExportDefinition) = {
+    logger.info(s"Uploading export definition ${exportDef.id.toString} to S3 at ${exportDefConfig.bucketName}")
+    val uri = s"rasterfoundry-development-data-us-east-1/${exportDefConfig.bucketName}"
+    val future = Future[Option[String]] {
+      S3.putObject(uri, s"${exportDef.id.toString}.json", None, exportDef.asJson.toString)
+      Some(uri)
+    }
+
+    future onComplete {
+      case Success(_) => {
+        logger.info(s"Export definition uploaded to S3 at ${uri}")
+      }
+      case Failure(ex) => {
+        logger.error(s"An error occurred uploading export defintion to S3 for ${exportDef.id}")
+        logger.error(ex.stackTraceString)
+      }
+    }
+
+    future
+  }
+
+  protected def getClusterId() = {
+    val dnsLookup = new Lookup(exportDefConfig.awsDataproc, Type.TXT, DClass.IN)
+    dnsLookup.run()
+    val clusterId = dnsLookup.getAnswers().map(_.rdataToString).head.replace("\"", "")
+    clusterId
+  }
+
+  protected def startExportEmrJob(exportDef: ExportDefinition, exportDefUri: String): Unit = {
+    val jarStep = new HadoopJarStepConfig()
+    jarStep.setJar(jarPath)
+    jarStep.setArgs(List("/usr/bin/spark-submit", "--master", "yarn", "--deploy-mode",
+          "cluster", "--class", exportDefConfig.sparkClass, "--driver-memory", exportDefConfig.sparkMemory,
+          s"${exportDefConfig.sparkJarS3}/${exportDefConfig.sparkJar}",
+          "-j", s"s3://${exportDefUri}/${exportDef.id}.json").asJava)
+
+    val steps = new StepConfig()
+    steps.setName(s"export-${exportDef.id}")
+    steps.setActionOnFailure("CONTINUE")
+    steps.setHadoopJarStep(jarStep)
+
+    val jobSteps = new AddJobFlowStepsRequest()
+    jobSteps.setJobFlowId(getClusterId())
+    jobSteps.setSteps(List(steps).asJava)
+
+    val emrClient = AmazonElasticMapReduceClientBuilder.standard().withCredentials(new DefaultAWSCredentialsProviderChain()).build()
+    emrClient.addJobFlowSteps(jobSteps)
+    ()
+  }
+
+  def updateExportStatus(export:Export, status: ExportStatus) = {
+    export.copy(exportStatus=status)
+  }
+
+  def run: Unit = {
+    logger.info("Starting export process...")
+
+    val startEmr = (ed:ExportDefinition, edu:String) => Future { startExportEmrJob(ed, edu) }
+
+    val createExportDef = for {
+      user: User <- OptionT(Users.getUserById(airflowUser))
+      export: Export <- OptionT(database.db.run(Exports.getExport(exportId, user)))
+      exportDef: ExportDefinition <- OptionT(Exports.getExportDefinition(export, user))
+      exportDefUri: String <- OptionT(writeExportDefToS3(exportDef))
+      exportStatus: Int <- OptionT.liftF(
+        database.db.run(
+          Exports.updateExport(
+            updateExportStatus(export, ExportStatus.Exporting),
+            exportId,
+            user)))
+      emrJobStatus <- OptionT.liftF(
+        startEmr(exportDef, exportDefUri)
+          .map(result => {
+            updateExportStatus(export, ExportStatus.Exported)
+          })
+          .recover {
+            case _ => {
+              updateExportStatus(export, ExportStatus.Failed)
+            }
+          }
+          .flatMap(result => {
+            database.db.run(Exports.updateExport(result, exportId, user))
+          }))
+    } yield {
+      emrJobStatus
+    }
+
+    createExportDef.value.onComplete {
+      case Success(s) => {
+        logger.info("Export job sent to cluster and status updated")
+        stop
+      }
+      case Failure(e) => {
+        stop
+        throw e
+      }
+    }
+  }
+}
+
+object CreateExportDef {
+  val name = "create_export_def"
+
+  def main(args: Array[String]): Unit = {
+    implicit val db = DB.DEFAULT
+
+    val job = args.toList match {
+      case List(exportId) => CreateExportDef(UUID.fromString(exportId))
+      case _ => {
+        throw new IllegalArgumentException("Argument could not be parsed to UUID")
+      }
+    }
+  
+    job.run
+  }
+}

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/util/S3.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/util/S3.scala
@@ -17,6 +17,7 @@ object S3 {
     val builder = AmazonS3ClientBuilder.standard()
       .withCredentials(new DefaultAWSCredentialsProviderChain())
 
+
     region.fold(builder)(builder.withRegion).build()
   }
 
@@ -25,6 +26,10 @@ object S3 {
   /** Get S3Object */
   def getObject(s3bucket: String, s3prefix: String, region: Option[String] = None): S3Object =
     getClient(region).getObject(s3bucket, s3prefix)
+
+  def putObject(s3bucket: String, s3Key:String, region: Option[String] = None, content:String) = {
+    getClient(region).putObject(s3bucket, s3Key, content)
+  }
 
   /** List the keys to files found within a given bucket */
   def listKeys(url: String, ext: String, recursive: Boolean): Array[URI] = {

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/util/conf/Config.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/util/conf/Config.scala
@@ -32,8 +32,13 @@ trait Config {
 
   protected case class ExportDef(
     awsRegion: Option[String],
-    bucketName: String
-  ) { }
+    bucketName: String,
+    awsDataproc: String,
+    sparkJarS3: String,
+    sparkJar: String,
+    sparkClass: String,
+    sparkMemory: String
+  )
 
   private lazy val config = ConfigFactory.load()
   protected lazy val landsat8Config = config.as[Landsat8]("landsat8")

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/util/conf/Config.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/util/conf/Config.scala
@@ -30,7 +30,14 @@ trait Config {
     def datasourceUUID = UUID.fromString(datasourceId)
   }
 
+  protected case class ExportDef(
+    awsRegion: Option[String],
+    bucketName: String
+  ) { }
+
   private lazy val config = ConfigFactory.load()
   protected lazy val landsat8Config = config.as[Landsat8]("landsat8")
   protected lazy val airflowUser = config.as[String]("airflow.user")
+  protected lazy val exportDefConfig = config.as[ExportDef]("export-def")
+  val jarPath = "s3://us-east-1.elasticmapreduce/libs/script-runner/script-runner.jar"
 }

--- a/app-backend/build.sbt
+++ b/app-backend/build.sbt
@@ -186,7 +186,8 @@ lazy val batch = Project("batch", file("batch"))
       Dependencies.hadoopAws,
       Dependencies.awsSdk,
       Dependencies.scopt,
-      Dependencies.ficus
+      Dependencies.ficus,
+      Dependencies.dnsJava
     )
   })
   .settings(assemblyShadeRules in assembly := Seq(

--- a/app-backend/project/Dependencies.scala
+++ b/app-backend/project/Dependencies.scala
@@ -56,4 +56,5 @@ object Dependencies {
   val gatlingApp              = "io.gatling"                   % "gatling-app"                       % Version.gatling % "test,it"
   val scalajHttp              = "org.scalaj"                  %% "scalaj-http"                       % Version.scalajHttp
   val ficus                   ="com.iheart"                   %% "ficus"                             % Version.ficus
+  val dnsJava                 = "dnsjava"                      % "dnsjava"                           % Version.dnsJava
 }

--- a/app-backend/project/Version.scala
+++ b/app-backend/project/Version.scala
@@ -36,5 +36,5 @@ object Version {
   val gatling            = "2.2.4"
   val scalajHttp         = "2.3.0"
   val ficus              = "1.4.0"
-  val awsSdk             = "1.7.4"
+  val awsSdk             = "1.11.92"
 }

--- a/app-backend/project/Version.scala
+++ b/app-backend/project/Version.scala
@@ -37,4 +37,5 @@ object Version {
   val scalajHttp         = "2.3.0"
   val ficus              = "1.4.0"
   val awsSdk             = "1.11.92"
+  val dnsJava            = "2.1.8"
 }

--- a/app-tasks/dags/export/do_export.py
+++ b/app-tasks/dags/export/do_export.py
@@ -1,0 +1,80 @@
+from __future__ import print_function
+import datetime
+import logging
+import os
+import time
+import json
+
+import subprocess
+
+from airflow.models import DAG
+from airflow.operators import BashOperator, PythonOperator
+from airflow.exceptions import AirflowException
+
+from rf.utils.io import get_session
+from rf.utils.exception_reporting import wrap_rollbar
+
+
+rf_logger = logging.getLogger('rf')
+ch = logging.StreamHandler()
+ch.setLevel(logging.INFO)
+formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+ch.setFormatter(formatter)
+rf_logger.addHandler(ch)
+
+HOST = os.getenv('RF_HOST')
+API_PATH = '/api/exports/'
+
+logger = logging.getLogger(__name__)
+
+default_args = {
+    'owner': 'raster-foundry',
+    'start_date': datetime.datetime(2017, 1, 1)
+}
+
+dag = DAG(
+    dag_id='do_export',
+    default_args=default_args,
+    schedule_interval=None,
+    concurrency=os.getenv('AIRFLOW_DAG_CONCURRENCY', 4)
+)
+
+# UTILS
+def start_export(export_id):
+    bash_cmd = 'java -cp /opt/raster-foundry/jars/rf-batch.jar com.azavea.rf.batch.Main create_export_def {0}'.format(export_id)
+
+    subprocess.call([bash_cmd], shell=True)
+    logger.info('Launched export creation process, watching for updates...')
+    is_success = wait_for_success()
+    
+    return is_success
+
+def wait_for_success(response=None):
+    # TODO: this is spurious until a means of determining success or failure is used
+    successful = True
+    if successful:
+        logger.info('Successfully completed export')
+        return True
+    else:
+        raise AirflowException('Export failed')
+
+# PythonOperators
+
+@wrap_rollbar
+def create_export_definition_op(*args, **kwargs):
+    logger.info('Beginning to create export definition')
+    xcom_client = kwargs['task_instance']
+    conf = kwargs['dag_run'].conf
+    export_id = conf['exportId']
+
+    
+    xcom_client.xcom_push(key='export_def_id',value=export_id)
+    start_export(export_id)
+
+# TASKS
+create_export_definition_task = PythonOperator(
+    task_id='create_export_definition',
+    provide_context=True,
+    python_callable=create_export_definition_op,
+    dag=dag
+)

--- a/app-tasks/dags/export/find_exports.py
+++ b/app-tasks/dags/export/find_exports.py
@@ -1,0 +1,117 @@
+import os
+from collections import namedtuple
+import datetime
+import logging
+import json
+import boto3
+from time import time
+
+from airflow.bin.cli import trigger_dag
+from airflow.models import DAG
+from airflow.operators.python_operator import PythonOperator
+
+from rf.utils.io import get_session
+from rf.utils.exception_reporting import wrap_rollbar
+
+rf_logger = logging.getLogger('rf')
+ch = logging.StreamHandler()
+ch.setLevel(logging.INFO)
+formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+ch.setFormatter(formatter)
+rf_logger.addHandler(ch)
+
+logger = logging.getLogger(__name__)
+
+default_args = {
+    'owner': 'raster-foundry',
+    'start_date': datetime.datetime(2017, 1, 1)
+}
+
+base_params = {'exportStatus': 'NOTEXPORTED'}
+
+DagArgs = namedtuple('DagArgs', 'dag_id, conf, run_id')
+
+
+HOST = os.getenv('RF_HOST')
+API_PATH = '/api/exports/'
+#############
+# Constants #
+#############
+
+FIND_TASK_ID = 'find_exports'
+#KICKOFF_TASK_ID = 'kickoff_export_checks'
+UPDATE_DAG_ID = 'do_export'
+
+# UTILS
+def update_status(export, status):
+    url = '{HOST}{API_PATH}{id}/'.format(HOST=HOST, API_PATH=API_PATH, id=export['id'])
+    session = get_session()
+    response = session.get(url)
+    obj = response.json()
+    obj['exportStatus'] = status
+    json_d = json.dumps(obj)
+    update_response = session.put(url, headers={'Content-Type':'application/json'}, data=json_d)
+    try:
+        update_response.raise_for_status()
+    except:
+        logger.exception('Unable to update: %s', update_response.text)
+        raise
+    return update_response
+
+#################################
+# Callables for PythonOperators #
+#################################
+@wrap_rollbar
+def get_exports():
+    session = get_session()
+    host = HOST
+    params = base_params.copy()
+    params['page'] = 0 
+    exports_url = '{host}{api}'.format(host=host, api=API_PATH)
+    response = session.get(exports_url, params=params).json()
+    queued_exports = response['results']
+    remaining_exports = response['hasNext']
+
+    while remaining_exports:
+        params['page'] += 1
+        logger.debug('Requesting page %s of queued exports', params['page'])
+        resp = session.get(exports_url, params=params).json()
+        queued_exports = resp['results']
+        remaining_exports = resp['hasNext']
+    return queued_exports
+
+@wrap_rollbar
+def find_exports():
+    """Find exports to check for updates and push their IDs to xcoms"""
+    logger.info('Finding queued exports')
+    exports = get_exports()
+    dag_id = 'do_export'
+
+    if len(exports) == 0:
+        return 'No queued exports'
+
+    logger.info('Initiating export processes for %s exports', len(exports))
+    for export in exports:
+        # update export status so it isn't picked up again
+        update_status(export, 'TOBEEXPORTED')
+
+
+        run_id = 'export_{}_{}'.format(export['id'], time())
+        logger.info('Starting export: %s', run_id)
+        conf = json.dumps({'exportId': export['id']})
+        dag_args = DagArgs(dag_id=dag_id, conf=conf, run_id=run_id)
+        trigger_dag(dag_args)
+    return 'Finished kicking off exports'
+
+dag = DAG(
+    dag_id='find_exports',
+    default_args=default_args,
+    schedule_interval=datetime.timedelta(seconds=10),
+    concurrency=os.getenv('AIRFLOW_DAG_CONCURRENCY', 24)
+)
+
+PythonOperator(
+    task_id=FIND_TASK_ID,
+    python_callable=find_exports,
+    dag=dag
+)


### PR DESCRIPTION
## Overview

This PR adds to the `app-backend/batch` project so that export jobs may be kicked off. It also adds Airflow DAGs to the same effect.

### Checklist

~~- [ ] Styleguide updated, if necessary~~
~~- [ ] Swagger specification updated, if necessary~~
~~- [ ] Symlinks from new migrations present or corrected for any new migrations~~

### Notes

There are a couple remaining points that should be eventually clarified about a couple implementation details; whether actually *addressing* them takes place as part of this PR or deferred in favor of a future one should probably depend on the difficulty.

Specifically:
* The Route 53 ID is provided literally in `CreateExportDef`; this should be config-derived but the manner of doing so wasn't immediately obvious.
* The airflow DAG doesn't really check the status of the job, and instead deems anything successful so long as the airflow task itself doesn't encounter any errors; the issue is that I think the only output available to it is shell output, and parsing that seems unnecessary and/or tedious. I don't see any reason that the DB couldn't just be updated within the `rf-batch` process.
* The airflow `do_exports` task makes use of `subprocess.call` which, in general, poses some security issues. I don't know how serious the issues could be in this specific context, but it's notable that the only outside data making it to the shell is appended to a fairly long java invocation. Airflow's `BashOperator` was problematic because it wasn't immediately obvious how to get data tagged onto the task (the export ID) appended to the bash command.


## Testing Instructions

* `sbt` `compile` & `assembly` the batch project, then bring up a server
* `docker-compose -f docker-compose.airflow.yml up | grep airflow-worker` to spin up airflow
* open the airflow UI at `localhost:8080`
* using PostMan or similar, mock an export `POST` (i.e. "create export") request using a valid export definition, e.g.
```
{
  "organizationId": "dfac6307-b5ef-43f7-beda-b9f208bb7726",
  "projectId": "[SOME PROJECT ID]",
  "sceneIds": [
    "63b15316-2b28-4280-8eb5-c98de4adffab"
  ],
  "exportStatus": "NOTEXPORTED",
  "exportType": "LOCAL",
  "visibility": "PRIVATE",
  "exportOptions": {
    "bands": null,
    "rasterSize": 1024,
    "stitch": false,
    "crop": false,
    "crs": 3857,
    "mask": null,
    "source": "s3://test",
    "resolution": 2
  }
}
```
* check that airflow is showing running export task(s)
* open AWS consoles for RF's S3 & EMR
* go to `rasterfoundry-development-data-us-east-1/export-definitions` bucket on S3, and check that the new export definition has been uploaded as a `.json` file
* go to whatever EMR cluster is active (probably `DataprocCluster v1` or something like that), and browse the "Steps" table to check for a new step (depending on how quickly you check, the status could be "Pending", "Running", or "Failed")
* once the EMR Steps table shows the step has completed, check the `stderr` logs linked in the "Log Files" field when the logs become available after a minute or so; look for something similar to `application_[...]_[...]`, which is the container ID
* go to the `rasterfoundry-dataproc-logs-us-east-1/j-1BHDO64C8OFPY/containers` S3 bucket to view the saved logs; the logs should be in a bucket with a path similar to this --> `rasterfoundry-dataproc-logs-us-east-1/j-1BHDO64C8OFPY/containers/`**`application_1492701974127_0035/container_1492701974127_0035_02_000001`**
* download the compressed log file and decompress & open it; check that there's an indication that the exception was raised from the `com.azavea.rf.batch.export.Export` class, which confirms that it was executed on the cluster


Closes #1417
