### PR TITLE
Safer interpreters

### DIFF
--- a/app-backend/tool/src/main/scala/eval/Interpreter.scala
+++ b/app-backend/tool/src/main/scala/eval/Interpreter.scala
@@ -20,38 +20,31 @@ object Interpreter extends LazyLogging {
   /** The Interpreted type is either a list of failures or a compiled MapAlgebra operation */
   type Interpreted[A] = ValidatedNel[InterpreterError, A]
 
-  // Binary operation evaluation
-  @SuppressWarnings(Array("TraversableHead"))
-  def evalBinary(tiles: List[LazyTile], f: (LazyTile, LazyTile) => LazyTile): LazyTile = {
-    logger.debug("evalBinary")
-    tiles.reduce(f)
-  }
-
   @SuppressWarnings(Array("TraversableHead"))
   def interpretOperation(op: Operation, eval: MapAlgebraAST => LazyTile): LazyTile = op match {
     case Addition(args, id, _) =>
       logger.debug(s"case addition at $id")
-      evalBinary(args.map(eval),  _ + _)
+      args.map(eval).reduce(_ + _)
 
     case Subtraction(args, id, _) =>
       logger.debug(s"case subtraction at $id")
-      evalBinary(args.map(eval),  _ - _)
+      args.map(eval).reduce(_ - _)
 
     case Multiplication(args, id, _) =>
       logger.debug(s"case multiplication at $id")
-      evalBinary(args.map(eval),  _ * _)
+      args.map(eval).reduce(_ * _)
 
     case Division(args, id, _) =>
       logger.debug(s"case division at $id")
-      evalBinary(args.map(eval),  _ / _)
+      args.map(eval).reduce(_ / _)
 
     case Max(args, id, _) =>
       logger.debug(s"case max at $id")
-      evalBinary(args.map(eval), _ max _)
+      args.map(eval).reduce(_ max _)
 
     case Min(args, id, _) =>
       logger.debug(s"case min at $id")
-      evalBinary(args.map(eval), _ min _)
+      args.map(eval).reduce(_ min _)
 
     case Classification(args, id, _, breaks) =>
       logger.debug(s"case classification at $id with breakmap ${breaks.toBreakMap}")

--- a/app-backend/tool/src/main/scala/eval/InterpreterError.scala
+++ b/app-backend/tool/src/main/scala/eval/InterpreterError.scala
@@ -37,8 +37,8 @@ case class AttributeStoreFetchError(id: UUID) extends InterpreterError {
 }
 
 /** An error encountered when a bound parameter's source can't be resolved */
-case class RasterRetrievalError(id: UUID) extends InterpreterError {
-  def repr = s"Unable to retrieve raster for $id"
+case class RasterRetrievalError(id: UUID, refId: UUID) extends InterpreterError {
+  def repr = s"Unable to retrieve raster for Scene ${refId} on AST node ${id}"
 }
 
 case class DatabaseError(id: UUID) extends InterpreterError {

--- a/app-backend/tool/src/main/scala/eval/InterpreterError.scala
+++ b/app-backend/tool/src/main/scala/eval/InterpreterError.scala
@@ -37,8 +37,8 @@ case class AttributeStoreFetchError(id: UUID) extends InterpreterError {
 }
 
 /** An error encountered when a bound parameter's source can't be resolved */
-case class RasterRetrievalError(id: UUID, refId: UUID) extends InterpreterError {
-  def repr = s"Unable to retrieve raster for $refId"
+case class RasterRetrievalError(id: UUID) extends InterpreterError {
+  def repr = s"Unable to retrieve raster for $id"
 }
 
 case class DatabaseError(id: UUID) extends InterpreterError {

--- a/app-backend/tool/src/test/scala/eval/InterpreterSpec.scala
+++ b/app-backend/tool/src/test/scala/eval/InterpreterSpec.scala
@@ -84,7 +84,7 @@ class InterpreterSpec
     val lt = Await.result(ret, 10.seconds)
 
     requests should be (empty)
-    lt should be (Invalid(NEL.of(RasterRetrievalError(redTileSource.id), MissingParameter(src2.id))))
+    lt should be (Invalid(NEL.of(MissingParameter(src2.id), RasterRetrievalError(src1.id, redTileSource.id))))
   }
 
   it("interpretPure - simple") {

--- a/app-backend/tool/src/test/scala/eval/InterpreterSpec.scala
+++ b/app-backend/tool/src/test/scala/eval/InterpreterSpec.scala
@@ -84,7 +84,7 @@ class InterpreterSpec
     val lt = Await.result(ret, 10.seconds)
 
     requests should be (empty)
-    lt should be (Invalid(NEL.of(MissingParameter(src2.id), RasterRetrievalError(src1.id, redTileSource.id))))
+    lt should be (Invalid(NEL.of(MissingParameter(src2.id), RasterRetrievalError(src1.id, theTileSource.id))))
   }
 
   it("interpretPure - simple") {
@@ -349,7 +349,7 @@ class InterpreterSpec
     val op = Await.result(ret, 10.seconds) match {
       case Valid(lazytile) =>
         val maybeTile = lazytile.evaluateDouble
-        requests.length should be (4)
+        requests.length should be (2)
         maybeTile.get.getDouble(0, 0) should be (-4.0/6.0)
       case i@Invalid(_) =>
         fail(s"$i")

--- a/app-backend/tool/src/test/scala/eval/InterpreterSpec.scala
+++ b/app-backend/tool/src/test/scala/eval/InterpreterSpec.scala
@@ -84,7 +84,7 @@ class InterpreterSpec
     val lt = Await.result(ret, 10.seconds)
 
     requests should be (empty)
-    lt should be (Invalid(NEL.of(RasterRetrievalError(src1.id, theTileSource.id), MissingParameter(src2.id))))
+    lt should be (Invalid(NEL.of(RasterRetrievalError(redTileSource.id), MissingParameter(src2.id))))
   }
 
   it("interpretPure - simple") {


### PR DESCRIPTION
## Overview

This builds on #1728 by separating pure and non-pure code in the original interpreters. They should be easier to reason about this way.