### PR TITLE
Update/fix color-mode selection

### DIFF
--- a/app-frontend/src/app/pages/projects/edit/colormode/colormode.controller.js
+++ b/app-frontend/src/app/pages/projects/edit/colormode/colormode.controller.js
@@ -5,51 +5,11 @@ export default class ProjectsEditColormode {
         this.$parent = $scope.$parent.$ctrl;
         this.colorCorrectService = colorCorrectService;
         this.projectService = projectService;
-
-        this.bands = {
-            natural: {
-                label: 'Natural Color',
-                value: {redBand: 3, greenBand: 2, blueBand: 1}
-            },
-            cir: {
-                label: 'Color infrared',
-                value: {redBand: 4, greenBand: 3, blueBand: 2}
-            },
-            urban: {
-                label: 'Urban',
-                value: {redBand: 6, greenBand: 5, blueBand: 4}
-            },
-            water: {
-                label: 'Water',
-                value: {redBand: 4, greenBand: 5, blueBand: 3}
-            },
-            atmosphere: {
-                label: 'Atmosphere penetration',
-                value: {redBand: 6, greenBand: 4, blueBand: 2}
-            },
-            agriculture: {
-                label: 'Agriculture',
-                value: {redBand: 5, greenBand: 4, blueBand: 1}
-            },
-            forestfire: {
-                label: 'Forest Fire',
-                value: {redBand: 6, greenBand: 4, blueBand: 1}
-            },
-            bareearth: {
-                label: 'Bare Earth change detection',
-                value: {redBand: 5, greenBand: 2, blueBand: 1}
-            },
-            vegwater: {
-                label: 'Vegetation & water',
-                value: {redBand: 4, greenBand: 6, blueBand: 0}
-            }
-        };
-
-        this.currentBands = null;
-        this.correction = null;
     }
 
     $onInit() {
+        this.currentBands = null;
+        this.correction = null;
         this.$parent.sceneListQuery.then(() => {
             let layer = this.$parent.sceneLayers.values().next();
             if (layer && layer.value) {
@@ -66,24 +26,32 @@ export default class ProjectsEditColormode {
     }
 
     isActiveColorMode(key) {
-        let keyBands = this.bands[key].value;
+        const unifiedComposites = this.$parent.unifiedComposites;
+        if (unifiedComposites) {
+            let keyBands = unifiedComposites[key].value;
 
-        let isActive = this.currentBands &&
-            keyBands.redBand === this.currentBands.redBand &&
-            keyBands.greenBand === this.currentBands.greenBand &&
-            keyBands.blueBand === this.currentBands.blueBand;
-        return isActive;
+            let isActive = this.currentBands &&
+                keyBands.redBand === this.currentBands.redBand &&
+                keyBands.greenBand === this.currentBands.greenBand &&
+                keyBands.blueBand === this.currentBands.blueBand;
+
+            return isActive;
+        }
+        return false;
     }
 
     setBands(bandName) {
-        this.currentBands = this.bands[bandName].value;
-        this.correction = Object.assign(this.correction, this.currentBands);
-        const promise = this.colorCorrectService.bulkUpdate(
-            this.projectService.currentProject.id,
-            Array.from(this.$parent.sceneLayers.keys()),
-            this.correction
-        );
-        this.redrawMosaic(promise);
+        const unifiedComposites = this.$parent.unifiedComposites;
+        if (unifiedComposites) {
+            this.currentBands = unifiedComposites[bandName].value;
+            this.correction = Object.assign(this.correction, this.currentBands);
+            const promise = this.colorCorrectService.bulkUpdate(
+                this.projectService.currentProject.id,
+                Array.from(this.$parent.sceneLayers.keys()),
+                this.correction
+            );
+            this.redrawMosaic(promise);
+        }
     }
 
     /**

--- a/app-frontend/src/app/pages/projects/edit/colormode/colormode.controller.js
+++ b/app-frontend/src/app/pages/projects/edit/colormode/colormode.controller.js
@@ -1,9 +1,8 @@
 export default class ProjectsEditColormode {
-    constructor($scope, $q, colorCorrectService, projectService) {
+    constructor($scope, colorCorrectService, projectService) {
         'ngInject';
         this.$scope = $scope;
         this.$parent = $scope.$parent.$ctrl;
-        this.$q = $q;
         this.colorCorrectService = colorCorrectService;
         this.projectService = projectService;
 
@@ -90,11 +89,11 @@ export default class ProjectsEditColormode {
     /**
      * Trigger the redraw of the mosaic layer with new bands
      *
-     * @param {promise[]} promises array of scene color correction promises
+     * @param {promise} promise color-correction promise
      * @returns {null} null
      */
-    redrawMosaic(promises) {
-        this.$q.all(promises).then(() => {
+    redrawMosaic(promise) {
+        promise.then(() => {
             this.$parent.layerFromProject();
         });
     }

--- a/app-frontend/src/app/pages/projects/edit/colormode/colormode.html
+++ b/app-frontend/src/app/pages/projects/edit/colormode/colormode.html
@@ -1,8 +1,18 @@
 <div class="sidebar-project">
-  <div class="sidebar-row">
-    <button class="btn" ui-sref="projects.edit"><i class="icon-caret-left"></i>Project</button>
-    <h5 class="sidebar-title">Color mode</h5>
+  <div class="sidebar-header">
+    <a class="btn sidebar-header-nav-btn" ui-sref="projects.edit">
+      <i class="icon-arrow-left"></i>
+    </a>
+    <h5 class="sidebar-title">Color Mode</h5>
   </div>
+
+  <ul class="sidebar-list">
+    <li>
+      <div class="label">
+        <span class="text">Color modes determine how various sensor bands are translated into visible color.</span>
+      </div>
+    </li>
+  </ul>
 </div>
 <div class="sidebar-scrollable">
   <div class="list-group">
@@ -12,12 +22,9 @@
         <span title="{{composite.label}}"><strong>{{composite.label}}</strong></span>
       </div>
       <div class="list-group-right">
-        <button class="btn btn-square"
-                ng-class="{'btn-secondary': $ctrl.isActiveColorMode(key)}"
-                ng-click="$ctrl.setBands(key)">
-          <i ng-class="{'icon-cross': $ctrl.isActiveColorMode(key),
-                       'icon-plus': !$ctrl.isActiveColorMode(key)}"></i>
-        </button>
+        <rf-toggle data-model="$ctrl.isActiveColorMode(key)" on-change="$ctrl.setBands(key)">
+          <i class="icon-check"></i>
+        </rf-toggle>
       </div>
     </div>
   </div>

--- a/app-frontend/src/app/pages/projects/edit/colormode/colormode.html
+++ b/app-frontend/src/app/pages/projects/edit/colormode/colormode.html
@@ -22,7 +22,7 @@
         <span title="{{composite.label}}"><strong>{{composite.label}}</strong></span>
       </div>
       <div class="list-group-right">
-        <rf-toggle data-model="$ctrl.isActiveColorMode(key)" on-change="$ctrl.setBands(key)">
+        <rf-toggle model="$ctrl.isActiveColorMode(key)" on-change="$ctrl.setBands(key)">
           <i class="icon-check"></i>
         </rf-toggle>
       </div>

--- a/app-frontend/src/app/pages/projects/edit/edit.controller.js
+++ b/app-frontend/src/app/pages/projects/edit/edit.controller.js
@@ -16,7 +16,6 @@ export default class ProjectsEditController {
         this.layerService = layerService;
         this.datasourceService = datasourceService;
         this.$uibModal = $uibModal;
-
         this.getMap = () => mapService.getMap('edit');
     }
 
@@ -156,12 +155,9 @@ export default class ProjectsEditController {
     }
 
     initColorComposites() {
-        this.$q.all(
-            this.sceneList.map(s => this.datasourceService.get(s.datasource))
-        ).then(
-            dsl => {
-                this.datasources = dsl;
-                this.unifiedComposites = this.unifyComposites(dsl);
+        this.fetchUnifiedComposites(true).then(
+            composites => {
+                this.unifiedComposites = composites;
             }
         );
     }
@@ -176,6 +172,26 @@ export default class ProjectsEditController {
                 return ao;
             }, {});
         }, composites[0]);
+    }
+
+    fetchDatasources(force = false) {
+        if (!this.datasourceRequest || force) {
+            this.datasourceRequest = this.$q.all(
+                this.sceneList.map(s => this.datasourceService.get(s.datasource))
+            );
+        }
+        return this.datasourceRequest;
+    }
+
+    fetchUnifiedComposites(force = false) {
+        if (!this.unifiedCompositeRequest || force) {
+            this.unifiedCompositeRequest = this.fetchDatasources(force).then(
+                datasources => {
+                    return this.unifyComposites(datasources);
+                }
+            );
+        }
+        return this.unifiedCompositeRequest;
     }
 
     publishModal() {

--- a/app-frontend/src/app/pages/projects/edit/edit.html
+++ b/app-frontend/src/app/pages/projects/edit/edit.html
@@ -45,33 +45,23 @@
     <div class="sidebar-scrollable">
       <!-- List Group -->
       <div class="list-group">
-        <!-- Color Mode -->
+        <!-- Color Adjustments -->
         <div class="list-group-item">
-          <label>Color mode</label>
-          <div class="list-group-right column-6 nogutter">
+          <label>Color adjustments</label>
+          <div class="list-group-right column-6 nogutter btn-group">
             <button class="btn btn-light btn-block"
-                    type="button"
-                    ui-sref="projects.edit.colormode">
-              Select mode
+                  type="button"
+                  ui-sref="projects.edit.colormode">
+              Mode
+            </button>
+            <button class="btn btn-light btn-block"
+                  type="button"
+                  ui-sref="projects.edit.color">
+              Correction
             </button>
           </div>
           <i class="icon-info"></i>
         </div>
-        <!-- Color Mode -->
-
-        <!-- Color Correction -->
-        <div class="list-group-item">
-          <label>Color correction</label>
-          <div class="list-group-right column-6 nogutter">
-            <button class="btn btn-light btn-block"
-                    type="button"
-                    ui-sref="projects.edit.color">
-              Color correct
-            </button>
-          </div>
-          <i class="icon-info"></i>
-        </div>
-        <!-- Color Correction -->
 
         <!-- Sharing -->
         <div class="list-group-item">

--- a/app-frontend/src/assets/styles/sass/components/_list-group.scss
+++ b/app-frontend/src/assets/styles/sass/components/_list-group.scss
@@ -82,6 +82,11 @@
     vertical-align: middle;
   }
 
+  .btn {
+    padding-left: 1.5rem;
+    padding-right: 1.5rem
+  }
+
   .list-group-right {
     margin-left: auto;
     text-align: right;


### PR DESCRIPTION
## Overview

This PR updates the styling of the color-mode page to match the rest of the editor. It also fixes a bug that caused the map to load 'new' tiles before changes had been persisted to the DB.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~

### Demo

<img width="439" alt="screen shot 2017-05-26 at 2 08 10 pm" src="https://cloud.githubusercontent.com/assets/2442245/26507154/0873f9ec-421d-11e7-8cd7-fee9b63e6ef2.png">
<img width="409" alt="screen shot 2017-05-26 at 2 08 20 pm" src="https://cloud.githubusercontent.com/assets/2442245/26507153/08730dca-421d-11e7-934e-d9f8f58c1940.png">

## Testing Instructions

 * Try out the color-mode switching and make sure you're getting what you asked for
