### PR TITLE
Respond with 400 for interpreter errors

### DIFF
--- a/app-backend/common/src/main/scala/InterpreterExceptionHandler.scala
+++ b/app-backend/common/src/main/scala/InterpreterExceptionHandler.scala
@@ -24,6 +24,6 @@ trait InterpreterExceptionHandling extends Directives with LazyLogging {
   val interpreterExceptionHandler = ExceptionHandler {
     case ie: InterpreterException =>
       logger.debug(ie.errors.asJson.noSpaces)
-      complete(ie.errors)
+      complete{ (StatusCodes.BadRequest, ie.errors) }
   }
 }


### PR DESCRIPTION
## Overview

200s Were previously returned for interpreter errors. 400s are more appropriate.


### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~

### Demo

<img width="979" alt="screen shot 2017-05-17 at 4 47 02 pm" src="https://cloud.githubusercontent.com/assets/1977405/26175457/bd81c43a-3b20-11e7-9503-b72d4e621c5e.png">

## Testing Instructions

Mess up a request that involves the interpretation of some AST and be dazzled by the 400

Closes #1783 
