### PR TITLE
Fix max zoom level

### DIFF
--- a/app-frontend/src/app/core/services/map.service.js
+++ b/app-frontend/src/app/core/services/map.service.js
@@ -44,7 +44,7 @@ class MapWrapper {
         let properties = {
             attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">' +
                 'OpenStreetMap</a> &copy;<a href="http://cartodb.com/attributions">CartoDB</a>',
-            maxZoom: 19
+            maxZoom: 30
         };
         return L.tileLayer(url, properties);
     }


### PR DESCRIPTION
## Overview
Fix max zoom level on map to 30

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~

### Notes

I'm not sure why we were able to zoom past zoom level 19 before, since this fixed it.

## Testing Instructions

 * Verify that you can zoom past zoom level 19 to zoom level 30

Closes #1856 
