### PR TITLE
Add min/max tool operations

### DIFF
--- a/app-backend/tool/src/main/scala/ast/MapAlgebraAST.scala
+++ b/app-backend/tool/src/main/scala/ast/MapAlgebraAST.scala
@@ -49,6 +49,12 @@ object MapAlgebraAST {
   case class Classification(args: List[MapAlgebraAST], id: UUID, metadata: Option[NodeMetadata], classMap: ClassMap)
       extends Operation("classify")
 
+  case class Max(args: List[MapAlgebraAST], id: UUID, metadata: Option[NodeMetadata])
+      extends Operation("max")
+
+  case class Min(args: List[MapAlgebraAST], id: UUID, metadata: Option[NodeMetadata])
+      extends Operation("min")
+
   /** Map Algebra sources (leaves) */
   @JsonCodec
   case class Source(id: UUID, metadata: Option[NodeMetadata]) extends MapAlgebraAST {

--- a/app-backend/tool/src/main/scala/ast/codec/MapAlgebraOperationCodecs.scala
+++ b/app-backend/tool/src/main/scala/ast/codec/MapAlgebraOperationCodecs.scala
@@ -20,6 +20,8 @@ trait MapAlgebraOperationCodecs {
       case Some("/") => ma.as[MapAlgebraAST.Division]
       case Some("*") => ma.as[MapAlgebraAST.Multiplication]
       case Some("mask") => ma.as[MapAlgebraAST.Masking]
+      case Some("min") => ma.as[MapAlgebraAST.Min]
+      case Some("max") => ma.as[MapAlgebraAST.Max]
       case Some("classify") => ma.as[MapAlgebraAST.Classification]
       case Some(unrecognized) =>
         Left(DecodingFailure(s"Unrecognized node type: $unrecognized", ma.history))
@@ -40,6 +42,10 @@ trait MapAlgebraOperationCodecs {
         multiplication.asJson
       case masking: MapAlgebraAST.Masking =>
         masking.asJson
+      case min: MapAlgebraAST.Min =>
+        min.asJson
+      case max: MapAlgebraAST.Max =>
+        max.asJson
       case classification: MapAlgebraAST.Classification =>
         classification.asJson
       case operation =>
@@ -78,4 +84,13 @@ trait MapAlgebraOperationCodecs {
   implicit lazy val encodeClassification: Encoder[MapAlgebraAST.Classification] =
     Encoder.forProduct5("apply", "args", "id", "metadata", "classMap")(op => (op.symbol, op.args, op.id, op.metadata, op.classMap))
 
+  implicit lazy val decodeMax: Decoder[MapAlgebraAST.Max] =
+    Decoder.forProduct3("args", "id", "metadata")(MapAlgebraAST.Max.apply)
+  implicit lazy val encodeMax: Encoder[MapAlgebraAST.Max] =
+    Encoder.forProduct4("apply", "args", "id", "metadata")(op => (op.symbol, op.args, op.id, op.metadata))
+
+  implicit lazy val decodeMin: Decoder[MapAlgebraAST.Min] =
+    Decoder.forProduct3("args", "id", "metadata")(MapAlgebraAST.Min.apply)
+  implicit lazy val encodeMin: Encoder[MapAlgebraAST.Min] =
+    Encoder.forProduct4("apply", "args", "id", "metadata")(op => (op.symbol, op.args, op.id, op.metadata))
 }

--- a/app-backend/tool/src/main/scala/ast/package.scala
+++ b/app-backend/tool/src/main/scala/ast/package.scala
@@ -28,7 +28,7 @@ package object ast extends MapAlgebraCodec {
 
   implicit class MapAlgebraASTHelperMethods(val self: MapAlgebraAST) {
     private def generateMetadata = Some(NodeMetadata(
-      Some(s"Classify(${self.metadata.flatMap(_.label).getOrElse(self.id)})"),
+      Some(s"${self.metadata.flatMap(_.label).getOrElse(self.id)}"),
       None,
       None
     ))
@@ -47,5 +47,11 @@ package object ast extends MapAlgebraCodec {
 
     def /(other: MapAlgebraAST): MapAlgebraAST.Operation =
       MapAlgebraAST.Division(List(self, other), UUID.randomUUID(), generateMetadata)
+
+    def max(other: MapAlgebraAST): MapAlgebraAST.Operation =
+      MapAlgebraAST.Max(List(self, other), UUID.randomUUID(), generateMetadata)
+
+    def min(other: MapAlgebraAST): MapAlgebraAST.Operation =
+      MapAlgebraAST.Min(List(self, other), UUID.randomUUID(), generateMetadata)
   }
 }

--- a/app-backend/tool/src/main/scala/eval/Interpreter.scala
+++ b/app-backend/tool/src/main/scala/eval/Interpreter.scala
@@ -84,10 +84,19 @@ object Interpreter extends LazyLogging {
       logger.debug(s"case division at $id")
       evalBinary(args.map(eval),  _ / _)
 
+    case Max(args, id, _) =>
+      logger.debug(s"case max at $id")
+      evalBinary(args.map(eval), _ max _)
+
+    case Min(args, id, _) =>
+      logger.debug(s"case min at $id")
+      evalBinary(args.map(eval), _ min _)
+
     case Classification(args, id, _, breaks) =>
       logger.debug(s"case classification at $id with breakmap ${breaks.toBreakMap}")
       val breakmap = breaks.toBreakMap
       evalUnary(eval(args.head), _.classify(breaks.toBreakMap))
+
   }
 
   /** Interpret an AST with its matched execution parameters, but do so

--- a/app-backend/tool/src/main/scala/eval/LazyTile.scala
+++ b/app-backend/tool/src/main/scala/eval/LazyTile.scala
@@ -12,6 +12,8 @@ sealed trait LazyTile extends TileLike with Grid with LazyLogging {
   def -(other: LazyTile) = this.dualCombine(other)(Subtract.combine)(Subtract.combine)
   def /(other: LazyTile) = this.dualCombine(other)(Divide.combine)(Divide.combine)
   def *(other: LazyTile) = this.dualCombine(other)(Multiply.combine)(Multiply.combine)
+  def max(other: LazyTile) = this.dualCombine(other)(Max.combine)(Max.combine)
+  def min(other: LazyTile) = this.dualCombine(other)(Min.combine)(Min.combine)
   def classify(breaks: BreakMap[Double, Int]) = this.classification({ i => breaks(i) })
 
   def left: LazyTile

--- a/app-backend/tool/src/test/scala/Generators.scala
+++ b/app-backend/tool/src/test/scala/Generators.scala
@@ -67,7 +67,9 @@ object Generators {
                      MapAlgebraAST.Subtraction.apply _,
                      MapAlgebraAST.Multiplication.apply _,
                      MapAlgebraAST.Division.apply _,
-                     MapAlgebraAST.Masking.apply _
+                     MapAlgebraAST.Masking.apply _,
+                     MapAlgebraAST.Max.apply _,
+                     MapAlgebraAST.Min.apply _
                    ))
     args <- containerOfN[List, MapAlgebraAST](2, genMapAlgebraAST(depth))
     id <- arbitrary[UUID]

--- a/app-backend/tool/src/test/scala/ast/MapAlgebraASTSpec.scala
+++ b/app-backend/tool/src/test/scala/ast/MapAlgebraASTSpec.scala
@@ -1,5 +1,6 @@
 package com.azavea.rf.tool.ast
 
+import com.azavea.rf.tool.ast.codec._
 import com.azavea.rf.tool.eval._
 
 import org.scalatest._
@@ -20,7 +21,9 @@ class MapAlgebraASTSpec extends FunSpec with Matchers {
     val src2 = randomSourceAST
     val src3 = randomSourceAST
     val src4 = randomSourceAST
-    val uberAst = src1 + src2 * src3 / src4
+    val src5 = randomSourceAST
+    val src6 = randomSourceAST
+    val uberAst = src1 + src2 * src3 / src4 max src5 min src6
 
     uberAst.find(src4.id) should be (Some(src4))
   }

--- a/app-backend/tool/src/test/scala/eval/LazyTileSpec.scala
+++ b/app-backend/tool/src/test/scala/eval/LazyTileSpec.scala
@@ -206,4 +206,46 @@ class LazyTileSpec
         fail(s"$i")
     }
   }
+
+  it("should evaluate max") {
+    requests = Nil
+    val src1 = randomSourceAST
+    val src2 = randomSourceAST
+    val tms = Interpreter.interpretTMS(
+      ast = src1.max(src2),
+      sourceMapping = Map(src1.id -> blueTileSource, src2.id -> nirTileSource),
+      source = goodSource
+    )
+
+    val ret = tms(0, 1, 1)
+    val op = Await.result(ret, 10.seconds) match {
+      case Valid(lazytile) =>
+        val maybeTile = lazytile.evaluateDouble
+        requests.length should be (2)
+        maybeTile.get.get(0, 0) should be (5)
+      case i@Invalid(_) =>
+        fail(s"$i")
+    }
+  }
+
+  it("should evaluate min") {
+    requests = Nil
+    val src1 = randomSourceAST
+    val src2 = randomSourceAST
+    val tms = Interpreter.interpretTMS(
+      ast = src1.min(src2),
+      sourceMapping = Map(src1.id -> blueTileSource, src2.id -> nirTileSource),
+      source = goodSource
+    )
+
+    val ret = tms(0, 1, 1)
+    val op = Await.result(ret, 10.seconds) match {
+      case Valid(lazytile) =>
+        val maybeTile = lazytile.evaluateDouble
+        requests.length should be (2)
+        maybeTile.get.get(0, 0) should be (1)
+      case i@Invalid(_) =>
+        fail(s"$i")
+    }
+  }
 }


### PR DESCRIPTION
## Overview

ModelLab tools lack Min/Max local operations. This PR adds them.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~


## Testing Instructions

Run tests in project `tool`

Closes #1618 