### PR TITLE
Allow downloading of completed exports

### DIFF
--- a/app-backend/api/src/main/scala/exports/package.scala
+++ b/app-backend/api/src/main/scala/exports/package.scala
@@ -1,1 +1,20 @@
-package object exports
+package com.azavea.rf.api
+
+import java.net.URL
+
+import com.azavea.rf.common.S3
+import com.azavea.rf.datamodel.ExportOptions
+import java.time.Duration
+
+package object exports {
+  implicit def listUrlToListString(urls: List[URL]): List[String] = urls.map(_.toString)
+
+  implicit class ExportOptionsMethods(exportOptions: ExportOptions) {
+    def getSignedUrls(duration: Duration = Duration.ofDays(1)): List[URL] = {
+      (exportOptions.source.getScheme match {
+        case "s3" | "s3a" | "s3n" => Some(S3.getSignedUrls(exportOptions.source))
+        case _ => None
+      }).getOrElse(Nil)
+    }
+  }
+}

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/export/airflow/DropboxCopy.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/export/airflow/DropboxCopy.scala
@@ -34,8 +34,8 @@ case class DropboxCopy(source: URI, target: URI, accessToken: String, region: Op
             is(obj.getObjectContent, key)
           } } ::: accumulator
 
-      if(!listing.isTruncated) getObjects ::: accumulator
-      else copy(s3Client.client.listNextBatchOfObjects(listing), getObjects ::: accumulator)
+      if(!listing.isTruncated) getObjects
+      else copy(s3Client.client.listNextBatchOfObjects(listing), getObjects)
     }
 
     val prefix = {

--- a/app-backend/common/src/main/scala/S3.scala
+++ b/app-backend/common/src/main/scala/S3.scala
@@ -1,16 +1,21 @@
 package com.azavea.rf.common
 
-import scala.util.{Success, Failure, Try}
-
+import jp.ne.opt.chronoscala.Imports._
 import org.apache.commons.io.IOUtils
-
 import com.amazonaws.auth._
 import com.amazonaws.regions._
 import com.amazonaws.services.s3.{AmazonS3ClientBuilder, AmazonS3URI}
-import com.amazonaws.services.s3.model.{S3Object, ObjectMetadata}
+import com.amazonaws.services.s3.model.{ListObjectsRequest, ObjectListing, ObjectMetadata, S3Object}
+import com.amazonaws.HttpMethod
+import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest
 
 import java.io._
 import java.net._
+import java.time.{Duration, ZoneOffset}
+import java.util.Date
+
+import scala.annotation.tailrec
+import scala.collection.JavaConverters._
 
 package object S3 {
   lazy val client = AmazonS3ClientBuilder.standard()
@@ -20,25 +25,66 @@ package object S3 {
 
   def getObject(uri: URI): S3Object = {
     val s3uri = new AmazonS3URI(uri)
-    Try(client.getObject(s3uri.getBucket, s3uri.getKey)) match {
-      case Success(o) => o
-      case Failure(ex) => throw new Exception(ex)
-    }
+    client.getObject(s3uri.getBucket, s3uri.getKey)
   }
 
-  def getObjectMetadata(s3Object: S3Object): ObjectMetadata = {
-    s3Object.getObjectMetadata()
-  }
+  def getObjectMetadata(s3Object: S3Object): ObjectMetadata = s3Object.getObjectMetadata
 
   def getObjectBytes(s3Object: S3Object): Array[Byte] = {
-    val s3InputStream = s3Object.getObjectContent()
-
-    try {
-      IOUtils.toByteArray(s3InputStream)
-    } finally {
-      s3InputStream.close()
-    }
+    val s3InputStream = s3Object.getObjectContent
+    try IOUtils.toByteArray(s3InputStream) finally s3InputStream.close()
   }
+
+  def getSignedUrl(bucket: String, key: String, duration: Duration = Duration.ofDays(1)): URL = {
+    val expiration = LocalDateTime.now + duration
+    val generatePresignedUrlRequest = new GeneratePresignedUrlRequest(bucket, key)
+    generatePresignedUrlRequest.setMethod(HttpMethod.GET)
+    generatePresignedUrlRequest.setExpiration(Date.from(expiration.toInstant(ZoneOffset.UTC)))
+    client.generatePresignedUrl(generatePresignedUrlRequest)
+  }
+
+  final def getSignedUrls(source: URI, duration: Duration = Duration.ofDays(1)): List[URL] = {
+    @tailrec
+    def get(listing: ObjectListing, accumulator: List[URL]): List[URL] = {
+      def getObjects: List[URL] =
+        listing
+          .getObjectSummaries
+          .asScala
+          .toList
+          .filterNot(_.getKey.endsWith("/"))
+          .map { os =>
+            val (bucket, key) = os.getBucketName -> os.getKey
+            getSignedUrl(bucket, key, duration)
+          } ::: accumulator
+
+      if(!listing.isTruncated) getObjects
+      else get(client.listNextBatchOfObjects(listing), getObjects)
+    }
+
+    val prefix = {
+      val p = source.getPath.tail
+      if(!p.endsWith("/")) s"$p/" else p
+    }
+
+    val listObjectsRequest =
+      new ListObjectsRequest()
+        .withBucketName(source.getHost)
+        .withPrefix(prefix)
+        .withDelimiter("/")
+
+    get(client.listObjects(listObjectsRequest), Nil)
+  }
+
+  def listObjects(uri: URI): ObjectListing = {
+    val s3uri = new AmazonS3URI(uri)
+    listObjects(s3uri.getBucket, s3uri.getKey)
+  }
+
+  def listObjects(bucketName: String, prefix: String): ObjectListing =
+    listObjects(new ListObjectsRequest(bucketName, prefix, null, null, null))
+
+  def listObjects(listObjectsRequest: ListObjectsRequest): ObjectListing =
+    client.listObjects(listObjectsRequest)
 
   def putObject(bucket: String, key: String, contents: String): String = {
     client.putObject(bucket, key, contents)

--- a/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Exports.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Exports.scala
@@ -102,6 +102,13 @@ object Exports extends TableQuery(tag => new Exports(tag)) with LazyLogging {
       .result
       .headOption
 
+  def getExportWithStatus(exportId: UUID, user: User, exportStatus: ExportStatus) =
+    Exports
+      .filterToSharedOrganizationIfNotInRoot(user)
+      .filter(e => e.id === exportId && e.exportStatus === exportStatus)
+      .result
+      .headOption
+
   /** Given an export ID, attempt to remove it from the database
     *
     * @param exportId UUID ID of export to remove
@@ -204,6 +211,8 @@ object Exports extends TableQuery(tag => new Exports(tag)) with LazyLogging {
       }
       .sequence
   }
+
+
 }
 
 class ExportTableQuery[M, U, C[_]](exports: Exports.TableQuery) {

--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/Export.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/Export.scala
@@ -3,6 +3,7 @@ package com.azavea.rf.datamodel
 import io.circe._
 import io.circe.parser._
 import io.circe.generic.JsonCodec
+import cats.implicits._
 
 import java.util.UUID
 import java.sql.Timestamp
@@ -21,7 +22,9 @@ case class Export(
   exportType: ExportType,
   visibility: Visibility,
   exportOptions: Json
-)
+) {
+  def getExportOptions: Option[ExportOptions] = exportOptions.as[ExportOptions].toOption
+}
 
 object Export {
 

--- a/docs/swagger/spec.yml
+++ b/docs/swagger/spec.yml
@@ -1630,6 +1630,26 @@ paths:
             UUID parameter does not refer to an export or the user is not able to view the export it refers to
           schema:
             $ref: '#/definitions/Error'
+  /exports/{uuid}/files:
+    x-resource: Exports
+    get:
+      summary: Get available files for the export
+      tags:
+        - Imagery
+      parameters:
+        - $ref: '#/parameters/uuid'
+      responses:
+        200:
+          description: List of urls to download exported data
+          schema:
+            type: "array"
+            items:
+              type: "string"
+        404:
+          description: |
+            UUID parameter does not refer to an export or the user is not able to view the export it refers to or export was not finished successfully yet.
+          schema:
+            $ref: '#/definitions/Error'
 
 parameters:
 


### PR DESCRIPTION
PR Adds API route with a list of signed S3 urls

## Overview

- PR Adds API route with a list of signed S3 urls
- Modifies listing function behaviour in a Dropbox copy object.
- Adds a part of functions into batch S3 object (preparation to the S3 objects refactor)

### Checklist

- [x] Swagger specification updated
- [x] Test

## Testing Instructions

The easies way is just to test get signed urls function: 

```scala
scala> val uri = new URI(uriString)
// uri: java.net.URI = s3://bucket/prefix/

scala> S3.getSignedUrls(uri)
// res0: List[java.net.URL] = List(..)
```
Otherwise, export entry should be created in the exports table, after that url can be tested.

## Notes

Refactor of S3 objects (we have in batch and in commons projects S3 object and more over GeoTrellis S3) probably should be done in a separate project. There is a question, can raster-foundry commons depend on `geotrellis-s3`?

Closes #1536
