### PR TITLE
Add one-way binding to toggle

### DIFF
--- a/app-frontend/src/app/components/toggle/toggle.component.js
+++ b/app-frontend/src/app/components/toggle/toggle.component.js
@@ -5,6 +5,7 @@ const rfToggle = {
     transclude: true,
     bindings: {
         model: '=',
+        value: '<',
         onChange: '&',
         className: '@'
     },

--- a/app-frontend/src/app/components/toggle/toggle.controller.js
+++ b/app-frontend/src/app/components/toggle/toggle.controller.js
@@ -3,18 +3,25 @@ export default class ToggleController {
         'ngInject';
     }
     $onInit() {
-        if (!this.model) {
-            this.model = false;
-        }
+        this.currentValue = this.value || this.model || false;
     }
     $onChanges(changes) {
-        if ('model' in changes && changes.dataModel.currentValue) {
-            this.model = changes.dataModel.currentValue;
+        if ('value' in changes) {
+            this.currentValue = changes.value.currentValue;
         }
     }
     toggle($event) {
         $event.stopPropagation();
         $event.preventDefault();
-        this.onChange({value: !this.model});
+        this.currentValue = !this.currentValue;
+
+        // Mutate `this.model` only if it is defined (which would
+        // indicate we are using two-way binding)
+        // eslint-disable-next-line no-eq-null, eqeqeq
+        if (this.model != null) {
+            this.model = this.currentValue;
+        }
+
+        this.onChange({value: this.currentValue});
     }
 }

--- a/app-frontend/src/app/components/toggle/toggle.html
+++ b/app-frontend/src/app/components/toggle/toggle.html
@@ -1,5 +1,5 @@
 <div class="checkbox-container {{$ctrl.className}}"
-     ng-class="{'is-checked': $ctrl.model}"
+     ng-class="{'is-checked': $ctrl.currentValue}"
      ng-click="$ctrl.toggle($event)"
      ng-transclude>
 </div>

--- a/app-frontend/src/app/pages/projects/edit/colormode/colormode.html
+++ b/app-frontend/src/app/pages/projects/edit/colormode/colormode.html
@@ -22,7 +22,7 @@
         <span title="{{composite.label}}"><strong>{{composite.label}}</strong></span>
       </div>
       <div class="list-group-right">
-        <rf-toggle model="$ctrl.isActiveColorMode(key)" on-change="$ctrl.setBands(key)">
+        <rf-toggle value="$ctrl.isActiveColorMode(key)" on-change="$ctrl.setBands(key)">
           <i class="icon-check"></i>
         </rf-toggle>
       </div>


### PR DESCRIPTION
## Overview

This adds a `value` attribute to the toggle component which is is one-way binding. This allows for using toggles when the toggle state is derived from various inputs. If both `model` and `value` attributes are provided, prefer `value`.

When the component is using the two-way binding style, the value of the toggle is changed internally.

This also adjusts the color-mode page to utilize this one-way binding

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~

## Testing Instructions

 * Test the color-mode page to ensure it works as expected (aside from any known bugs)
 * Test some other spots where we use the `model` attribute and check that the toggle works as expected (the scene browser is always a good choice)

Closes #1854
