### PR TITLE
Change AOI redirect. Show both tile url formats

### DIFF
--- a/app-frontend/src/app/components/createProjectModal/createProjectModal.controller.js
+++ b/app-frontend/src/app/components/createProjectModal/createProjectModal.controller.js
@@ -142,9 +142,10 @@ export default class CreateProjectModalController {
                     });
                 }
             } else if (this.currentStepIs('ADD_SCENES')) {
-                if (this.projectBuffer.isAOIProject && this.projectAttributeIs('addType', 'public')) {
+                let isPublic = this.projectAttributeIs('addType', 'public');
+                if (this.projectBuffer.isAOIProject && isPublic) {
                     this.gotoAOIParameters();
-                } else if (this.projectAttributeIs('addType', 'public')) {
+                } else if (isPublic) {
                     this.gotoSceneBrowser();
                 } else {
                     this.startImport();

--- a/app-frontend/src/app/components/createProjectModal/createProjectModal.controller.js
+++ b/app-frontend/src/app/components/createProjectModal/createProjectModal.controller.js
@@ -88,6 +88,13 @@ export default class CreateProjectModalController {
         }
     }
 
+    gotoAOIParameters() {
+        if (this.project) {
+            this.close();
+            this.$state.go('projects.edit.aoi-parameters', {projectid: this.project.id});
+        }
+    }
+
     startImport() {
         if (this.activeModal) {
             this.activeModal.dismiss();
@@ -135,7 +142,9 @@ export default class CreateProjectModalController {
                     });
                 }
             } else if (this.currentStepIs('ADD_SCENES')) {
-                if (this.projectAttributeIs('addType', 'public')) {
+                if (this.projectBuffer.isAOIProject && this.projectAttributeIs('addType', 'public')) {
+                    this.gotoAOIParameters();
+                } else if (this.projectAttributeIs('addType', 'public')) {
                     this.gotoSceneBrowser();
                 } else {
                     this.startImport();

--- a/app-frontend/src/app/components/publishModal/publishModal.html
+++ b/app-frontend/src/app/components/publishModal/publishModal.html
@@ -44,22 +44,19 @@
       </div>
 
       <div class="form-group">
-        <label>Tile URL Template</label>
-        <div class="form-group">
-          <div class="btn-group inline">
-            <button class="btn btn-primary"
-                    ng-repeat="mapping in $ctrl.urlMappings"
-                    ng-click="$ctrl.onUrlMappingChange(mapping)"
-                    ng-class="{'active': mapping.active}">
-              {{mapping.label}}
-            </button>
-          </div>
-        </div>
+        <label for="tile-link">ZXY Tile Layer URL</label>
         <div class="form-group all-in-one">
-          <label for="tile-link" class="sr-only">URI Link</label>
           <input id="tile-link" type="text" class="form-control"
-                  value="{{$ctrl.mappedTileUrl}}" readonly>
-          <button clipboard text="$ctrl.mappedTileUrl" class="btn btn-link">
+                  value="{{$ctrl.tileLayerUrls.standard}}" readonly>
+          <button clipboard text="$ctrl.tileLayerUrls.standard" class="btn btn-link">
+            Copy
+          </button>
+        </div>
+        <label for="tile-link">ArcGIS Tile Layer URL</label>
+        <div class="form-group all-in-one">
+          <input id="tile-link" type="text" class="form-control"
+                  value="{{$ctrl.tileLayerUrls.arcGIS}}" readonly>
+          <button clipboard text="$ctrl.tileLayerUrls.arcGIS" class="btn btn-link">
             Copy
           </button>
         </div>


### PR DESCRIPTION
## Overview

This PR does two things (since they are small):

- redirects the user to the AOI parameters page if the user creates an AOI project.
- shows both ZXY and ArcGIS tile layer urls for copying and removes the button to switch between them

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~

### Demo

<img width="923" alt="screen shot 2017-06-01 at 2 44 41 pm" src="https://cloud.githubusercontent.com/assets/2442245/26695622/7dd56e76-46d9-11e7-9485-fd975ae02b62.png">
<img width="938" alt="screen shot 2017-06-01 at 2 44 47 pm" src="https://cloud.githubusercontent.com/assets/2442245/26695620/7d8d4d62-46d9-11e7-851f-6d8117c92e76.png">

## Testing Instructions

 * Create and AOI project and choose to add public imagery, you should be taken to the aoi-parameters page
* Share a project and both the ZXY and ArcGIS tile layer urls should be visible and copyable.
* Switch the share policy and check that the token is removed from the URLs when the project is public.

Closes #1873 
Closes #1891
