### PR TITLE
Add a scene owner filter to the browse view

### DIFF
--- a/app-frontend/src/app/components/filterPane/filterPane.controller.js
+++ b/app-frontend/src/app/components/filterPane/filterPane.controller.js
@@ -223,6 +223,8 @@ export default class FilterPaneController {
         this.initIngestFilter();
 
         this.initSourceFilters();
+
+        this.importOwnerFilter = this.filters.owner ? 'user' : 'any';
     }
 
     initIngestFilter() {
@@ -258,36 +260,6 @@ export default class FilterPaneController {
                 }
             }
         });
-
-        // Define static source filters
-        this.staticSourceFilters = {
-            mine: {
-                datasource: {
-                    id: 'mine',
-                    name: 'My Imports'
-                },
-                enabled: false
-            },
-            users: {
-                datasource: {
-                    id: 'users',
-                    name: 'Raster Foundry Users'
-                },
-                enabled: false
-            }
-        };
-
-        if (this.filters.datasource) {
-            if (Array.isArray(this.filters.datasource)) {
-                this.filters.datasource.forEach(dsf => {
-                    if (this.staticSourceFilters[dsf]) {
-                        this.staticSourceFilters[dsf].enabled = true;
-                    }
-                });
-            } else if (this.staticSourceFilters[this.filters.datasource]) {
-                this.staticSourceFilters[this.filters.datasource].enabled = true;
-            }
-        }
     }
 
     resetAllFilters() {
@@ -297,7 +269,6 @@ export default class FilterPaneController {
         this.cloudCoverFilters.maxModel = this.cloudCoverRange.max;
         this.filters.minCloudCover = this.cloudCoverRange.min;
         delete this.filters.maxCloudCover;
-
 
         this.sunElevationFilters.minModel = this.sunElevationRange.min;
         this.sunElevationFilters.maxModel = this.sunElevationRange.max;
@@ -313,10 +284,6 @@ export default class FilterPaneController {
             .forEach((ds) => {
                 ds.enabled = false;
             });
-        Object.values(this.staticSourceFilters)
-            .forEach((ds) => {
-                ds.enabled = false;
-            });
         this.filters.datasource = [];
 
         this.ingestFilter = 'any';
@@ -328,6 +295,20 @@ export default class FilterPaneController {
     setIngestFilter(mode) {
         this.ingestFilter = mode;
         this.onIngestFilterChange();
+    }
+
+    setImportOwnerFilter(mode) {
+        this.importOwnerFilter = mode;
+        this.onImportOwnerFilterChange();
+    }
+
+    onImportOwnerFilterChange() {
+        if (this.importOwnerFilter === 'user') {
+            let profile = this.authService.profile();
+            this.filters.owner = profile ? profile.user_id : null;
+        } else {
+            delete this.filters.owner;
+        }
     }
 
     onIngestFilterChange() {
@@ -352,19 +333,12 @@ export default class FilterPaneController {
         Object.values(this.dynamicSourceFilters)
             .filter(ds => ds.enabled)
             .forEach(ds => this.filters.datasource.push(ds.datasource.id));
-
-        Object.values(this.staticSourceFilters)
-            .filter(ds => ds.enabled)
-            .forEach(ds => this.filters.datasource.push(ds.datasource.id));
     }
 
     toggleSourceFilter(sourceId) {
         if (this.dynamicSourceFilters[sourceId]) {
             this.dynamicSourceFilters[sourceId].enabled =
                 !this.dynamicSourceFilters[sourceId].enabled;
-        } else if (this.staticSourceFilters[sourceId]) {
-            this.staticSourceFilters[sourceId].enabled =
-                !this.staticSourceFilters[sourceId].enabled;
         }
         this.onSourceFilterChange();
     }

--- a/app-frontend/src/app/components/filterPane/filterPane.html
+++ b/app-frontend/src/app/components/filterPane/filterPane.html
@@ -98,16 +98,30 @@
           <button class="btn btn-toggle btn-small"
                   ng-click="$ctrl.toggleSourceFilter(id)"
                   ng-class="{'active': filter.enabled}"
-                  ng-repeat="(id, filter) in $ctrl.staticSourceFilters track by id"
-                  disabled>
-            {{filter.datasource.name}}
-          </button>
-          <button class="btn btn-toggle btn-small"
-                  ng-click="$ctrl.toggleSourceFilter(id)"
-                  ng-class="{'active': filter.enabled}"
                   ng-repeat="(id, filter) in $ctrl.dynamicSourceFilters track by id">
             {{filter.datasource.name}}
           </button>
+        </div>
+      </div>
+    </div>
+    <div class="filter-group">
+      <div class="filter">
+        <label>Owner</label>
+        <div class="filter-item tag-filter">
+          <div class="btn-group">
+            <button type="button"
+                    class="btn btn-toggle btn-small"
+                    ng-class="{'active': $ctrl.importOwnerFilter === 'any'}"
+                    ng-click="$ctrl.setImportOwnerFilter('any')">
+              All Users
+            </button>
+            <button type="button"
+                    class="btn btn-toggle btn-small"
+                    ng-class="{'active': $ctrl.importOwnerFilter === 'user'}"
+                    ng-click="$ctrl.setImportOwnerFilter('user')">
+              My Imports
+            </button>
+          </div>
         </div>
       </div>
     </div>

--- a/app-frontend/src/app/index.routes.js
+++ b/app-frontend/src/app/index.routes.js
@@ -54,7 +54,8 @@ function projectEditStates($stateProvider) {
         'minSunElevation',
         'bbox',
         'point',
-        'ingested'
+        'ingested',
+        'owner'
     ].join('&');
 
     $stateProvider


### PR DESCRIPTION
## Overview
Add a scene owner filter to the browse view
Remove old static filter code

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~

### Demo
![image](https://cloud.githubusercontent.com/assets/4392704/26071703/f12bc804-3976-11e7-86b5-305921569b5f.png)


### Notes

Decided that a separate filter section with a multi-button made more sense than a checkbox in the existing datasource filter, since it's a different field that has a different intention behind it 


## Testing Instructions

* Change the owner field of a scene to your user
* Search for the scene using the new filter
* Verify that the filter works as expected
* Verify that the filter is persisted in the URL like all the other filters

Closes #1663 
