### PR TITLE
C1 Scala Landsat8 import 

### DIFF
--- a/app-backend/batch/src/main/resources/application.conf
+++ b/app-backend/batch/src/main/resources/application.conf
@@ -37,11 +37,13 @@ landsat8 {
     ]
   }
 
-  datasourceId   = "697a0b91-b7a8-446e-842c-97cda155554d"
-  usgsLandsatUrl = "https://landsat.usgs.gov/landsat/metadata_service/bulk_metadata_files/LANDSAT_8.csv"
-  awsRegion      = "us-west-2"
-  awsLandsatBase = "http://landsat-pds.s3.amazonaws.com/"
-  bucketName     = "landsat-pds"
+  datasourceId     = "697a0b91-b7a8-446e-842c-97cda155554d"
+  usgsLandsatUrl   = "https://landsat.usgs.gov/landsat/metadata_service/bulk_metadata_files/LANDSAT_8.csv"
+  usgsLandsatUrlC1 = "https://landsat.usgs.gov/landsat/metadata_service/bulk_metadata_files/LANDSAT_8_C1.csv"
+  awsRegion        = "us-west-2"
+  awsLandsatBase   = "http://landsat-pds.s3.amazonaws.com/"
+  awsLandsatBaseC1 = "http://landsat-pds.s3.amazonaws.com/c1/"
+  bucketName       = "landsat-pds"
 }
 
 export-def {

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/Main.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/Main.scala
@@ -3,7 +3,7 @@ package com.azavea.rf.batch
 import com.azavea.rf.batch.export.spark.Export
 import com.azavea.rf.batch.export.airflow.{CreateExportDef, DropboxCopy, S3Copy}
 import com.azavea.rf.batch.ingest.spark.Ingest
-import com.azavea.rf.batch.landsat8.airflow.ImportLandsat8
+import com.azavea.rf.batch.landsat8.airflow.{ImportLandsat8, ImportLandsat8C1}
 import com.azavea.rf.batch.sentinel2.airflow.ImportSentinel2
 import com.azavea.rf.batch.aoi.airflow.{FindAOIProjects, UpdateAOIProject}
 
@@ -17,7 +17,8 @@ object Main {
     FindAOIProjects.name  -> (FindAOIProjects.main(_)),
     UpdateAOIProject.name -> (UpdateAOIProject.main(_)),
     S3Copy.name           -> (S3Copy.main(_)),
-    DropboxCopy.name      -> (DropboxCopy.main(_))
+    DropboxCopy.name      -> (DropboxCopy.main(_)),
+    ImportLandsat8C1.name -> (ImportLandsat8C1.main(_))
   )
 
   def main(args: Array[String]): Unit = {

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/util/conf/Config.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/util/conf/Config.scala
@@ -26,8 +26,10 @@ trait Config {
     bandLookup: Landsat8Bands,
     datasourceId: String,
     usgsLandsatUrl: String,
+    usgsLandsatUrlC1: String,
     awsRegion: Option[String],
     awsLandsatBase: String,
+    awsLandsatBaseC1: String,
     bucketName: String
   ) {
     def organizationUUID = UUID.fromString(organization)


### PR DESCRIPTION
## Overview

New landsat8 md import on Scala.

### Demo

```scala
 java -cp rf-batch.jar com.azavea.rf.batch.Main import_landsat8_c1 YYYY-MM-DD
```

### Notes

I called it ~~`NewImportLandsat8`~~ `ImportLandsat8C1` ~~, but in the future it makes sense to delete old import and to rename this into `ImportLandsat8`~~. In fact it's a copy paste of the old one with a few changes, makes sense to copy paste in order to allow stress-less migration. 

\+ for old db entries (already ingested / imported scenes) it makes sense to write smth like a migration from old style into a new one (in the future the new collection should have 100% coverage of the old one).

Closes #1586
