### PR TITLE
Add tiffs to acceptable file patterns

### DIFF
--- a/app-frontend/src/app/components/importModal/importModal.html
+++ b/app-frontend/src/app/components/importModal/importModal.html
@@ -84,7 +84,7 @@
   <!-- Body for LOCAL_UPLOAD -->
   <div class="modal-body" ng-if="$ctrl.currentStepIs('LOCAL_UPLOAD')"
     ngf-multiple=true
-    ngf-pattern="'*.tif'"
+    ngf-pattern="'*.tif,*.tiff'"
     ngf-drop-available=true
     ng-model="$ctrl.selectedFiles"
     ngf-keep="'distinct'"
@@ -99,7 +99,7 @@
           <button class="btn btn-primary"
                   ngf-multiple=true
                   ng-model="$ctrl.selectedFiles"
-                  ngf-pattern="'*.tif'"
+                  ngf-pattern="'*.tif,*.tiff'"
                   ngf-keep="'distinct'"
                   ngf-change="$ctrl.filesSelected($files)"
                   ngf-select
@@ -120,7 +120,7 @@
           <button class="btn btn-primary"
                   ngf-multiple=true
                   ng-model="$ctrl.selectedFiles"
-                  ngf-pattern="'*.tif'"
+                  ngf-pattern="'*.tif,*.tiff'"
                   ngf-keep="'distinct'"
                   ngf-change="$ctrl.filesSelected($files)"
                   ngf-select


### PR DESCRIPTION
## Overview

This PR adds `*.tiff` to the acceptable file patterns in the upload modal.

### Checklist

- [x] ~Styleguide updated, if necessary~
- [x] ~Swagger specification updated, if necessary~
- [x] ~Symlinks from new migrations present or corrected for any new migrations~

## Testing Instructions

 * Upload a two-f `tiff`
 * Verify that network traffic happens and that airflow starts processing your upload

Closes #1826
