### PR TITLE
Cleans up main project edit page

### DIFF
--- a/app-frontend/src/app/pages/projects/edit/browse/browse.html
+++ b/app-frontend/src/app/pages/projects/edit/browse/browse.html
@@ -14,11 +14,9 @@
 <div class="sidebar-project" ng-show="!$ctrl.activeScene">
   <ul class="sidebar-list">
     <li ng-if="$ctrl.$parent.project.isAOIProject && $ctrl.$parent.pendingSceneList.length">
-      <div class="banner banner-secondary">
-        <div>{{$ctrl.$parent.pendingSceneList.length}} scenes awaiting approval</div>
-        <div>
-          <button class="btn btn-border-light" ui-sref="projects.edit.aoi-approve">Review Scenes</button>
-        </div>
+      <div class="alert alert-secondary">
+        <div class="alert-message">{{$ctrl.$parent.pendingSceneList.length}} scenes awaiting approval</div>
+        <button class="alert-action" ui-sref="projects.edit.aoi-approve">Review Scenes</button>
       </div>
     </li>
     <li>

--- a/app-frontend/src/app/pages/projects/edit/edit.html
+++ b/app-frontend/src/app/pages/projects/edit/edit.html
@@ -1,79 +1,113 @@
 <div class="container column-stretch container-not-scrollable">
   <div class="sidebar" ui-view>
-    <div class="sidebar-project">
+
+    <!-- Sidebar static / non scrolling -->
+    <div class="sidebar-static">
+      <!-- Sidebar Header -->
       <div class="sidebar-header">
         <h5 class="sidebar-title">Editing project</h5>
         <div ng-if="$ctrl.project.isAOIProject" class="inline-tag aoi-tag">AOI Project</div>
-        <div ng-if="$ctrl.project.isAOIProject" class="header-controls">
+        <div ng-if="$ctrl.project.isAOIProject" class="sidebar-actions">
           <a ui-sref="projects.edit.aoi-parameters">Edit AOI Parameters</a>
         </div>
       </div>
-      <ul class="sidebar-list">
-        <li ng-if="$ctrl.project.isAOIProject && $ctrl.pendingSceneList.length">
-          <div class="banner banner-secondary">
-            <div>{{$ctrl.pendingSceneList.length}} scenes awaiting approval</div>
-            <div>
-              <button class="btn btn-border-light" ui-sref="projects.edit.aoi-approve">Review Scenes</button>
-            </div>
+      <!-- Sidebar Header -->
+
+      <!-- Alert -->
+      <div ng-if="$ctrl.project.isAOIProject && $ctrl.pendingSceneList.length" class="content">
+        <div class="alert alert-secondary">
+          <div class="alert-message">{{$ctrl.pendingSceneList.length}} scenes awaiting approval</div>
+          <button class="alert-action" ui-sref="projects.edit.aoi-approve">Review Scenes</button>
+        </div>
+      </div>
+      <!-- Alert -->
+
+      <!-- List Group -->
+      <div class="list-group">
+        <div class="list-group-item">
+          <label>Scenes</label>
+          <div class="list-group-right column-6 nogutter btn-group">
+            <button class="btn btn-primary btn-block" type="button" ui-sref="projects.edit.scenes">
+              Manage
+            </button>
+            <button class="btn btn-primary btn-block" type="button" ng-click="$ctrl.openImportModal()">
+              Import
+            </button>
           </div>
-        </li>
-        <li>
-          <span class="label">Scene Management</span>
-          <a class="btn btn-primary fixedwidth" ui-sref="projects.edit.scenes">
-            Add/Remove scenes
-          </a>
           <i class="icon-info"></i>
-        </li>
-        <li>
-          <span class="label"></span>
-          <button class="btn btn-primary fixedwidth" ng-click="$ctrl.openImportModal()">
-            Import Scenes
-          </button>
-          <i class="icon-info"></i>
-        </li>
-      </ul>
+        </div>
+      </div>
+      <!-- List Group -->
     </div>
+    <!-- Sidebar static / non scrolling -->
+
+    <!-- Sidebar scrollable area -->
     <div class="sidebar-scrollable">
-      <ul class="sidebar-list">
-        <li class="separator">
-          <span class="label">Color mode</span>
-          <button class="btn btn-light fixedwidth"
-                  type="button"
-                  ui-sref="projects.edit.colormode">
-            Select Mode
-          </button>
+      <!-- List Group -->
+      <div class="list-group">
+        <!-- Color Mode -->
+        <div class="list-group-item">
+          <label>Color mode</label>
+          <div class="list-group-right column-6 nogutter">
+            <button class="btn btn-light btn-block"
+                    type="button"
+                    ui-sref="projects.edit.colormode">
+              Select mode
+            </button>
+          </div>
           <i class="icon-info"></i>
-        </li>
-        <li class="separator">
-          <span class="label">Color correction</span>
-          <button class="btn btn-light fixedwidth"
-                  type="button"
-                  ui-sref="projects.edit.color">
-            Color correct
-          </button>
+        </div>
+        <!-- Color Mode -->
+
+        <!-- Color Correction -->
+        <div class="list-group-item">
+          <label>Color correction</label>
+          <div class="list-group-right column-6 nogutter">
+            <button class="btn btn-light btn-block"
+                    type="button"
+                    ui-sref="projects.edit.color">
+              Color correct
+            </button>
+          </div>
           <i class="icon-info"></i>
-        </li>
-        <li class="separator">
-          <span class="label">Share</span>
-          <button class="btn btn-light fixedwidth"
-                  type="button"
-                  ng-click="$ctrl.publishModal()">
-            Share project
-          </button>
+        </div>
+        <!-- Color Correction -->
+
+        <!-- Sharing -->
+        <div class="list-group-item">
+          <label>Sharing</label>
+          <div class="list-group-right column-6 nogutter">
+            <button class="btn btn-light btn-block"
+                    type="button"
+                    ng-click="$ctrl.publishModal()">
+              Share project
+            </button>
+          </div>
           <i class="icon-info"></i>
-        </li>
-        <li class="separator">
-          <span class="label">Export</span>
-          <button class="btn btn-light fixedwidth"
-                  type="button"
-                  ng-click="$ctrl.openExportModal()">
-            Export project
-          </button>
+        </div>
+        <!-- Sharing -->
+
+        <!-- Export -->
+        <div class="list-group-item">
+          <label>Export</label>
+          <div class="list-group-right column-6 nogutter">
+            <button class="btn btn-light btn-block"
+                    type="button"
+                    ng-click="$ctrl.openExportModal()">
+              Export project
+            </button>
+          </div>
           <i class="icon-info"></i>
-        </li>
-      </ul>
+        </div>
+        <!-- Export -->
+      </div>
+      <!-- List Group -->
     </div>
+    <!-- Sidebar scrollable area -->
   </div>
+  <!-- Sidebar -->
+
+  <!-- Main map area -->
   <div class="main">
     <rf-map-container map-id="edit" ng-show="!$ctrl.showPreviewMap"></rf-map-container>
     <rf-map-container map-id="preview"
@@ -82,4 +116,5 @@
                       initial-zoom="$ctrl.zoom"
     ></rf-map-container>
   </div>
-</div
+  <!-- Main map area -->
+</div>

--- a/app-frontend/src/app/pages/projects/edit/scenes/scenes.html
+++ b/app-frontend/src/app/pages/projects/edit/scenes/scenes.html
@@ -7,11 +7,9 @@
 <div class="sidebar-project">
   <ul class="sidebar-list">
     <li ng-if="$ctrl.$parent.project.isAOIProject && $ctrl.$parent.pendingSceneList.length">
-      <div class="banner banner-secondary">
-        <div>{{$ctrl.$parent.pendingSceneList.length}} scenes awaiting approval</div>
-        <div>
-          <button class="btn btn-border-light" ui-sref="projects.edit.aoi-approve">Review Scenes</button>
-        </div>
+      <div class="alert alert-secondary">
+        <div class="alert-message">{{$ctrl.$parent.pendingSceneList.length}} scenes awaiting approval</div>
+        <button class="alert-action" ui-sref="projects.edit.aoi-approve">Review Scenes</button>
       </div>
     </li>
     <li>

--- a/app-frontend/src/app/pages/projects/navbar/navbar.html
+++ b/app-frontend/src/app/pages/projects/navbar/navbar.html
@@ -1,9 +1,10 @@
+<span class="navbar-vertical-divider"></span>
+<span class="project-title" ng-if="$ctrl.projectService.currentProject.name">{{$ctrl.projectService.currentProject.name}}</span>
 <div class="dropdown-project"
      uib-dropdown
      on-toggle="toggled($ctrl.optionsOpen)">
-  <span class="navbar-vertical-divider"></span>
   <a uib-dropdown-toggle>
-    <span class="username">My Project</span>
+    <span class="sr-only">Project options dropdown</span>
     <i class="icon-caret-down"></i>
   </a>
   <ul class="dropdown-menu" aria-labelledby="dLabel">
@@ -31,4 +32,3 @@
     </a></li>
   </ul>
 </div>
-<span class="username" ng-if="$ctrl.projectService.currentProject.name">{{$ctrl.projectService.currentProject.name}}</span>

--- a/app-frontend/src/assets/styles/sass/_shame.scss
+++ b/app-frontend/src/assets/styles/sass/_shame.scss
@@ -1,4 +1,21 @@
 /*
+ - What is the purpose of this file?
+   This file is used for styles that don't quite
+   fit anywhere in the sass directory yet. The idea
+   is simple, quick styling to avoid the headache
+   of worrying about scss structure. 
+
+ - Who is this for?
+   Project contributors that hate css or worry about
+   the sass structure. Use this file to put in quick 
+   styling that a designer can easily find and fix later.
+
+ - By the end of project development, this file
+   should be completely empty. This is all temporary.
+*/
+
+
+/*
  * app-wide
  */
 

--- a/app-frontend/src/assets/styles/sass/app.scss
+++ b/app-frontend/src/assets/styles/sass/app.scss
@@ -45,6 +45,7 @@
 **/
 // TODO: Matt Look at color-correct, carousel
 @import
+  "components/alert",
   "components/spacing",
   "components/breadcrumb",
   "components/button",

--- a/app-frontend/src/assets/styles/sass/base/_grid.scss
+++ b/app-frontend/src/assets/styles/sass/base/_grid.scss
@@ -58,6 +58,10 @@
 .column {
   flex: 1;
   padding: $column-padding;
+
+  &.nogutter {
+    padding: 0;
+  }
 }
 
 @for $i from 1 through $column-count {
@@ -65,6 +69,10 @@
     flex: none;
     padding: $column-padding;
     width: ($i/$column-count) * 100%;
+
+    &.nogutter {
+      padding: 0;
+    }
   }
 }
 

--- a/app-frontend/src/assets/styles/sass/components/_alert.scss
+++ b/app-frontend/src/assets/styles/sass/components/_alert.scss
@@ -1,0 +1,38 @@
+.alert {
+  padding: 1rem;
+  border-radius: 2px;
+  flex: 1;
+  text-align: center;
+  color: #fff;
+  background-color: $shade-normal;
+}
+
+@mixin alert-state($color) {
+  background-color: $color;
+}
+
+.alert-primary {
+  @include alert-state($brand-primary);
+}
+
+.alert-secondary {
+  @include alert-state($brand-secondary);
+}
+
+.alert-warning {
+  @include alert-state($warning);
+}
+
+.alert-danger {
+  @include alert-state($danger);
+}
+
+.alert-message {
+  @extend .p;
+  margin-top: 0;
+}
+
+.alert-action {
+  @extend .btn;
+  @extend .btn-ghost-white
+}

--- a/app-frontend/src/assets/styles/sass/components/_button.scss
+++ b/app-frontend/src/assets/styles/sass/components/_button.scss
@@ -25,6 +25,34 @@
   }
 }
 
+@mixin ghost-button-states($color, $textColor) {
+  &:hover, &.hover,
+  &:active, &.active, {
+    color: $textColor;
+    background-color: rgba($color, .25);
+    border-color: darken($color, 5%);
+  }
+
+  &:active, &.active {
+    box-shadow: inset 0 2px 2px 0px rgba(black, .2);
+  }
+
+  &:focus, &.focus {
+    outline: none;
+    box-shadow: 0 1px 2px -1px $brand-primary;
+  }
+
+  // Note: <buttons> and <a> handle active+focus differently. This will normalize behaviour.
+  &:focus:active {
+    box-shadow: inset 0 2px 2px 0px rgba(black, .2);
+  }
+
+  &:disabled, &.disabled, &[disabled] {
+    opacity: .5;
+    cursor: not-allowed;
+  }
+}
+
 .btn {
   position: relative;
   cursor: pointer;
@@ -68,6 +96,9 @@
   }
 }
 
+/* 
+ * Solid bg-color buttons
+ */
 .btn-default {
   background: $shade-normal;
   border-color: darken($shade-normal, 5%);
@@ -108,6 +139,48 @@
   @include button-states($brand-tertiary);
 }
 
+.btn-warning {
+  background: $warning;
+  border-color: darken($warning, 5%);
+  color: #fff;
+
+  @include button-states($warning);
+}
+
+.btn-danger {
+  background: $danger;
+  border-color: darken($danger, 5%);
+  color: #fff;
+
+  @include button-states($danger);
+}
+
+/* 
+ * Ghost buttons, borders only
+ */
+.btn-ghost {
+  background-color: transparent;
+}
+
+.btn-ghost-white {
+  background-color: transparent;
+  color: #fff;
+  border-color: #fff;
+
+  @include ghost-button-states(#fff, #fff);
+}
+
+.btn-ghost-default {
+  background-color: transparent;
+  color: $shade-normal;
+  border-color: $shade-normal;
+
+  @include ghost-button-states($shade-normal, #fff);
+}
+
+/* 
+ * Button styled link a link
+ */
 .btn-link {
   border-color: transparent;
   color: $brand-primary;
@@ -122,65 +195,12 @@
   }
 }
 
-.btn-warning {
-  background: $warning;
-  border-color: darken($warning, 5%);
-  color: #fff;
-
-  @include button-states($warning);
-}
-
-.btn-danger {
-	background: $danger;
-  border-color: darken($danger, 5%);
-  color: #fff;
-
-  @include button-states($danger);
-}
-
 .btn-tag {
   background-color: $brand-primary;
   color: #fff;
   font-weight: 700;
   padding: 0.5rem;
   border-radius: 1px;
-}
-
-
-.btn-flat {
-  border-color: transparent;
-  color: $brand-primary;
-  background-color: transparent;
-  font-weight: 700;
-
-  &:hover, &.hover,
-  &:active, &.active, {
-    background-color: transparent;
-    border-color: transparent;
-    color: $brand-secondary;
-  }
-}
-
-.btn-border{
-  border-color: $text-base;
-  background: none;
-  color: $text-base;
-  font-weight: 700;
-  &:hover, &.hover,
-  &:active, &.active, {
-    background: $brand-primary;
-  }
-}
-
-.btn-border-light {
-  border-color: $white;
-  background: none;
-  color: $white;
-  font-weight: 700;
-  &:hover, &.hover,
-  &:active, &.active, {
-    background: $brand-primary;
-  }
 }
 
 
@@ -211,7 +231,7 @@
 }
 
 /*
- * Button actions
+ * Button toggles
  */
 .btn-toggle {
   background : $shade-dark;
@@ -264,7 +284,7 @@
 /*
  * Button groups
  */
- .btn-group {
+.btn-group {
   display: flex !important;
 
   .btn {
@@ -304,4 +324,4 @@
     flex-grow: 0;
     flex-shrink: 0;
   }
- }
+}

--- a/app-frontend/src/assets/styles/sass/components/_list-group.scss
+++ b/app-frontend/src/assets/styles/sass/components/_list-group.scss
@@ -87,7 +87,6 @@
     text-align: right;
 
     > * {
-      margin-left: 5px;
       vertical-align: middle;
     }
   }

--- a/app-frontend/src/assets/styles/sass/layout/_navbar.scss
+++ b/app-frontend/src/assets/styles/sass/layout/_navbar.scss
@@ -52,8 +52,10 @@
   }
 
   .dropdown > a {
-    padding: 1rem 1.5rem;
+    padding: .8rem 1rem;
     margin: 0 1rem;
+    border: 1px solid $shade-dark;
+    border-radius: 2px;
 
     i {
       vertical-align: middle;
@@ -66,6 +68,29 @@
   &.secondary-navbar {
     border-top: 1px solid $shade-dark;
     padding: 0;
+  }
+
+  .project-title {
+    display: inline-block;
+    vertical-align: middle;
+    font-weight: 600;
+    color: #fff;
+    padding: 1.5rem;
+    max-width: 30rem;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .dropdown-project {
+    margin-left: -1.5rem;
+
+    > a.dropdown-toggle {
+      padding: .8rem 1rem;
+      border: 1px solid $shade-dark;
+      border-radius: 2px;
+      color: #fff;
+    }
   }
 }
 
@@ -94,7 +119,7 @@
 .navbar-vertical-divider {
   display: inline-block;
   width: 1px;
-  height: 48px;
+  height: 4.8rem;
   background-color: $shade-dark;
   vertical-align: middle;
 }

--- a/app-frontend/src/assets/styles/sass/layout/_sidebar.scss
+++ b/app-frontend/src/assets/styles/sass/layout/_sidebar.scss
@@ -19,14 +19,21 @@
     width: 25rem;
   }
 
+  .row {
+    margin: 0 -1rem;
+  }
+
+  .content {
+    padding: 1rem 1.5rem;
+  }
+
+  hr {
+    margin: .5rem 0;
+  }
+
   .btn ~ nav {
     margin: 2rem 0;
   }
-  
-  /* Will handle mobile responsive at a later date */
-  /* @include respond-to('xs') {
-    display: none;
-  } */
 
   .sub-category {
     padding-left: 2em;
@@ -37,9 +44,9 @@
   flex: none;
   position: relative;
   border-bottom: 2px solid #ddd;
-  padding: 1rem 1.5rem;
   display: flex;
   align-items: center;
+  flex-wrap: wrap;
 
   &:first-child {
     border-bottom: 2px solid #ddd;
@@ -48,6 +55,10 @@
   &:last-child {
     border-top: 2px solid #ddd;
     border-bottom: none;
+  }
+
+  > div {
+    width: 100%;
   }
 
   p {
@@ -86,9 +97,6 @@
   font-weight: 700;
 }
 
-.sidebar-category-contents {
-
-}
 .sidebar-selection {
   cursor: pointer;
   &:hover {


### PR DESCRIPTION
## Overview
The primary focus for this PR is the main project edit page but not the subsequent edit pages (color mode, etc).
- New alert element
- cleans up the project navbar to more closely mimic vizzuality layout.
- adds some FAQ to the `_shame.scss` for clarity to outside Azavea followers.
- adds a new ghost-button type. Used in the new alert element.
- adds a new `.nogutter` class for columns
- removal of some css that is not being used anywhere.


~### Checklist~
~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~

### Demo
<img width="1038" alt="screen shot 2017-05-24 at 2 26 07 pm" src="https://cloud.githubusercontent.com/assets/1928955/26419538/07e801a2-408e-11e7-833c-ceb36565de23.png">
<img width="900" alt="screen shot 2017-05-24 at 2 26 32 pm" src="https://cloud.githubusercontent.com/assets/1928955/26419539/07e92d16-408e-11e7-82b2-5d4eaacf80d9.png">

### Notes
Some pages beyond the edit page have changes. This is due to reworking elements/markup that existed on the edit page and other pages. For example, the scene alert that shows for AOI projects.

