### PR TITLE
Force deletion of images that have multiple tags

### DIFF
--- a/deployment/ansible/roles/raster-foundry.jenkins/tasks/main.yml
+++ b/deployment/ansible/roles/raster-foundry.jenkins/tasks/main.yml
@@ -58,6 +58,7 @@
     job: >
       /usr/bin/docker run
       --rm
+      -e FORCE_IMAGE_REMOVAL=1
       -v /var/run/docker.sock:/var/run/docker.sock
       -v /etc:/etc
       spotify/docker-gc


### PR DESCRIPTION
## Overview

By default, Docker will not remove an image if it is tagged in multiple repositories (which happens when we re-tag images for pushing to ECR).

See: https://github.com/spotify/docker-gc#forcing-deletion-of-images-that-have-multiple-tags

Fixes https://github.com/azavea/operations/issues/34

## Testing Instructions

From the Jenkins machine, build a dummy container image and then tag it with another name:

```bash
ubuntu@ip-172-31-52-80:~$ cat Dockerfile 
FROM python:3
ubuntu@ip-172-31-52-80:~$ docker build -t test .
Sending build context to Docker daemon 783.4 kB
Step 1 : FROM python:3
3: Pulling from library/python

10a267c67f42: Already exists 
fb5937da9414: Already exists 
9021b2326a1e: Pull complete 
dbed9b09434e: Pull complete 
ea8a37f15161: Pull complete 
9fb634154ace: Pull complete 
6df6941e6752: Pull complete 
df67ecfc860b: Pull complete 
Digest: sha256:b2dfd12f7fb4997345b11b74b154849d0549e270221030cd0450b85b7f6c0e92
Status: Downloaded newer image for python:3
 ---> b6cc5d70bc28
Successfully built b6cc5d70bc28
ubuntu@ip-172-31-52-80:~$ docker tag test test2                                                                                                                                  
ubuntu@ip-172-31-52-80:~$ docker images | grep test
test2                                                                     latest              b6cc5d70bc28        4 days ago          688.9 MB
test                                                                      latest              b6cc5d70bc28        4 days ago          688.9 MB
spotify/docker-gc                                                         latest              60ff048f7774        7 days ago          22.63 MB
```

Run `docker-gc` and confirm that both images were removed:

```bash
ubuntu@ip-172-31-52-80:~$ /usr/bin/docker run --rm -e FORCE_IMAGE_REMOVAL=1 -v /var/run/docker.sock:/var/run/docker.sock -v /etc:/etc spotify/docker-gc
[2017-05-16T16:54:03] [INFO] : Container running ce412a3a203b43132abe8f9e5775f82a29dc295a63bb573414be0fc7edd9d02a /evil_saha
[2017-05-16T16:54:04] [INFO] : Removing image sha256:0346349a1a640da9535acfc0f68be9d9b81e85957725ecb76f3b522f4e2f0455 [nginx:1.10]
[2017-05-16T16:54:04] [INFO] : Removing image sha256:05bab99f4f91d89be8926087493fcb54fa41275f955524856f31dcb98c5cd829 [openjdk:8-jre]
[2017-05-16T16:54:04] [INFO] : Removing image sha256:319698b3b71a29b8c0458846e2c4f2b0a24ada659d8e48b691d3f6056e6e4ce4 [openjdk:8-jre-alpine]
[2017-05-16T16:54:04] [INFO] : Removing image sha256:b6cc5d70bc28d437472e4fdb85982fa89262489196ad5c54de4c826983e5109c [python:3 test2:latest test:latest]
ubuntu@ip-172-31-52-80:~$ docker images | grep test
spotify/docker-gc                                                         latest              60ff048f7774        7 days ago          22.63 MB
```