### PR TITLE
Add support for external S3 export

### DIFF
--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/Main.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/Main.scala
@@ -1,7 +1,7 @@
 package com.azavea.rf.batch
 
 import com.azavea.rf.batch.export.spark.Export
-import com.azavea.rf.batch.export.airflow.CreateExportDef
+import com.azavea.rf.batch.export.airflow.{CreateExportDef, S3Copy}
 import com.azavea.rf.batch.ingest.spark.Ingest
 import com.azavea.rf.batch.landsat8.airflow.ImportLandsat8
 import com.azavea.rf.batch.sentinel2.airflow.ImportSentinel2
@@ -15,7 +15,8 @@ object Main {
     ImportSentinel2.name  -> (ImportSentinel2.main(_)),
     CreateExportDef.name  -> (CreateExportDef.main(_)),
     FindAOIProjects.name  -> (FindAOIProjects.main(_)),
-    UpdateAOIProject.name -> (UpdateAOIProject.main(_))
+    UpdateAOIProject.name -> (UpdateAOIProject.main(_)),
+    S3Copy.name           -> (S3Copy.main(_))
   )
 
   def main(args: Array[String]): Unit = {

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/export/CommandLine.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/export/CommandLine.scala
@@ -1,6 +1,7 @@
 package com.azavea.rf.batch.export
 
 import java.net.URI
+
 import scala.util._
 
 object CommandLine {
@@ -19,7 +20,7 @@ object CommandLine {
     head("raster-foundry-export", "0.1")
 
     opt[URI]('j',"jobDefinition")
-      .action( (jd, conf) => conf.copy(jobDefinition = jd) )
+      .action((jd, conf) => conf.copy(jobDefinition = jd))
       .text("The location of the json which defines an ingest job")
       .required
   }

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/export/airflow/CreateExportDef.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/export/airflow/CreateExportDef.scala
@@ -22,10 +22,10 @@ import com.azavea.rf.database.tables._
 import com.azavea.rf.datamodel._
 
 case class CreateExportDef(exportId: UUID)(implicit val database: DB) extends Job {
-  val name = "create_export_def"
+  val name = CreateExportDef.name
 
   /** Get S3 client per each call */
-  def s3Client = S3(None)
+  def s3Client = S3()
     
   protected def writeExportDefToS3(exportDef: ExportDefinition) = {
     logger.info(s"Uploading export definition ${exportDef.id.toString} to S3 at ${exportDefConfig.bucketName}")

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/export/airflow/S3Copy.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/export/airflow/S3Copy.scala
@@ -1,0 +1,45 @@
+package com.azavea.rf.batch.export.airflow
+
+import com.azavea.rf.batch.Job
+import com.azavea.rf.batch.util.S3
+
+import java.net.URI
+
+case class S3Copy(source: URI, target: URI, region: Option[String] = None) extends Job {
+  val name = S3Copy.name
+
+  lazy val client = S3(region = region)
+
+  def run: Unit = try {
+    logger.info(s"S3 copy from $source to $target started...")
+    client.copyListing(
+      source.getHost,
+      target.getHost,
+      source.getPath.tail,
+      target.getPath.tail,
+      client.listObjects(source.getHost, source.getPath.tail)
+    )
+    logger.info("S3 copy finished")
+  } catch {
+    case e: Throwable => {
+      sendError(e)
+      e.printStackTrace()
+      System.exit(1)
+    }
+  }
+}
+
+object S3Copy {
+  val name = "s3_copy"
+
+  def main(args: Array[String]): Unit = {
+    val job = args.toList match {
+      case List(source, target, targetRegion) => S3Copy(new URI(source), new URI(target), Some(targetRegion))
+      case List(source, target) => S3Copy(new URI(source), new URI(target))
+      case list =>
+        throw new IllegalArgumentException(s"Arguments could not be parsed: $list")
+    }
+
+    job.run
+  }
+}

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/landsat8/airflow/ImportLandsat8.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/landsat8/airflow/ImportLandsat8.scala
@@ -26,7 +26,7 @@ case class ImportLandsat8(startDate: LocalDate = LocalDate.now(ZoneOffset.UTC), 
   val name = ImportLandsat8.name
 
   /** Get S3 client per each call */
-  def s3Client = S3(landsat8Config.awsRegion)
+  def s3Client = S3(region = landsat8Config.awsRegion)
 
   protected def scenesFromCsv(srcProj: CRS = CRS.fromName("EPSG:4326"), targetProj: CRS = CRS.fromName("EPSG:3857")): Future[ListBuffer[Scene.Create]] = {
     val reader = CSV.parse(landsat8Config.usgsLandsatUrl)

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/sentinel2/airflow/ImportSentinel2.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/sentinel2/airflow/ImportSentinel2.scala
@@ -28,7 +28,7 @@ case class ImportSentinel2(startDate: LocalDate = LocalDate.now(ZoneOffset.UTC))
   val name = ImportSentinel2.name
 
   /** Get S3 client per each call */
-  def s3Client = S3(sentinel2Config.awsRegion)
+  def s3Client = S3(region = sentinel2Config.awsRegion)
 
   def createImages(sceneId: UUID, tileInfo: Json, resolution: Float): List[Image.Banded] = {
     val tileInfoPath = tileInfo.hcursor.downField("path").as[String].toOption.getOrElse("")


### PR DESCRIPTION
This PR: 

- Adds s3 copy job

## Overview

Adds S3Copy job, to copy files between the two S3 buckets.
Modifies S3Export job to allow user defined credentials, to do export directly into user bucket.


### Demo

```
java -cp rf-batch.jar com.azavea.rf.batch.Main s3_copy s3://sBucket/sPrefix s3://tBucket/tPrefix targetRegion
```

`targetRegion` is an optional field.

### Notes

The format of credentials is arguable, probably it makes sense to provide it somehow different.
In the export job case it makes sense to make it a part of the `ExportDefinition`.

Closes #1650
