### PR TITLE
Don't cache color-corrections

### DIFF
--- a/app-frontend/src/app/core/services/colorCorrect.service.js
+++ b/app-frontend/src/app/core/services/colorCorrect.service.js
@@ -7,7 +7,7 @@ export default (app) => {
                 '/api/projects/:projectId/mosaic/:sceneId/', {}, {
                     get: {
                         method: 'GET',
-                        cache: true,
+                        cache: false,
                         transformResponse: (data) => {
                             let parsedData = {};
                             if (data !== '') {


### PR DESCRIPTION
## Overview

This PR removes caching from the color-correction GET method in the `colorCorrect.service`. This caching was causing the front-end to hold on to outdated color-corrections.

### Checklist

~[ ] Styleguide updated, if necessary~
~[ ] Swagger specification updated, if necessary~
~[ ] Symlinks from new migrations present or corrected for any new migrations~

## Testing Instructions

*Bug Reproduction:*
- change the color mode of a project, notice the tiles change
- exit the color-mode selection
- go back into color-mode selection
- notice that the tiles are still the same but the color-mode _appears_ to be back to what it was before

To test the fix, do the above and see that the color-mode does not go back to what it was before.


Closes #1869
