### PR TITLE
Add multi-scene accept endpoint

### DIFF
--- a/docs/swagger/spec.yml
+++ b/docs/swagger/spec.yml
@@ -823,6 +823,24 @@ paths:
         204:
           description: Successfully accepted the Scene.
 
+  /projects/{uuid}/scenes/accept:
+    post:
+      summary: Approve a list of pending scenes which have passed an area of interest check.
+      tags:
+        - Imagery
+      parameters:
+        - $ref: '#/parameters/uuid'
+        - name: scenes
+          in: body
+          required: true
+          description: UUIDs of scenes to approve
+          schema:
+            $ref: '#/definitions/BulkAcceptParams'
+      responses:
+        204:
+          description: Successfully accepted scenes
+      
+
   /projects/{uuid}/scenes/bulk-add-from-query/:
     x-resource: Projects
     post:
@@ -3219,3 +3237,13 @@ definitions:
         description: bands in the exported geotiffs
         items:
           type: integer
+
+  BulkAcceptParams:
+    type: object
+    description: bulk accept params 
+    properties:
+      sceneIds:
+        type: array
+        items:
+          type: string
+          format: uuid


### PR DESCRIPTION
## Overview

This PR adds an endpoint at `api/projects/{uuid}/scenes/accept` that will accept all scenes in the `POST`ed body.

### Checklist

~~- [ ] Styleguide updated, if necessary~~
- [x] Swagger specification updated, if necessary
~~- [ ] Symlinks from new migrations present or corrected for any new migrations~~


## Testing Instructions
* with a project that has multiple scenes, change the DB values to `false` if they aren't already --> `update scenes_to_projects set accepted=FALSE where project_id={uuid}::uuid;`
* `POST` a subset of the scenes to the new endpoint, and check that the scenes are correctly updated
* check that the existing, single-scene endpoint works as it previously has
* check that the swagger doc is correct

Closes #1757
