### PR TITLE
Bump Terraform version on Jenkins to 0.9.6

### DIFF
--- a/deployment/ansible/group_vars/jenkins
+++ b/deployment/ansible/group_vars/jenkins
@@ -3,6 +3,6 @@ docker_users:
   - "{{ ansible_user }}"
   - "{{ jenkins_name }}"
 
-terraform_version: "0.9.1"
+terraform_version: "0.9.6"
 
 java_version: "7u121*"


### PR DESCRIPTION
## Overview

Upgrade the version of Terraform used on Jenkins to 0.9.6.

## Testing Instructions

See that http://jenkins.staging.rasterfoundry.com/job/raster-foundry/job/raster-foundry/job/hotfix%252F0.9.1/1/ completed successfully.