### PR TITLE
Change `ingested` filters to use`scene.ingestStatus`

### DIFF
--- a/app-backend/api/src/main/scala/grid/QueryParameters.scala
+++ b/app-backend/api/src/main/scala/grid/QueryParameters.scala
@@ -26,7 +26,8 @@ trait GridQueryParameterDirective extends QueryParametersCommon
     'minSunAzimuth.as[Float].?,
     'maxSunElevation.as[Float].?,
     'minSunElevation.as[Float].?,
-    'ingested.as[Boolean].?
+    'ingested.as[Boolean].?,
+    'ingestStatus.as[String].*
   )).as(GridQueryParameters.apply _)
 
   val gridQueryParameters = (orgQueryParams &

--- a/app-backend/database/src/main/scala/com/azavea/rf/database/QueryParameters.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/QueryParameters.scala
@@ -100,7 +100,8 @@ case class GridQueryParameters(
   minSunAzimuth: Option[Float] = None,
   maxSunElevation: Option[Float] = None,
   minSunElevation: Option[Float] = None,
-  ingested: Option[Boolean] = None
+  ingested: Option[Boolean] = None,
+  ingestStatus: Iterable[String] = Seq[String]()
 )
 
 /** Combined all query parameters */

--- a/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Scenes.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Scenes.scala
@@ -499,7 +499,7 @@ class ScenesTableQuery[M, U, C[_]](scenes: Scenes.TableQuery) extends LazyLoggin
       }
     }.filter { scene =>
       sceneParams.ingested
-        .map(scene.ingestLocation.isDefined === _)
+        .map((scene.ingestStatus === IngestStatus.fromString("INGESTED")) === _:Rep[Boolean])
         .reduceLeftOption(_ || _)
         .getOrElse(true: Rep[Boolean])
     }.filter { scene =>
@@ -576,7 +576,21 @@ class ScenesTableQuery[M, U, C[_]](scenes: Scenes.TableQuery) extends LazyLoggin
         .getOrElse(true: Rep[Boolean])
     }.filter { scene =>
       gridParams.ingested
-        .map(scene.ingestLocation.isDefined === _)
+        .map((scene.ingestStatus === IngestStatus.fromString("INGESTED")) === _:Rep[Boolean])
+        .reduceLeftOption(_ || _)
+        .getOrElse(true: Rep[Boolean])
+    }.filter { scene =>
+      gridParams.ingestStatus
+        .map( status =>
+          try {
+            scene.ingestStatus === IngestStatus.fromString(status)
+          } catch {
+            case e : Exception =>
+              throw new IllegalArgumentException(
+                s"Invalid Ingest Status: $status"
+              )
+          }
+        )
         .reduceLeftOption(_ || _)
         .getOrElse(true: Rep[Boolean])
     }

--- a/docs/swagger/spec.yml
+++ b/docs/swagger/spec.yml
@@ -579,6 +579,7 @@ paths:
         - $ref: '#/parameters/maxResolution'
         - $ref: '#/parameters/tags'
         - $ref: '#/parameters/ingested'
+        - $ref: '#/parameters/ingestStatus'
       responses:
         200:
           description: Statistics for the given bounding box


### PR DESCRIPTION
## Overview

This PR updates the way the `ingested` scene filter is handled on the backend. Rather than using `ingestLocation`, it now uses the ingest status. When a value of `true` is passed as the `ingested` query parameter, only scenes _with_ a status of `INGESTED` will be returned. If the query parameter is `false` only scenes _without_ a status of `INGESTED` will be retuned.

In addition, I updated the filters for the scene-grid so that they match the scenes endpoint.

### Checklist

- ~Styleguide updated, if necessary~
- [x] Swagger specification updated, if necessary
- ~Symlinks from new migrations present or corrected for any new migrations~


## Testing Instructions

 * Manually set the `ingestStatus` of a particular scene to `INGESTED`.
 * Fire up the front-end and in the scene-browser, set your filter to 'Ingested scenes only' *_or_* use the API and the `ingested=true` query param
* Either way, only truly ingested scenes should be returned


Closes #1550 
Closes #1658
