### PR TITLE
Update swagger spec

### DIFF
--- a/docs/swagger/spec.yml
+++ b/docs/swagger/spec.yml
@@ -740,6 +740,7 @@ paths:
         - $ref: '#/parameters/tags'
         - $ref: '#/parameters/ingested'
         - $ref: '#/parameters/ingestStatus'
+        - $ref: '#/parameters/pending'
       responses:
         200:
           description: Paginated list of scenes associated with this project
@@ -1936,6 +1937,12 @@ parameters:
     description: Filter by specific ingest status
     in: query
     type: string
+    required: false
+  pending:
+    name: pending
+    description: Filter by scene's acceptance for an AOI project
+    in: query
+    type: boolean
     required: false
   tool:
     name: toolId


### PR DESCRIPTION
## Overview

The swagger spec didn't reflect what the backend was actually doing. That was causing problems for the the python client when it couldn't pass "page" as a query parameter and when it tried to deserialize "project" as a dict instead of a string.

### Checklist

- ~Styleguide updated, if necessary~
- [x] Swagger specification updated, if necessary
- ~Symlinks from new migrations present or corrected for any new migrations~

## Testing Instructions

 * Compare changes to changes in azavea/raster-foundry-python-client#4
