### PR TITLE
Tool Metadata + ToolRun Overrides

### DIFF
--- a/app-backend/api/src/main/scala/toolrun/Routes.scala
+++ b/app-backend/api/src/main/scala/toolrun/Routes.scala
@@ -19,7 +19,7 @@ trait ToolRunRoutes extends Authentication
     with ToolRunQueryParametersDirective
     with CommonHandlers
     with UserErrorHandler
-    with InterpreterErrorHandler
+    with InterpreterExceptionHandling
     with ActionRunner {
 
   implicit def database: Database

--- a/app-backend/build.sbt
+++ b/app-backend/build.sbt
@@ -245,6 +245,7 @@ lazy val tool = Project("tool", file("tool"))
       Dependencies.circeCore,
       Dependencies.circeGeneric,
       Dependencies.circeParser,
-      Dependencies.circeOptics
+      Dependencies.circeOptics,
+      Dependencies.scalaCheck
     )
   })

--- a/app-backend/common/src/main/scala/CommonHandlers.scala
+++ b/app-backend/common/src/main/scala/CommonHandlers.scala
@@ -1,8 +1,10 @@
 package com.azavea.rf.common
 
 import akka.http.scaladsl.model.StatusCodes
-import akka.http.scaladsl.server.StandardRoute
+import akka.http.scaladsl.server.{StandardRoute, ExceptionHandler}
 import akka.http.scaladsl.server.directives.RouteDirectives
+import io.circe._
+import cats.syntax.show
 
 
 trait CommonHandlers extends RouteDirectives {
@@ -10,5 +12,9 @@ trait CommonHandlers extends RouteDirectives {
     case 1 => complete(StatusCodes.NoContent)
     case 0 => complete(StatusCodes.NotFound)
     case _ => throw new IllegalStateException(s"Result expected to be 1, was $count")
+  }
+
+  def circeDecodingError = ExceptionHandler {
+    case df: DecodingFailure => complete { (StatusCodes.InternalServerError, DecodingFailure.showDecodingFailure.show(df)) }
   }
 }

--- a/app-backend/common/src/main/scala/InterpreterExceptionHandler.scala
+++ b/app-backend/common/src/main/scala/InterpreterExceptionHandler.scala
@@ -3,17 +3,17 @@ package com.azavea.rf.common
 import com.azavea.rf.tool.eval.InterpreterError
 
 import akka.http.scaladsl.server.{Directives, ExceptionHandler}
+import akka.http.scaladsl.model._
 import cats.data.NonEmptyList
 import com.typesafe.scalalogging.LazyLogging
 import io.circe._
 import io.circe.syntax._
 import de.heikoseeberger.akkahttpcirce.CirceSupport._
 
-// --- //
 
 case class InterpreterException(errors: NonEmptyList[InterpreterError]) extends Exception
 
-trait InterpreterErrorHandler extends Directives with LazyLogging {
+trait InterpreterExceptionHandling extends Directives with LazyLogging {
   implicit val encodeErrorList: Encoder[NonEmptyList[InterpreterError]] =
     new Encoder[NonEmptyList[InterpreterError]] {
       final def apply(errors: NonEmptyList[InterpreterError]): Json = JsonObject.fromMap {

--- a/app-backend/project/Dependencies.scala
+++ b/app-backend/project/Dependencies.scala
@@ -58,4 +58,5 @@ object Dependencies {
   val ficus                   = "com.iheart"                  %% "ficus"                             % Version.ficus
   val dnsJava                 = "dnsjava"                      % "dnsjava"                           % Version.dnsJava
   val dropbox                 = "com.dropbox.core"             % "dropbox-core-sdk"                  % Version.dropbox
+  val scalaCheck              = "org.scalacheck"              %% "scalacheck"                        % Version.scalaCheck % "test"
 }

--- a/app-backend/project/Version.scala
+++ b/app-backend/project/Version.scala
@@ -39,4 +39,5 @@ object Version {
   val awsSdk             = "1.11.92"
   val dnsJava            = "2.1.8"
   val dropbox            = "2.1.1"
+  val scalaCheck         = "1.13.4"
 }

--- a/app-backend/tile/src/main/scala/Router.scala
+++ b/app-backend/tile/src/main/scala/Router.scala
@@ -19,6 +19,12 @@ class Router extends LazyLogging
 
   def root = handleExceptions(tileExceptionHandler) {
     pathPrefix("tiles") {
+      pathPrefix(JavaUUID) { projectId =>
+        tileAccessAuthorized(projectId) {
+          case true => MosaicRoutes.mosaicProject(projectId)(database)
+          case _ => reject(AuthorizationFailedRejection)
+        }
+      } ~
       pathPrefix("healthcheck") {
         pathEndOrSingleSlash {
           get {
@@ -29,15 +35,14 @@ class Router extends LazyLogging
         }
       } ~
       tileAuthenticateOption { _ =>
-        SceneRoutes.root ~
-        pathPrefix("tools") {
-          toolRoutes.root(TileSources.cachedTmsSource)
-        }
+        SceneRoutes.root
       } ~
-      pathPrefix(JavaUUID) { projectId =>
-        tileAccessAuthorized(projectId) {
-          case true => MosaicRoutes.mosaicProject(projectId)(database)
-          case _ => reject(AuthorizationFailedRejection)
+      pathPrefix("tools") {
+        get {
+          tileAuthenticateOption { _ =>
+            toolRoutes.tms(TileSources.cachedTmsSource) ~
+            toolRoutes.preflight
+          }
         }
       }
     }

--- a/app-backend/tile/src/main/scala/routes/ToolRoutes.scala
+++ b/app-backend/tile/src/main/scala/routes/ToolRoutes.scala
@@ -76,11 +76,11 @@ class ToolRoutes(implicit val database: Database) extends Authentication
                   toolRun <- OptionT(database.db.run(ToolRuns.getToolRun(toolRunId, user)))
                   tool    <- OptionT(Tools.getTool(toolRun.tool, user))
                   params  <- OptionT.fromOption[Future](maybeThrow(toolRun.executionParameters.as[EvalParams]))
-                  ramp    <- OptionT.fromOption[Future](defaultRamps.get(colorRamp))
                   ast     <- OptionT.fromOption[Future](maybeThrow(tool.definition.as[MapAlgebraAST]).flatMap(entireAST =>
                                nodeId.flatMap(id => entireAST.find(id)).orElse(Some(entireAST))
                              ))
                   hist    <- LayerCache.modelLayerGlobalHistogram(toolRun, tool, nodeId)
+                  ramp    <- OptionT.fromOption[Future](defaultRamps.get(colorRamp))
                   tile    <- OptionT({
                                val tms = Interpreter.interpretTMS(ast, params, source)
                                tms(z, x, y).map {

--- a/app-backend/tool/src/main/scala/ast/ClassMap.scala
+++ b/app-backend/tool/src/main/scala/ast/ClassMap.scala
@@ -6,18 +6,28 @@ import geotrellis.raster.render._
 import spire.std.any._
 
 @JsonCodec
-case class ClassBreaks(
-  classMap: Map[Double, Int],
-  options: ClassBreaks.Options = ClassBreaks.Options()
+case class ClassMap(
+  classifications: Map[Double, Int],
+  options: ClassMap.Options = ClassMap.Options()
 ) {
   lazy val mapStrategy =
     new MapStrategy(options.boundaryType, options.ndValue, options.fallback, false)
 
   def toBreakMap =
-    new BreakMap(classMap, mapStrategy, { i: Double => isNoData(i) })
+    new BreakMap(classifications, mapStrategy, { i: Double => isNoData(i) })
+
+  def toColorMap =
+    ColorMap(
+      classifications,
+      ColorMap.Options(
+        options.boundaryType,
+        options.ndValue,
+        options.fallback
+      )
+    )
 }
 
-object ClassBreaks {
+object ClassMap {
   @JsonCodec
   case class Options(
     boundaryType: ClassBoundaryType = LessThanOrEqualTo,

--- a/app-backend/tool/src/main/scala/ast/MapAlgebraAST.scala
+++ b/app-backend/tool/src/main/scala/ast/MapAlgebraAST.scala
@@ -44,28 +44,22 @@ object MapAlgebraAST {
     def sources: Seq[UUID] = args.flatMap(_.sources)
   }
 
-  @JsonCodec
   case class Addition(args: List[MapAlgebraAST], id: UUID, metadata: Option[NodeMetadata])
       extends Operation("+")
 
-  @JsonCodec
   case class Subtraction(args: List[MapAlgebraAST], id: UUID, metadata: Option[NodeMetadata])
       extends Operation("-")
 
-  @JsonCodec
   case class Multiplication(args: List[MapAlgebraAST], id: UUID, metadata: Option[NodeMetadata])
       extends Operation("*")
 
-  @JsonCodec
   case class Division(args: List[MapAlgebraAST], id: UUID, metadata: Option[NodeMetadata])
       extends Operation("/")
 
-  @JsonCodec
   case class Masking(args: List[MapAlgebraAST], id: UUID, metadata: Option[NodeMetadata])
       extends Operation("mask")
 
-  @JsonCodec
-  case class Classification(args: List[MapAlgebraAST], id: UUID, metadata: Option[NodeMetadata], classBreaks: ClassBreaks)
+  case class Classification(args: List[MapAlgebraAST], id: UUID, metadata: Option[NodeMetadata], classMap: ClassMap)
       extends Operation("classify")
 
   /** Map Algebra sources (leaves) */
@@ -83,6 +77,6 @@ object MapAlgebraAST {
     def empty: Source = Source(UUID.randomUUID(), None)
   }
 
-  /** TODO: Add other source types (or treat of them as hyperparameters - e.g. ClassBreaks, above) */
+  /** TODO: Add other source types (or treat of them as hyperparameters - e.g. ClassMap, above) */
 
 }

--- a/app-backend/tool/src/main/scala/ast/MapAlgebraAST.scala
+++ b/app-backend/tool/src/main/scala/ast/MapAlgebraAST.scala
@@ -9,9 +9,22 @@ import io.circe.generic.JsonCodec
 sealed trait MapAlgebraAST extends Product with Serializable {
   def id: UUID
   def args: List[MapAlgebraAST]
-  def label: Option[String]
+  def metadata: Option[NodeMetadata]
   def find(id: UUID): Option[MapAlgebraAST]
   def sources: Seq[UUID]
+
+  def overrideMetadata(otherMD: Option[NodeMetadata]): Option[NodeMetadata] =
+    (metadata, otherMD) match {
+      case (Some(defaults), Some(overrides)) =>
+        Some(NodeMetadata(
+          overrides.label.orElse(defaults.label),
+          overrides.description.orElse(defaults.description),
+          overrides.histogram.orElse(defaults.histogram)
+        ))
+      case (None, Some(_)) => otherMD
+      case (Some(_), None) => metadata
+      case _ => None
+    }
 }
 
 object MapAlgebraAST {
@@ -32,32 +45,32 @@ object MapAlgebraAST {
   }
 
   @JsonCodec
-  case class Addition(args: List[MapAlgebraAST], id: UUID, label: Option[String])
+  case class Addition(args: List[MapAlgebraAST], id: UUID, metadata: Option[NodeMetadata])
       extends Operation("+")
 
   @JsonCodec
-  case class Subtraction(args: List[MapAlgebraAST], id: UUID, label: Option[String])
+  case class Subtraction(args: List[MapAlgebraAST], id: UUID, metadata: Option[NodeMetadata])
       extends Operation("-")
 
   @JsonCodec
-  case class Multiplication(args: List[MapAlgebraAST], id: UUID, label: Option[String])
+  case class Multiplication(args: List[MapAlgebraAST], id: UUID, metadata: Option[NodeMetadata])
       extends Operation("*")
 
   @JsonCodec
-  case class Division(args: List[MapAlgebraAST], id: UUID, label: Option[String])
+  case class Division(args: List[MapAlgebraAST], id: UUID, metadata: Option[NodeMetadata])
       extends Operation("/")
 
   @JsonCodec
-  case class Masking(args: List[MapAlgebraAST], id: UUID, label: Option[String])
+  case class Masking(args: List[MapAlgebraAST], id: UUID, metadata: Option[NodeMetadata])
       extends Operation("mask")
 
   @JsonCodec
-  case class Classification(args: List[MapAlgebraAST], id: UUID, label: Option[String], classBreaks: ClassBreaks)
+  case class Classification(args: List[MapAlgebraAST], id: UUID, metadata: Option[NodeMetadata], classBreaks: ClassBreaks)
       extends Operation("classify")
 
   /** Map Algebra sources (leaves) */
   @JsonCodec
-  case class Source(id: UUID, label: Option[String]) extends MapAlgebraAST {
+  case class Source(id: UUID, metadata: Option[NodeMetadata]) extends MapAlgebraAST {
     def args: List[MapAlgebraAST] = List.empty
 
     def find(id: UUID): Option[MapAlgebraAST] =

--- a/app-backend/tool/src/main/scala/ast/MapAlgebraAST.scala
+++ b/app-backend/tool/src/main/scala/ast/MapAlgebraAST.scala
@@ -12,19 +12,6 @@ sealed trait MapAlgebraAST extends Product with Serializable {
   def metadata: Option[NodeMetadata]
   def find(id: UUID): Option[MapAlgebraAST]
   def sources: Seq[UUID]
-
-  def overrideMetadata(otherMD: Option[NodeMetadata]): Option[NodeMetadata] =
-    (metadata, otherMD) match {
-      case (Some(defaults), Some(overrides)) =>
-        Some(NodeMetadata(
-          overrides.label.orElse(defaults.label),
-          overrides.description.orElse(defaults.description),
-          overrides.histogram.orElse(defaults.histogram)
-        ))
-      case (None, Some(_)) => otherMD
-      case (Some(_), None) => metadata
-      case _ => None
-    }
 }
 
 object MapAlgebraAST {

--- a/app-backend/tool/src/main/scala/ast/NodeMetadata.scala
+++ b/app-backend/tool/src/main/scala/ast/NodeMetadata.scala
@@ -1,0 +1,26 @@
+package com.azavea.rf.tool.ast
+
+import geotrellis.raster.render.ColorRamp
+import geotrellis.raster.histogram._
+import io.circe._
+import io.circe.syntax._
+import io.circe.disjunctionCodecs._
+import io.circe.generic.JsonCodec
+
+import com.azavea.rf.tool.ast.codec.MapAlgebraCodec
+
+
+case class NodeMetadata(
+  label: Option[String],
+  description: Option[String],
+  histogram: Option[Histogram[Double]]
+)
+
+object NodeMetadata extends MapAlgebraCodec {
+  implicit val nodeMetadataEncoder: Encoder[NodeMetadata] =
+    Encoder.forProduct3("label", "description", "histogram")(nmd =>
+      (nmd.label, nmd.description, nmd.histogram)
+    )
+  implicit val nodeMetadataDecoder: Decoder[NodeMetadata] =
+    Decoder.forProduct3("label", "description", "histogram")(NodeMetadata.apply)
+}

--- a/app-backend/tool/src/main/scala/ast/NodeMetadata.scala
+++ b/app-backend/tool/src/main/scala/ast/NodeMetadata.scala
@@ -1,6 +1,6 @@
 package com.azavea.rf.tool.ast
 
-import geotrellis.raster.render.ColorRamp
+import geotrellis.raster.render._
 import geotrellis.raster.histogram._
 import io.circe._
 import io.circe.syntax._
@@ -11,16 +11,30 @@ import com.azavea.rf.tool.ast.codec.MapAlgebraCodec
 
 
 case class NodeMetadata(
-  label: Option[String],
-  description: Option[String],
-  histogram: Option[Histogram[Double]]
-)
+  label: Option[String] = None,
+  description: Option[String] = None,
+  histogram: Option[Histogram[Double]] = None,
+  colorRamp: Option[ColorRamp] = None,
+  classMap: Option[ClassMap] = None
+) {
+
+  /** A helper method for merging default values with overrides */
+  def fallbackTo(that: NodeMetadata): NodeMetadata = {
+    NodeMetadata(
+      this.label.orElse(that.label),
+      this.description.orElse(that.description),
+      this.histogram.orElse(that.histogram),
+      this.colorRamp.orElse(that.colorRamp),
+      this.classMap.orElse(that.classMap)
+    )
+  }
+}
 
 object NodeMetadata extends MapAlgebraCodec {
   implicit val nodeMetadataEncoder: Encoder[NodeMetadata] =
-    Encoder.forProduct3("label", "description", "histogram")(nmd =>
-      (nmd.label, nmd.description, nmd.histogram)
+    Encoder.forProduct5("label", "description", "histogram", "colorRamp", "classMap")(nmd =>
+      (nmd.label, nmd.description, nmd.histogram, nmd.colorRamp, nmd.classMap)
     )
   implicit val nodeMetadataDecoder: Decoder[NodeMetadata] =
-    Decoder.forProduct3("label", "description", "histogram")(NodeMetadata.apply)
+    Decoder.forProduct5("label", "description", "histogram", "colorRamp", "classMap")(NodeMetadata.apply)
 }

--- a/app-backend/tool/src/main/scala/ast/RFMLRaster.scala
+++ b/app-backend/tool/src/main/scala/ast/RFMLRaster.scala
@@ -17,19 +17,11 @@ case class SceneRaster(id: UUID, band: Option[Int]) extends RFMLRaster("scene")
 @JsonCodec
 case class ProjectRaster(id: UUID, band: Option[Int]) extends RFMLRaster("project")
 
-@JsonCodec
-case class MLToolRaster(id: UUID, node: Option[UUID]) extends RFMLRaster("tool")
-
-@JsonCodec
-case class RasterReference(id: UUID) extends RFMLRaster("reference")
-
 object RFMLRaster {
   implicit lazy val decodeRFMLRaster = Decoder.instance[RFMLRaster] { rasterSrc =>
     rasterSrc._type match {
       case Some("scene") => rasterSrc.as[SceneRaster]
       case Some("project") => rasterSrc.as[ProjectRaster]
-      case Some("tool") => rasterSrc.as[MLToolRaster]
-      case Some("reference") => rasterSrc.as[RasterReference]
       case Some(unrecognized) =>
         throw new InvalidParameterException(s"'$unrecognized' is not a recognized map algebra raster source type")
       case None =>
@@ -41,20 +33,6 @@ object RFMLRaster {
     def apply(rasterDefinition: RFMLRaster): Json = rasterDefinition match {
       case scene: SceneRaster => scene.asJson
       case project: ProjectRaster => project.asJson
-      case mltool: MLToolRaster => mltool.asJson
-      case reference: RasterReference => reference.asJson
     }
   }
-
-  implicit lazy val encodeSceneRaster: Encoder[SceneRaster] =
-    Encoder.forProduct3("id", "band", "type")(rfml => (rfml.id, rfml.band, rfml.`type`))
-
-  implicit lazy val encodeProjectRaster: Encoder[ProjectRaster] =
-    Encoder.forProduct3("id", "band", "type")(rfml => (rfml.id, rfml.band, rfml.`type`))
-
-  implicit lazy val encodeMLToolRaster: Encoder[MLToolRaster] =
-    Encoder.forProduct3("id", "node", "type")(rfml => (rfml.id, rfml.node, rfml.`type`))
-
-  implicit lazy val encodeRasterReference: Encoder[RasterReference] =
-    Encoder.forProduct2("id", "type")(rfml => (rfml.id, rfml.`type`))
 }

--- a/app-backend/tool/src/main/scala/ast/RFMLRaster.scala
+++ b/app-backend/tool/src/main/scala/ast/RFMLRaster.scala
@@ -11,10 +11,8 @@ sealed abstract class RFMLRaster(val `type`: String) {
   def id: UUID
 }
 
-@JsonCodec
 case class SceneRaster(id: UUID, band: Option[Int]) extends RFMLRaster("scene")
 
-@JsonCodec
 case class ProjectRaster(id: UUID, band: Option[Int]) extends RFMLRaster("project")
 
 object RFMLRaster {
@@ -28,6 +26,16 @@ object RFMLRaster {
         throw new InvalidParameterException("Required property, 'type', not found on map algebra raster source")
     }
   }
+
+  implicit lazy val decodeSceneRaster: Decoder[SceneRaster] =
+    Decoder.forProduct2("id", "band")(SceneRaster.apply)
+  implicit lazy val encodeSceneRaster: Encoder[SceneRaster] =
+    Encoder.forProduct3("id", "band", "type")(op => (op.id, op.band, op.`type`))
+
+  implicit lazy val decodeProjectRaster: Decoder[ProjectRaster] =
+    Decoder.forProduct2("id", "band")(ProjectRaster.apply)
+  implicit lazy val encodeProjectRaster: Encoder[ProjectRaster] =
+    Encoder.forProduct3("id", "band", "type")(op => (op.id, op.band, op.`type`))
 
   implicit lazy val encodeRFMLRaster = new Encoder[RFMLRaster] {
     def apply(rasterDefinition: RFMLRaster): Json = rasterDefinition match {

--- a/app-backend/tool/src/main/scala/ast/codec/MapAlgebraOperationCodecs.scala
+++ b/app-backend/tool/src/main/scala/ast/codec/MapAlgebraOperationCodecs.scala
@@ -44,36 +44,4 @@ trait MapAlgebraOperationCodecs {
         throw new InvalidParameterException(s"Encoder for $operation not yet implemented")
     }
   }
-
-  // Codec instances
-  implicit lazy val decodeAddition: Decoder[MapAlgebraAST.Addition] =
-    Decoder.forProduct3("args", "id", "label")(MapAlgebraAST.Addition.apply)
-  implicit lazy val encodeAddition: Encoder[MapAlgebraAST.Addition] =
-    Encoder.forProduct4("apply", "args", "id", "label")(op => (op.symbol, op.args, op.id, op.label))
-
-  implicit lazy val decodeSubtraction: Decoder[MapAlgebraAST.Subtraction] =
-    Decoder.forProduct3("args", "id", "label")(MapAlgebraAST.Subtraction.apply)
-  implicit lazy val encodeSubtraction: Encoder[MapAlgebraAST.Subtraction] =
-    Encoder.forProduct4("apply", "args", "id", "label")(op => (op.symbol, op.args, op.id, op.label))
-
-  implicit lazy val decodeDivision: Decoder[MapAlgebraAST.Division] =
-    Decoder.forProduct3("args", "id", "label")(MapAlgebraAST.Division.apply)
-  implicit lazy val encodeDivision: Encoder[MapAlgebraAST.Division] =
-    Encoder.forProduct4("apply", "args", "id", "label")(op => (op.symbol, op.args, op.id, op.label))
-
-  implicit lazy val decodeMultiplication: Decoder[MapAlgebraAST.Multiplication] =
-    Decoder.forProduct3("args", "id", "label")(MapAlgebraAST.Multiplication.apply)
-  implicit lazy val encodeMultiplication: Encoder[MapAlgebraAST.Multiplication] =
-    Encoder.forProduct4("apply", "args", "id", "label")(op => (op.symbol, op.args, op.id, op.label))
-
-  implicit lazy val decodeMasking: Decoder[MapAlgebraAST.Masking] =
-    Decoder.forProduct3("args", "id", "label")(MapAlgebraAST.Masking.apply)
-  implicit lazy val encodeMasking: Encoder[MapAlgebraAST.Masking] =
-    Encoder.forProduct4("apply", "args", "id", "label")(op => (op.symbol, op.args, op.id, op.label))
-
-  implicit lazy val decodeClassification: Decoder[MapAlgebraAST.Classification] =
-    Decoder.forProduct4("args", "id", "label", "classBreaks")(MapAlgebraAST.Classification.apply _)
-  implicit lazy val encodeClassification: Encoder[MapAlgebraAST.Classification] =
-    Encoder.forProduct5("apply", "args", "id", "label", "classBreaks")(op => (op.symbol, op.args, op.id, op.label, op.classBreaks))
-
 }

--- a/app-backend/tool/src/main/scala/ast/codec/MapAlgebraOperationCodecs.scala
+++ b/app-backend/tool/src/main/scala/ast/codec/MapAlgebraOperationCodecs.scala
@@ -1,10 +1,12 @@
 package com.azavea.rf.tool.ast.codec
 
-import java.security.InvalidParameterException
-
 import com.azavea.rf.tool.ast._
+import com.azavea.rf.tool.eval._
 import io.circe._
 import io.circe.syntax._
+
+import java.security.InvalidParameterException
+
 
 trait MapAlgebraOperationCodecs {
   implicit def mapAlgebraDecoder: Decoder[MapAlgebraAST]
@@ -20,9 +22,9 @@ trait MapAlgebraOperationCodecs {
       case Some("mask") => ma.as[MapAlgebraAST.Masking]
       case Some("classify") => ma.as[MapAlgebraAST.Classification]
       case Some(unrecognized) =>
-        throw new InvalidParameterException(s"'$unrecognized' is not a recognized map algebra operation")
+        Left(DecodingFailure(s"Unrecognized node type: $unrecognized", ma.history))
       case None =>
-        throw new InvalidParameterException(s"Required 'apply' property not found on MapAlgebraAST operation ${ma.value}")
+        Left(DecodingFailure("The property 'apply' is mandatory on all AST operations", ma.history))
     }
   }
 
@@ -44,4 +46,36 @@ trait MapAlgebraOperationCodecs {
         throw new InvalidParameterException(s"Encoder for $operation not yet implemented")
     }
   }
+
+  /** NOTE: We need to keep these specialized encoder/decoders around for correct parsing of trees */
+  implicit lazy val decodeAddition: Decoder[MapAlgebraAST.Addition] =
+    Decoder.forProduct3("args", "id", "metadata")(MapAlgebraAST.Addition.apply)
+  implicit lazy val encodeAddition: Encoder[MapAlgebraAST.Addition] =
+    Encoder.forProduct4("apply", "args", "id", "metadata")(op => (op.symbol, op.args, op.id, op.metadata))
+
+  implicit lazy val decodeSubtraction: Decoder[MapAlgebraAST.Subtraction] =
+    Decoder.forProduct3("args", "id", "metadata")(MapAlgebraAST.Subtraction.apply)
+  implicit lazy val encodeSubtraction: Encoder[MapAlgebraAST.Subtraction] =
+    Encoder.forProduct4("apply", "args", "id", "metadata")(op => (op.symbol, op.args, op.id, op.metadata))
+
+  implicit lazy val decodeDivision: Decoder[MapAlgebraAST.Division] =
+    Decoder.forProduct3("args", "id", "metadata")(MapAlgebraAST.Division.apply)
+  implicit lazy val encodeDivision: Encoder[MapAlgebraAST.Division] =
+    Encoder.forProduct4("apply", "args", "id", "metadata")(op => (op.symbol, op.args, op.id, op.metadata))
+
+  implicit lazy val decodeMultiplication: Decoder[MapAlgebraAST.Multiplication] =
+    Decoder.forProduct3("args", "id", "metadata")(MapAlgebraAST.Multiplication.apply)
+  implicit lazy val encodeMultiplication: Encoder[MapAlgebraAST.Multiplication] =
+    Encoder.forProduct4("apply", "args", "id", "metadata")(op => (op.symbol, op.args, op.id, op.metadata))
+
+  implicit lazy val decodeMasking: Decoder[MapAlgebraAST.Masking] =
+    Decoder.forProduct3("args", "id", "metadata")(MapAlgebraAST.Masking.apply)
+  implicit lazy val encodeMasking: Encoder[MapAlgebraAST.Masking] =
+    Encoder.forProduct4("apply", "args", "id", "metadata")(op => (op.symbol, op.args, op.id, op.metadata))
+
+  implicit lazy val decodeClassification: Decoder[MapAlgebraAST.Classification] =
+    Decoder.forProduct4("args", "id", "metadata", "classMap")(MapAlgebraAST.Classification.apply)
+  implicit lazy val encodeClassification: Encoder[MapAlgebraAST.Classification] =
+    Encoder.forProduct5("apply", "args", "id", "metadata", "classMap")(op => (op.symbol, op.args, op.id, op.metadata, op.classMap))
+
 }

--- a/app-backend/tool/src/main/scala/ast/codec/MapAlgebraUtilityCodecs.scala
+++ b/app-backend/tool/src/main/scala/ast/codec/MapAlgebraUtilityCodecs.scala
@@ -64,16 +64,12 @@ trait MapAlgebraUtilityCodecs {
     final def apply(cRamp: ColorRamp): Json = cRamp.colors.toArray.asJson
   }
 
-  implicit val histogramDecoder: Decoder[Histogram[Double]] = Decoder[JsValue].map { js =>
-    js.convertTo[Histogram[Double]]
+  implicit val histogramDecoder: Decoder[Histogram[Double]] = Decoder[Json].map { js =>
+    js.noSpaces.parseJson.convertTo[Histogram[Double]]
   }
 
   implicit val histogramEncoder: Encoder[Histogram[Double]] = new Encoder[Histogram[Double]] {
     final def apply(hist: Histogram[Double]): Json = hist.toJson.asJson
-  }
-
-  implicit val sprayJsonDecoder: Decoder[JsValue] = Decoder[Json].map { js =>
-    js.noSpaces.parseJson
   }
 
   implicit val sprayJsonEncoder: Encoder[JsValue] = new Encoder[JsValue] {

--- a/app-backend/tool/src/main/scala/ast/package.scala
+++ b/app-backend/tool/src/main/scala/ast/package.scala
@@ -11,7 +11,7 @@ package object ast extends MapAlgebraCodec {
   implicit class CirceMapAlgebraJsonMethods(val self: Json) {
     def _id: Option[UUID] = root.id.string.getOption(self).map(UUID.fromString(_))
     def _type: Option[String] = root.`type`.string.getOption(self)
-    def _label: Option[String] = root.label.string.getOption(self)
+    def _label: Option[String] = root.metadata.label.string.getOption(self)
     def _symbol: Option[String] = root.selectDynamic("apply").string.getOption(self)
 
     def _fields: Option[Seq[String]] = root.obj.getOption(self).map(_.fields)
@@ -27,19 +27,25 @@ package object ast extends MapAlgebraCodec {
   }
 
   implicit class MapAlgebraASTHelperMethods(val self: MapAlgebraAST) {
+    private def generateMetadata = Some(NodeMetadata(
+      Some(s"Classify(${self.metadata.flatMap(_.label).getOrElse(self.id)})"),
+      None,
+      None
+    ))
+
     def classify(breaks: ClassBreaks) =
-      MapAlgebraAST.Classification(List(self), UUID.randomUUID(), Some(s"Classify(${self.label.getOrElse(self.id)})"), breaks)
+      MapAlgebraAST.Classification(List(self), UUID.randomUUID(), generateMetadata, breaks)
 
     def +(other: MapAlgebraAST): MapAlgebraAST.Operation =
-      MapAlgebraAST.Addition(List(self, other), UUID.randomUUID(), Some(s"${self.label.getOrElse(self.id)}_+_${other.label.getOrElse(other.id)}"))
+      MapAlgebraAST.Addition(List(self, other), UUID.randomUUID(), generateMetadata)
 
     def -(other: MapAlgebraAST): MapAlgebraAST.Operation =
-      MapAlgebraAST.Subtraction(List(self, other), UUID.randomUUID(), Some(s"${self.label.getOrElse(self.id)}_-_${other.label.getOrElse(other.id)}"))
+      MapAlgebraAST.Subtraction(List(self, other), UUID.randomUUID(), generateMetadata)
 
     def *(other: MapAlgebraAST): MapAlgebraAST.Operation =
-      MapAlgebraAST.Multiplication(List(self, other), UUID.randomUUID(), Some(s"${self.label.getOrElse(self.id)}_*_${other.label.getOrElse(other.id)}"))
+      MapAlgebraAST.Multiplication(List(self, other), UUID.randomUUID(), generateMetadata)
 
     def /(other: MapAlgebraAST): MapAlgebraAST.Operation =
-      MapAlgebraAST.Division(List(self, other), UUID.randomUUID(), Some(s"${self.label.getOrElse(self.id)}_/_${other.label.getOrElse(other.id)}"))
+      MapAlgebraAST.Division(List(self, other), UUID.randomUUID(), generateMetadata)
   }
 }

--- a/app-backend/tool/src/main/scala/ast/package.scala
+++ b/app-backend/tool/src/main/scala/ast/package.scala
@@ -33,8 +33,8 @@ package object ast extends MapAlgebraCodec {
       None
     ))
 
-    def classify(breaks: ClassBreaks) =
-      MapAlgebraAST.Classification(List(self), UUID.randomUUID(), generateMetadata, breaks)
+    def classify(classmap: ClassMap) =
+      MapAlgebraAST.Classification(List(self), UUID.randomUUID(), generateMetadata, classmap)
 
     def +(other: MapAlgebraAST): MapAlgebraAST.Operation =
       MapAlgebraAST.Addition(List(self, other), UUID.randomUUID(), generateMetadata)

--- a/app-backend/tool/src/main/scala/params/EvalParams.scala
+++ b/app-backend/tool/src/main/scala/params/EvalParams.scala
@@ -2,11 +2,25 @@ package com.azavea.rf.tool.params
 
 import com.azavea.rf.tool.ast._
 
+import io.circe._
 import io.circe.generic.JsonCodec
+import io.circe.parser._
+import cats.syntax.either._
 
 import java.util.UUID
 
 
-@JsonCodec
-case class EvalParams(sources: Map[UUID, RFMLRaster], metadataOverrides: Map[UUID, NodeMetadata])
+case class EvalParams(sources: Map[UUID, RFMLRaster] = Map(), metadata: Map[UUID, NodeMetadata] = Map())
 
+object EvalParams {
+  implicit val encodeEvalParams: Encoder[EvalParams] =
+    Encoder.forProduct2("sources", "metadata")(ep => (ep.sources, ep.metadata))
+
+  implicit val decodeEvalParams: Decoder[EvalParams] = new Decoder[EvalParams] {
+    final def apply(c: HCursor): Decoder.Result[EvalParams] = {
+      val sources = c.get[Map[UUID, RFMLRaster]]("sources").getOrElse(Map())
+      val overrides = c.get[Map[UUID, NodeMetadata]]("metadata").getOrElse(Map())
+      Right(EvalParams(sources, overrides))
+    }
+  }
+}

--- a/app-backend/tool/src/main/scala/params/EvalParams.scala
+++ b/app-backend/tool/src/main/scala/params/EvalParams.scala
@@ -8,5 +8,5 @@ import java.util.UUID
 
 
 @JsonCodec
-case class EvalParams(sources: Map[UUID, RFMLRaster])
+case class EvalParams(sources: Map[UUID, RFMLRaster], metadataOverrides: Map[UUID, NodeMetadata])
 

--- a/app-backend/tool/src/test/scala/Generators.scala
+++ b/app-backend/tool/src/test/scala/Generators.scala
@@ -1,0 +1,96 @@
+package com.azavea.rf.tool
+
+import com.azavea.rf.tool.ast._
+import com.azavea.rf.tool.eval._
+import com.azavea.rf.tool.params._
+
+import org.scalacheck._
+import org.scalacheck.Gen._
+import org.scalacheck.Arbitrary.arbitrary
+import org.scalacheck.Prop.forAll
+import geotrellis.raster.histogram._
+import geotrellis.raster.render._
+
+import scala.util.Random
+import java.util.UUID
+
+
+object Generators {
+
+  implicit lazy val arbUUID: Arbitrary[UUID] = Arbitrary(UUID.randomUUID)
+
+  implicit lazy val arbHistogram: Arbitrary[Histogram[Double]] = Arbitrary {
+    val hist = StreamingHistogram()
+    1 to Random.nextInt(500) foreach(hist.countItem(_))
+    hist
+  }
+
+  lazy val genClassMapOptions: Gen[ClassMap.Options] = for {
+    bounds <- Gen.lzy(Gen.oneOf(LessThanOrEqualTo, LessThan, Exact, GreaterThan, GreaterThanOrEqualTo))
+    ndVal <- arbitrary[Int]
+    fallback <- arbitrary[Int]
+  } yield ClassMap.Options(bounds, ndVal, fallback)
+
+  lazy val genClassMap: Gen[ClassMap] = for {
+    dubs <- Gen.containerOfN[List, Double](30, arbitrary[Double])
+    ints <- Gen.containerOfN[List, Int](30, arbitrary[Int])
+    opts <- genClassMapOptions
+  } yield ClassMap(dubs.zip(ints).toMap, opts)
+
+  lazy val genNodeMetadata: Gen[NodeMetadata] = for {
+    label <- Gen.option(arbitrary[String])
+    desc  <- Gen.option(arbitrary[String])
+    hist  <- Gen.option(arbitrary[Histogram[Double]])
+    cRamp <- Gen.lzy(Gen.option(Gen.oneOf(ColorRamps.Viridis, ColorRamps.Inferno, ColorRamps.Magma)))
+    cMap  <- Gen.option(genClassMap)
+  } yield NodeMetadata(label, desc, hist, cRamp, cMap)
+
+  lazy val genRFMLRaster: Gen[RFMLRaster] = for {
+    band <- arbitrary[Int]
+    id <- arbitrary[UUID]
+    constructor <- Gen.lzy(Gen.oneOf(SceneRaster.apply _, ProjectRaster.apply _))
+  } yield constructor(id, Some(band))
+
+  lazy val genEvalParams: Gen[EvalParams] = for {
+    astIds  <- containerOfN[List, UUID](12, arbitrary[UUID])
+    rasters <- containerOfN[List, RFMLRaster](12, genRFMLRaster)
+  } yield EvalParams(astIds.zip(rasters).toMap)
+
+  lazy val genSourceAST = for {
+    id <- arbitrary[UUID]
+    nmd <- Gen.option(genNodeMetadata)
+  } yield MapAlgebraAST.Source(id, nmd)
+
+  def genBinaryOpAST(depth: Int) = for {
+    constructor <- Gen.lzy(Gen.oneOf(
+                     MapAlgebraAST.Addition.apply _,
+                     MapAlgebraAST.Subtraction.apply _,
+                     MapAlgebraAST.Multiplication.apply _,
+                     MapAlgebraAST.Division.apply _,
+                     MapAlgebraAST.Masking.apply _
+                   ))
+    args <- containerOfN[List, MapAlgebraAST](2, genMapAlgebraAST(depth))
+    id <- arbitrary[UUID]
+    nmd <- Gen.option(genNodeMetadata)
+  } yield constructor(args, id, nmd)
+
+  def genClassificationAST(depth: Int) = for {
+    args <- containerOfN[List, MapAlgebraAST](1, genMapAlgebraAST(depth))
+    id <- arbitrary[UUID]
+    nmd <- Gen.option(genNodeMetadata)
+    cmap <- genClassMap
+  } yield MapAlgebraAST.Classification(args, id, nmd, cmap)
+
+  def genOpAST(depth: Int) = Gen.frequency(
+    (5 -> genBinaryOpAST(depth)),
+    (1 -> genClassificationAST(depth))
+  )
+
+  /** We are forced to manually control flow in this generator to prevent stack overflows
+    *  See: http://stackoverflow.com/questions/19829293/scalacheck-arbitrary-implicits-and-recursive-generators
+    */
+  def genMapAlgebraAST(depth: Int = 1): Gen[MapAlgebraAST] =
+    if (depth >= 100) genSourceAST
+    else Gen.frequency((1 -> genOpAST(depth + 1)), (1 -> genSourceAST))
+
+}

--- a/app-backend/tool/src/test/scala/eval/LazyTileSpec.scala
+++ b/app-backend/tool/src/test/scala/eval/LazyTileSpec.scala
@@ -57,11 +57,11 @@ class LazyTileSpec
   it("should evaluate classification") {
     requests = Nil
     // This breakmap should convert all cells (which are set to a value of 5) to 77
-    val breakmap = ClassBreaks(Map(6.0 -> 77), ClassBreaks.Options(LessThanOrEqualTo, 123))
+    val breakmap = ClassMap(Map(6.0 -> 77), ClassMap.Options(LessThanOrEqualTo, 123))
     val srcAST = randomSourceAST
     val tms = Interpreter.interpretTMS(
       ast = srcAST.classify(breakmap),
-      params = EvalParams(Map(srcAST.id -> redTileSource)),
+      sourceMapping = Map(srcAST.id -> redTileSource),
       source = goodSource
     )
 
@@ -82,7 +82,7 @@ class LazyTileSpec
     val src2 = randomSourceAST
     val tms = Interpreter.interpretTMS(
       ast = src1 - src2,
-      params = EvalParams(Map(src1.id -> blueTileSource, src2.id -> nirTileSource)),
+      sourceMapping = Map(src1.id -> blueTileSource, src2.id -> nirTileSource),
       source = goodSource
     )
 
@@ -106,7 +106,7 @@ class LazyTileSpec
     val ast = Subtraction(List(src1, src2, src3), UUID.randomUUID(), None)
     val tms = Interpreter.interpretTMS(
       ast = ast,
-      params = EvalParams(Map(src1.id -> nirTileSource, src2.id -> redTileSource, src3.id -> blueTileSource)),
+      sourceMapping = Map(src1.id -> nirTileSource, src2.id -> redTileSource, src3.id -> blueTileSource),
       source = goodSource
     )
 
@@ -127,7 +127,7 @@ class LazyTileSpec
     val src2 = randomSourceAST
     val tms = Interpreter.interpretTMS(
       ast = src1 / src2,
-      params = EvalParams(Map(src1.id -> redTileSource, src2.id -> nirTileSource)),
+      sourceMapping = Map(src1.id -> redTileSource, src2.id -> nirTileSource),
       source = goodSource
     )
 
@@ -150,7 +150,7 @@ class LazyTileSpec
     val ast = Division(List(src1, src2, src3), UUID.randomUUID(), None)
     val tms = Interpreter.interpretTMS(
       ast = ast,
-      params = EvalParams(Map(src1.id -> blueTileSource, src2.id -> nirTileSource, src3.id -> redTileSource)),
+      sourceMapping = Map(src1.id -> blueTileSource, src2.id -> nirTileSource, src3.id -> redTileSource),
       source = goodSource
     )
 
@@ -171,7 +171,7 @@ class LazyTileSpec
     val src2 = randomSourceAST
     val tms = Interpreter.interpretTMS(
       ast = src1 * src2,
-      params = EvalParams(Map(src1.id -> redTileSource, src2.id -> nirTileSource)),
+      sourceMapping = Map(src1.id -> redTileSource, src2.id -> nirTileSource),
       source = goodSource
     )
 
@@ -192,7 +192,7 @@ class LazyTileSpec
     val src2 = randomSourceAST
     val tms = Interpreter.interpretTMS(
       ast = src1 + src2,
-      params = EvalParams(Map(src1.id -> redTileSource, src2.id -> nirTileSource)),
+      sourceMapping = Map(src1.id -> redTileSource, src2.id -> nirTileSource),
       source = goodSource
     )
 

--- a/app-backend/tool/src/test/scala/params/EvalParamsSpec.scala
+++ b/app-backend/tool/src/test/scala/params/EvalParamsSpec.scala
@@ -1,12 +1,9 @@
-package com.azavea.rf.tool.ast.codec
+package com.azavea.rf.tool.params
 
 import com.azavea.rf.tool.ast._
 import com.azavea.rf.tool.eval._
 import com.azavea.rf.tool.Generators._
 
-import org.scalacheck._
-import org.scalacheck.Gen._
-import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.Prop.forAll
 import org.scalatest.prop._
 import org.scalatest._
@@ -15,16 +12,17 @@ import io.circe.parser._
 import io.circe.syntax._
 import cats.syntax.either._
 
+import scala.util.Random
 import java.util.UUID
 
 
-class MapAlgebraASTCodecSpec extends PropSpec with Checkers {
+class EvalParamsSpec extends PropSpec with Matchers with Checkers {
   property("bijective serialization") {
-    check(forAll(genMapAlgebraAST()) { (ast: MapAlgebraAST) =>
-      val json = ast.asJson
-      val ast2 = json.as[MapAlgebraAST].toOption
-      val json2 = ast2.asJson
-      ast == ast2
+    check(forAll(genEvalParams) { (params: EvalParams) =>
+      val json = params.asJson
+      val params2 = json.as[EvalParams].toOption
+      val json2 = params2.asJson
+      params == params2
       json == json2
     })
   }


### PR DESCRIPTION
## Overview

This PR adds the `NodeMetadata` type, which will serve as an (optional) means of specifying preferences vis-a-vis rendering tiles and labelling/describing the semantics of AST nodes.

### Notes

I ended up running into some difficulties due to the serialization of ASTs and ToolRuns (essentially, they weren't round-tripping without loss and overriding values storied in the database could under certain circumstances lead to loss of data integrity). In response to this, I added some property based testing to ensure the validity of our `Encoder`/`Decoder` pairs.


## Testing Instructions

 * Create a Tool and ToolRun in the database. Here are some example POST bodies (note that the `ToolRun` refers to the `Tool` and that the `ToolRun`'s 'sources' block consists of mappings from IDs which specify nodes of the referent AST to a scene id and a band):
```json
{
	"organizationId": "dfac6307-b5ef-43f7-beda-b9f208bb7726",
	"title": "test",
	"description": "a simple, local-addition AST",
	"requirements": "",
	"license": "",
	"visibility": "public",
	"compatibleDataSources": [""],
	"stars": 5.5,
	"definition": {
    "id": "e76c3198-93a0-4a22-9d58-4ba645f8d6f4",
    "args": [
      {
        "id": "a9f4066b-a783-46b6-997d-a0e0d377a1ec"
      },
      {
        "id": "580dc0c8-9454-43f5-b72f-1854d7c18e13"
      }
    ],
    "apply": "+"
  },
	"tags": [],
	"categories": []
}
```
```json
{
  "visibility" : "PUBLIC",
  "organizationId" : "dfac6307-b5ef-43f7-beda-b9f208bb7726",
  "tool" : <TOOL-ID>,
  "executionParameters" : {
        "sources": {
          "a9f4066b-a783-46b6-997d-a0e0d377a1ec": {
            "id": <SOME_SCENE_ID>,
            "band": 4,
            "type": "scene"
          },
          "580dc0c8-9454-43f5-b72f-1854d7c18e13": {
            "id": <SOME_SCENE_ID>,
            "band": 5,
            "type": "scene"
          }
        }
      }
}
```
 * Assuming you've provided meaningful (and ingested) scene information, you should be able to see a tile at `http://localhost:9900/tiles/tools/<TOOLRUN_ID/{z}/{x}/{y}/?token=<RF_TOKEN>`
 * To test out per-node viewing, simply add the query parameter node + the UUID of the node you'd like to see TMS rendered (`&node=<NODE_ID>`)

Closes #1561
Closes #1555
