### PR TITLE
Make parallel ingest cooperate

### DIFF
--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/ingest/CommandLine.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/ingest/CommandLine.scala
@@ -5,11 +5,13 @@ import java.net.URI
 
 object CommandLine {
   case class Params(
+    sceneId: String = "",
     jobDefinition: URI = new URI(""),
     testRun: Boolean = false,
     overwrite: Boolean = false,
     windowSize: Int = 1024,
-    partitionsPerFile: Int = 8
+    partitionsPerFile: Int = 8,
+    statusBucket: String = "rasterfoundry-dataproc-ingest-status-us-east-1"
   )
 
   // Used for reading text in as URI
@@ -28,6 +30,11 @@ object CommandLine {
     opt[Unit]("overwrite").action( (_, conf) =>
       conf.copy(overwrite = true) ).text("Overwrite conflicting layers")
 
+    opt[String]('s', "sceneId")
+      .action( (scene, conf) => conf.copy(sceneId = scene) )
+      .text("The id of the scene to ingest")
+      .required
+
     opt[URI]('j',"jobDefinition")
       .action( (jd, conf) => conf.copy(jobDefinition = jd) )
       .text("The location of the json which defines an ingest job")
@@ -41,5 +48,8 @@ object CommandLine {
       .action( (s, conf) => conf.copy(partitionsPerFile = s) )
       .text("Number of RDD partitions to create per each source file")
 
+    opt[String]('b',"statusBucket")
+      .action( (s, conf) => conf.copy(statusBucket = s) )
+      .text("S3 bucket to write status jsons to")
   }
 }

--- a/app-backend/build.sbt
+++ b/app-backend/build.sbt
@@ -195,7 +195,13 @@ lazy val batch = Project("batch", file("batch"))
     )
   })
   .settings(assemblyShadeRules in assembly := Seq(
-      ShadeRule.rename("shapeless.**" -> "com.azavea.shaded.shapeless.@1").inAll
+      ShadeRule.rename("shapeless.**" -> "com.azavea.shaded.shapeless.@1").inAll,
+      ShadeRule.rename(
+        "com.amazonaws.services.s3.**" -> "com.azavea.shaded.amazonaws.services.s3.@1"
+      ).inAll,
+      ShadeRule.rename(
+        "com.amazonaws.**" -> "com.azavea.shaded.amazonaws.@1"
+      ).inAll
     )
   )
 

--- a/app-backend/common/src/main/scala/S3.scala
+++ b/app-backend/common/src/main/scala/S3.scala
@@ -13,7 +13,7 @@ import java.io._
 import java.net._
 
 package object S3 {
-  val client = AmazonS3ClientBuilder.standard()
+  def client = AmazonS3ClientBuilder.standard()
     .withCredentials(new DefaultAWSCredentialsProviderChain())
     .withRegion(Regions.US_EAST_1)
     .build()
@@ -41,9 +41,7 @@ package object S3 {
   }
 
   def putObject(bucket: String, key: String, contents: String): String = {
-    Try(client.putObject(bucket, key, contents)) match {
-      case Success(_) => contents
-      case Failure(ex) => throw new Exception(ex)
-    }
+    client.putObject(bucket, key, contents)
+    contents
   }
 }

--- a/app-backend/common/src/main/scala/S3.scala
+++ b/app-backend/common/src/main/scala/S3.scala
@@ -13,7 +13,7 @@ import java.io._
 import java.net._
 
 package object S3 {
-  def client = AmazonS3ClientBuilder.standard()
+  lazy val client = AmazonS3ClientBuilder.standard()
     .withCredentials(new DefaultAWSCredentialsProviderChain())
     .withRegion(Regions.US_EAST_1)
     .build()

--- a/app-backend/common/src/main/scala/S3.scala
+++ b/app-backend/common/src/main/scala/S3.scala
@@ -12,10 +12,11 @@ import java.io._
 import java.net._
 
 package object S3 {
+  val builder = AmazonS3ClientBuilder.standard()
+  builder.setRegion("us-east-1")
+  val client = builder.build()
+
   def getObject(uri: URI): S3Object = {
-    val client = AmazonS3ClientBuilder.standard()
-      .withCredentials(new DefaultAWSCredentialsProviderChain())
-      .build()
     val s3uri = new AmazonS3URI(uri)
     Try(client.getObject(s3uri.getBucket, s3uri.getKey)) match {
       case Success(o) => o
@@ -38,10 +39,6 @@ package object S3 {
   }
 
   def putObject(bucket: String, key: String, contents: String): String = {
-    val client = AmazonS3ClientBuilder.standard()
-      .withCredentials(new DefaultAWSCredentialsProviderChain())
-      .build()
-
     Try(client.putObject(bucket, key, contents)) match {
       case Success(_) => contents
       case Failure(ex) => throw new Exception(ex)

--- a/app-backend/common/src/main/scala/S3.scala
+++ b/app-backend/common/src/main/scala/S3.scala
@@ -36,4 +36,15 @@ package object S3 {
       s3InputStream.close()
     }
   }
+
+  def putObject(bucket: String, key: String, contents: String): String = {
+    val client = AmazonS3ClientBuilder.standard()
+      .withCredentials(new DefaultAWSCredentialsProviderChain())
+      .build()
+
+    Try(client.putObject(bucket, key, contents)) match {
+      case Success(_) => contents
+      case Failure(ex) => throw new Exception(ex)
+    }
+  }
 }

--- a/app-backend/common/src/main/scala/S3.scala
+++ b/app-backend/common/src/main/scala/S3.scala
@@ -5,6 +5,7 @@ import scala.util.{Success, Failure, Try}
 import org.apache.commons.io.IOUtils
 
 import com.amazonaws.auth._
+import com.amazonaws.regions._
 import com.amazonaws.services.s3.{AmazonS3ClientBuilder, AmazonS3URI}
 import com.amazonaws.services.s3.model.{S3Object, ObjectMetadata}
 
@@ -12,9 +13,10 @@ import java.io._
 import java.net._
 
 package object S3 {
-  val builder = AmazonS3ClientBuilder.standard()
-  builder.setRegion("us-east-1")
-  val client = builder.build()
+  val client = AmazonS3ClientBuilder.standard()
+    .withCredentials(new DefaultAWSCredentialsProviderChain())
+    .withRegion(Regions.US_EAST_1)
+    .build()
 
   def getObject(uri: URI): S3Object = {
     val s3uri = new AmazonS3URI(uri)

--- a/app-tasks/dags/ingest_project_scenes.py
+++ b/app-tasks/dags/ingest_project_scenes.py
@@ -42,8 +42,7 @@ dag = DAG(
 batch_job_definition = os.getenv('BATCH_INGEST_JOB_NAME')
 batch_job_queue = os.getenv('BATCH_INGEST_JOB_QUEUE')
 hosted_zone_id = os.getenv('HOSTED_ZONE_ID')
-jar_path = 'rf-batch-ingest-status.jar'
-#jar_path = os.getenv('BATCH_JAR_PATH', 'rf-batch-ba1b872.jar')
+jar_path = os.getenv('BATCH_JAR_PATH', 'rf-batch-ba1b872.jar')
 
 
 ################################

--- a/app-tasks/dags/ingest_project_scenes.py
+++ b/app-tasks/dags/ingest_project_scenes.py
@@ -11,6 +11,7 @@ import dns.resolver
 
 from rf.utils.io import IngestStatus
 from rf.models import Scene
+from rf.ingest.models import Ingest
 from rf.ingest import create_landsat8_ingest, create_ingest_definition
 from rf.uploads.landsat8.settings import datasource_id as landsat_id
 from rf.utils.exception_reporting import wrap_rollbar
@@ -41,7 +42,8 @@ dag = DAG(
 batch_job_definition = os.getenv('BATCH_INGEST_JOB_NAME')
 batch_job_queue = os.getenv('BATCH_INGEST_JOB_QUEUE')
 hosted_zone_id = os.getenv('HOSTED_ZONE_ID')
-jar_path = os.getenv('BATCH_JAR_PATH', 'rf-batch-53937da.jar')
+jar_path = 'rf-batch-ingest-status.jar'
+#jar_path = os.getenv('BATCH_JAR_PATH', 'rf-batch-ba1b872.jar')
 
 
 ################################
@@ -56,12 +58,14 @@ def get_cluster_id():
 
 
 @wrap_rollbar
-def execute_ingest_emr_job(ingest_s3_uri, ingest_def_id, cluster_id):
+def execute_ingest_emr_job(scene_id, ingest_s3_uri, ingest_def_id, cluster_id):
     """Kick off ingest in AWS EMR
 
     Args:
+        scene_id (str): id of the scene to ingest
         ingest_s3_uri (str): URI for ingest definition
         ingest_def_id (str): ID to namespace ingest job
+        cluster_id (str): ID of the cluster to submit work to
 
     Returns:
         dict
@@ -75,11 +79,15 @@ def execute_ingest_emr_job(ingest_s3_uri, ingest_def_id, cluster_id):
                      'yarn',
                      '--deploy-mode',
                      'cluster',
+                     '--conf',
+                     'spark.yarn.submit.waitAppCompletion=false',
                      '--class',
                      'com.azavea.rf.batch.ingest.spark.Ingest',
                      's3://rasterfoundry-global-artifacts-us-east-1/batch/{}'.format(jar_path),
                      '-t',
                      '--overwrite',
+                     '-s',
+                     scene_id,
                      '-j',
                      ingest_s3_uri],
             'Jar': 's3://us-east-1.elasticmapreduce/libs/script-runner/script-runner.jar'
@@ -164,6 +172,7 @@ def create_ingest_definition_op(*args, **kwargs):
     # Store values for later tasks
     xcom_client.xcom_push(key='ingest_def_uri', value=ingest_definition.s3_uri)
     xcom_client.xcom_push(key='ingest_def_id', value=ingest_definition.id)
+    xcom_client.xcom_push(key='scene_id', value=scene.id)
 
 
 @wrap_rollbar
@@ -172,40 +181,29 @@ def launch_spark_ingest_job_op(*args, **kwargs):
     xcom_client = kwargs['task_instance']
     ingest_def_uri = xcom_client.xcom_pull(key='ingest_def_uri', task_ids=None)
     ingest_def_id = xcom_client.xcom_pull(key='ingest_def_id', task_ids=None)
+    scene_id = xcom_client.xcom_pull(key='scene_id', task_ids=None)
 
     logger.info('Launching Spark ingest job with ingest definition %s', ingest_def_uri)
     cluster_id = get_cluster_id()
-    emr_response = execute_ingest_emr_job(ingest_def_uri, ingest_def_id, cluster_id)
+    emr_response = execute_ingest_emr_job(scene_id, ingest_def_uri, ingest_def_id, cluster_id)
     logger.info('Finished launching Spark ingest job. Waiting for status changes.')
     is_success = wait_for_success(emr_response, cluster_id)
     return is_success
 
 
 @wrap_rollbar
-def set_ingest_status_success_op(*args, **kwargs):
-    """Set scene ingest status on success"""
+def wait_for_status_op(*args, **kwargs):
+    """Wait for a result from the Spark job"""
     xcom_client = kwargs['task_instance']
-    scene_id = xcom_client.xcom_pull(key='ingest_scene_id', task_ids=None)
-    logger.info("Setting scene (%s) ingested status to success", scene_id)
+    ingest_def_id = xcom_client.xcom_pull(key='ingest_def_id', task_ids=None)
+    ingest_status_dict = Ingest.get_status_from_s3(ingest_def_id)
+    scene_id = ingest_status_dict['sceneId']
+    status = ingest_status_dict['ingestStatus']
     scene = Scene.from_id(scene_id)
-    scene.ingestStatus = IngestStatus.INGESTED
-
-    layer_s3_bucket = os.getenv('TILE_SERVER_BUCKET')
-
-    s3_output_location = 's3://{}/layers'.format(layer_s3_bucket)
-    scene.ingestLocation = s3_output_location
+    scene.ingestStatus = IngestStatus.fromString(status)
+    logger.info('Setting scene %s ingest status to %s', scene.id, scene.ingestStatus)
     scene.update()
-    logger.info("Finished setting scene (%s) ingest status (%s)", scene_id, IngestStatus.INGESTED)
-    return "Done Success"
-
-@wrap_rollbar
-def set_ingest_status_failure_op(*args, **kwargs):
-    """Set ingest status on failure"""
-    xcom_client = kwargs['task_instance']
-    scene_id = xcom_client.xcom_pull(key='ingest_scene_id', task_ids=None)
-    logger.info("Setting scene (%s) ingested status to failed", scene_id)
-    logger.info("Finished setting scene (%s) ingest status (%s)", scene_id, IngestStatus.FAILED)
-    return "Done Success"
+    logger.infoi('Successfully updated scene %s\'s ingest status', scene.id)
 
 ################################
 # Tasks                        #
@@ -225,21 +223,10 @@ launch_spark_ingest_task = PythonOperator(
     dag=dag
 )
 
-
-set_ingest_status_success_task = PythonOperator(
-    task_id='set_ingest_status_success',
-    python_callable=set_ingest_status_success_op,
+wait_for_status_task = PythonOperator(
+    task_id='wait_for_status',
     provide_context=True,
-    trigger_rule='all_success',
-    dag=dag
-)
-
-
-set_ingest_status_failure_task = PythonOperator(
-    task_id='set_ingest_status_failure',
-    python_callable=set_ingest_status_failure_op,
-    provide_context=True,
-    trigger_rule='all_failed',
+    python_callable=wait_for_status_op,
     dag=dag
 )
 
@@ -247,6 +234,5 @@ set_ingest_status_failure_task = PythonOperator(
 ################################
 # DAG Structure Specification  #
 ################################
-set_ingest_status_success_task.set_upstream(launch_spark_ingest_task)
-set_ingest_status_failure_task.set_upstream(launch_spark_ingest_task)
 launch_spark_ingest_task.set_upstream(create_ingest_definition_task)
+wait_for_status_task.set_upstream(launch_spark_ingest_task)

--- a/app-tasks/dags/ingest_project_scenes.py
+++ b/app-tasks/dags/ingest_project_scenes.py
@@ -42,7 +42,7 @@ dag = DAG(
 batch_job_definition = os.getenv('BATCH_INGEST_JOB_NAME')
 batch_job_queue = os.getenv('BATCH_INGEST_JOB_QUEUE')
 hosted_zone_id = os.getenv('HOSTED_ZONE_ID')
-jar_path = os.getenv('BATCH_JAR_PATH', 'rf-batch-ba1b872.jar')
+jar_path = os.getenv('BATCH_JAR_PATH', 'rf-batch-g874b19.jar')
 
 
 ################################

--- a/app-tasks/rf/src/rf/utils/io.py
+++ b/app-tasks/rf/src/rf/utils/io.py
@@ -88,6 +88,15 @@ class IngestStatus(object):
     INGESTED = 'INGESTED'
     FAILED = 'FAILED'
 
+    @classmethod
+    def from_string(s):
+        lookup = {
+            k: k.upper() for k in [
+                'notingested', 'tobeingested', 'ingesting',
+                'ingested', 'failed'
+            ]
+        }
+        return lookup[s.lower()]
 
 class Visibility(object):
     PUBLIC = 'PUBLIC'


### PR DESCRIPTION
## Overview

This PR changes status monitoring to look for a file on S3, which is put there in the
batch jar when ingest completes.

### Checklist

- ~Styleguide updated, if necessary~
- ~Swagger specification updated, if necessary~
- ~Symlinks from new migrations present or corrected for any new migrations~

## Testing Instructions

 * `batch/assembly` from `sbt` -- you're gonna want to do this outside the vm so it takes a minute instead of an hour (not joking)
 * upload a small sample scene to kick off the upload / ingest workflow (I can send you one if you need it)
 * wait
 * after the ingest finishes (takes a few minutes), there should be a file in `s3://rasterfoundry-dataproc-ingest-status-us-east-1/` with your `ingest_id` as the key, and that file's existence should clue airflow in that it can update the scene status

Closes #1746
