### PR TITLE
Fix object copied to clipboard in share modal

### DIFF
--- a/app-frontend/src/app/components/publishModal/publishModal.controller.js
+++ b/app-frontend/src/app/components/publishModal/publishModal.controller.js
@@ -1,5 +1,5 @@
 export default class PublishModalController {
-    constructor($q, projectService, $log, tokenService, authService, $uibModal) {
+    constructor($q, projectService, $log, tokenService, authService, $uibModal, $window, $state) {
         'ngInject';
 
         this.authService = authService;
@@ -8,6 +8,8 @@ export default class PublishModalController {
         this.tokenService = tokenService;
         this.$uibModal = $uibModal;
         this.$q = $q;
+        this.$window = $window;
+        this.$state = $state;
     }
 
     $onInit() {
@@ -106,6 +108,11 @@ export default class PublishModalController {
             });
         }
         this.hydrateTileUrl(this.getActiveMapping());
+    }
+
+    openProjectShare() {
+        let url = this.$state.href('share', {projectid: this.resolve.project.id});
+        this.$window.open(url, '_blank');
     }
 
     onUrlMappingChange(mapping) {

--- a/app-frontend/src/app/components/publishModal/publishModal.html
+++ b/app-frontend/src/app/components/publishModal/publishModal.html
@@ -36,11 +36,10 @@
                   clipboard text="$ctrl.shareUrl">
             Copy
           </button>
-          <a class="btn btn-primary"
-             target="_blank"
-             ui-sref="share({projectid: $ctrl.resolve.project.id})">
+          <button class="btn btn-primary"
+                  ng-click="$ctrl.openProjectShare()">
             Open
-          </a>
+          </button>
         </div>
       </div>
 
@@ -71,7 +70,7 @@
           <input id="tile-link" type="text" class="form-control"
                  value="{{$ctrl.mapToken.id}}" readonly>
           <button class="btn btn-link"
-                  clipboard text="$ctrl.mapToken">
+                  clipboard text="$ctrl.mapToken.id">
             Copy
           </button>
         </div>


### PR DESCRIPTION
## Overview

Copy token instead of object to clipboard
Fix style on the open button

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~


## Testing Instructions

 * Copy a map token to your clipboard using the button in the share modal and verify that it doesn't copy an `[Object object]`
Closes #1732 