### PR TITLE
Remove unecessary from_string method

### DIFF
--- a/app-tasks/dags/ingest_project_scenes.py
+++ b/app-tasks/dags/ingest_project_scenes.py
@@ -199,7 +199,7 @@ def wait_for_status_op(*args, **kwargs):
     scene_id = ingest_status_dict['sceneId']
     status = ingest_status_dict['ingestStatus']
     scene = Scene.from_id(scene_id)
-    scene.ingestStatus = IngestStatus.from_string(status)
+    scene.ingestStatus = status
     logger.info('Setting scene %s ingest status to %s', scene.id, scene.ingestStatus)
     scene.update()
     logger.infoi('Successfully updated scene %s\'s ingest status', scene.id)

--- a/app-tasks/rf/src/rf/utils/io.py
+++ b/app-tasks/rf/src/rf/utils/io.py
@@ -88,15 +88,6 @@ class IngestStatus(object):
     INGESTED = 'INGESTED'
     FAILED = 'FAILED'
 
-    @classmethod
-    def from_string(s):
-        lookup = {
-            k: k.upper() for k in [
-                'notingested', 'tobeingested', 'ingesting',
-                'ingested', 'failed'
-            ]
-        }
-        return lookup[s.lower()]
 
 class Visibility(object):
     PUBLIC = 'PUBLIC'


### PR DESCRIPTION
This commit removes an unnecessary from_string method
that has proven to be error prone. It is not necessary
because the status from the status object is already in
the exact form that we need it.

Trivial - merging