### PR TITLE
Add initial UI for Area of Interest projects

### DIFF
--- a/app-frontend/src/app/components/aoiFilterPane/aoiFilterPane.component.js
+++ b/app-frontend/src/app/components/aoiFilterPane/aoiFilterPane.component.js
@@ -1,0 +1,12 @@
+import aoiFilterTpl from './aoiFilterPane.html';
+
+const rfAOIFilterPane = {
+    templateUrl: aoiFilterTpl,
+    controller: 'AOIFilterPaneController',
+    bindings: {
+        filters: '=',
+        opened: '='
+    }
+};
+
+export default rfAOIFilterPane;

--- a/app-frontend/src/app/components/aoiFilterPane/aoiFilterPane.controller.js
+++ b/app-frontend/src/app/components/aoiFilterPane/aoiFilterPane.controller.js
@@ -1,0 +1,394 @@
+export default class AOIFilterPaneController {
+    constructor(datasourceService, authService, $scope, $rootScope, $timeout,
+                $uibModal, moment) {
+        'ngInject';
+        this.datasourceService = datasourceService;
+        this.authService = authService;
+        this.$scope = $scope;
+        this.$rootScope = $rootScope;
+        this.$timeout = $timeout;
+        this.$uibModal = $uibModal;
+        this.Moment = moment;
+    }
+
+    $onInit() {
+        if (this.authService.isLoggedIn) {
+            this.initFilters();
+            this.initDatefilter();
+        }
+
+        this.toggleDrag = {toggle: false, enabled: false};
+
+        this.$scope.$watch(() => this.authService.isLoggedIn, (isLoggedIn) => {
+            if (isLoggedIn) {
+                this.initFilters();
+                this.initDatefilter();
+            }
+        });
+
+        this.$scope.$watch('$ctrl.opened', (opened) => {
+            if (opened) {
+                this.$timeout(() => this.$rootScope.$broadcast('reCalcViewDimensions'), 50);
+            }
+        });
+    }
+
+    initDatefilter() {
+        this.datefilter = {
+            start: this.Moment().subtract(100, 'years'),
+            end: this.Moment()
+        };
+        this.dateranges = [
+            {
+                name: 'Today',
+                start: this.Moment(),
+                end: this.Moment()
+            },
+            {
+                name: 'The last month',
+                start: this.Moment().subtract(1, 'months'),
+                end: this.Moment()
+            },
+            {
+                name: 'The last year',
+                start: this.Moment().subtract(1, 'years'),
+                end: this.Moment()
+            },
+            {
+                name: 'All',
+                start: this.Moment().subtract(100, 'years'),
+                end: this.Moment()
+            }
+        ];
+
+        if (this.filters.minAcquisitionDatetime && this.filters.maxAcquisitionDatetime) {
+            this.datefilter.start = this.Moment(this.filters.minAcquisitionDatetime);
+            this.datefilter.end = this.Moment(this.filters.maxAcquisitionDatetime);
+        }
+
+        if (!this.filters.minAcquisitionDatetime || !this.filters.maxAcquisitionDatetime) {
+            this.clearDateFilter();
+        } else {
+            this.dateFilterToggle = {value: true};
+        }
+    }
+
+    clearDateFilter() {
+        delete this.filters.minAcquisitionDatetime;
+        delete this.filters.maxAcquisitionDatetime;
+        this.dateFilterToggle = {value: false};
+    }
+
+    setDateRange(start, end, preset) {
+        this.datefilter.start = start;
+        this.datefilter.end = end;
+        this.datefilterPreset = preset || false;
+        this.dateFilterToggle.value = true;
+        this.filters.minAcquisitionDatetime = start.toISOString();
+        this.filters.maxAcquisitionDatetime = end.toISOString();
+        this.cacheYearFilters();
+    }
+
+    onDateFilterToggle(value) {
+        if (value) {
+            this.filters.minAcquisitionDatetime = this.datefilter.start.toISOString();
+            this.filters.maxAcquisitionDatetime = this.datefilter.end.toISOString();
+        } else {
+            delete this.filters.minAcquisitionDatetime;
+            delete this.filters.maxAcquisitionDatetime;
+        }
+    }
+
+    close() {
+        this.opened = false;
+    }
+
+    onCloudCoverFiltersChange(id, minModel, maxModel) {
+        // Some scenes have a cloudCover < 0, which is invalid. filter them out.
+        this.filters.minCloudCover = minModel;
+
+        if (maxModel === this.cloudCoverRange.max) {
+            delete this.filters.maxCloudCover;
+        } else {
+            this.filters.maxCloudCover = maxModel;
+        }
+    }
+
+    onSunElevationFiltersChange(id, minModel, maxModel) {
+        if (minModel === this.sunElevationRange.min) {
+            delete this.filters.minSunElevation;
+        } else {
+            this.filters.minSunElevation = minModel;
+        }
+
+        if (maxModel === this.sunElevationRange.max) {
+            delete this.filters.maxSunElevation;
+        } else {
+            this.filters.maxSunElevation = maxModel;
+        }
+    }
+
+    onSunAzimuthFiltersChange(id, minModel, maxModel) {
+        if (minModel === this.sunAzimuthRange.min) {
+            delete this.filters.minSunAzimuth;
+        } else {
+            this.filters.minSunAzimuth = minModel;
+        }
+
+        if (maxModel === this.sunAzimuthRange.max) {
+            delete this.filters.maxSunAzimuth;
+        } else {
+            this.filters.maxSunAzimuth = maxModel;
+        }
+    }
+
+    initFilters() {
+        this.cachedFilters = {};
+
+        this.cloudCoverRange = {min: 0, max: 100};
+
+        let minCloudCover = this.cloudCoverRange.min;
+        if (this.filters.minCloudCover) {
+            minCloudCover = parseInt(this.filters.minCloudCover, 10);
+        }
+
+        let maxCloudCover = parseInt(this.filters.maxCloudCover, 10) || 10;
+
+        if (!this.filters.minCloudCover && minCloudCover !== this.cloudCoverRange.min) {
+            this.filters.minCloudCover = minCloudCover;
+        }
+
+        if (!this.filters.maxCloudCover && maxCloudCover !== this.cloudCoverRange.max) {
+            this.filters.maxCloudCover = maxCloudCover;
+        }
+
+        this.cloudCoverFilters = {
+            minModel: minCloudCover,
+            maxModel: maxCloudCover,
+            options: {
+                floor: this.cloudCoverRange.min,
+                ceil: this.cloudCoverRange.max,
+                minRange: 0,
+                showTicks: 10,
+                showTicksValues: true,
+                step: 10,
+                pushRange: true,
+                draggableRange: true,
+                onEnd: this.onCloudCoverFiltersChange.bind(this)
+            }
+        };
+
+        this.sunElevationRange = {min: 0, max: 180};
+        let minSunElevation = parseInt(this.filters.minSunElevation, 10) ||
+            this.sunElevationRange.min;
+        let maxSunElevation = parseInt(this.filters.maxSunElevation, 10) ||
+            this.sunElevationRange.max;
+        this.sunElevationFilters = {
+            minModel: minSunElevation,
+            maxModel: maxSunElevation,
+            options: {
+                floor: this.sunElevationRange.min,
+                ceil: this.sunElevationRange.max,
+                minRange: 0,
+                showTicks: 30,
+                showTicksValues: true,
+                step: 10,
+                pushRange: true,
+                draggableRange: true,
+                onEnd: this.onSunElevationFiltersChange.bind(this)
+            }
+        };
+
+        this.sunAzimuthRange = {min: 0, max: 360};
+        let minSunAzimuth = parseInt(this.filters.minSunAzimuth, 10) ||
+            this.sunAzimuthRange.min;
+        let maxSunAzimuth = parseInt(this.filters.maxSunAzimuth, 10) ||
+            this.sunAzimuthRange.max;
+        this.sunAzimuthFilters = {
+            minModel: minSunAzimuth,
+            maxModel: maxSunAzimuth,
+            options: {
+                floor: this.sunAzimuthRange.min,
+                ceil: this.sunAzimuthRange.max,
+                minRange: 0,
+                showTicks: 60,
+                showTicksValues: true,
+                step: 10,
+                pushRange: true,
+                draggableRange: true,
+                onEnd: this.onSunAzimuthFiltersChange.bind(this)
+            }
+        };
+
+        this.initIngestFilter();
+
+        this.initSourceFilters();
+    }
+
+    initIngestFilter() {
+        this.ingestFilter = 'any';
+        if (this.filters.hasOwnProperty('ingest')) {
+            if (this.filters.ingest) {
+                this.ingestFilter = 'ingested';
+            } else {
+                this.ingestFilter = 'uningested';
+            }
+        }
+    }
+
+    initSourceFilters() {
+        this.datasourceService.query().then(d => {
+            this.datasources = d.results;
+            this.dynamicSourceFilters = {};
+            d.results.forEach(ds => {
+                this.dynamicSourceFilters[ds.id] = {
+                    datasource: ds,
+                    enabled: false
+                };
+            });
+            if (this.filters.datasource) {
+                if (Array.isArray(this.filters.datasource)) {
+                    this.filters.datasource.forEach(dsf => {
+                        if (this.dynamicSourceFilters[dsf]) {
+                            this.dynamicSourceFilters[dsf].enabled = true;
+                        }
+                    });
+                } else if (this.dynamicSourceFilters[this.filters.datasource]) {
+                    this.dynamicSourceFilters[this.filters.datasource].enabled = true;
+                }
+            }
+        });
+
+        // Define static source filters
+        this.staticSourceFilters = {
+            mine: {
+                datasource: {
+                    id: 'mine',
+                    name: 'My Imports'
+                },
+                enabled: false
+            },
+            users: {
+                datasource: {
+                    id: 'users',
+                    name: 'Raster Foundry Users'
+                },
+                enabled: false
+            }
+        };
+
+        if (this.filters.datasource) {
+            if (Array.isArray(this.filters.datasource)) {
+                this.filters.datasource.forEach(dsf => {
+                    if (this.staticSourceFilters[dsf]) {
+                        this.staticSourceFilters[dsf].enabled = true;
+                    }
+                });
+            } else if (this.staticSourceFilters[this.filters.datasource]) {
+                this.staticSourceFilters[this.filters.datasource].enabled = true;
+            }
+        }
+    }
+
+    resetAllFilters() {
+        this.clearDateFilter();
+
+        this.cloudCoverFilters.minModel = this.cloudCoverRange.min;
+        this.cloudCoverFilters.maxModel = this.cloudCoverRange.max;
+        this.filters.minCloudCover = this.cloudCoverRange.min;
+        delete this.filters.maxCloudCover;
+
+
+        this.sunElevationFilters.minModel = this.sunElevationRange.min;
+        this.sunElevationFilters.maxModel = this.sunElevationRange.max;
+        delete this.filters.minSunElevation;
+        delete this.filters.maxSunElevation;
+
+        this.sunAzimuthFilters.minModel = this.sunAzimuthRange.min;
+        this.sunAzimuthFilters.maxModel = this.sunAzimuthRange.max;
+        delete this.filters.minSunAzimuth;
+        delete this.filters.maxSunAzimuth;
+
+        Object.values(this.dynamicSourceFilters)
+            .forEach((ds) => {
+                ds.enabled = false;
+            });
+        Object.values(this.staticSourceFilters)
+            .forEach((ds) => {
+                ds.enabled = false;
+            });
+        this.filters.datasource = [];
+
+        this.ingestFilter = 'any';
+        delete this.filters.ingested;
+
+        delete this.filters.datasource;
+    }
+
+    setIngestFilter(mode) {
+        this.ingestFilter = mode;
+        this.onIngestFilterChange();
+    }
+
+    onIngestFilterChange() {
+        if (this.ingestFilter === 'any') {
+            delete this.filters.ingested;
+        } else if (this.ingestFilter === 'uningested') {
+            this.filters.ingested = false;
+        } else {
+            this.filters.ingested = true;
+        }
+    }
+
+
+    cacheYearFilters() {
+        this.cachedFilters.minAcquisitionDatetime = this.filters.minAcquisitionDatetime;
+        this.cachedFilters.maxAcquisitionDatetime = this.filters.maxAcquisitionDatetime;
+    }
+
+    onSourceFilterChange() {
+        this.filters.datasource = [];
+
+        Object.values(this.dynamicSourceFilters)
+            .filter(ds => ds.enabled)
+            .forEach(ds => this.filters.datasource.push(ds.datasource.id));
+
+        Object.values(this.staticSourceFilters)
+            .filter(ds => ds.enabled)
+            .forEach(ds => this.filters.datasource.push(ds.datasource.id));
+    }
+
+    toggleSourceFilter(sourceId) {
+        if (this.dynamicSourceFilters[sourceId]) {
+            this.dynamicSourceFilters[sourceId].enabled =
+                !this.dynamicSourceFilters[sourceId].enabled;
+        } else if (this.staticSourceFilters[sourceId]) {
+            this.staticSourceFilters[sourceId].enabled =
+                !this.staticSourceFilters[sourceId].enabled;
+        }
+        this.onSourceFilterChange();
+    }
+
+    openDatePickerModal() {
+        if (this.activeModal) {
+            this.activeModal.dismiss();
+        }
+
+        this.activeModal = this.$uibModal.open({
+            component: 'rfDatePickerModal',
+            resolve: {
+                config: () => Object({
+                    range: this.datefilter,
+                    ranges: this.dateranges
+                })
+            }
+        });
+
+        this.activeModal.result.then(
+            range => {
+                if (range) {
+                    this.setDateRange(range.start, range.end, range.preset);
+                }
+            });
+    }
+}

--- a/app-frontend/src/app/components/aoiFilterPane/aoiFilterPane.html
+++ b/app-frontend/src/app/components/aoiFilterPane/aoiFilterPane.html
@@ -1,0 +1,56 @@
+<div class="sidebar-static" >
+  <h5>Filters</h5>
+  <div class="sidebar-actions">
+    <button class="btn btn-default btn-small" ng-click="$ctrl.close()">
+      Close
+    </button>
+  </div>
+</div>
+<div class="sidebar-scrollable" >
+  <div class="content">
+    <div class="filter-group">
+      <div class="filter">
+        <a href ng-click="$ctrl.resetAllFilters()" class="btn btn-toggle btn-small btn-block">Clear all filters</a>
+      </div>
+    </div>
+    <div class="filter-group">
+      <div class="filter"
+          ng-mouseleave="$ctrl.toggleDrag.toggle = false"
+          ng-mouseup="$ctrl.toggleDrag.toggle = false">
+        <label>Imagery sources</label>
+        <div class="filter-item tag-filter">
+          <button class="btn btn-toggle btn-small"
+                  ng-click="$ctrl.toggleSourceFilter(id)"
+                  ng-class="{'active': filter.enabled}"
+                  ng-repeat="(id, filter) in $ctrl.dynamicSourceFilters track by id">
+            {{filter.datasource.name}}
+          </button>
+        </div>
+      </div>
+    </div>
+    <div class="filter-group">
+      <div class="filter">
+        <label>Cloud cover</label>
+        <rzslider rz-slider-model="$ctrl.cloudCoverFilters.minModel"
+                  rz-slider-high="$ctrl.cloudCoverFilters.maxModel"
+                  rz-slider-options="$ctrl.cloudCoverFilters.options"></rzslider>
+      </div>
+    </div>
+    <div class="filter-group">
+      <div class="filter">
+        <label>Sun elevation</label>
+        <rzslider rz-slider-model="$ctrl.sunElevationFilters.minModel"
+                  rz-slider-high="$ctrl.sunElevationFilters.maxModel"
+                  rz-slider-options="$ctrl.sunElevationFilters.options"></rzslider>
+      </div>
+    </div>
+    <div class="filter-group">
+      <div class="filter">
+        <label>Sun azimuth</label>
+        <rzslider rz-slider-model="$ctrl.sunAzimuthFilters.minModel"
+                  rz-slider-high="$ctrl.sunAzimuthFilters.maxModel"
+                  rz-slider-options="$ctrl.sunAzimuthFilters.options"></rzslider>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app-frontend/src/app/components/aoiFilterPane/aoiFilterPane.module.js
+++ b/app-frontend/src/app/components/aoiFilterPane/aoiFilterPane.module.js
@@ -1,0 +1,13 @@
+import angular from 'angular';
+import slider from 'angularjs-slider';
+require('../../../assets/font/fontello/css/fontello.css');
+
+import AOIFilterPaneComponent from './aoiFilterPane.component.js';
+import AOIFilterPaneController from './aoiFilterPane.controller.js';
+
+const AOIFilterPaneModule = angular.module('components.AOIFilterPane', [slider]);
+
+AOIFilterPaneModule.component('rfAoiFilterPane', AOIFilterPaneComponent);
+AOIFilterPaneModule.controller('AOIFilterPaneController', AOIFilterPaneController);
+
+export default AOIFilterPaneModule;

--- a/app-frontend/src/app/components/statusTag/statusTag.html
+++ b/app-frontend/src/app/components/statusTag/statusTag.html
@@ -1,1 +1,1 @@
-<div class="status-tag {{$ctrl.getStatusClass()}}">{{ $ctrl.getStatusString() }}</div>
+<div class="inline-tag {{$ctrl.getStatusClass()}}">{{ $ctrl.getStatusString() }}</div>

--- a/app-frontend/src/app/components/statusTag/statusTag.scss
+++ b/app-frontend/src/app/components/statusTag/statusTag.scss
@@ -1,8 +1,7 @@
-div.status-tag {
+div.inline-tag {
   display: inline-block;
   font-size: 1rem;
   padding: 0.33em 0.5em;
-  color: #777;
   border-radius: 2px;
   font-weight: normal;
   vertical-align: middle;
@@ -10,16 +9,27 @@ div.status-tag {
 
 .grey-tag {
   background: #dadada;
+  color: #777;
 }
 
 .yellow-tag {
   background: #FFCA28;
+  color: #777;
 }
 
 .green-tag {
-  background: #81C784
+  background: #81C784;
+  color: #777;
 }
 
 .red-tag {
   background: #E57373;
+  color: #777;
+}
+
+.border-teal-tag {
+  $color: #2FC1D0;
+  color: $color;
+  border: 1px solid $color;
+  text-transform: uppercase;
 }

--- a/app-frontend/src/app/core/services/status.service.js
+++ b/app-frontend/src/app/core/services/status.service.js
@@ -106,10 +106,10 @@ export default (app) => {
         }
 
         getStatusFields(entityType, status) {
-          if (statusMapping[entityType] && statusMapping[entityType][status]) {
-              return statusMapping[entityType][status];
-          }
-          return false;
+            if (statusMapping[entityType] && statusMapping[entityType][status]) {
+                return statusMapping[entityType][status];
+            }
+            return false;
         }
     }
 

--- a/app-frontend/src/app/index.components.js
+++ b/app-frontend/src/app/index.components.js
@@ -33,5 +33,6 @@ export default angular.module('index.components', [
     require('./components/sceneDetailModal/sceneDetailModal.module.js').name,
     require('./components/datePickerModal/datePickerModal.module.js').name,
     require('./components/exportModal/exportModal.module.js').name,
-    require('./components/statusTag/statusTag.module.js').name
+    require('./components/statusTag/statusTag.module.js').name,
+    require('./components/aoiFilterPane/aoiFilterPane.module.js').name
 ]);

--- a/app-frontend/src/app/index.module.js
+++ b/app-frontend/src/app/index.module.js
@@ -66,6 +66,8 @@ const App = angular.module(
         require('./pages/projects/edit/order/order.module.js').name,
         require('./pages/projects/edit/masking/masking.module.js').name,
         require('./pages/projects/edit/masking/draw/draw.module.js').name,
+        require('./pages/projects/edit/aoi-approve/aoi-approve.module.js').name,
+        require('./pages/projects/edit/aoi-parameters/aoi-parameters.module.js').name,
 
         require('./pages/imports/imports.module.js').name,
         require('./pages/imports/datasources/datasources.module.js').name,

--- a/app-frontend/src/app/index.routes.js
+++ b/app-frontend/src/app/index.routes.js
@@ -22,6 +22,8 @@ import projectsSceneBrowserTpl from './pages/projects/edit/browse/browse.html';
 import projectOrderScenesTpl from './pages/projects/edit/order/order.html';
 import projectMaskingTpl from './pages/projects/edit/masking/masking.html';
 import projectMaskingDrawTpl from './pages/projects/edit/masking/draw/draw.html';
+import aoiApproveTpl from './pages/projects/edit/aoi-approve/aoi-approve.html';
+import aoiParametersTpl from './pages/projects/edit/aoi-parameters/aoi-parameters.html';
 
 import settingsTpl from './pages/settings/settings.html';
 import profileTpl from './pages/settings/profile/profile.html';
@@ -124,6 +126,18 @@ function projectEditStates($stateProvider) {
             url: '/mask',
             templateUrl: projectMaskingDrawTpl,
             controller: 'ProjectsMaskingDrawController',
+            controllerAs: '$ctrl'
+        })
+        .state('projects.edit.aoi-approve', {
+            url: '/aoi-approve',
+            templateUrl: aoiApproveTpl,
+            controller: 'AOIApproveController',
+            controllerAs: '$ctrl'
+        })
+        .state('projects.edit.aoi-parameters', {
+            url: '/aoi-parameters',
+            templateUrl: aoiParametersTpl,
+            controller: 'AOIParametersController',
             controllerAs: '$ctrl'
         });
 }
@@ -237,14 +251,12 @@ function labStates($stateProvider) {
             abstract: true
         })
         .state('lab.edit', {
-            parent: 'lab',
             url: '/edit',
             templateUrl: labEditTpl,
             controller: 'LabEditController',
             controllerAs: '$ctrl'
         })
         .state('lab.run', {
-            parent: 'lab',
             url: '/run/:projectid?',
             templateUrl: labRunTpl,
             controller: 'LabRunController',

--- a/app-frontend/src/app/pages/projects/edit/aoi-approve/aoi-approve.controller.js
+++ b/app-frontend/src/app/pages/projects/edit/aoi-approve/aoi-approve.controller.js
@@ -1,0 +1,5 @@
+export default class AOIApproveController {
+    constructor() {
+        'ngInject';
+    }
+}

--- a/app-frontend/src/app/pages/projects/edit/aoi-approve/aoi-approve.html
+++ b/app-frontend/src/app/pages/projects/edit/aoi-approve/aoi-approve.html
@@ -1,0 +1,32 @@
+<div class="sidebar-project">
+  <div class="sidebar-header">
+    <a class="btn sidebar-header-nav-btn" ui-sref="projects.edit">
+      <i class="icon-arrow-left"></i>
+    </a>
+    <h5 class="sidebar-title">AOI Scene Approval</h5>
+  </div>
+  <ul class="sidebar-list">
+    <li>
+      <div class="label">
+        <span class="text">
+          Select scenes to approve and click <strong>Approve Scenes</strong> to add to the project.
+        </span>
+      </div>
+      <div class="btn-group fixedwidth">
+        <button type="button"
+                class="btn btn-primary"
+                style="width: 12rem;"
+                ng-click="$ctrl.sceneModal()">
+          Approve Scenes
+        </button>
+        <button type="button"
+                class="btn dropdown-toggle"
+                ng-class="{'btn-secondary': $ctrl.allSelected}"
+                ng-click="$ctrl.selectAllScenes()">
+          <i ng-class="{'icon-plus': !$ctrl.allSelected,
+                       'icon-cross': $ctrl.allSelected}"></i>
+        </button>
+      </div>
+    </li>
+  </ul>
+</div>

--- a/app-frontend/src/app/pages/projects/edit/aoi-approve/aoi-approve.module.js
+++ b/app-frontend/src/app/pages/projects/edit/aoi-approve/aoi-approve.module.js
@@ -1,0 +1,8 @@
+import angular from 'angular';
+import AOIApproveController from './aoi-approve.controller.js';
+
+const AOIApproveModule = angular.module('page.projects.edit.aoi-approve', []);
+
+AOIApproveModule.controller('AOIApproveController', AOIApproveController);
+
+export default AOIApproveModule;

--- a/app-frontend/src/app/pages/projects/edit/aoi-parameters/aoi-parameters.controller.js
+++ b/app-frontend/src/app/pages/projects/edit/aoi-parameters/aoi-parameters.controller.js
@@ -1,0 +1,36 @@
+const updateFrequencies = [
+    {
+        label: 'every 6 hours'
+    },
+    {
+        label: 'every 12 hours'
+    },
+    {
+        label: 'every day'
+    },
+    {
+        label: 'every week'
+    },
+    {
+        label: 'every two weeks'
+    },
+    {
+        label: 'every month'
+    }
+];
+
+export default class AOIParametersController {
+    constructor() {
+        'ngInject';
+    }
+
+    $onInit() {
+        this.updateFrequencies = updateFrequencies;
+        this.showFilters = false;
+        this.filters = {};
+    }
+
+    toggleFilters() {
+        this.showFilters = !this.showFilters;
+    }
+}

--- a/app-frontend/src/app/pages/projects/edit/aoi-parameters/aoi-parameters.html
+++ b/app-frontend/src/app/pages/projects/edit/aoi-parameters/aoi-parameters.html
@@ -1,0 +1,80 @@
+<div class="sidebar-header">
+  <a class="btn sidebar-header-nav-btn" ui-sref="projects.edit">
+    <i class="icon-arrow-left"></i>
+  </a>
+  <h5 class="sidebar-title">AOI Parameters</h5>
+</div>
+<ul class="sidebar-list">
+  <li class="separator separator-primary">
+    <div class="label">
+      Area of Interest
+      <div class="info">Required</div>
+    </div>
+    <button class="btn btn-default fixedwidth">
+      Edit Area of Interest
+    </button>
+    <i class="icon-info"></i>
+  </li>
+  <li class="separator">
+    <span class="label">Filters</span>
+    <button class="btn btn-light fixedwidth" ng-click="$ctrl.toggleFilters()">
+      Adjust Filters
+    </button>
+    <i class="icon-info"></i>
+  </li>
+  <li class="separator">
+    <span class="label">Update frequency</span>
+    <div class="dropdown btn-group fixedwidth" uib-dropdown>
+      <a class="btn dropdown-label">
+
+      </a>
+      <button type="button" class="btn  dropdown-toggle" uib-dropdown-toggle>
+        <i class="icon-caret-down"></i>
+      </button>
+      <ul class="dropdown-menu dropdown-menu-light" uib-dropdown-menu role="menu">
+        <li ng-repeat="frequency in $ctrl.updateFrequencies" role="menuitem">
+          {{frequency.label}}
+        </li>
+      </ul>
+    </div>
+    <i class="icon-info"></i>
+  </li>
+  <li class="separator">
+    <span class="label">Update method</span>
+    <div class="dropdown btn-group fixedwidth" uib-dropdown>
+      <a class="btn dropdown-label">
+      </a>
+      <button type="button" class="btn  dropdown-toggle" uib-dropdown-toggle>
+        <i class="icon-caret-down"></i>
+      </button>
+      <ul class="dropdown-menu dropdown-menu-light" uib-dropdown-menu role="menu">
+        <li role="menuitem">Added when found</li>
+        <li role="menuitem">Added when approved</li>
+      </ul>
+    </div>
+    <i class="icon-info"></i>
+  </li>
+  <li class="separator">
+    <span class="label">Start time</span>
+    <div class="dropdown btn-group fixedwidth">
+      <a class="btn dropdown-label" >
+        Edit
+      </a>
+      <button type="button" class="btn  dropdown-toggle" uib-dropdown-toggle>
+        <i class="icon-calendar"></i>
+      </button>
+    </div>
+    <i class="icon-info"></i>
+  </li>
+</ul>
+<div class="sidebar-content">
+  <button class="btn btn-primary btn-block" type="button">
+    Start AOI Monitoring
+  </button>
+</div>
+<div class="sidebar sidebar-extended map-filters"
+     ng-show="$ctrl.showFilters">
+  <rf-aoi-filter-pane ng-if="$ctrl.showFilters"
+                  data-opened="$ctrl.showFilters"
+                  filters="$ctrl.filters"></rf-aoi-filter-pane>
+</div>

--- a/app-frontend/src/app/pages/projects/edit/aoi-parameters/aoi-parameters.module.js
+++ b/app-frontend/src/app/pages/projects/edit/aoi-parameters/aoi-parameters.module.js
@@ -1,0 +1,8 @@
+import angular from 'angular';
+import AOIParametersController from './aoi-parameters.controller.js';
+
+const AOIParametersModule = angular.module('page.projects.edit.aoi-parameters', []);
+
+AOIParametersModule.controller('AOIParametersController', AOIParametersController);
+
+export default AOIParametersModule;

--- a/app-frontend/src/app/pages/projects/edit/browse/browse.html
+++ b/app-frontend/src/app/pages/projects/edit/browse/browse.html
@@ -50,11 +50,7 @@
     <strong class="color-dark">{{$ctrl.lastSceneResult.count | number}} scenes found</strong>
   </div>
 </div>
-<div class="sidebar-scrollable"
-     infinite-scroll="$ctrl.getMoreScenes()"
-     infinite-scroll-disabled="$ctrl.loadingScenes || ($ctrl.lastSceneResult && !$ctrl.lastSceneResult.hasNext) || $ctrl.errorMsg"
-     infinite-scroll-immediate-check=false
-     class="list-group">
+<div class="sidebar-scrollable list-group">
   <rf-scene-item
       ng-click="$ctrl.openDetailPane(scene)"
       scene="scene"
@@ -67,6 +63,13 @@
       ng-mouseleave="$ctrl.removeHoveredScene()"
       ng-repeat="scene in $ctrl.sceneList track by scene.id">
   </rf-scene-item>
+  <div class="sidebar-content">
+    <button class="btn btn-block btn-secondary"
+            ng-if="!$ctrl.loadingScenes && $ctrl.lastSceneResult && $ctrl.lastSceneResult.hasNext && !$ctrl.errorMsg"
+            ng-click="$ctrl.getMoreScenes()">
+      Load More Scenes
+    </button>
+  </div>
 </div>
 <div class="sidebar sidebar-extended map-filters"
      ng-show="$ctrl.showFilterPane && !$ctrl.activeScene">

--- a/app-frontend/src/app/pages/projects/edit/browse/browse.html
+++ b/app-frontend/src/app/pages/projects/edit/browse/browse.html
@@ -1,19 +1,33 @@
-<div class="sidebar-project" ng-show="!$ctrl.activeScene">
-  <div class="sidebar-row">
-    <button class="btn" ng-click="$ctrl.gotoProjectScenes()">
-      <i class="icon-caret-left"></i>Scenes
-    </button>
-    <h5 class="sidebar-title">Browse scenes</h5>
-    <button class="btn btn-default"
+<div class="sidebar-header">
+  <a class="btn sidebar-header-nav-btn" ui-sref="projects.edit.scenes">
+    <i class="icon-arrow-left"></i>
+  </a>
+  <h5 class="sidebar-title">Browse Scenes</h5>
+  <div class="header-controls">
+    <button class="btn btn-default btn-small"
             type="button"
             ng-click="$ctrl.toggleFilterPane()">
       Sort/Filter
     </button>
   </div>
+</div>
+<div class="sidebar-project" ng-show="!$ctrl.activeScene">
   <ul class="sidebar-list">
-    <li class="header">
-      <span>Select scenes and click <strong>Add Scenes</strong> to add to the project.</span>
-      <div class="btn-group">
+    <li ng-if="$ctrl.$parent.project.isAOIProject">
+      <div class="banner banner-secondary">
+        <div>12 scenes awaiting approval</div>
+        <div>
+          <button class="btn btn-border-light" ui-sref="projects.edit.aoi-approve">Review Scenes</button>
+        </div>
+      </div>
+    </li>
+    <li>
+      <div class="label">
+        <span class="text">
+          Select scenes and click <strong>Add Scenes</strong> to add to the project.
+        </span>
+      </div>
+      <div class="btn-group fixedwidth">
         <button type="button"
                 class="btn btn-primary"
                 style="width: 12rem;"
@@ -21,7 +35,7 @@
           Add Scenes
         </button>
         <button type="button"
-                class="btn btn-square"
+                class="btn dropdown-toggle"
                 ng-class="{'btn-secondary': $ctrl.allSelected}"
                 ng-click="$ctrl.selectAllScenes()">
           <i ng-class="{'icon-plus': !$ctrl.allSelected,
@@ -31,31 +45,28 @@
     </li>
   </ul>
 </div>
-<div class="sidebar-scrollable">
-  <div class="list-group" ng-if="$ctrl.lastSceneResult && $ctrl.projectScenesReady">
-    <div class="list-group-item">
-      <strong class="color-dark">{{$ctrl.lastSceneResult.count | number}} scenes found</strong>
-    </div>
+<div class="list-group" ng-if="$ctrl.lastSceneResult && $ctrl.projectScenesReady">
+  <div class="list-group-item">
+    <strong class="color-dark">{{$ctrl.lastSceneResult.count | number}} scenes found</strong>
   </div>
-  <div infinite-scroll="$ctrl.getMoreScenes()"
-       infinite-scroll-distance="0.5"
-       infinite-scroll-disabled="$ctrl.loadingScenes || ($ctrl.lastSceneResult && !$ctrl.lastSceneResult.hasNext) || $ctrl.errorMsg"
-       infinite-scroll-container="'#infscroll'"
-       infinite-scroll-immediate-check=false
-       class="list-group">
-    <rf-scene-item
-        ng-click="$ctrl.openDetailPane(scene)"
-        scene="scene"
-        selectable
-        selected="$ctrl.isSelected(scene)"
-        is-disabled="$ctrl.isInProject(scene)"
-        on-select="$ctrl.setSelected(scene, selected)"
-        class="selectable"
-        ng-mouseenter="$ctrl.setHoveredScene(scene)"
-        ng-mouseleave="$ctrl.removeHoveredScene()"
-        ng-repeat="scene in $ctrl.sceneList track by scene.id">
-    </rf-scene-item>
-  </div>
+</div>
+<div class="sidebar-scrollable"
+     infinite-scroll="$ctrl.getMoreScenes()"
+     infinite-scroll-disabled="$ctrl.loadingScenes || ($ctrl.lastSceneResult && !$ctrl.lastSceneResult.hasNext) || $ctrl.errorMsg"
+     infinite-scroll-immediate-check=false
+     class="list-group">
+  <rf-scene-item
+      ng-click="$ctrl.openDetailPane(scene)"
+      scene="scene"
+      selectable
+      selected="$ctrl.isSelected(scene)"
+      is-disabled="$ctrl.isInProject(scene)"
+      on-select="$ctrl.setSelected(scene, selected)"
+      class="selectable"
+      ng-mouseenter="$ctrl.setHoveredScene(scene)"
+      ng-mouseleave="$ctrl.removeHoveredScene()"
+      ng-repeat="scene in $ctrl.sceneList track by scene.id">
+  </rf-scene-item>
 </div>
 <div class="sidebar sidebar-extended map-filters"
      ng-show="$ctrl.showFilterPane && !$ctrl.activeScene">

--- a/app-frontend/src/app/pages/projects/edit/edit.html
+++ b/app-frontend/src/app/pages/projects/edit/edit.html
@@ -1,15 +1,30 @@
 <div class="container column-stretch container-not-scrollable">
   <div class="sidebar" ui-view>
     <div class="sidebar-project">
-      <h5 class="sidebar-title">Editing project</h5>
+      <div class="sidebar-header">
+        <h5 class="sidebar-title">Editing project</h5>
+        <div ng-if="$ctrl.project.isAOIProject" class="inline-tag border-teal-tag">AOI Project</div>
+        <div ng-if="$ctrl.project.isAOIProject" class="header-controls">
+          <a ui-sref="projects.edit.aoi-parameters">Edit AOI Parameters</a>
+        </div>
+      </div>
       <ul class="sidebar-list">
-        <li class="header">
+        <li ng-if="$ctrl.project.isAOIProject">
+          <div class="banner banner-secondary">
+            <div>12 scenes awaiting approval</div>
+            <div>
+              <button class="btn btn-border-light" ui-sref="projects.edit.aoi-approve">Review Scenes</button>
+            </div>
+          </div>
+        </li>
+        <li>
           <span class="label">Add/Remove Scenes</span>
           <button class="btn btn-primary fixedwidth" type="button" ui-sref="projects.edit.scenes">
             Add/Remove scenes
           </button>
           <i class="icon-info"></i>
         </li>
+      </ul>
     </div>
     <div class="sidebar-scrollable">
       <ul class="sidebar-list">
@@ -40,7 +55,7 @@
           </button>
           <i class="icon-info"></i>
         </li>
-        <li>
+        <li class="separator">
           <span class="label">Export</span>
           <button class="btn btn-light fixedwidth"
                   type="button"

--- a/app-frontend/src/app/pages/projects/edit/scenes/scenes.html
+++ b/app-frontend/src/app/pages/projects/edit/scenes/scenes.html
@@ -1,14 +1,24 @@
+<div class="sidebar-header">
+  <a class="btn sidebar-header-nav-btn" ui-sref="projects.edit">
+    <i class="icon-arrow-left"></i>
+  </a>
+  <h5 class="sidebar-title">Add or Remove Scenes</h5>
+</div>
 <div class="sidebar-project">
-  <div class="sidebar-row">
-    <button class="btn" ui-sref="projects.edit"><i class="icon-caret-left"></i>Project</button>
-    <h5 class="sidebar-title">Add/Remove scenes</h5>
-  </div>
   <ul class="sidebar-list">
-    <li class="header">
-      <span>
-        Remove scenes by clicking <i class="icon-trash"></i>
-        or browse scenes to add.
-      </span>
+    <li ng-if="$ctrl.$parent.project.isAOIProject">
+      <div class="banner banner-secondary">
+        <div>12 scenes awaiting approval</div>
+        <div>
+          <button class="btn btn-border-light" ui-sref="projects.edit.aoi-approve">Review Scenes</button>
+        </div>
+      </div>
+    </li>
+    <li>
+      <div class="label">
+        <span class="text">Remove scenes by clicking <i class="icon-trash"></i>
+        or browse scenes to add.</span>
+      </div>
       <button type="button"
               class="btn btn-primary fixedwidth"
               ui-sref="projects.edit.browse({sceneid: null})">

--- a/app-frontend/src/assets/styles/sass/_shame.scss
+++ b/app-frontend/src/assets/styles/sass/_shame.scss
@@ -212,10 +212,6 @@ rf-project-editor .leaflet-tile {
 .flex-column {
   flex-grow: 1;
 }
-
-.btn-group .btn {
-  flex-grow: 1;
-}
 //
 
 
@@ -319,7 +315,6 @@ rf-project-editor .leaflet-tile {
 .sidebar-project {
   position: relative;
   border-bottom: 2px solid #ddd;
-  padding: 1rem 1.5rem;
   .sidebar-row {
     display: flex;
     align-content: row;
@@ -329,44 +324,112 @@ rf-project-editor .leaflet-tile {
     }
   }
 }
+.sidebar-header {
+  padding: 1.25rem 2rem;
+  background: #f1f1f1;
+  display: flex;
+  align-items: center;
+  height: 48px;
+  border-bottom: 1px solid #ddd;
+  & > * {
+    margin-top: 0;
+    margin-bottom: 0;
+  }
+  .header-controls {
+    flex: 1;
+    text-align: right;
+    font-size: 1.2rem;
+  }
+  .inline-tag {
+    margin-left: 1rem;
+  }
+  .sidebar-header-nav-btn {
+    padding: 0;
+    border: none;
+    background: none;
+    color: #465076;
+    font-size: 2.8rem;
+  }
+}
+
 .sidebar-list {
   list-style: none;
   display: block;
   margin: 0 0 0 0;
   padding: 0;
 
-  li {
+  & > li {
     display: flex;
     align-items: center;
-    padding: 1.5rem 1rem 2.5rem 1rem;
-
+    padding: 1.5rem 1rem 1.5rem 1rem;
+    &:not(:first-child) {
+      padding-top: 0rem;
+    }
+    &.separator {
+      border-bottom: 1px solid #ddd;
+      margin-bottom: 1rem;
+      margin: 0rem 1rem 0rem 1rem;
+      padding: 1.5rem 0 1.5rem 0;
+      &:last-of-type{
+        border-bottom: none;
+      }
+      &.separator-primary {
+        margin: 0rem;
+        padding: 1.5rem 1rem;
+        border-bottom: none;
+        background: #738FFC;
+        color: #fff;
+      }
+    }
+    &.header {
+      margin-left: 0;
+      padding: 1rem 0 1rem 0;
+    }
     .fixedwidth {
       width: 20rem;
     }
 
     .label {
       flex: 1;
-      font-weight: bold;
+      font-weight: 700;
+      display: flex;
+      flex-direction: column;
+      margin-right: 1rem;
+      .text {
+        font-weight: normal;
+        font-size: 1.2rem;
+      }
+      .info {
+        font-size: 1.2rem;
+        font-style: italic;
+        font-weight: normal;
+      }
     }
 
     i .icon-info {
       cursor: help;
     }
 
-    &.separator {
-      border-bottom: 1px solid #ddd;
-      margin-bottom: 1rem;
-      margin: 0rem 1rem 0rem 1rem;
-      padding: 1.5rem 0 1.5rem 0;
-    }
-
-    &.header {
-      margin-left: 0;
-      padding: 1rem 0 1rem 0;
+    .banner {
+      padding: 1rem;
+      border-radius: 2px;
+      color: #fff;
+      flex: 1;
+      text-align: center;
+      div:not(:last-child) {
+        margin-bottom: 1rem;
+      }
     }
   }
-}
 
+
+}
+.sidebar-content {
+  padding: 1rem;
+}
+.banner-secondary {
+  background: #2FC1D0;
+}
 .navbar {
   padding-top: 0.7rem;
   padding-bottom: 0.8rem;

--- a/app-frontend/src/assets/styles/sass/components/_button.scss
+++ b/app-frontend/src/assets/styles/sass/components/_button.scss
@@ -161,7 +161,30 @@
   }
 }
 
-/* 
+.btn-border{
+  border-color: $text-base;
+  background: none;
+  color: $text-base;
+  font-weight: 700;
+  &:hover, &.hover,
+  &:active, &.active, {
+    background: $brand-primary;
+  }
+}
+
+.btn-border-light {
+  border-color: $white;
+  background: none;
+  color: $white;
+  font-weight: 700;
+  &:hover, &.hover,
+  &:active, &.active, {
+    background: $brand-primary;
+  }
+}
+
+
+/*
  * Button Sizes
  */
 .btn-tiny {
@@ -187,8 +210,7 @@
   width: 100%;
 }
 
-
-/* 
+/*
  * Button actions
  */
 .btn-toggle {
@@ -239,7 +261,7 @@
 }
 
 
-/* 
+/*
  * Button groups
  */
  .btn-group {
@@ -247,7 +269,7 @@
 
   .btn {
     margin: 0 !important;
-
+    flex-grow: 1;
 
     // FIX ISSUE WHERE ONLY ONE BUTTON HAS MESSED UP RADIUS
     &:not(:last-child):not(.dropdown-toggle) {
@@ -270,9 +292,16 @@
     margin-left: -1px !important;
   }
 
+  .dropdown-label {
+    text-align: left;
+    font-weight: normal;
+  }
+
   // changes padding on toggle for dropdown btn-groups
   .dropdown-toggle {
     padding-left: 1rem;
     padding-right: 1rem;
+    flex-grow: 0;
+    flex-shrink: 0;
   }
  }


### PR DESCRIPTION
## Overview

This PR adds an initial UI for Area of Interest projects.

The main `projects/{projectid}/edit` page has been adjusted to handle an AOI project (see demo below).

This adds two routes and corresponding templates:
- `projects/edit/{projectid}/aoi-parameters` - houses the page to adjust AOI parameters (filters, frequency, etc.)
- `projects/edit/{projectid}/aoi-approve` - houses the page to approve AOI scenes when an AOI project is set to require manual approval for scene addition

This PR also updates the style of several sidepanels to match new mockups.

Most of the front-end is non-functional.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~

### Demo

The `projects/{projectid}/edit` page for a standard project.
<img width="553" alt="screen shot 2017-05-10 at 5 13 23 pm" src="https://cloud.githubusercontent.com/assets/2442245/25922023/a28ad11a-35a5-11e7-831b-fa99b7ba37ac.png">


The `projects/{projectid}/edit` page for an AOI project. Notice the tag and link in the sidebar header.
<img width="583" alt="screen shot 2017-05-10 at 5 13 42 pm" src="https://cloud.githubusercontent.com/assets/2442245/25922024/a28b7e26-35a5-11e7-925e-f0a7107c7089.png">


Then we step through the scene management pages with an AOI project.
<img width="578" alt="screen shot 2017-05-10 at 5 14 47 pm" src="https://cloud.githubusercontent.com/assets/2442245/25922077/d5f9261e-35a5-11e7-82ca-ef195de65c5b.png">
<img width="626" alt="screen shot 2017-05-10 at 5 14 54 pm" src="https://cloud.githubusercontent.com/assets/2442245/25922078/d5fbf4e8-35a5-11e7-970a-277baa6e3343.png">


Click the 'Approve Scenes' button takes the user to the...'Approve Scenes' page (`projects/edit/{projectid}/aoi-approve`). When we have some backend stuff hooked up this will have a list of the scenes to approve. Each scene will be able to be approved or rejected, and when the user is done assessing each scene (or however many scenes they feel like), they can click 'Approve Scenes'.
<img width="576" alt="screen shot 2017-05-10 at 5 28 22 pm" src="https://cloud.githubusercontent.com/assets/2442245/25922241/65d394f4-35a6-11e7-9833-6d9da6ade74a.png">

From the project edit page, if the user clicks the 'Edit AOI Parameters', they are taken to the `projects/edit/{projectid}/aoi-parameters` route.
<img width="548" alt="screen shot 2017-05-10 at 5 32 12 pm" src="https://cloud.githubusercontent.com/assets/2442245/25922314/bb16efb0-35a6-11e7-8520-08ec1aca6c9e.png">

There is a filter built in here that is a new component (rf-aoi-filter-pane) since the filters we are displaying are different than our standard browse filters.
<img width="890" alt="screen shot 2017-05-10 at 5 33 49 pm" src="https://cloud.githubusercontent.com/assets/2442245/25922340/da661792-35a6-11e7-8acf-1ede2231fdd2.png">


### Notes

The scene approval banner element is not dynamic and is shown to demonstrate the UI. I added it to most pages having to do with adding imagery so that it is consistent. I also added the banner to the main AOI project edit page so that a user would be aware of the need to approve scenes without having to first go into the 'Add/Remove Scenes' area.

I adjusted some wording to keep things consistent.

Our icons have a bit of extra space around them so headers that contain the back arrow seem pushed to the right a bit too much for my own comfort. Not sure of the best way to handle this.

## Testing Instructions

 * Set a project to an AOI project using PSQL. `update scenes set is_aoi_project=true where id='<scene_id>';`
 * Click through the project edit pages with your AOI project and see that everything looks about like the mockups and buttons take you where you think they should take you.
 * Do the same for a standard project to make sure I didn't break anything.

Closes #1669 
Closes #1665
