### PR TITLE
Add Intercom websocket endpoints to content security policy

### DIFF
--- a/nginx/etc/nginx/nginx.conf
+++ b/nginx/etc/nginx/nginx.conf
@@ -37,7 +37,7 @@ http {
 
     map $http_x_forwarded_proto $policy {
         default "";
-        https   "default-src https: data: blob: 'unsafe-inline' 'unsafe-eval'";
+        https   "default-src https: data: blob: 'unsafe-inline' 'unsafe-eval'; connect-src 'self' https: wss://nexus-websocket-a.intercom.io wss://nexus-websocket-b.intercom.io";
     }
 
     include /etc/nginx/conf.d/*.conf;


### PR DESCRIPTION
## Overview

Ensure that the connect-src attribute of the content security policy allows HTTPS connections, as well as those directed at the Intercom websocket endpoints. This allows interactive chat to work via the website.

## Testing Instructions

- Start a message thread via the staging website
- Respond via the Intercom web application
- Ensure that the response is visible in the Intercom chat window on the site

Closes https://github.com/azavea/raster-foundry/issues/1864
