### PR TITLE
Tool source endpoint

### DIFF
--- a/app-backend/tile/src/main/scala/tool/TileSources.scala
+++ b/app-backend/tile/src/main/scala/tool/TileSources.scala
@@ -38,12 +38,13 @@ object TileSources extends LazyLogging {
         Future.successful(None)
 
       case project @ ProjectRaster(projId, Some(band)) =>
-        Mosaic.fetchRenderedExtent(projId, 1, Some(Projected(WebMercator.worldExtent.toPolygon, 4326)))
+        Mosaic.rawForExtent(projId, 1, Some(Projected(LatLng.worldExtent.toPolygon, 4326)))
           .map({ tile => tile.bands(band) }).value
 
       case project @ ProjectRaster(projId, None) =>
         logger.warn(s"Request for $project does not contain band index")
         Future.successful(None)
+
     }
 
   /** This source provides support for z/x/y TMS tiles */
@@ -58,7 +59,7 @@ object TileSources extends LazyLogging {
         Future.successful(None)
 
       case project @ ProjectRaster(projId, Some(band)) =>
-        Mosaic.fetch(projId, z, x, y)
+        Mosaic.raw(projId, z, x, y)
           .map(tile => tile.bands(band)).value
 
       case project @ ProjectRaster(projId, None) =>

--- a/app-backend/tool/src/main/scala/ast/MapAlgebraAST.scala
+++ b/app-backend/tool/src/main/scala/ast/MapAlgebraAST.scala
@@ -11,7 +11,7 @@ sealed trait MapAlgebraAST extends Product with Serializable {
   def args: List[MapAlgebraAST]
   def metadata: Option[NodeMetadata]
   def find(id: UUID): Option[MapAlgebraAST]
-  def sources: Seq[UUID]
+  def sources: Seq[MapAlgebraAST.Source]
 }
 
 object MapAlgebraAST {
@@ -28,7 +28,7 @@ object MapAlgebraAST {
         matches.headOption
       }
 
-    def sources: Seq[UUID] = args.flatMap(_.sources)
+    def sources: Seq[MapAlgebraAST.Source] = args.flatMap(_.sources).distinct
   }
 
   case class Addition(args: List[MapAlgebraAST], id: UUID, metadata: Option[NodeMetadata])
@@ -63,7 +63,7 @@ object MapAlgebraAST {
     def find(id: UUID): Option[MapAlgebraAST] =
       if (this.id == id) Some(this)
       else None
-    def sources: Seq[UUID] = List(this.id)
+    def sources: Seq[MapAlgebraAST.Source] = List(this)
   }
 
   object Source {

--- a/app-backend/tool/src/main/scala/eval/Interpreter.scala
+++ b/app-backend/tool/src/main/scala/eval/Interpreter.scala
@@ -120,27 +120,29 @@ object Interpreter extends LazyLogging {
     sourceMapping: Map[UUID, RFMLRaster],
     source: RFMLRaster => Future[Option[Tile]]
   )(implicit ec: ExecutionContext): Future[Interpreted[LazyTile]] = {
-    val emptyTile = IntArrayTile(Array(), 0, 0)
+    val emptyTile = IntConstantNoDataArrayTile(Array(NODATA), 1, 1)
 
-    def eval(ast: MapAlgebraAST): Future[Interpreted[LazyTile]] = ast match {
-      case Source(id, label) =>
-        if (sourceMapping.isDefinedAt(id)) {
-          val rfmlRaster = sourceMapping(id)
-          source(rfmlRaster).map({ maybeTile =>
-            val lazyTile = maybeTile.map(LazyTile(_)).getOrElse(LazyTile(emptyTile))
-            Valid(lazyTile)
-          }).recover({ case t: Throwable =>
-            Invalid(NonEmptyList.of(RasterRetrievalError(id, rfmlRaster.id)))
-          })
-        } else {
-          Future.successful { Invalid(NonEmptyList.of(MissingParameter(id))) }
-        }
+    def eval(ast: MapAlgebraAST): Future[Interpreted[LazyTile]] = {
+      ast match {
+        case Source(id, label) =>
+          if (sourceMapping.isDefinedAt(id)) {
+            val rfmlRaster = sourceMapping(id)
+            source(rfmlRaster).map({ maybeTile =>
+              val lazyTile = maybeTile.map(LazyTile(_)).getOrElse(LazyTile(emptyTile))
+              Valid(lazyTile)
+            }).recover({ case t: Throwable =>
+              Invalid(NonEmptyList.of(RasterRetrievalError(id, rfmlRaster.id)))
+            })
+          } else {
+            Future.successful { Invalid(NonEmptyList.of(MissingParameter(id))) }
+          }
 
-      // For the exhaustive match
-      case op: Operation =>
-        interpretOperation(op, eval)
-      case unsupported =>
-        throw new java.lang.IllegalStateException(s"Pattern match failure on putative AST: $unsupported")
+        // For the exhaustive match
+        case op: Operation =>
+          interpretOperation(op, eval)
+        case unsupported =>
+          throw new java.lang.IllegalStateException(s"Pattern match failure on putative AST: $unsupported")
+      }
     }
 
     eval(ast)
@@ -158,7 +160,7 @@ object Interpreter extends LazyLogging {
     source: (RFMLRaster, Int, Int, Int) => Future[Option[Tile]]
   )(implicit ec: ExecutionContext): (Int, Int, Int) => Future[Interpreted[LazyTile]] = {
     // have to parse AST per-request because there is no structure to capture intermediate results
-    val emptyTile = IntArrayTile(Array(), 0, 0)
+    val emptyTile = IntConstantNoDataArrayTile(Array(NODATA), 1, 1)
 
     (z: Int, x: Int, y: Int) => {
 


### PR DESCRIPTION
## Overview

We need to be able to see which IDs in a tool will require source definitions to carry out a tool run. This PR provides an endpoint which returns that.
