### PR TITLE
Handle possible undefined return from project create modal

### DIFF
--- a/app-frontend/src/app/pages/projects/list/list.controller.js
+++ b/app-frontend/src/app/pages/projects/list/list.controller.js
@@ -79,7 +79,7 @@ class ProjectsListController {
         });
 
         this.newProjectModal.result.then((data) => {
-            if (data.reloadProjectList) {
+            if (data && data.reloadProjectList) {
                 this.populateProjectList(1);
             }
         });


### PR DESCRIPTION
## Overview

This PR makes a small fix that introduces a check for an undefined variable being returned from a modal. Very minor. This is an error that shows up in rollbar occasionally.
