### PR TITLE
Update scala dockerignore to include new subprojects

### DIFF
--- a/app-backend/.dockerignore
+++ b/app-backend/.dockerignore
@@ -1,4 +1,7 @@
 api/target/*
+authentication/target/*
+batch/target/*
+common/target/*
 database/target/*
 datamodel/target/*
 ingest/target/*
@@ -6,4 +9,5 @@ migrations/target/*
 project/target/*
 target/*
 tile/target/*
+tool/target/*
 .idea/*


### PR DESCRIPTION
Our dockerignore file was a little out of date and was leading to
a long `copy` step in our docker file as context was gathered.

Trivial, merging