### PR TITLE
Add support for single band raster import

### DIFF
--- a/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Scenes.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Scenes.scala
@@ -413,7 +413,7 @@ object Scenes extends TableQuery(tag => new Scenes(tag)) with LazyLogging {
     val updateTime = new Timestamp((new java.util.Date).getTime)
 
     val updateSceneQuery = for {
-      updateScene <- Scenes.filterToOwner(user).filter(_.id === sceneId)
+      updateScene <- Scenes.filterToOwnerIfNotInRootOrganization(user).filter(_.id === sceneId)
     } yield (
       updateScene.modifiedAt, updateScene.modifiedBy, updateScene.ingestSizeBytes,
       updateScene.datasource, updateScene.cloudCover,  updateScene.acquisitionDate,

--- a/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Tools.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Tools.scala
@@ -28,8 +28,7 @@ class Tools(_tableTag: Tag) extends Table[Tool](_tableTag, "tools")
     with ToolFields
     with LazyLogging
     with OrganizationFkFields
-    with UserFkFields
-    with VisibilityField
+    with UserFkVisibleFields
     with TimestampFields
 {
   def * = (id, createdAt, modifiedAt, createdBy, modifiedBy, owner, organizationId,
@@ -133,7 +132,7 @@ object Tools extends TableQuery(tag => new Tools(tag)) with LazyLogging {
   def listTools(page: PageRequest, user: User)(implicit database: DB):
       Future[PaginatedResponse[Tool.WithRelated]] = {
 
-    val accessibleTools = Tools.filterToSharedOrganizationIfNotInRoot(user)
+    val accessibleTools = Tools.filterUserVisibility(user)
 
     val pagedTools = accessibleTools
       .sort(page.sort)

--- a/app-backend/tile/build.sbt
+++ b/app-backend/tile/build.sbt
@@ -1,1 +1,27 @@
 name := "raster-foundry-tile-server"
+
+initialCommands in console := """
+  |import com.azavea.rf.tile.Config
+  |import com.azavea.rf.datamodel._
+  |import com.azavea.rf.database.Database
+  |import com.azavea.rf.database.ExtendedPostgresDriver.api._
+  |import com.azavea.rf.database.tables._
+  |import io.circe._
+  |import io.circe.syntax._
+  |import java.util.UUID
+  |import java.sql.Timestamp
+  |import java.time.Instant
+  |import scala.concurrent.{Future,Await}
+  |import scala.concurrent.duration._
+  |import akka.actor.ActorSystem
+  |import akka.stream.ActorMaterializer
+  |val publicOrgId = UUID.fromString("dfac6307-b5ef-43f7-beda-b9f208bb7726")
+  |import geotrellis.vector.{MultiPolygon, Polygon, Point, Geometry}
+  |import geotrellis.slick.Projected
+  |object Rollbar extends com.azavea.rf.common.RollbarNotifier {
+  |  implicit val system = ActorSystem("rf-system")
+  |  implicit val materializer = ActorMaterializer()
+  |}
+  |object Main extends Config { implicit val database = Database.DEFAULT }
+  |import Main._
+""".trim.stripMargin

--- a/app-tasks/rf/src/rf/uploads/geotiff/create_bands.py
+++ b/app-tasks/rf/src/rf/uploads/geotiff/create_bands.py
@@ -28,7 +28,8 @@ band_data_lookup = {
     'red': ('Red', [590, 670]),
     'green': ('Green', [490, 590]),
     'blue': ('Blue', [400, 490]),
-    'pan': ('Panchromatic', [400, 760])
+    'pan': ('Panchromatic', [400, 760]),
+    'gray': ('Gray', [0, 0])
 }
 
 


### PR DESCRIPTION
## Overview

A few minor fixes to allow imports and ingests to process successfully.

1. Allows root users to update any scene, this manifested itself in a bunch of `400` errors on staging
2. Check bands before generating thumbnails
3. Adds resampling before footprint generation
4. Adds a few convenience imports for the tile subproject
5. Fixes filtering for tools

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~

## Testing Instructions

 * Start servers and airflow, limit airflow to finding geotiffs to import and the import geotiff dags
 * Upload a singleband geotiff
 * Ensure that it gets processed successfully
 * Go to Tools UI - ensure that you can see tools now