### PR TITLE
Update old ImportLandsat8

### DIFF
--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/Job.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/Job.scala
@@ -14,6 +14,8 @@ trait Job extends Config with RollbarNotifier {
   implicit lazy val executionContext = materializer.executionContext
 
   /** ActorSystem needs to be closed manually. */
-  def stop: Unit =
-    system.terminate()
+  def stop: Unit = system.terminate()
+
+  /** Run function should be defined for all Jobs */
+  def run: Unit
 }

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/landsat8/airflow/ImportLandsat8.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/landsat8/airflow/ImportLandsat8.scala
@@ -280,7 +280,10 @@ object ImportLandsat8 {
   def main(args: Array[String]): Unit = {
     implicit val db = DB.DEFAULT
 
+    /** Since 30/04/2017 old LC8 collection is not updated */
     val job = args.toList match {
+      case List(date, threshold) if LocalDate.parse(date) > LocalDate.of(2017, 4, 30) => ImportLandsat8C1(LocalDate.parse(date), threshold.toInt)
+      case List(date) if LocalDate.parse(date) > LocalDate.of(2017, 4, 30) => ImportLandsat8C1(LocalDate.parse(date))
       case List(date, threshold) => ImportLandsat8(LocalDate.parse(date), threshold.toInt)
       case List(date) => ImportLandsat8(LocalDate.parse(date))
       case _ => ImportLandsat8()


### PR DESCRIPTION
Updates `ImportLandsat8` to use `ImportLandsat8C1` if the request date is > than 30.04.2017

## Overview

PR allows a soft migration on a new import. Probably we need to consider migration of the old metadata in the future.

Related to #1586
Related to #1750
