### PR TITLE
Add thread count on tile healthcheck

### DIFF
--- a/app-backend/tile/src/main/scala/Router.scala
+++ b/app-backend/tile/src/main/scala/Router.scala
@@ -33,9 +33,7 @@ class Router extends LazyLogging
         pathPrefix("healthcheck") {
           pathEndOrSingleSlash {
             get {
-              complete {
-                HttpResponse(StatusCodes.OK)
-              }
+              HealthCheckRoute.root
             }
           }
         } ~

--- a/app-backend/tile/src/main/scala/routes/HealthCheckRoute.scala
+++ b/app-backend/tile/src/main/scala/routes/HealthCheckRoute.scala
@@ -1,0 +1,19 @@
+package com.azavea.rf.tile.routes
+
+import akka.http.scaladsl.server._
+import akka.http.scaladsl.server.Directives._
+import com.typesafe.scalalogging.LazyLogging
+import de.heikoseeberger.akkahttpcirce.CirceSupport._
+
+import scala.concurrent.ExecutionContext.Implicits.global
+
+
+object HealthCheckRoute extends LazyLogging {
+  def root: Route = complete {
+    Map(
+      "service" -> "tile",
+      "status" -> "OK",
+      "active threads" -> Thread.activeCount.toString
+    )
+  }
+}


### PR DESCRIPTION
## Overview

Add information about the number of threads in the default `ForkJoinPool` underlying `scala.concurrent.ExecutionContext.Implicits.global` to the healthcheck endpoint.

An exemplary response:
```json
{
  "service": "tile",
  "status": "OK",
  "active threads": "10"
}
```

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~


## Testing Instructions

 * Go to /tiles/healthcheck
 * See the number of currently running threads

Closes #715 
