### PR TITLE
NodeMetadata on AST [WIP]

### DIFF
--- a/app-backend/tile/src/main/scala/LayerCache.scala
+++ b/app-backend/tile/src/main/scala/LayerCache.scala
@@ -5,6 +5,7 @@ import com.azavea.rf.datamodel.{Tool, ToolRun}
 import com.azavea.rf.tool.eval._
 import com.azavea.rf.tool.params._
 import com.azavea.rf.tool.ast.MapAlgebraAST
+import com.azavea.rf.common._
 import com.azavea.rf.common.cache._
 import com.azavea.rf.common.cache.kryo.KryoMemcachedClient
 import com.azavea.rf.database.Database
@@ -91,12 +92,9 @@ object LayerCache extends Config with LazyLogging {
 
   def modelLayerGlobalHistogram(toolRun: ToolRun, tool: Tool.WithRelated, nodeId: Option[UUID]): OptionT[Future, Histogram[Double]] =
     histogramCache.cachingOptionT(s"model-${toolRun.id}-$nodeId") { implicit ec =>
-      val maybeAST = tool.definition.as[MapAlgebraAST] match {
-        case Right(entireAST) =>
-          nodeId.flatMap(id => entireAST.find(id)).orElse(Some(entireAST))
-        case Left(failure) =>
-          throw failure
-      }
+    val maybeAST = maybeThrow(tool.definition.as[MapAlgebraAST]).flatMap(entireAST =>
+      nodeId.flatMap(id => entireAST.find(id)).orElse(Some(entireAST))
+    )
 
       OptionT.fromOption[Future](
         for {
@@ -106,10 +104,7 @@ object LayerCache extends Config with LazyLogging {
         } yield hist
       ).orElse(
         for {
-          params <- OptionT.fromOption[Future](toolRun.executionParameters.as[EvalParams] match {
-                      case Right(toolRunParams) => Some(toolRunParams)
-                      case Left(failure) => throw failure
-                    })
+          params <- OptionT.fromOption[Future](maybeThrow(toolRun.executionParameters.as[EvalParams]))
           ast    <- OptionT.fromOption[Future](maybeAST)
           lztile <- OptionT(Interpreter.interpretGlobal(ast, params, TileSources.cachedGlobalSource).map(_.toOption))
           tile   <- OptionT.fromOption[Future](lztile.evaluateDouble)

--- a/app-backend/tile/src/main/scala/routes/ToolRoutes.scala
+++ b/app-backend/tile/src/main/scala/routes/ToolRoutes.scala
@@ -76,11 +76,11 @@ class ToolRoutes(implicit val database: Database) extends Authentication
                   toolRun <- OptionT(database.db.run(ToolRuns.getToolRun(toolRunId, user)))
                   tool    <- OptionT(Tools.getTool(toolRun.tool, user))
                   params  <- OptionT.fromOption[Future](maybeThrow(toolRun.executionParameters.as[EvalParams]))
-                  ramp    <- OptionT.fromOption[Future](defaultRamps.get(colorRamp))
                   ast     <- OptionT.fromOption[Future](maybeThrow(tool.definition.as[MapAlgebraAST]).flatMap(entireAST =>
                                nodeId.flatMap(id => entireAST.find(id)).orElse(Some(entireAST))
                              ))
                   hist    <- LayerCache.modelLayerGlobalHistogram(toolRun, tool, nodeId)
+                  ramp    <- OptionT.fromOption[Future](defaultRamps.get(colorRamp))
                   tile    <- OptionT({
                                val tms = Interpreter.interpretTMS(ast, params, source)
                                tms(z, x, y).map {

--- a/app-backend/tile/src/main/scala/routes/ToolRoutes.scala
+++ b/app-backend/tile/src/main/scala/routes/ToolRoutes.scala
@@ -73,8 +73,7 @@ class ToolRoutes(implicit val database: Database) extends Authentication
               complete {
                 val nodeId = node.map(UUID.fromString(_))
                 val responsePng = for {
-                  toolRun <- OptionT(database.db.run(ToolRuns.getToolRun(toolRunId, user)))
-                  tool    <- OptionT(Tools.getTool(toolRun.tool, user))
+                  (toolRun, tool) <- LayerCache.toolRunAndTool(toolRunId, user)
                   params  <- OptionT.fromOption[Future](maybeThrow(toolRun.executionParameters.as[EvalParams]))
                   ast     <- OptionT.fromOption[Future](maybeThrow(tool.definition.as[MapAlgebraAST]).flatMap(entireAST =>
                                nodeId.flatMap(id => entireAST.find(id)).orElse(Some(entireAST))

--- a/app-backend/tool/src/main/scala/ast/MapAlgebraAST.scala
+++ b/app-backend/tool/src/main/scala/ast/MapAlgebraAST.scala
@@ -12,6 +12,19 @@ sealed trait MapAlgebraAST extends Product with Serializable {
   def metadata: Option[NodeMetadata]
   def find(id: UUID): Option[MapAlgebraAST]
   def sources: Seq[UUID]
+
+  def overrideMetadata(otherMD: Option[NodeMetadata]): Option[NodeMetadata] =
+    (metadata, otherMD) match {
+      case (Some(defaults), Some(overrides)) =>
+        Some(NodeMetadata(
+          overrides.label.orElse(defaults.label),
+          overrides.description.orElse(defaults.description),
+          overrides.histogram.orElse(defaults.histogram)
+        ))
+      case (None, Some(_)) => otherMD
+      case (Some(_), None) => metadata
+      case _ => None
+    }
 }
 
 object MapAlgebraAST {

--- a/app-backend/tool/src/main/scala/ast/MapAlgebraAST.scala
+++ b/app-backend/tool/src/main/scala/ast/MapAlgebraAST.scala
@@ -9,7 +9,7 @@ import io.circe.generic.JsonCodec
 sealed trait MapAlgebraAST extends Product with Serializable {
   def id: UUID
   def args: List[MapAlgebraAST]
-  def label: Option[String]
+  def metadata: Option[NodeMetadata]
   def find(id: UUID): Option[MapAlgebraAST]
   def sources: Seq[UUID]
 }
@@ -32,32 +32,32 @@ object MapAlgebraAST {
   }
 
   @JsonCodec
-  case class Addition(args: List[MapAlgebraAST], id: UUID, label: Option[String])
+  case class Addition(args: List[MapAlgebraAST], id: UUID, metadata: Option[NodeMetadata])
       extends Operation("+")
 
   @JsonCodec
-  case class Subtraction(args: List[MapAlgebraAST], id: UUID, label: Option[String])
+  case class Subtraction(args: List[MapAlgebraAST], id: UUID, metadata: Option[NodeMetadata])
       extends Operation("-")
 
   @JsonCodec
-  case class Multiplication(args: List[MapAlgebraAST], id: UUID, label: Option[String])
+  case class Multiplication(args: List[MapAlgebraAST], id: UUID, metadata: Option[NodeMetadata])
       extends Operation("*")
 
   @JsonCodec
-  case class Division(args: List[MapAlgebraAST], id: UUID, label: Option[String])
+  case class Division(args: List[MapAlgebraAST], id: UUID, metadata: Option[NodeMetadata])
       extends Operation("/")
 
   @JsonCodec
-  case class Masking(args: List[MapAlgebraAST], id: UUID, label: Option[String])
+  case class Masking(args: List[MapAlgebraAST], id: UUID, metadata: Option[NodeMetadata])
       extends Operation("mask")
 
   @JsonCodec
-  case class Classification(args: List[MapAlgebraAST], id: UUID, label: Option[String], classBreaks: ClassBreaks)
+  case class Classification(args: List[MapAlgebraAST], id: UUID, metadata: Option[NodeMetadata], classBreaks: ClassBreaks)
       extends Operation("classify")
 
   /** Map Algebra sources (leaves) */
   @JsonCodec
-  case class Source(id: UUID, label: Option[String]) extends MapAlgebraAST {
+  case class Source(id: UUID, metadata: Option[NodeMetadata]) extends MapAlgebraAST {
     def args: List[MapAlgebraAST] = List.empty
 
     def find(id: UUID): Option[MapAlgebraAST] =

--- a/app-backend/tool/src/main/scala/ast/NodeMetadata.scala
+++ b/app-backend/tool/src/main/scala/ast/NodeMetadata.scala
@@ -1,6 +1,7 @@
 package com.azavea.rf.tool.ast
 
 import geotrellis.raster.render.ColorRamp
+import geotrellis.raster.histogram._
 import io.circe._
 import io.circe.syntax._
 import io.circe.disjunctionCodecs._
@@ -12,14 +13,14 @@ import com.azavea.rf.tool.ast.codec.MapAlgebraCodec
 case class NodeMetadata(
   label: Option[String],
   description: Option[String],
-  rendering: Option[Either[ColorRamp, ClassBreaks]]
+  histogram: Option[Histogram[Double]]
 )
 
 object NodeMetadata extends MapAlgebraCodec {
   implicit val nodeMetadataEncoder: Encoder[NodeMetadata] =
-    Encoder.forProduct3("label", "description", "rendering")(nmd =>
-      (nmd.label, nmd.description, nmd.rendering)
+    Encoder.forProduct3("label", "description", "histogram")(nmd =>
+      (nmd.label, nmd.description, nmd.histogram)
     )
   implicit val nodeMetadataDecoder: Decoder[NodeMetadata] =
-    Decoder.forProduct3("label", "description", "rendering")(NodeMetadata.apply)
+    Decoder.forProduct3("label", "description", "histogram")(NodeMetadata.apply)
 }

--- a/app-backend/tool/src/main/scala/ast/NodeMetadata.scala
+++ b/app-backend/tool/src/main/scala/ast/NodeMetadata.scala
@@ -1,0 +1,25 @@
+package com.azavea.rf.tool.ast
+
+import geotrellis.raster.render.ColorRamp
+import io.circe._
+import io.circe.syntax._
+import io.circe.disjunctionCodecs._
+import io.circe.generic.JsonCodec
+
+import com.azavea.rf.tool.ast.codec.MapAlgebraCodec
+
+
+case class NodeMetadata(
+  label: Option[String],
+  description: Option[String],
+  rendering: Option[Either[ColorRamp, ClassBreaks]]
+)
+
+object NodeMetadata extends MapAlgebraCodec {
+  implicit val nodeMetadataEncoder: Encoder[NodeMetadata] =
+    Encoder.forProduct3("label", "description", "rendering")(nmd =>
+      (nmd.label, nmd.description, nmd.rendering)
+    )
+  implicit val nodeMetadataDecoder: Decoder[NodeMetadata] =
+    Decoder.forProduct3("label", "description", "rendering")(NodeMetadata.apply)
+}

--- a/app-backend/tool/src/main/scala/ast/RFMLRaster.scala
+++ b/app-backend/tool/src/main/scala/ast/RFMLRaster.scala
@@ -17,19 +17,11 @@ case class SceneRaster(id: UUID, band: Option[Int]) extends RFMLRaster("scene")
 @JsonCodec
 case class ProjectRaster(id: UUID, band: Option[Int]) extends RFMLRaster("project")
 
-@JsonCodec
-case class MLToolRaster(id: UUID, node: Option[UUID]) extends RFMLRaster("tool")
-
-@JsonCodec
-case class RasterReference(id: UUID) extends RFMLRaster("reference")
-
 object RFMLRaster {
   implicit lazy val decodeRFMLRaster = Decoder.instance[RFMLRaster] { rasterSrc =>
     rasterSrc._type match {
       case Some("scene") => rasterSrc.as[SceneRaster]
       case Some("project") => rasterSrc.as[ProjectRaster]
-      case Some("tool") => rasterSrc.as[MLToolRaster]
-      case Some("reference") => rasterSrc.as[RasterReference]
       case Some(unrecognized) =>
         throw new InvalidParameterException(s"'$unrecognized' is not a recognized map algebra raster source type")
       case None =>
@@ -41,20 +33,6 @@ object RFMLRaster {
     def apply(rasterDefinition: RFMLRaster): Json = rasterDefinition match {
       case scene: SceneRaster => scene.asJson
       case project: ProjectRaster => project.asJson
-      case mltool: MLToolRaster => mltool.asJson
-      case reference: RasterReference => reference.asJson
     }
   }
-
-  implicit lazy val encodeSceneRaster: Encoder[SceneRaster] =
-    Encoder.forProduct3("id", "band", "type")(rfml => (rfml.id, rfml.band, rfml.`type`))
-
-  implicit lazy val encodeProjectRaster: Encoder[ProjectRaster] =
-    Encoder.forProduct3("id", "band", "type")(rfml => (rfml.id, rfml.band, rfml.`type`))
-
-  implicit lazy val encodeMLToolRaster: Encoder[MLToolRaster] =
-    Encoder.forProduct3("id", "node", "type")(rfml => (rfml.id, rfml.node, rfml.`type`))
-
-  implicit lazy val encodeRasterReference: Encoder[RasterReference] =
-    Encoder.forProduct2("id", "type")(rfml => (rfml.id, rfml.`type`))
 }

--- a/app-backend/tool/src/main/scala/ast/codec/MapAlgebraOperationCodecs.scala
+++ b/app-backend/tool/src/main/scala/ast/codec/MapAlgebraOperationCodecs.scala
@@ -44,36 +44,4 @@ trait MapAlgebraOperationCodecs {
         throw new InvalidParameterException(s"Encoder for $operation not yet implemented")
     }
   }
-
-  // Codec instances
-  implicit lazy val decodeAddition: Decoder[MapAlgebraAST.Addition] =
-    Decoder.forProduct3("args", "id", "label")(MapAlgebraAST.Addition.apply)
-  implicit lazy val encodeAddition: Encoder[MapAlgebraAST.Addition] =
-    Encoder.forProduct4("apply", "args", "id", "label")(op => (op.symbol, op.args, op.id, op.label))
-
-  implicit lazy val decodeSubtraction: Decoder[MapAlgebraAST.Subtraction] =
-    Decoder.forProduct3("args", "id", "label")(MapAlgebraAST.Subtraction.apply)
-  implicit lazy val encodeSubtraction: Encoder[MapAlgebraAST.Subtraction] =
-    Encoder.forProduct4("apply", "args", "id", "label")(op => (op.symbol, op.args, op.id, op.label))
-
-  implicit lazy val decodeDivision: Decoder[MapAlgebraAST.Division] =
-    Decoder.forProduct3("args", "id", "label")(MapAlgebraAST.Division.apply)
-  implicit lazy val encodeDivision: Encoder[MapAlgebraAST.Division] =
-    Encoder.forProduct4("apply", "args", "id", "label")(op => (op.symbol, op.args, op.id, op.label))
-
-  implicit lazy val decodeMultiplication: Decoder[MapAlgebraAST.Multiplication] =
-    Decoder.forProduct3("args", "id", "label")(MapAlgebraAST.Multiplication.apply)
-  implicit lazy val encodeMultiplication: Encoder[MapAlgebraAST.Multiplication] =
-    Encoder.forProduct4("apply", "args", "id", "label")(op => (op.symbol, op.args, op.id, op.label))
-
-  implicit lazy val decodeMasking: Decoder[MapAlgebraAST.Masking] =
-    Decoder.forProduct3("args", "id", "label")(MapAlgebraAST.Masking.apply)
-  implicit lazy val encodeMasking: Encoder[MapAlgebraAST.Masking] =
-    Encoder.forProduct4("apply", "args", "id", "label")(op => (op.symbol, op.args, op.id, op.label))
-
-  implicit lazy val decodeClassification: Decoder[MapAlgebraAST.Classification] =
-    Decoder.forProduct4("args", "id", "label", "classBreaks")(MapAlgebraAST.Classification.apply _)
-  implicit lazy val encodeClassification: Encoder[MapAlgebraAST.Classification] =
-    Encoder.forProduct5("apply", "args", "id", "label", "classBreaks")(op => (op.symbol, op.args, op.id, op.label, op.classBreaks))
-
 }

--- a/app-backend/tool/src/main/scala/ast/codec/MapAlgebraUtilityCodecs.scala
+++ b/app-backend/tool/src/main/scala/ast/codec/MapAlgebraUtilityCodecs.scala
@@ -64,16 +64,12 @@ trait MapAlgebraUtilityCodecs {
     final def apply(cRamp: ColorRamp): Json = cRamp.colors.toArray.asJson
   }
 
-  implicit val histogramDecoder: Decoder[Histogram[Double]] = Decoder[JsValue].map { js =>
-    js.convertTo[Histogram[Double]]
+  implicit val histogramDecoder: Decoder[Histogram[Double]] = Decoder[Json].map { js =>
+    js.noSpaces.parseJson.convertTo[Histogram[Double]]
   }
 
   implicit val histogramEncoder: Encoder[Histogram[Double]] = new Encoder[Histogram[Double]] {
     final def apply(hist: Histogram[Double]): Json = hist.toJson.asJson
-  }
-
-  implicit val sprayJsonDecoder: Decoder[JsValue] = Decoder[Json].map { js =>
-    js.noSpaces.parseJson
   }
 
   implicit val sprayJsonEncoder: Encoder[JsValue] = new Encoder[JsValue] {

--- a/app-backend/tool/src/main/scala/ast/codec/MapAlgebraUtilityCodecs.scala
+++ b/app-backend/tool/src/main/scala/ast/codec/MapAlgebraUtilityCodecs.scala
@@ -2,7 +2,11 @@ package com.azavea.rf.tool.ast.codec
 
 import com.azavea.rf.tool.ast._
 
+import geotrellis.raster.io._
+import geotrellis.raster.histogram._
 import geotrellis.raster.render._
+import spray.json._
+import DefaultJsonProtocol._
 import io.circe._
 import io.circe.syntax._
 
@@ -57,6 +61,14 @@ trait MapAlgebraUtilityCodecs {
 
   implicit val colorRampEncoder: Encoder[ColorRamp] = new Encoder[ColorRamp] {
     final def apply(cRamp: ColorRamp): Json = cRamp.colors.toArray.asJson
+  }
+
+  implicit val histogramDecoder: Decoder[Histogram[Double]] = Decoder[Json].map { js =>
+    js.noSpaces.parseJson.convertTo[Histogram[Double]]
+  }
+
+  implicit val histogramEncoder: Encoder[Histogram[Double]] = new Encoder[Histogram[Double]] {
+    final def apply(hist: Histogram[Double]): Json = ???
   }
 }
 

--- a/app-backend/tool/src/main/scala/ast/codec/MapAlgebraUtilityCodecs.scala
+++ b/app-backend/tool/src/main/scala/ast/codec/MapAlgebraUtilityCodecs.scala
@@ -4,9 +4,11 @@ import com.azavea.rf.tool.ast._
 
 import geotrellis.raster.render._
 import io.circe._
+import io.circe.syntax._
 
-import scala.util.Try
 import java.security.InvalidParameterException
+import java.util.UUID
+import scala.util.Try
 
 trait MapAlgebraUtilityCodecs {
   implicit def mapAlgebraDecoder: Decoder[MapAlgebraAST]
@@ -17,6 +19,13 @@ trait MapAlgebraUtilityCodecs {
   }
   implicit val encodeKeyDouble: KeyEncoder[Double] = new KeyEncoder[Double] {
     final def apply(key: Double): String = key.toString
+  }
+
+  implicit val decodeKeyUUID: KeyDecoder[UUID] = new KeyDecoder[UUID] {
+    final def apply(key: String): Option[UUID] = Try(UUID.fromString(key)).toOption
+  }
+  implicit val encodeKeyUUID: KeyEncoder[UUID] = new KeyEncoder[UUID] {
+    final def apply(key: UUID): String = key.toString
   }
 
   implicit lazy val classBoundaryDecoder: Decoder[ClassBoundaryType] =
@@ -42,5 +51,12 @@ trait MapAlgebraUtilityCodecs {
           throw new InvalidParameterException(s"'$unrecognized' is not a recognized ClassBoundaryType")
       }
     })
+
+  implicit val colorRampDecoder: Decoder[ColorRamp] =
+    Decoder[Vector[Int]].map({ ColorRamp(_) })
+
+  implicit val colorRampEncoder: Encoder[ColorRamp] = new Encoder[ColorRamp] {
+    final def apply(cRamp: ColorRamp): Json = cRamp.colors.toArray.asJson
+  }
 }
 

--- a/app-backend/tool/src/main/scala/ast/package.scala
+++ b/app-backend/tool/src/main/scala/ast/package.scala
@@ -11,7 +11,7 @@ package object ast extends MapAlgebraCodec {
   implicit class CirceMapAlgebraJsonMethods(val self: Json) {
     def _id: Option[UUID] = root.id.string.getOption(self).map(UUID.fromString(_))
     def _type: Option[String] = root.`type`.string.getOption(self)
-    def _label: Option[String] = root.label.string.getOption(self)
+    def _label: Option[String] = root.metadata.label.string.getOption(self)
     def _symbol: Option[String] = root.selectDynamic("apply").string.getOption(self)
 
     def _fields: Option[Seq[String]] = root.obj.getOption(self).map(_.fields)
@@ -27,19 +27,25 @@ package object ast extends MapAlgebraCodec {
   }
 
   implicit class MapAlgebraASTHelperMethods(val self: MapAlgebraAST) {
+    private def generateMetadata = Some(NodeMetadata(
+      Some(s"Classify(${self.metadata.flatMap(_.label).getOrElse(self.id)})"),
+      None,
+      None
+    ))
+
     def classify(breaks: ClassBreaks) =
-      MapAlgebraAST.Classification(List(self), UUID.randomUUID(), Some(s"Classify(${self.label.getOrElse(self.id)})"), breaks)
+      MapAlgebraAST.Classification(List(self), UUID.randomUUID(), generateMetadata, breaks)
 
     def +(other: MapAlgebraAST): MapAlgebraAST.Operation =
-      MapAlgebraAST.Addition(List(self, other), UUID.randomUUID(), Some(s"${self.label.getOrElse(self.id)}_+_${other.label.getOrElse(other.id)}"))
+      MapAlgebraAST.Addition(List(self, other), UUID.randomUUID(), generateMetadata)
 
     def -(other: MapAlgebraAST): MapAlgebraAST.Operation =
-      MapAlgebraAST.Subtraction(List(self, other), UUID.randomUUID(), Some(s"${self.label.getOrElse(self.id)}_-_${other.label.getOrElse(other.id)}"))
+      MapAlgebraAST.Subtraction(List(self, other), UUID.randomUUID(), generateMetadata)
 
     def *(other: MapAlgebraAST): MapAlgebraAST.Operation =
-      MapAlgebraAST.Multiplication(List(self, other), UUID.randomUUID(), Some(s"${self.label.getOrElse(self.id)}_*_${other.label.getOrElse(other.id)}"))
+      MapAlgebraAST.Multiplication(List(self, other), UUID.randomUUID(), generateMetadata)
 
     def /(other: MapAlgebraAST): MapAlgebraAST.Operation =
-      MapAlgebraAST.Division(List(self, other), UUID.randomUUID(), Some(s"${self.label.getOrElse(self.id)}_/_${other.label.getOrElse(other.id)}"))
+      MapAlgebraAST.Division(List(self, other), UUID.randomUUID(), generateMetadata)
   }
 }

--- a/app-backend/tool/src/main/scala/params/EvalParams.scala
+++ b/app-backend/tool/src/main/scala/params/EvalParams.scala
@@ -8,5 +8,5 @@ import java.util.UUID
 
 
 @JsonCodec
-case class EvalParams(sources: Map[UUID, RFMLRaster])
+case class EvalParams(sources: Map[UUID, RFMLRaster], metadataOverrides: Map[UUID, NodeMetadata])
 

--- a/app-backend/tool/src/main/scala/params/EvalParams.scala
+++ b/app-backend/tool/src/main/scala/params/EvalParams.scala
@@ -10,3 +10,4 @@ import java.util.UUID
 @JsonCodec
 case class EvalParams(sources: Map[UUID, RFMLRaster], metadataOverrides: Map[UUID, NodeMetadata])
 
+


### PR DESCRIPTION
## Overview

This PR implements storage of metadata on `Tool` ASTs with overrides stored on `ToolRuns`. Further work will add color ramps, color maps, labels, and other pieces of metadata