### PR TITLE
Implement individual RGB color channel clipping

### DIFF
--- a/app-backend/api/src/test/scala/datasource/DatasourceSpec.scala
+++ b/app-backend/api/src/test/scala/datasource/DatasourceSpec.scala
@@ -38,6 +38,8 @@ class DatasourceSpec extends WordSpec
     redBand = 3,
     greenBand = 2,
     blueBand = 1,
+    redMax = Some(20000), greenMax = Some(20000), blueMax = Some(20000),
+    redMin = None, greenMin = None, blueMin = None,
     redGamma = Some(0.0),
     greenGamma = Some(0.0),
     blueGamma = Some(0.0),

--- a/app-backend/api/src/test/scala/project/ProjectSceneSpec.scala
+++ b/app-backend/api/src/test/scala/project/ProjectSceneSpec.scala
@@ -286,6 +286,8 @@ class ProjectSceneSpec extends WordSpec
       val colorCorrectParams = ColorCorrect.Params(
         1, 2, 3,                           // Band Order (R, G, B)
         Some(0.53), Some(0.8), Some(0.32), // Gamma levels
+        None, None, None,                  // Clipping max
+        None, None, None,                  // Clipping min
         Some(10), Some(20),                // Contrast, Brightness
         None, None,                        // Alpha, Beta
         None, None,                        // Min, Max

--- a/app-backend/batch/src/test/resources/export/localJob.json
+++ b/app-backend/batch/src/test/resources/export/localJob.json
@@ -11,6 +11,8 @@
                     "redBand": 0,
                     "blueBand": 2,
                     "greenBand": 1,
+                    "redMax": 9, "greenMax": 9, "blueMax": 9,
+                    "redMin": null, "greenMin": null, "blueMin": null,
                     "alpha": 6.0,
                     "min": 8,
                     "max": 9,

--- a/app-backend/batch/src/test/resources/export/testFileJob.json
+++ b/app-backend/batch/src/test/resources/export/testFileJob.json
@@ -12,6 +12,8 @@
                     "redBand": 4,
                     "greenBand": 3,
                     "blueBand": 2,
+                    "redMax": 9, "greenMax": 9, "blueMax": 9,
+                    "redMin": null, "greenMin": null, "blueMin": null,
                     "redGamma": 0.5,
                     "greenGamma": 0.5,
                     "blueGamma": 0.5,

--- a/app-backend/batch/src/test/resources/export/testJob.json
+++ b/app-backend/batch/src/test/resources/export/testJob.json
@@ -11,6 +11,8 @@
                     "redBand": 4,
                     "greenBand": 3,
                     "blueBand": 2,
+                    "redMax": 9, "greenMax": 9, "blueMax": 9,
+                    "redMin": null, "greenMin": null, "blueMin": null,
                     "redGamma": 0.5,
                     "greenGamma": 0.5,
                     "blueGamma": 0.5,

--- a/app-backend/batch/src/test/scala/com/azavea/rf/batch/export/model/ExportDefinitionSpec.scala
+++ b/app-backend/batch/src/test/scala/com/azavea/rf/batch/export/model/ExportDefinitionSpec.scala
@@ -33,6 +33,8 @@ class ExportDefinitionSpec extends FunSpec with Matchers with BatchSpec {
                 redBand = 0,
                 greenBand = 1,
                 blueBand = 2,
+                redMax = Some(9), greenMax = Some(9), blueMax = Some(9),
+                redMin = None, greenMin = None, blueMin = None,
                 redGamma = Some(1d),
                 greenGamma = Some(2d),
                 blueGamma = Some(3d),

--- a/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Projects.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Projects.scala
@@ -391,6 +391,8 @@ object Projects extends TableQuery(tag => new Projects(tag)) with LazyLogging {
                     ColorCorrect.Params(
                       redBand, greenBand, blueBand, // Bands
                       None, None, None,             // Gamma
+                      None, None, None,             // Clipping Max: R,G,B
+                      None, None, None,             // Clipping Min: R,G,B
                       None, None,                   // Contrast, Brightness
                       None, None,                   // Alpha, Beta
                       None, None,                   // Min, Max

--- a/app-backend/tile/src/main/scala/package.scala
+++ b/app-backend/tile/src/main/scala/package.scala
@@ -16,6 +16,6 @@ package object tile {
         deserializationError("Failed to parse UUID string ${js} to java UUID")
     }
   }
-  implicit val defaultColorCorrectParamsFormat = jsonFormat14(ColorCorrect.Params.apply)
+  implicit val defaultColorCorrectParamsFormat = jsonFormat20(ColorCorrect.Params.apply)
   implicit val defaultMosaicDefinitionFormat = jsonFormat2(MosaicDefinition.apply)
 }

--- a/docs/swagger/spec.yml
+++ b/docs/swagger/spec.yml
@@ -2062,6 +2062,24 @@ definitions:
       blueGamma:
         type: number
         format: float
+      redMax:
+        type: number
+        format: float
+      redMin:
+        type: number
+        format: float
+      greenMax:
+        type: number
+        format: float
+      greenMin:
+        type: number
+        format: float
+      blueMax:
+        type: number
+        format: float
+      blueMin:
+        type: number
+        format: float
       brightness:
         type: number
         format: float


### PR DESCRIPTION
## Overview

This PR implements individual clipping for RGB bands as part of the set of `ColorCorrection` parameters.

### Checklist

~~- [ ] Styleguide updated, if necessary~~
- [x] Swagger specification updated, if necessary
~~- [ ] Symlinks from new migrations present or corrected for any new migrations~~

### Demo
With color correction settings:
```
{"items":[{"sceneId":"63b15316-2b28-4280-8eb5-c98de4adffab","params":{"redBand":4,"greenBand":3,"blueBand":2,"redGamma":null,"blueGamma":null,"greenGamma":null,"brightness":-6,"contrast":0,"alpha":null,"beta":null,"min":null,"max":null,"equalize":false,"redMax":null,"greenMax":null,"blueMax":null,"redMin":null,"greenMin":null,"blueMin":null,"saturation":null}}]}
```

Unmodified:
![screenshot 3](https://cloud.githubusercontent.com/assets/18290666/25670895/351767fa-2ffc-11e7-9123-3a7ce96d41e6.jpeg)

With `redMax:20000` `redMin:500`:
![screenshot 5](https://cloud.githubusercontent.com/assets/18290666/25670942/52d126c8-2ffc-11e7-93f8-bf025cde0bd5.jpeg)

As above, plus `greenMax:30000`:
![screenshot 6](https://cloud.githubusercontent.com/assets/18290666/25670971/6d446272-2ffc-11e7-8b53-138e0142ea76.jpeg)

As above, plus `blueMax:1000` & `blueMin:300`:
![screenshot 7](https://cloud.githubusercontent.com/assets/18290666/25670975/70e991fe-2ffc-11e7-9b3f-4c967e7ea7df.jpeg)

As above, plus `min:10000` (which replaces any unspecified RGB `min`):
![screenshot 9](https://cloud.githubusercontent.com/assets/18290666/25671389/d3878770-2ffd-11e7-8d22-5f3df21bd3a0.jpeg)


As above, but with `redMax:200000` (bogus value), which yields the same result as if `redMax` were simply `null`:
![screenshot 8](https://cloud.githubusercontent.com/assets/18290666/25671159/fe32c1f2-2ffc-11e7-80be-579a985c172a.jpeg)


## Testing Instructions

* bounce the server
* with a valid project/scene combination, `POST` some sample color corrections and then retrieve the tiles; the flow I found most convenient was to create a project and then sit on the "Pick Color Mode" sidebar while I `POST`ed corrections, re-clicking whatever color mode I had selected to refresh the tile
* try using bogus values, such as numbers outside the accepted range, as min/max, and check that the tile returned is rendered as it would be if the bogus min/max were simply `null`
* check that the swagger spec is correctly updated

Closes #1539 
