### PR TITLE
Various Upload Processing Fixes

### DIFF
--- a/app-tasks/requirements.txt
+++ b/app-tasks/requirements.txt
@@ -5,7 +5,7 @@ airflow[async,celery,crypto,hive,password,postgres,s3,slack]==1.7.1.3
 redis==2.10.5
 pytest==2.9.2
 pytest-runner==2.9
-rasterio==0.36.0
+rasterio==1.0a8
 pyproj==1.9.5
 ipython==5.1.0
 pyjwt==1.4.2

--- a/app-tasks/rf/src/rf/uploads/geotiff/create_footprints.py
+++ b/app-tasks/rf/src/rf/uploads/geotiff/create_footprints.py
@@ -10,6 +10,7 @@ from rasterio.features import shapes
 
 from rf.models import Footprint
 from rf.uploads.landsat8.io import get_tempdir
+from rasterio.features import sieve
 
 logger = logging.getLogger(__name__)
 
@@ -37,8 +38,8 @@ def create_tif_mask(temp_dir, local_tif_path):
         })
 
         with rasterio.open(data_mask_tif_path, 'w', **kwargs) as dst:
-            dataset_mask = src.dataset_mask()
-            dst.write(dataset_mask, indexes=1)
+            mask = sieve(src.dataset_mask(), size=40)
+            dst.write(mask, indexes=1)
 
         with rasterio.open(tile_mask_tif_path, 'w', **kwargs) as dst:
             for _, window in src.block_windows(1):


### PR DESCRIPTION
## Overview

In debugging how a 12 gb upload failed to process I came across the following issues and fixed them:
 - switched to `gdal_translate` for all resampling -- it's faster and produces more consistent outputs for deriving polygons from the source image
 - resampled down to `512` width for incoming images when generating footprints (still produces good footprints)
 - add more logging so we can identify the location of problems more easily
 - updates rasterio
 - adds `sieve` to footprint generation

### Checklist

- ~[ ] Styleguide updated, if necessary~
- ~[ ] Swagger specification updated, if necessary~
- ~[ ] Symlinks from new migrations present or corrected for any new migrations~

### Notes

This doesn't quite get large ingests working -- the ingest code fails when GeoTrellis tries to read a `BIGTIFF` from S3 right now.

## Testing Instructions

 * Try and upload a bunch of different tiffs (maybe one large one) and everything should work

Closes #1741 
