### PR TITLE
Set data value explicitly

### DIFF
--- a/app-tasks/rf/src/rf/uploads/geotiff/create_footprints.py
+++ b/app-tasks/rf/src/rf/uploads/geotiff/create_footprints.py
@@ -113,7 +113,8 @@ def extract_polygon(mask_tif_path):
     geoms = shapes(raster, mask=mask.astype('bool'), transform=src_affine, connectivity=4)
 
     footprint, value = geoms.next()
-    assert value == FILL_VALUE, 'Geometry should be of value 255, got %r' % value
+    assert value == FILL_VALUE, 'Geometry should be of value %s, got %r' % (
+        FILL_VALUE, value)
 
     target_crs = Proj(init='epsg:4326')
     feature = transform_polygon_coordinates(footprint, src_crs, target_crs)


### PR DESCRIPTION
## Overview

This PR addresses bad arrays coming out of our effort to deal with degenerate geotiffs.
`sieve` was doing what it's supposed to do sort of -- it merged small regions into regions
with their higher-valued neighbors. It didn't care about what the values were though, so
our assertion about geometry values failed.

### Checklist

- [x] ~Styleguide updated, if necessary~
- [x] ~Swagger specification updated, if necessary~
- [x] ~Symlinks from new migrations present or corrected for any new migrations~

## Notes

There may be some `rasterio` magic you can do to accomplish the change below, but it
seems hardly worth it, and updates on `ndarray`s from boolean filters are fast.

## Testing Instructions

 * Get some sample tiffs -- ask where those can be found
 * Bring up the server and airflow
 * Upload them
 * Processing the upload shouldn't fail