### PR TITLE
Use thumbnails in project list

### DIFF
--- a/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Datasources.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Datasources.scala
@@ -100,7 +100,7 @@ object Datasources extends TableQuery(tag => new Datasources(tag)) with LazyLogg
     */
   def getDatasource(datasourceId: UUID, user: User) =
     Datasources
-      .filterToSharedOrganizationIfNotInRoot(user)
+      .filterUserVisibility(user)
       .filter(_.id === datasourceId)
       .result
       .headOption

--- a/app-frontend/src/app/components/projectItem/projectItem.controller.js
+++ b/app-frontend/src/app/components/projectItem/projectItem.controller.js
@@ -25,6 +25,13 @@ export default class ProjectItemController {
         this.fitProjectExtent();
         this.addProjectLayer();
         this.getProjectStatus();
+        this.getThumbnailURL();
+    }
+
+    getThumbnailURL() {
+        this.thumbnailUrl = this.projectService.getProjectThumbnailURL(
+            this.project, this.authService.token()
+        );
     }
 
     addProjectLayer() {

--- a/app-frontend/src/app/components/projectItem/projectItem.html
+++ b/app-frontend/src/app/components/projectItem/projectItem.html
@@ -55,7 +55,9 @@
       </div> -->
 
       <!-- IF using a project's thumbnail: -->
-      <div class="project-preview-container thumbnail" ng-if="$ctrl.project.scenes" style="background-image: url(...);">
+      <div class="project-preview-container thumbnail"
+           ng-if="$ctrl.project.scenes && $ctrl.thumbnailUrl && $ctrl.status === 'CURRENT'"
+           style="background-image: url({{$ctrl.thumbnailUrl}})">
       </div>
     </div>
   </div>

--- a/app-frontend/src/app/pages/projects/edit/advancedcolor/adjust/adjust.controller.js
+++ b/app-frontend/src/app/pages/projects/edit/advancedcolor/adjust/adjust.controller.js
@@ -33,26 +33,26 @@ export default class ProjectsColorAdjustController {
         };
 
         let alphaOptions = {
-            value: 0.6,
             floor: 0,
-            ceil: 1,
+            ceil: 2,
             step: 0.01,
-            precision: 2,
-            showTicks: 0.1
+            showTicks: 0.25,
+            precision: 2
         };
 
         let betaOptions = {
-            value: 10,
+            value: 0.6,
             floor: 0,
-            ceil: 50,
-            step: 1,
-            showTicks: 10
+            ceil: 10,
+            step: 0.1,
+            precision: 2,
+            showTicks: 1
         };
 
         let minMaxOptions = {
             floor: 0,
-            ceil: 65535,
-            step: 10
+            ceil: 255,
+            step: 1
         };
 
         let allGamma = ['redGamma', 'greenGamma', 'blueGamma'];

--- a/app-frontend/src/app/pages/projects/edit/advancedcolor/adjust/adjust.html
+++ b/app-frontend/src/app/pages/projects/edit/advancedcolor/adjust/adjust.html
@@ -53,8 +53,8 @@
               <input class="filter-adjust-input"
                      type="number"
                      min=0
-                     max=50
-                     step=1
+                     max=1
+                     step=0.01
                      ng-model="$ctrl.sliderCorrection.beta"
                      ng-model-options="{ debounce: 250 }"
                      ng-change="$ctrl.onFilterChange('beta', $ctrl.sliderCorrection.beta)">


### PR DESCRIPTION
## Overview

Uses thumbnail for project lists instead of using a leaflet map. This should reduce load on the tile server and the problem of cascading errors.

Two other fixes are incorporated as well:
 1. Adjust datasource permissions for detail requests so that public datasources can be used
 2. Adjust parameters for color correction until we get a handle on the source of problems/issues there

### Checklist

- ~[ ] Styleguide updated, if necessary~
- ~[ ] Swagger specification updated, if necessary~
- ~[ ] Symlinks from new migrations present or corrected for any new migrations~

### Demo

![thumbnail-demo](https://cloud.githubusercontent.com/assets/898060/26152015/421e3a50-3ad3-11e7-84a8-03f2d59e752f.png)

![thumbnail-demo-2](https://cloud.githubusercontent.com/assets/898060/26152017/44406830-3ad3-11e7-8345-78986dec16f8.png)

### Notes

It is not clear if this is going to scale well -- I attempted to test a wide variety of maps -- including a Landsat, Planet, small drone area, and large manned aerial imagery. The heuristic applied in determining the zoom level is based on the widest difference in width or height, scaled down slightly if an area is in mid/low latitudes. Given that, we may need to revisit this at a later date to generate thumbnails on the fly as projects are color-corrected or something.

## Testing Instructions

 * Add a variety of projects -- note they need to have all scenes ingested for thumbnails to be generated. Also, color correct them to ensure imagery is showing up.
 * Go to list view for projects and ensure that green projects have thumbnails show up

Closes #1660 
