### PR TITLE
AOI Scala airflow jobs implementation

### DIFF
--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/Main.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/Main.scala
@@ -5,14 +5,17 @@ import com.azavea.rf.batch.export.airflow.CreateExportDef
 import com.azavea.rf.batch.ingest.spark.Ingest
 import com.azavea.rf.batch.landsat8.airflow.ImportLandsat8
 import com.azavea.rf.batch.sentinel2.airflow.ImportSentinel2
+import com.azavea.rf.batch.aoi.airflow.{FindAOIProjects, UpdateAOIProject}
 
 object Main {
   val modules = Map[String, Array[String] => Unit](
-    Export.name          -> (Export.main(_)),
-    Ingest.name          -> (Ingest.main(_)),
-    ImportLandsat8.name  -> (ImportLandsat8.main(_)),
-    ImportSentinel2.name -> (ImportSentinel2.main(_)),
-    CreateExportDef.name -> (CreateExportDef.main(_))
+    Export.name           -> (Export.main(_)),
+    Ingest.name           -> (Ingest.main(_)),
+    ImportLandsat8.name   -> (ImportLandsat8.main(_)),
+    ImportSentinel2.name  -> (ImportSentinel2.main(_)),
+    CreateExportDef.name  -> (CreateExportDef.main(_)),
+    FindAOIProjects.name  -> (FindAOIProjects.main(_)),
+    UpdateAOIProject.name -> (UpdateAOIProject.main(_))
   )
 
   def main(args: Array[String]): Unit = {

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/aoi/airflow/FindAOIProjects.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/aoi/airflow/FindAOIProjects.scala
@@ -1,0 +1,70 @@
+package com.azavea.rf.batch.aoi.airflow
+
+import com.azavea.rf.batch.Job
+import com.azavea.rf.database.tables._
+import com.azavea.rf.database.{Database => DB}
+
+import java.sql.Timestamp
+import java.time.ZonedDateTime
+
+import scala.util.{Failure, Success}
+
+case class FindAOIProjects(implicit val database: DB) extends Job {
+  val name = FindAOIProjects.name
+
+  import database.driver.api._
+
+  /** Function to sum Reps of diff types */
+  val sumTime: (Rep[String], Rep[Timestamp], Rep[Long]) => Rep[Timestamp] =
+    SimpleFunction.ternary[String, Timestamp, Long, Timestamp]("+")
+
+  def run: Unit = {
+    logger.info("Finding AOI projects...")
+    Users.getUserById(airflowUser).flatMap { userOpt =>
+      val user = userOpt.getOrElse {
+        val e = new Exception(s"User $airflowUser doesn't exist.")
+        sendError(e)
+        stop
+        throw e
+      }
+
+      database.db.run {
+        Projects
+          .filterToSharedOrganizationIfNotInRoot(user)
+          .filter { p =>
+            p.isAOIProject && sumTime("TIME", p.aoisLastChecked, p.aoiCadenceMillis) <= Timestamp.from(ZonedDateTime.now.toInstant)
+          }
+          .join(AoisToProjects)
+          .on { case (p, o) => p.id === o.projectId }
+          .join(AOIs)
+          .on { case ((_, atp), a) => atp.aoiId === a.id }
+          .map { case ((p, _), _) => p.id }
+          .result
+      }
+    } onComplete {
+      case Success(seq) => {
+        println(s"ProjectIds: ${seq.map(_.toString).mkString(",")}")
+        stop
+      }
+      case Failure(e) => {
+        sendError(e)
+        stop
+        throw e
+      }
+    }
+  }
+}
+
+object FindAOIProjects {
+  val name = "find_aoi_projects"
+
+  def main(args: Array[String]): Unit = {
+    implicit val db = DB.DEFAULT
+
+    val job = args.toList match {
+      case _ => FindAOIProjects()
+    }
+
+    job.run
+  }
+}

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/aoi/airflow/FindAOIProjects.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/aoi/airflow/FindAOIProjects.scala
@@ -23,7 +23,6 @@ case class FindAOIProjects(implicit val database: DB) extends Job {
       val user = userOpt.getOrElse {
         val e = new Exception(s"User $airflowUser doesn't exist.")
         sendError(e)
-        stop
         throw e
       }
 
@@ -46,9 +45,10 @@ case class FindAOIProjects(implicit val database: DB) extends Job {
         stop
       }
       case Failure(e) => {
+        e.printStackTrace()
         sendError(e)
         stop
-        throw e
+        sys.exit(1)
       }
     }
   }

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/aoi/airflow/UpdateAOIProject.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/aoi/airflow/UpdateAOIProject.scala
@@ -64,9 +64,10 @@ case class UpdateAOIProject(projectId: UUID)(implicit val database: DB) extends 
         stop
       }
       case Failure(e) => {
+        e.printStackTrace()
         sendError(e)
         stop
-        throw e
+        sys.exit(1)
       }
     }
   }

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/aoi/airflow/UpdateAOIProject.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/aoi/airflow/UpdateAOIProject.scala
@@ -1,0 +1,140 @@
+package com.azavea.rf.batch.aoi.airflow
+
+import com.azavea.rf.batch.Job
+import com.azavea.rf.database.tables._
+import com.azavea.rf.database.{Database => DB}
+import com.azavea.rf.database.query._
+import com.azavea.rf.datamodel._
+
+import cats.data._
+import cats.implicits._
+
+import java.sql.Timestamp
+import java.time.ZonedDateTime
+import java.util.UUID
+
+import scala.concurrent.Future
+import scala.util.{Failure, Success}
+
+case class UpdateAOIProject(projectId: UUID)(implicit val database: DB) extends Job {
+  val name = FindAOIProjects.name
+
+  import database.driver.api._
+
+  /** Function to sum Reps of diff types */
+  val sumTime: (Rep[String], Rep[Timestamp], Rep[Long]) => Rep[Timestamp] =
+    SimpleFunction.ternary[String, Timestamp, Long, Timestamp]("+")
+
+  def run: Unit = {
+    logger.info(s"Updating Project $projectId AOI...")
+    val result = for {
+      user: User                          <- OptionT(Users.getUserById(airflowUser))
+      (project: Project, aoi: AOI)        <- OptionT(Projects.getAOIProject(projectId, user))
+      scenes: Iterable[Scene.WithRelated] <- OptionT({
+        val area = aoi.area
+        val queryParams = aoi.filters.as[CombinedSceneQueryParams].getOrElse(CombinedSceneQueryParams())
+
+        val scenes: Future[Iterable[Scene.WithRelated]] = (for {
+          sceneIds <- OptionT.liftF(
+            database.db.run {
+              Scenes
+                .filterScenes(queryParams)
+                .filter { _.dataFootprint.intersects(area) }
+                .map { _.id }
+                .result
+            }
+          )
+          projects <- OptionT.liftF(Projects.addScenesToProject(sceneIds, projectId, user))
+        } yield projects).value.map(_.getOrElse(Seq()))
+
+        scenes.collect {
+          case scenesSeq if scenesSeq.nonEmpty => {
+            logger.info(s"Project $projectId is updated.")
+            Projects.updateProject(project.copy(aoisLastChecked = Timestamp.from(ZonedDateTime.now.toInstant)), projectId, user)
+            Some(scenesSeq)
+          }
+          case _ => {
+            logger.info(s"Project $projectId update is not required.")
+            None
+          }
+        }
+      })
+    } yield scenes
+
+    val future: Future[Iterable[Scene.WithRelated]] = result.value.map { _.getOrElse(Seq()) }
+
+    future onComplete {
+      case Success(seq) if seq.nonEmpty => {
+        logger.info(s"Updated Project $projectId with scenes: ${seq.mkString(",")}")
+        stop
+      }
+      case Success(seq) if seq.isEmpty => {
+        logger.info(s"Project $projectId required no update")
+        stop
+      }
+      case Failure(e) => {
+        sendError(e)
+        stop
+        throw e
+      }
+    }
+
+    /*val r: Future[Option[Future[Iterable[Scene.WithRelated]]]] = Users.getUserById(airflowUser).flatMap { userOpt =>
+      val user = userOpt.getOrElse {
+        val e = new Exception(s"User $airflowUser doesn't exist.")
+        sendError(e)
+        stop
+        throw e
+      }
+
+      Projects.getAOIProject(projectId, user).map { v => user -> v }
+    }.map { case (user, ps) => ps.map { case (p, a) =>
+      val area = a.area
+      val queryParams = a.filters.as[CombinedSceneQueryParams].getOrElse(CombinedSceneQueryParams())
+
+      val scenes: Future[Iterable[Scene.WithRelated]] = (for {
+        sceneIds <- OptionT.liftF(
+          database.db.run {
+            Scenes
+              .filterScenes(queryParams)
+              .filter { _.dataFootprint.intersects(area) }
+              .map { _.id }
+              .result
+          }
+        )
+        projects <- OptionT.liftF(Projects.addScenesToProject(sceneIds, projectId, user))
+      } yield projects).value.map(_.getOrElse(Seq()))
+
+
+      scenes.collect {
+        case scenesSeq if scenesSeq.nonEmpty => {
+          logger.info(s"Project $projectId is updated.")
+          Projects.updateProject(p.copy(aoisLastChecked = Timestamp.from(ZonedDateTime.now.toInstant)), projectId, user)
+          scenesSeq
+        }
+        case scenesSeq => {
+          logger.info(s"Project $projectId update is not required.")
+          scenesSeq
+        }
+      }
+    } }*/
+
+  }
+}
+
+object UpdateAOIProject {
+  val name = "update_aoi_projects"
+
+  def main(args: Array[String]): Unit = {
+    implicit val db = DB.DEFAULT
+
+    val job = args.toList match {
+      case List(projectId) => UpdateAOIProject(UUID.fromString(projectId))
+      case _ =>
+        throw new IllegalArgumentException("Argument could not be parsed to UUID")
+    }
+
+    job.run
+  }
+}
+

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/aoi/airflow/UpdateAOIProject.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/aoi/airflow/UpdateAOIProject.scala
@@ -21,55 +21,46 @@ case class UpdateAOIProject(projectId: UUID)(implicit val database: DB) extends 
 
   import database.driver.api._
 
-  /** Function to sum Reps of diff types */
-  val sumTime: (Rep[String], Rep[Timestamp], Rep[Long]) => Rep[Timestamp] =
-    SimpleFunction.ternary[String, Timestamp, Long, Timestamp]("+")
-
   def run: Unit = {
     logger.info(s"Updating Project $projectId AOI...")
     val result = for {
-      user: User                          <- OptionT(Users.getUserById(airflowUser))
-      (project: Project, aoi: AOI)        <- OptionT(Projects.getAOIProject(projectId, user))
-      scenes: Iterable[Scene.WithRelated] <- OptionT({
+      user: User                   <- OptionT(Users.getUserById(airflowUser))
+      (project: Project, aoi: AOI) <- OptionT(Projects.getAOIProject(projectId, user))
+      scenes: Iterable[UUID]       <- OptionT({
         val area = aoi.area
-        val queryParams = aoi.filters.as[CombinedSceneQueryParams].getOrElse(CombinedSceneQueryParams())
+        val queryParams =
+          aoi
+            .filters.as[CombinedSceneQueryParams]
+            .getOrElse(throw new Exception(s"No valid queryParams passed: ${aoi.filters}"))
 
-        val scenes: Future[Iterable[Scene.WithRelated]] = (for {
+        val scenes: Future[Iterable[UUID]] = (for {
           sceneIds <- OptionT.liftF(
             database.db.run {
               Scenes
                 .filterScenes(queryParams)
-                .filter { _.dataFootprint.intersects(area) }
+                .filterUserVisibility(user)
+                .filter { s => s.dataFootprint.intersects(area) && s.createdAt > project.aoisLastChecked }
                 .map { _.id }
                 .result
             }
           )
           projects <- OptionT.liftF(Projects.addScenesToProject(sceneIds, projectId, user))
-        } yield projects).value.map(_.getOrElse(Seq()))
+        } yield projects.map(_.id)).value.map(_.getOrElse(Seq()))
 
-        scenes.collect {
-          case scenesSeq if scenesSeq.nonEmpty => {
-            logger.info(s"Project $projectId is updated.")
-            Projects.updateProject(project.copy(aoisLastChecked = Timestamp.from(ZonedDateTime.now.toInstant)), projectId, user)
-            Some(scenesSeq)
-          }
-          case _ => {
-            logger.info(s"Project $projectId update is not required.")
-            None
-          }
-        }
+        scenes.map { scenesSeq => {
+          logger.info(s"Project $projectId is updated.")
+          Projects.updateProject(project.copy(aoisLastChecked = Timestamp.from(ZonedDateTime.now.toInstant)), projectId, user)
+          scenesSeq.some
+        } }
       })
     } yield scenes
 
-    val future: Future[Iterable[Scene.WithRelated]] = result.value.map { _.getOrElse(Seq()) }
+    val future: Future[Iterable[UUID]] = result.value.map { _.getOrElse(Seq()) }
 
     future onComplete {
-      case Success(seq) if seq.nonEmpty => {
-        logger.info(s"Updated Project $projectId with scenes: ${seq.mkString(",")}")
-        stop
-      }
-      case Success(seq) if seq.isEmpty => {
-        logger.info(s"Project $projectId required no update")
+      case Success(seq) => {
+        if(seq.nonEmpty) logger.info(s"Updated Project $projectId with scenes: ${seq.mkString(",")}")
+        else logger.info(s"Project $projectId required no update")
         stop
       }
       case Failure(e) => {
@@ -78,52 +69,11 @@ case class UpdateAOIProject(projectId: UUID)(implicit val database: DB) extends 
         throw e
       }
     }
-
-    /*val r: Future[Option[Future[Iterable[Scene.WithRelated]]]] = Users.getUserById(airflowUser).flatMap { userOpt =>
-      val user = userOpt.getOrElse {
-        val e = new Exception(s"User $airflowUser doesn't exist.")
-        sendError(e)
-        stop
-        throw e
-      }
-
-      Projects.getAOIProject(projectId, user).map { v => user -> v }
-    }.map { case (user, ps) => ps.map { case (p, a) =>
-      val area = a.area
-      val queryParams = a.filters.as[CombinedSceneQueryParams].getOrElse(CombinedSceneQueryParams())
-
-      val scenes: Future[Iterable[Scene.WithRelated]] = (for {
-        sceneIds <- OptionT.liftF(
-          database.db.run {
-            Scenes
-              .filterScenes(queryParams)
-              .filter { _.dataFootprint.intersects(area) }
-              .map { _.id }
-              .result
-          }
-        )
-        projects <- OptionT.liftF(Projects.addScenesToProject(sceneIds, projectId, user))
-      } yield projects).value.map(_.getOrElse(Seq()))
-
-
-      scenes.collect {
-        case scenesSeq if scenesSeq.nonEmpty => {
-          logger.info(s"Project $projectId is updated.")
-          Projects.updateProject(p.copy(aoisLastChecked = Timestamp.from(ZonedDateTime.now.toInstant)), projectId, user)
-          scenesSeq
-        }
-        case scenesSeq => {
-          logger.info(s"Project $projectId update is not required.")
-          scenesSeq
-        }
-      }
-    } }*/
-
   }
 }
 
 object UpdateAOIProject {
-  val name = "update_aoi_projects"
+  val name = "update_aoi_project"
 
   def main(args: Array[String]): Unit = {
     implicit val db = DB.DEFAULT
@@ -137,4 +87,3 @@ object UpdateAOIProject {
     job.run
   }
 }
-

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/export/airflow/CreateExportDef.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/export/airflow/CreateExportDef.scala
@@ -82,7 +82,7 @@ case class CreateExportDef(exportId: UUID)(implicit val database: DB) extends Jo
   def run: Unit = {
     logger.info("Starting export process...")
 
-    val startEmr = (ed:ExportDefinition, edu:String) => Future { startExportEmrJob(ed, edu) }
+    val startEmr = (ed: ExportDefinition, edu: String) => Future { startExportEmrJob(ed, edu) }
 
     val createExportDef = for {
       user: User <- OptionT(Users.getUserById(airflowUser))
@@ -118,9 +118,10 @@ case class CreateExportDef(exportId: UUID)(implicit val database: DB) extends Jo
         stop
       }
       case Failure(e) => {
+        e.printStackTrace()
         sendError(e)
         stop
-        throw e
+        sys.exit(1)
       }
     }
   }

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/export/airflow/CreateExportDef.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/export/airflow/CreateExportDef.scala
@@ -139,9 +139,8 @@ object CreateExportDef {
 
     val job = args.toList match {
       case List(exportId) => CreateExportDef(UUID.fromString(exportId))
-      case _ => {
+      case _ =>
         throw new IllegalArgumentException("Argument could not be parsed to UUID")
-      }
     }
   
     job.run

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/landsat8/airflow/ImportLandsat8.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/landsat8/airflow/ImportLandsat8.scala
@@ -222,7 +222,6 @@ case class ImportLandsat8(startDate: LocalDate = LocalDate.now(ZoneOffset.UTC), 
       val user = userOpt.getOrElse {
         val e = new Exception(s"User $airflowUser doesn't exist.")
         sendError(e)
-        stop
         throw e
       }
 
@@ -257,16 +256,18 @@ case class ImportLandsat8(startDate: LocalDate = LocalDate.now(ZoneOffset.UTC), 
         if(scenes.nonEmpty) logger.info(s"Successfully imported scenes: ${scenes.map(_.id.toString).mkString(", ")}.")
         else {
           val e = new Exception(s"No scenes available for the ${startDate}")
+          e.printStackTrace()
           sendError(e)
           stop
-          throw e
+          sys.exit(1)
         }
         stop
       }
       case Failure(e) => {
-        logger.error(e.stackTraceString)
+        e.printStackTrace()
         sendError(e)
         stop
+        sys.exit(1)
       }
     }
   }

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/sentinel2/airflow/ImportSentinel2.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/sentinel2/airflow/ImportSentinel2.scala
@@ -213,7 +213,6 @@ case class ImportSentinel2(startDate: LocalDate = LocalDate.now(ZoneOffset.UTC))
       findScenes(startDate, userOpt.getOrElse {
         val e = new Exception(s"User $airflowUser doesn't exist.")
         sendError(e)
-        stop
         throw e
       })
     } onComplete {
@@ -221,16 +220,18 @@ case class ImportSentinel2(startDate: LocalDate = LocalDate.now(ZoneOffset.UTC))
         if(scenes.nonEmpty) logger.info(s"Successfully imported scenes: ${scenes.map(_.id.toString).mkString(", ")}.")
         else {
           val e = new Exception(s"No scenes available for the ${startDate}")
+          e.printStackTrace()
           sendError(e)
           stop
-          throw e
+          sys.exit(1)
         }
         stop
       }
       case Failure(e) => {
-        logger.error(e.stackTraceString)
+        e.printStackTrace()
         sendError(e)
         stop
+        sys.exit(1)
       }
     }
   }


### PR DESCRIPTION
## Overview

Implements batch jobs to updated AOI and AOI DAGs to use batch.jar

### Checklist

- [x] Check to see which projects need to be updated/checked for updates (`FindAOIProjects`)
- [x] Performs checks for each project that needs to be updated (`UpdateAOIProject`)
- [x] Updates last update time of projects that have been updated (`UpdateAOIProject`)
- [x] Modify Airflow DAG
- [x] Tests and check it

### Note (related to Scala part)

The format of printing found AOI projects UUIDs is arguable and any comments are appreciated (currently just a println message in the stdout). However it can be discussed after updating Airflow DAGs in a separate PR.

### Demo

**find_aoi_projects_to_update**
![1](https://cloud.githubusercontent.com/assets/4929546/25895910/a0d43c82-358a-11e7-94be-5faccd0a5e3d.png)

**find_aoi_projects_to_update**
![11](https://cloud.githubusercontent.com/assets/4929546/25895924/b4213ace-358a-11e7-9900-08e7b8014d09.png)

**update_aoi_projects**
![111](https://cloud.githubusercontent.com/assets/4929546/25895934/c1ed7d52-358a-11e7-926e-127f3250db9d.png)

### Testing Instructions

To test Scala part:

To do the commands below, it's necessary to have an AOI project with AOI and AoiToProject relation.

```bash
# Finds all AOI project to update, prints UUIDs
java -cp rf-batch.jar com.azavea.rf.batch.Main find_aoi_projects

# Updates AOI project if it's possible / required
java -cp rf-batch.jar com.azavea.rf.batch.Main update_aoi_project <UUID>
```

To test Airflow part:

Run this DAG through UI

Be careful with run times, as it generates run_ids basing on the DAG run time, it can cause collisions: `https://github.com/azavea/raster-foundry/blob/feature/aoi-batch-dag/app-tasks/dags/aoi-monitoring/find_aoi_projects_to_update.py#L74`

Closes #1431
Closes #1717
