### PR TITLE
Make project list reload when project created

### DIFF
--- a/app-frontend/src/app/components/createProjectModal/createProjectModal.controller.js
+++ b/app-frontend/src/app/components/createProjectModal/createProjectModal.controller.js
@@ -17,6 +17,7 @@ export default class CreateProjectModalController {
             addType: 'public'
         };
         this.allowNext = true;
+        this.returnData = Object.assign({}, this.resolve.returnData);
     }
 
     projectAttributeIs(attr, value) {
@@ -99,7 +100,7 @@ export default class CreateProjectModalController {
             }
         });
 
-        this.dismiss();
+        this.closeWithData();
 
         return this.activeModal;
     }
@@ -126,6 +127,7 @@ export default class CreateProjectModalController {
                     this.isCreatingProject = true;
                     this.createProject().then(p => {
                         this.project = p;
+                        this.returnData.reloadProjectList = true;
                         this.gotoNextStep();
                     }).finally(() => {
                         this.allowNext = true;
@@ -144,7 +146,7 @@ export default class CreateProjectModalController {
         }
     }
 
-    closeWithData(data) {
-        this.close({$value: data});
+    closeWithData() {
+        this.close({$value: this.returnData});
     }
 }

--- a/app-frontend/src/app/components/createProjectModal/createProjectModal.html
+++ b/app-frontend/src/app/components/createProjectModal/createProjectModal.html
@@ -1,6 +1,6 @@
 <div class="modal-scrollable-body modal-sidebar-header">
   <div class="modal-header">
-    <button type="button" class="close" aria-label="Close" ng-click="$ctrl.dismiss()">
+    <button type="button" class="close" aria-label="Close" ng-click="$ctrl.closeWithData()">
       <span aria-hidden="true">&times;</span>
     </button>
     <h4 class="modal-title">

--- a/app-frontend/src/app/components/createProjectModal/createProjectModal.html
+++ b/app-frontend/src/app/components/createProjectModal/createProjectModal.html
@@ -47,7 +47,7 @@
     </div>
   </div>
 
-  <!--Body for NAME-->
+  <!--Body for ADD_SCENES-->
   <div class="modal-body" ng-if="$ctrl.currentStepIs('ADD_SCENES')">
     <div class="content">
       <h3 class="modal-content-header">Add Scenes to your Project</h3>
@@ -75,7 +75,7 @@
 
   <!--Default Footer-->
   <div
-    ng-if="$ctrl.currentStepIsNot(['SUCCESS', 'ADD_SCENES', 'IMPORT', 'IMPORT_SUCCESS'])"
+    ng-if="$ctrl.currentStepIs('TYPE')"
     class="modal-footer"
   >
     <button type="button" class="btn pull-left"
@@ -96,40 +96,16 @@
   </div>
 
   <!--Footer for ADD_SCENES-->
-  <div ng-if="$ctrl.currentStepIs('ADD_SCENES')" class="modal-footer">
+  <div ng-if="$ctrl.currentStepIs('ADD_SCENES')"
+       class="modal-footer"
+  >
     <button type="button" class="btn pull-left"
-            ng-click="$ctrl.closeWithData(1)">
+            ng-click="$ctrl.closeWithData()">
       Add Scenes later
     </button>
     <button type="button" class="btn btn-primary"
             ng-click="$ctrl.handleNext()">
       Next
-    </button>
-  </div>
-
-  <!--Footer for IMPORT-->
-  <div ng-if="$ctrl.currentStepIs('IMPORT')" class="modal-footer">
-    <button type="button" class="btn pull-left"
-            ng-click="$ctrl.closeWithData(1)">
-      Add Scenes later
-    </button>
-    <button type="button" class="btn"
-            ng-if="$ctrl.hasPreviousStep()"
-            ng-click="$ctrl.gotoPreviousStep()">
-      Back
-    </button>
-    <button type="button" class="btn btn-primary"
-            ng-click="$ctrl.handleNext()">
-      Next
-    </button>
-  </div>
-
-
-  <!--Footer for SUCCESS-->
-  <div ng-if="$ctrl.currentStepIs('IMPORT_SUCCESS')" class="modal-footer">
-    <button type="button" class="btn btn-primary"
-            ng-click="$ctrl.closeWithData(1)">
-      Done
     </button>
   </div>
 </div>

--- a/app-frontend/src/app/pages/projects/list/list.controller.js
+++ b/app-frontend/src/app/pages/projects/list/list.controller.js
@@ -78,9 +78,10 @@ class ProjectsListController {
             component: 'rfCreateProjectModal'
         });
 
-        this.newProjectModal.result.then(() => {
-            // TODO once workflow is a bit more fleshed out
-            // project => {}
+        this.newProjectModal.result.then((data) => {
+            if (data.reloadProjectList) {
+                this.populateProjectList(1);
+            }
         });
 
         return this.newProjectModal;


### PR DESCRIPTION
## Overview

This PR makes a change to the project creation modal and project list page that triggers a reload of the project list if a new project has been created.

Previously, when creating a project within the modal sequence and then choosing to import your own imagery would eventually result in the user being back on the project list page which would not show the project they just created.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~

### Notes

I made a small change to a method that I've implemented on several modals: `closeWithData`. Previously, this method would take a single argument that would be passed on as the resolved value of the modal. In this modal, I instead created an object, `returnData` that could be modified at any point in the controller. This object is now automatically used as the resolving value. During the project creation process we set a key on that object to signal that the project list should be reloaded `reloadProjectList`. This allows us to set the object once, but be assured that if the modal is closed at any point after, with the `closeWithData` method, the proper flag will be present without having to explicitly set the flag each time.

## Testing Instructions

 * Go to the project list page
 * 'Create a New Project'
 * Make sure that if you exit the process at any point after the first step (project creation) is complete, the project list is reloaded
 * Make sure also that if you proceed to the import step (which is actually a different modal) that the project list is reloaded in the background

Closes #1601
