### PR TITLE
Add per-scenes histogram endpoint

### DIFF
--- a/app-backend/tile/src/main/scala/routes/MosaicRoutes.scala
+++ b/app-backend/tile/src/main/scala/routes/MosaicRoutes.scala
@@ -1,17 +1,26 @@
 package com.azavea.rf.tile.routes
 
+import cats.data.OptionT
+import cats.implicits._
+
 import com.azavea.rf.tile._
 import com.azavea.rf.tile.image._
 import com.azavea.rf.database.Database
+import com.azavea.rf.database.tables.ScenesToProjects
+import com.azavea.rf.datamodel.ColorCorrect
 
 import geotrellis.raster._
 import geotrellis.raster.render.Png
 import akka.http.scaladsl.server._
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.model.{ContentType, HttpEntity, HttpResponse, MediaTypes}
+import akka.http.scaladsl.unmarshalling._
 import com.typesafe.scalalogging.LazyLogging
 import cats.implicits._
+import de.heikoseeberger.akkahttpcirce.CirceSupport._
+import scala.collection.mutable.ArrayBuffer
 import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
 import java.util.UUID
 
 object MosaicRoutes extends LazyLogging {
@@ -34,6 +43,8 @@ object MosaicRoutes extends LazyLogging {
           }
         }
       }
+    } ~ pathPrefix("histogram") {
+      post { getProjectScenesHistogram(projectId) }
     } ~ pathPrefix (IntNumber / IntNumber / IntNumber ) { (zoom, x, y) =>
       parameter("tag".?) { tag =>
         get {
@@ -47,6 +58,49 @@ object MosaicRoutes extends LazyLogging {
       }
     }
 
+  /** Return the histogram (with color correction applied) for a list of scenes in a project */
+  def getProjectScenesHistogram(projectId: UUID)(implicit database: Database): Route = {
+    def correctedHistograms(sceneId: UUID, projectId: UUID) = {
+      val tileFuture = StitchLayer(sceneId, 64)
+      // getColorCorrectParams returns a Future[Option[Option]] for some reason
+      val ccParamFuture = ScenesToProjects.getColorCorrectParams(projectId, sceneId).map { _.flatten }
+      for {
+        tile <- tileFuture
+        params <- OptionT(ccParamFuture)
+      } yield {
+        val (rgbBands, rgbHist) = params.reorderBands(tile, tile.histogramDouble)
+        val sceneBands = ColorCorrect(rgbBands, rgbHist, params).bands
+        sceneBands.map(tile => tile.histogram)
+      }
+    }
+    entity(as[Array[UUID]]) { sceneIds =>
+      val scenesHistograms = Future.sequence(sceneIds
+        .map(correctedHistograms(_, projectId)) // Array[OptionT]
+        .map(_.value).toList                    // Array[Future[Option[...]]]
+      )                                         // Future[Array[Option[...]]]
+
+      val mergedBandHistograms = scenesHistograms.map { scenes =>
+        // We need to switch this from a list of histograms by tile, to a list of histograms by band,
+        // hence the transpose call.
+        // Then reduce each band down to a single histogram (still leaving us with an array of histograms,
+        // one for each band).
+        val mergedHists = scenes.flatten.transpose.map { bandHists =>
+          bandHists.reduceLeft((lHist, rHist) => lHist.merge(rHist))
+        }
+        // Turn histograms into value -> count mapping.
+        // TODO: This is more complicated than it needs to be because there's only one way to map over
+        // a histogram's (val, count) pairs.
+        mergedHists.map(hist => {
+          val valCounts = ArrayBuffer[(Int, Long)]()
+          hist.foreach { (value, count) => valCounts += Tuple2(value, count) }
+          valCounts.toMap
+        })
+      }
+      complete {
+        mergedBandHistograms
+      }
+    }
+  }
 // TODO: re-enable this, needed for project color correction endpoint
 //   def mosaicScenes: Route =
 //     pathPrefix(JavaUUID / Segment / "mosaic" / IntNumber / IntNumber / IntNumber) { (orgId, userId, zoom, x, y) =>


### PR DESCRIPTION
## Overview

Adds a histogram endpoint that is designed to power the color-correction histogram. If provided a Project ID and a list of Scene IDs, returns an array of histograms for those Scenes after color correction from the Project has been applied.

### Checklist

- [ ] ~Styleguide updated, if necessary~
- [ ] ~Swagger specification updated, if necessary~
- [ ] ~Symlinks from new migrations present or corrected for any new migrations~

### Notes

* This doesn't currently include a summary histogram, even though it's in the wireframes. That can either be computed on the front end or this endpoint can be updated to include one (in which case the response format should probably be updated to differentiate per-band histograms from the summary histogram). I wasn't sure which approach would make the most sense, so I left it out, but it should be straightforward to add if necessary.
* The Scenes are currently getting resampled down to 64x64 pixels for the histogram calculation; anything significantly larger caused memcached errors. This will cause a loss of precision in the histograms but it's not clear whether it'll be significant enough that we'll need to address it.
* This is kind of in an awkward place in terms of API placement; it'll be used a lot like an API endpoint in practice, but in the background it behaves basically the same as a tiler endpoint. I tried both and settled on a tiler endpoint because it leans on the caching capabilities built into the tiler; if we put it in the API, we'd have had to replicate that capability in the API servers too, which didn't seem desirable.
* The Tiler API is not documented in our swagger spec but probably should be.

## Testing Instructions

 * Spin up UI and `./scripts/server`.
 * Go to the color-correction interface
 * Pull up the inspector, intercept one of the tile requests, and replicate it in a REST client.
 * Switch the URL to `/api/tiles/[UUID]/histogram/`.
 * Remove the color correction parameters and `tag` parameters (keep `token`). Switch to a `POST` request and update the body to be a JSON array of Scene IDs, e.g. `["63b15316-2b28-4280-8eb5-c98de4adffab"]` (the Scene IDs need to match the scenes in the project; you can get them from the bulk color correction API requests).
 * You should get back an array of dicts with band values mapped to pixel counts.

Closes #1537 
