### PR TITLE
Add state tags to various UI items

### DIFF
--- a/app-frontend/src/app/components/projectItem/projectItem.controller.js
+++ b/app-frontend/src/app/components/projectItem/projectItem.controller.js
@@ -24,6 +24,7 @@ export default class ProjectItemController {
 
         this.fitProjectExtent();
         this.addProjectLayer();
+        this.getProjectStatus();
     }
 
     addProjectLayer() {
@@ -48,6 +49,15 @@ export default class ProjectItemController {
     toggleSelected(event) {
         this.onSelect({project: this.project, selected: !this.selectedStatus});
         event.stopPropagation();
+    }
+
+    getProjectStatus() {
+        if (!this.statusFetched) {
+            this.projectService.getProjectStatus(this.project.id).then(status => {
+                this.status = status;
+            });
+            this.statusFetched = true;
+        }
     }
 
     publishModal() {

--- a/app-frontend/src/app/components/projectItem/projectItem.html
+++ b/app-frontend/src/app/components/projectItem/projectItem.html
@@ -1,5 +1,10 @@
 <div class="list-group-item with-rows">
-  <div><h4 class="color-dark">{{$ctrl.project.name}}</h4></div>
+  <div>
+    <h4 class="color-dark">
+      {{$ctrl.project.name}}
+      <rf-status-tag ng-if="$ctrl.status" entity-type="project" status="$ctrl.status"></rf-status-tag>
+    </h4>
+  </div>
   <div class="list-group-item-content">
     <div class="list-group-overflow project-preview-container" ng-if="!$ctrl.project.scenes">
       This project doesn't have any scenes yet

--- a/app-frontend/src/app/components/sceneItem/sceneItem.html
+++ b/app-frontend/src/app/components/sceneItem/sceneItem.html
@@ -8,11 +8,17 @@
   <div ng-if="!$ctrl.scene.thumbnails.length"
        class="rounded-img item-img image-placeholder"></div>
   <div class="list-group-overflow">
-    <span title="{{$ctrl.scene.name}}">
-      <strong class="color-dark">{{$ctrl.scene.name}}</strong>
-    </span>
-    <br>
-    <span title="{{$ctrl.datasource.name}}">{{$ctrl.datasourceLoaded ? $ctrl.datasource.name : 'Loading datasource'}}</span>
+    <div>
+      <span title="{{$ctrl.scene.name}}">
+        <strong class="color-dark">{{$ctrl.scene.createdAt | date}}</strong>
+      </span>
+    </div>
+    <div>
+      <span title="{{$ctrl.datasource.name}}">{{$ctrl.datasourceLoaded ? $ctrl.datasource.name : 'Loading datasource'}}</span>
+    </div>
+    <div>
+      <rf-status-tag entity-type="scene" status="$ctrl.scene.statusFields.ingestStatus"></rf-status-tag>
+    </div>
   </div>
   <div class="list-group-right">
     <button class="btn btn-square"

--- a/app-frontend/src/app/components/statusTag/statusTag.component.js
+++ b/app-frontend/src/app/components/statusTag/statusTag.component.js
@@ -1,0 +1,12 @@
+import statusTagTpl from './statusTag.html';
+
+const rfStatusTag = {
+    templateUrl: statusTagTpl,
+    controller: 'StatusTagController',
+    bindings: {
+        entityType: '@',
+        status: '<'
+    }
+};
+
+export default rfStatusTag;

--- a/app-frontend/src/app/components/statusTag/statusTag.controller.js
+++ b/app-frontend/src/app/components/statusTag/statusTag.controller.js
@@ -1,0 +1,18 @@
+export default class StatusTagController {
+    constructor(statusService) {
+        'ngInject';
+        this.statusService = statusService;
+    }
+
+    $onInit() {
+        this.statusFields = this.statusService.getStatusFields(this.entityType, this.status);
+    }
+
+    getStatusString() {
+        return this.statusFields.label;
+    }
+
+    getStatusClass() {
+        return `${this.statusFields.color}-tag`;
+    }
+}

--- a/app-frontend/src/app/components/statusTag/statusTag.html
+++ b/app-frontend/src/app/components/statusTag/statusTag.html
@@ -1,0 +1,1 @@
+<div class="status-tag {{$ctrl.getStatusClass()}}">{{ $ctrl.getStatusString() }}</div>

--- a/app-frontend/src/app/components/statusTag/statusTag.module.js
+++ b/app-frontend/src/app/components/statusTag/statusTag.module.js
@@ -1,0 +1,12 @@
+import angular from 'angular';
+import StatusTagComponent from './statusTag.component.js';
+import StatusTagController from './statusTag.controller.js';
+
+require('./statusTag.scss');
+
+const StatusTagModule = angular.module('components.statusTag', []);
+
+StatusTagModule.component('rfStatusTag', StatusTagComponent);
+StatusTagModule.controller('StatusTagController', StatusTagController);
+
+export default StatusTagModule;

--- a/app-frontend/src/app/components/statusTag/statusTag.scss
+++ b/app-frontend/src/app/components/statusTag/statusTag.scss
@@ -1,0 +1,25 @@
+div.status-tag {
+  display: inline-block;
+  font-size: 1rem;
+  padding: 0.33em 0.5em;
+  color: #777;
+  border-radius: 2px;
+  font-weight: normal;
+  vertical-align: middle;
+}
+
+.grey-tag {
+  background: #dadada;
+}
+
+.yellow-tag {
+  background: #FFCA28;
+}
+
+.green-tag {
+  background: #81C784
+}
+
+.red-tag {
+  background: #E57373;
+}

--- a/app-frontend/src/app/core/core.module.js
+++ b/app-frontend/src/app/core/core.module.js
@@ -23,6 +23,7 @@ require('./services/feed.service')(shared);
 require('./services/intercom.service')(shared);
 require('./services/rollbarWrapper.service')(shared);
 require('./services/upload.service')(shared);
+require('./services/status.service')(shared);
 
 require('./services/featureFlagOverrides.service')(shared);
 require('./services/featureFlags.provider')(shared);

--- a/app-frontend/src/app/core/services/project.service.js
+++ b/app-frontend/src/app/core/services/project.service.js
@@ -217,7 +217,8 @@ export default (app) => {
             return this.getAllProjectScenes({ projectId }).then(scenes => {
                 if (scenes) {
                     const counts = scenes.reduce((acc, scene) => {
-                        acc[scene.statusFields.ingestStatus] = acc[scene.statusFields.ingestStatus] + 1 || 1;
+                        const ingestStatus = scene.statusFields.ingestStatus;
+                        acc[ingestStatus] = acc[ingestStatus] + 1 || 1;
                         return acc;
                     }, {});
                     if (counts.FAILED) {

--- a/app-frontend/src/app/core/services/project.service.js
+++ b/app-frontend/src/app/core/services/project.service.js
@@ -2,11 +2,13 @@
 
 export default (app) => {
     class ProjectService {
-        constructor($resource, $location, tokenService, userService, $http, $q, APP_CONFIG) {
+        constructor($resource, $location, tokenService, userService, statusService,
+                    $http, $q, APP_CONFIG) {
             'ngInject';
 
             this.tokenService = tokenService;
             this.userService = userService;
+            this.statusService = statusService;
             this.$http = $http;
             this.$location = $location;
             this.$q = $q;
@@ -209,6 +211,25 @@ export default (app) => {
             });
 
             return deferred.promise;
+        }
+
+        getProjectStatus(projectId) {
+            return this.getAllProjectScenes({ projectId }).then(scenes => {
+                if (scenes) {
+                    const counts = scenes.reduce((acc, scene) => {
+                        acc[scene.statusFields.ingestStatus] = acc[scene.statusFields.ingestStatus] + 1 || 1;
+                        return acc;
+                    }, {});
+                    if (counts.FAILED) {
+                        return 'FAILED';
+                    } else if (counts.NOTINGESTING || counts.TOBEINGESTED || counts.INGESTING) {
+                        return 'PARTIAL';
+                    } else if (counts.INGESTED) {
+                        return 'CURRENT';
+                    }
+                }
+                return 'NOSCENES';
+            });
         }
 
         getProjectSceneCount(params) {

--- a/app-frontend/src/app/core/services/status.service.js
+++ b/app-frontend/src/app/core/services/status.service.js
@@ -1,0 +1,117 @@
+/* eslint-disable quotes */
+
+const statusMapping = {
+    "export": {
+        "NOTEXPORTED": {
+            "label": "Not queued for export",
+            "color": "grey"
+        },
+        "TOBEEXPORTED": {
+            "label": "Queued for export",
+            "color": "yellow"
+        },
+        "EXPORTING": {
+            "label": "Currently being exported",
+            "color": "yellow"
+        },
+        "EXPORTED": {
+            "label": "Successfully exported",
+            "color": "green"
+        },
+        "FAILED": {
+            "label": "Export failed",
+            "color": "red"
+        }
+    },
+    "import": {
+        "CREATED": {
+            "label": "Upload created",
+            "color": "grey"
+        },
+        "UPLOADING": {
+            "label": "Waiting for user to upload files",
+            "color": "yellow"
+        },
+        "UPLOADED": {
+            "label": "Files uploaded",
+            "color": "yellow"
+        },
+        "QUEUED": {
+            "label": "Queued import for processing",
+            "color": "yellow"
+        },
+        "PROCESSING": {
+            "label": "Processing import",
+            "color": "yellow"
+        },
+        "COMPLETE": {
+            "label": "Finished import",
+            "color": "green"
+        },
+        "FAILED": {
+            "label": "Import failed for one or more uploads",
+            "color": "red"
+        }
+    },
+    "scene": {
+        "NOTINGESTED": {
+            "label": "Not scheduled for ingest",
+            "color": "grey"
+        },
+        "TOBEINGESTED": {
+            "label": "Queued for ingest",
+            "color": "yellow"
+        },
+        "INGESTING": {
+            "label": "Being ingested",
+            "color": "yellow"
+        },
+        "INGESTED": {
+            "label": "Successfully ingested",
+            "color": "green"
+        },
+        "FAILED": {
+            "label": "Ingest failed",
+            "color": "red"
+        }
+    },
+    "project": {
+        "NOSCENES": {
+            "label": "No scenes",
+            "color": "grey"
+        },
+        "PARTIAL": {
+            "label": "Not all scenes have been ingested",
+            "color": "yellow"
+        },
+        "PENDINGREVIEW": {
+            "label": "Scenes are pending review",
+            "color": "yellow"
+        },
+        "CURRENT": {
+            "label": "All scenes ingested",
+            "color": "green"
+        },
+        "FAILED": {
+            "label": "Ingest failed for some scenes",
+            "color": "red"
+        }
+    }
+};
+
+export default (app) => {
+    class StatusService {
+        constructor() {
+            'ngInject';
+        }
+
+        getStatusFields(entityType, status) {
+          if (statusMapping[entityType] && statusMapping[entityType][status]) {
+              return statusMapping[entityType][status];
+          }
+          return false;
+        }
+    }
+
+    app.service('statusService', StatusService);
+};

--- a/app-frontend/src/app/index.components.js
+++ b/app-frontend/src/app/index.components.js
@@ -32,5 +32,6 @@ export default angular.module('index.components', [
     require('./components/staticMap/staticMap.module.js').name,
     require('./components/sceneDetailModal/sceneDetailModal.module.js').name,
     require('./components/datePickerModal/datePickerModal.module.js').name,
-    require('./components/exportModal/exportModal.module.js').name
+    require('./components/exportModal/exportModal.module.js').name,
+    require('./components/statusTag/statusTag.module.js').name
 ]);


### PR DESCRIPTION
## Overview

This PR adds the display of statuses to the UI through tags.

There are a few parts to this which each have their own commit.

1) **Adds a `statusService` service and `statusTag` component** - the `statusService` maintains the map of entity-types (project, scene, import, etc) to the various statuses and their user-facing label and color. The `statusTag` component uses this service and can display any status that is defined in the service. The `statusTag` component takes an `entity-type` (i.e. 'project', 'scene', etc.) and a `status` ('INGESTING', 'FAILURE', etc.).

2) **Adds the status tag to scenes using `scene.statusFields.ingestStatus`**

3) **Adds a method to compute project status to the `projectService`** - this method gets the statuses of all scenes within a project and determines the resulting status of the scene.
    - If any scene within a project has a ingest status of `FAILED`, the project gets a status of `FAILED`
    - Otherwise, if there are any scenes in the process of being ingested (`NOTINGESTED`, `TOBEINGESTED`, `INGESTING`), the project is given a status of `PARTIAL`
    - Otherwise, if there are only scenes that have been `INGESTED`, the project is given a status of `CURRENT`
    - If there are no scene within a project, it is given the `NOSCENES` status.

4) **Adds the status tag to projects using the above computation**

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~

### Demo

<img width="914" alt="screen shot 2017-05-09 at 12 09 33 pm" src="https://cloud.githubusercontent.com/assets/2442245/25861369/830911c4-34b2-11e7-8ec2-43eb30934772.png">
<img width="888" alt="screen shot 2017-05-09 at 12 09 44 pm" src="https://cloud.githubusercontent.com/assets/2442245/25861371/830afdae-34b2-11e7-8c88-7774294b9711.png">
<img width="590" alt="screen shot 2017-05-09 at 12 10 10 pm" src="https://cloud.githubusercontent.com/assets/2442245/25861370/830a21ea-34b2-11e7-95f3-1345b29a21e2.png">


### Notes

The method defined in step 3 above will need to be moved to the backend.

## Testing Instructions

 * Browse around the UI and see that scene tags match the tag defined in `scene.statusFields.ingestStatus`
 * Check that project statuses are displayed in project lists, and that the resulting status makes sense.

Closes #1671 
Closes #1572 
