### PR TITLE
Add `pending` boolean query parameter to project scenes endpoint

### DIFF
--- a/app-backend/api/src/main/scala/scene/QueryParameters.scala
+++ b/app-backend/api/src/main/scala/scene/QueryParameters.scala
@@ -30,7 +30,8 @@ trait SceneQueryParameterDirective extends QueryParametersCommon
     'point.as[String].?,
     'project.as[UUID].?,
     'ingested.as[Boolean].?,
-    'ingestStatus.as[String].*
+    'ingestStatus.as[String].*,
+    'pending.as[Boolean].?
   )).as(SceneQueryParameters.apply _)
 
   val sceneQueryParameters = (orgQueryParams &

--- a/app-backend/database/src/main/scala/com/azavea/rf/database/QueryParameters.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/QueryParameters.scala
@@ -53,7 +53,8 @@ case class SceneQueryParameters(
   point: Option[String] = None,
   project: Option[UUID] = None,
   ingested: Option[Boolean] = None,
-  ingestStatus: Iterable[String] = Seq[String]()
+  ingestStatus: Iterable[String] = Seq[String](),
+  pending: Option[Boolean] = None
 ) {
   val bboxPolygon: Option[Seq[Projected[Polygon]]] = try {
     bbox match {

--- a/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Scenes.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Scenes.scala
@@ -521,7 +521,15 @@ class ScenesTableQuery[M, U, C[_]](scenes: Scenes.TableQuery) extends LazyLoggin
     sceneParams.project match {
       case Some(projectId) => {
         filteredScenes.filter { scene =>
-          scene.id in ScenesToProjects.filter(_.projectId === projectId).map(_.sceneId)
+          scene.id in ScenesToProjects
+            .filter(_.projectId === projectId)
+            .filter { s2p =>
+              sceneParams.pending
+                .map(s2p.accepted =!= _)
+                .reduceLeftOption(_ || _)
+                .getOrElse(true: Rep[Boolean])
+            }
+            .map(_.sceneId)
         }
       }
       case _ => {

--- a/docs/swagger/spec.yml
+++ b/docs/swagger/spec.yml
@@ -740,6 +740,7 @@ paths:
         - $ref: '#/parameters/tags'
         - $ref: '#/parameters/ingested'
         - $ref: '#/parameters/ingestStatus'
+        - $ref: '#/parameters/pending'
       responses:
         200:
           description: Paginated list of scenes associated with this project
@@ -1937,6 +1938,12 @@ parameters:
     in: query
     type: string
     required: false
+  pending:
+    name: pending
+    description: Filter by scene's acceptance for an AOI project
+    in: query
+    type: boolean
+    required: false
   tool:
     name: toolId
     description: Filter by tool\'s slug label
@@ -2471,6 +2478,9 @@ definitions:
         manualOrder:
           type: boolean
           description: Is true if project scenes are manually ordered
+        isAOIProject:
+          type: boolean
+          description: Is true if project is an area-of-interest project
   Image:
     allOf:
     - $ref: '#/definitions/BaseModel'


### PR DESCRIPTION
## Overview

This PR adds a `pending` query parameter to the `project/scenes` endpoint.

It filters against the value of `scenes_to_projects.accepted`.

### Checklist

~- [ ] Styleguide updated, if necessary~
- [x] Swagger specification updated, if necessary
~- [ ] Symlinks from new migrations present or corrected for any new migrations~

### Notes

The filtering for this only kicks in if a `project_id` is also specified (which it is for this endpoint).

## Testing Instructions

 * Set `accepted=false` on some `scenes_to_projects` for a certain project.
 * Hit the `projects/{uuid}/scenes` endpoint and get a scene count
 * Hit  `projects/{uuid}/scenes?pending=false` and `projects/{uuid}/scenes?pending=false`...the number of results from both should add up to the count above

Closes #1740
