### PR TITLE
Use bulk-update for color mode changes

### DIFF
--- a/app-frontend/src/app/components/colorCorrectPane/colorCorrectPane.controller.js
+++ b/app-frontend/src/app/components/colorCorrectPane/colorCorrectPane.controller.js
@@ -92,6 +92,7 @@ export default class ColorCorrectPaneController {
         promise.then(() => {
             this.mosaic.getMosaicTileLayer().then((tiles) => {
                 let newParams = this.mosaic.paramsFromObject(newCorrection);
+                newParams.tag = new Date().getTime();
                 this.mosaic.getMosaicLayerURL(newParams).then((url) => {
                     tiles.setUrl(url);
                 });

--- a/app-frontend/src/app/core/services/layer.service.js
+++ b/app-frontend/src/app/core/services/layer.service.js
@@ -207,12 +207,19 @@ export default (app) => {
                 redGamma: object.redGamma,
                 greenGamma: object.greenGamma,
                 blueGamma: object.blueGamma,
+                redMax: object.redMax,
+                blueMax: object.blueMax,
+                greenMax: object.greenMax,
+                redMin: object.redMin,
+                blueMin: object.blueMin,
+                greenMin: object.greenMin,
                 brightness: object.brightness,
                 contrast: object.contrast,
                 alpha: object.alpha,
                 beta: object.beta,
                 min: object.min,
                 max: object.max,
+                equalize: object.equalize,
                 tag: object.tag ? object.tag : (new Date()).getTime()
             };
         }

--- a/app-frontend/src/app/pages/projects/edit/advancedcolor/advancedcolor.controller.js
+++ b/app-frontend/src/app/pages/projects/edit/advancedcolor/advancedcolor.controller.js
@@ -245,6 +245,7 @@ export default class ProjectsAdvancedColorController {
         return promise.then(() => {
             this.mosaic().getMosaicTileLayer().then((tiles) => {
                 let newParams = this.mosaic().paramsFromObject(newCorrection);
+                newParams.tag = new Date().getTime();
                 this.mosaic().getMosaicLayerURL(newParams).then((url) => {
                     tiles.setUrl(url);
                 });

--- a/app-frontend/src/app/pages/projects/edit/advancedcolor/advancedcolor.controller.js
+++ b/app-frontend/src/app/pages/projects/edit/advancedcolor/advancedcolor.controller.js
@@ -220,7 +220,7 @@ export default class ProjectsAdvancedColorController {
                 sceneIds,
                 newCorrection
             );
-            return this.redrawMosaic(promise, newCorrection);
+            return this.redrawMosaic(promise);
         }
         return this.$q.reject();
     }
@@ -241,15 +241,9 @@ export default class ProjectsAdvancedColorController {
         this.correction = correction;
     }
 
-    redrawMosaic(promise, newCorrection) {
+    redrawMosaic(promise) {
         return promise.then(() => {
-            this.mosaic().getMosaicTileLayer().then((tiles) => {
-                let newParams = this.mosaic().paramsFromObject(newCorrection);
-                newParams.tag = new Date().getTime();
-                this.mosaic().getMosaicLayerURL(newParams).then((url) => {
-                    tiles.setUrl(url);
-                });
-            });
+            this.$parent.layerFromProject();
         });
     }
 }

--- a/app-frontend/src/app/pages/projects/edit/colormode/colormode.controller.js
+++ b/app-frontend/src/app/pages/projects/edit/colormode/colormode.controller.js
@@ -1,9 +1,10 @@
 export default class ProjectsEditColormode {
-    constructor($scope, $q) {
+    constructor($scope, $q, colorCorrectService) {
         'ngInject';
         this.$scope = $scope;
         this.$parent = $scope.$parent.$ctrl;
         this.$q = $q;
+        this.colorCorrectService = colorCorrectService;
 
         this.bands = {
             natural: {
@@ -91,6 +92,11 @@ export default class ProjectsEditColormode {
                         tiles.setUrl(url);
                     });
                 });
+                this.colorCorrectService.bulkUpdate(
+                    this.$parent.project.id,
+                    Array.from(this.$parent.sceneList.map((scene) => scene.id)),
+                    newCorrection
+                );
             });
         });
     }

--- a/app-frontend/src/app/pages/projects/edit/colormode/colormode.controller.js
+++ b/app-frontend/src/app/pages/projects/edit/colormode/colormode.controller.js
@@ -83,6 +83,7 @@ export default class ProjectsEditColormode {
         }
         this.mosaic.getColorCorrection().then((lastCorrection) => {
             let ccParams = this.mosaic.paramsFromObject(lastCorrection);
+            ccParams.tag = new Date().getTime();
             return Object.assign(ccParams, newBands);
         }).then((newCorrection) => {
             this.$q.all(promises).then(() => {

--- a/app-frontend/src/app/pages/projects/edit/colormode/colormode.controller.js
+++ b/app-frontend/src/app/pages/projects/edit/colormode/colormode.controller.js
@@ -74,31 +74,11 @@ export default class ProjectsEditColormode {
      * Trigger the redraw of the mosaic layer with new bands
      *
      * @param {promise[]} promises array of scene color correction promises
-     * @param {object} newBands new mapping of band numbers
      * @returns {null} null
      */
-    redrawMosaic(promises, newBands) {
-        if (!promises.length) {
-            return;
-        }
-        this.mosaic.getColorCorrection().then((lastCorrection) => {
-            let ccParams = this.mosaic.paramsFromObject(lastCorrection);
-            ccParams.tag = new Date().getTime();
-            return Object.assign(ccParams, newBands);
-        }).then((newCorrection) => {
-            this.$q.all(promises).then(() => {
-                this.mosaic.getMosaicTileLayer().then((tiles) => {
-                    // eslint-disable-next-line max-nested-callbacks
-                    this.mosaic.getMosaicLayerURL(newCorrection).then((url) => {
-                        tiles.setUrl(url);
-                    });
-                });
-                this.colorCorrectService.bulkUpdate(
-                    this.$parent.project.id,
-                    Array.from(this.$parent.sceneList.map((scene) => scene.id)),
-                    newCorrection
-                );
-            });
+    redrawMosaic(promises) {
+        this.$q.all(promises).then(() => {
+            this.$parent.layerFromProject();
         });
     }
 }

--- a/app-frontend/src/app/pages/projects/edit/edit.controller.js
+++ b/app-frontend/src/app/pages/projects/edit/edit.controller.js
@@ -27,7 +27,6 @@ export default class ProjectsEditController {
             }
         });
 
-        this._cachedLayer = null;
         this.mosaicLayer = new Map();
         this.sceneLayers = new Map();
         this.projectId = this.$state.params.projectid;
@@ -101,11 +100,7 @@ export default class ProjectsEditController {
         let layer = L.tileLayer(url);
 
         this.getMap().then(m => {
-            if (this._cachedLayer) {
-                m.map.removeLayer(this._cachedLayer);
-            }
-            m.addLayer('project-layer', layer);
-            this._cachedLayer = layer;
+            m.setLayer('project-layer', layer);
         });
         this.mosaicLayer.set(this.projectId, layer);
     }


### PR DESCRIPTION
## Overview

This PR standardizes how we redraw the mosaic. We had three implementations --

1. in the edit controller
2. in the color mode controller
3. in the advanced color correction controller

Even though all of these had the same task -- redraw the project layer when things change.
Meanwhile, none of them actually worked. The only place the color correction changes were
consistently reflected was on the project detail page, so I stole that implementation, threw it
into the edit controller, and used it everywhere.

### Checklist

- [x] ~Styleguide updated, if necessary~
- [x] ~Swagger specification updated, if necessary~
- [x] ~Symlinks from new migrations present or corrected for any new migrations~

### Notes

This did not fix #1805, and I also discovered another route to the issue in #1805, documented there.

## Testing Instructions

 * edit a project with ingested scenes
 * change color correction somehow
 * get back to the page from some other route. some suggestions:
    * refresh
    * navigate elsewhere in the app, then come back
    * close the tab, open it again
 * verify that your color correction has stuck
