### PR TITLE
Set max zoom level to 30 instead of leaving undefined

### DIFF
--- a/app-frontend/src/app/components/exportModal/exportModal.controller.js
+++ b/app-frontend/src/app/components/exportModal/exportModal.controller.js
@@ -6,7 +6,7 @@ export default class ExportModalController {
 
     $onInit() {
         this.minZoom = 1;
-        this.maxZoom = 22;
+        this.maxZoom = 30;
         this.projectId = this.resolve.project.id;
         this.zoom = this.resolve.zoom;
         this.exportSuccess = false;

--- a/app-frontend/src/app/core/services/layer.service.js
+++ b/app-frontend/src/app/core/services/layer.service.js
@@ -84,8 +84,11 @@ export default (app) => {
             if (this._sceneTiles) {
                 return this._sceneTiles;
             }
-            this._sceneTiles = L.tileLayer(this.getSceneLayerURL(),
-                {bounds: this.bounds, attribution: 'Raster Foundry'}
+            this._sceneTiles = L.tileLayer(
+                this.getSceneLayerURL(),
+                {
+                    maxZoom: 30, bounds: this.bounds, attribution: 'Raster Foundry'
+                }
             );
             return this._sceneTiles;
         }
@@ -113,8 +116,11 @@ export default (app) => {
                     resolve(this._tiles);
                 });
             }
-            this._tiles = L.tileLayer(this.getNDVIURL(bands),
-                {bounds: this.bounds, attribution: 'Raster Foundry'}
+            this._tiles = L.tileLayer(
+                this.getNDVIURL(bands),
+                {
+                    maxZoom: 30, bounds: this.bounds, attribution: 'Raster Foundry'
+                }
             );
             return this._tiles;
         }

--- a/app-frontend/src/app/pages/projects/edit/edit.controller.js
+++ b/app-frontend/src/app/pages/projects/edit/edit.controller.js
@@ -123,7 +123,9 @@ export default class ProjectsEditController {
             this.project,
             this.authService.token()
         );
-        let layer = L.tileLayer(url);
+        let layer = L.tileLayer(url, {
+            maxZoom: 30
+        });
 
         this.getMap().then(m => {
             m.setLayer('project-layer', layer);


### PR DESCRIPTION
## Overview
Fix tile layer options not being set in project edit controller

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~


## Testing Instructions

 * Verify that the frontend tries to load project mosaic tiles at zoom levels up to 30

Closes #1856