### PR TITLE
Fix bad Thumbnail urls in LC8 Imports

### DIFF
--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/landsat8/airflow/ImportLandsat8.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/landsat8/airflow/ImportLandsat8.scala
@@ -82,8 +82,8 @@ case class ImportLandsat8(startDate: LocalDate = LocalDate.now(ZoneOffset.UTC), 
 
   protected def createThumbnails(sceneId: UUID, landsatId: String): List[Thumbnail.Identified] = {
     val path = getLandsatUrl(landsatId)
-    val smallUrl = s"$path${landsatId}_thumb_small.jpg}"
-    val largeUrl = s"$path${landsatId}_thumb_large.jpg}"
+    val smallUrl = s"$path/${landsatId}_thumb_small.jpg}"
+    val largeUrl = s"$path/${landsatId}_thumb_large.jpg}"
 
     Thumbnail.Identified(
       id = None,
@@ -115,7 +115,7 @@ case class ImportLandsat8(startDate: LocalDate = LocalDate.now(ZoneOffset.UTC), 
     val ul = row("upperLeftCornerLongitude").toDouble -> row("upperLeftCornerLatitude").toDouble
     val ur = row("upperRightCornerLongitude").toDouble -> row("upperRightCornerLatitude").toDouble
 
-    val srcCoords  = ll :: lr :: ul :: ur :: Nil
+    val srcCoords  = ll :: ul :: ur :: lr :: Nil
     val srcPolygon = Polygon(Line(srcCoords :+ srcCoords.head))
 
     val sortedByX = srcCoords.sortBy(_.x)

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/landsat8/airflow/ImportLandsat8C1.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/landsat8/airflow/ImportLandsat8C1.scala
@@ -82,8 +82,8 @@ case class ImportLandsat8C1(startDate: LocalDate = LocalDate.now(ZoneOffset.UTC)
 
   protected def createThumbnails(sceneId: UUID, productId: String): List[Thumbnail.Identified] = {
     val path = getLandsatUrl(productId)
-    val smallUrl = s"$path${productId}_thumb_small.jpg}"
-    val largeUrl = s"$path${productId}_thumb_large.jpg}"
+    val smallUrl = s"$path/${productId}_thumb_small.jpg}"
+    val largeUrl = s"$path/${productId}_thumb_large.jpg}"
 
     Thumbnail.Identified(
       id = None,
@@ -115,7 +115,7 @@ case class ImportLandsat8C1(startDate: LocalDate = LocalDate.now(ZoneOffset.UTC)
     val ul = row("upperLeftCornerLongitude").toDouble -> row("upperLeftCornerLatitude").toDouble
     val ur = row("upperRightCornerLongitude").toDouble -> row("upperRightCornerLatitude").toDouble
 
-    val srcCoords  = ll :: lr :: ul :: ur :: Nil
+    val srcCoords  = ll :: ul :: ur :: lr :: Nil
     val srcPolygon = Polygon(Line(srcCoords :+ srcCoords.head))
 
     val sortedByX = srcCoords.sortBy(_.x)


### PR DESCRIPTION
## Overview

This PR fixes thumbnail urls

## Testing Instructions

```bash
java -cp batch/target/scala-2.11/rf-batch.jar com.azavea.rf.batch.Main import_landsat8 2017-05-01
# or
java -cp batch/target/scala-2.11/rf-batch.jar com.azavea.rf.batch.Main import_landsat8_c1 2017-05-01
```

## Demo

I decided to go through all the significant parts of the import, and doublechecked all urls.

```bash
rasterfoundry=# select url from thumbnails where scene = '0a3c5a42-f307-4252-9da9-9ec7c3f60492';
                                                                         url
------------------------------------------------------------------------------------------------------------------------------------------------------
 http://landsat-pds.s3.amazonaws.com/c1/L8/097/012/LC08_L1TP_097012_20170501_20170515_01_T1/LC08_L1TP_097012_20170501_20170515_01_T1_thumb_large.jpg}
 http://landsat-pds.s3.amazonaws.com/c1/L8/097/012/LC08_L1TP_097012_20170501_20170515_01_T1/LC08_L1TP_097012_20170501_20170515_01_T1_thumb_small.jpg}
(2 rows)

# select metadata_files from scenes where id = '0a3c5a42-f307-4252-9da9-9ec7c3f60492';
                                                                metadata_files
-----------------------------------------------------------------------------------------------------------------------------------------------
 {http://landsat-pds.s3.amazonaws.com/c1/L8/097/012/LC08_L1TP_097012_20170501_20170515_01_T1/LC08_L1TP_097012_20170501_20170515_01_T1_MTL.txt}
(1 row)

rasterfoundry=# select sourceuri from images where scene = '0a3c5a42-f307-4252-9da9-9ec7c3f60492';
                                                                  sourceuri
---------------------------------------------------------------------------------------------------------------------------------------------
 http://landsat-pds.s3.amazonaws.com/c1/L8/097/012/LC08_L1TP_097012_20170501_20170515_01_T1/LC08_L1TP_097012_20170501_20170515_01_T1_B8.TIF
 http://landsat-pds.s3.amazonaws.com/c1/L8/097/012/LC08_L1TP_097012_20170501_20170515_01_T1/LC08_L1TP_097012_20170501_20170515_01_T1_B1.TIF
 http://landsat-pds.s3.amazonaws.com/c1/L8/097/012/LC08_L1TP_097012_20170501_20170515_01_T1/LC08_L1TP_097012_20170501_20170515_01_T1_B2.TIF
 http://landsat-pds.s3.amazonaws.com/c1/L8/097/012/LC08_L1TP_097012_20170501_20170515_01_T1/LC08_L1TP_097012_20170501_20170515_01_T1_B3.TIF
 http://landsat-pds.s3.amazonaws.com/c1/L8/097/012/LC08_L1TP_097012_20170501_20170515_01_T1/LC08_L1TP_097012_20170501_20170515_01_T1_B4.TIF
 http://landsat-pds.s3.amazonaws.com/c1/L8/097/012/LC08_L1TP_097012_20170501_20170515_01_T1/LC08_L1TP_097012_20170501_20170515_01_T1_B5.TIF
 http://landsat-pds.s3.amazonaws.com/c1/L8/097/012/LC08_L1TP_097012_20170501_20170515_01_T1/LC08_L1TP_097012_20170501_20170515_01_T1_B6.TIF
 http://landsat-pds.s3.amazonaws.com/c1/L8/097/012/LC08_L1TP_097012_20170501_20170515_01_T1/LC08_L1TP_097012_20170501_20170515_01_T1_B7.TIF
 http://landsat-pds.s3.amazonaws.com/c1/L8/097/012/LC08_L1TP_097012_20170501_20170515_01_T1/LC08_L1TP_097012_20170501_20170515_01_T1_B9.TIF
 http://landsat-pds.s3.amazonaws.com/c1/L8/097/012/LC08_L1TP_097012_20170501_20170515_01_T1/LC08_L1TP_097012_20170501_20170515_01_T1_B10.TIF
 http://landsat-pds.s3.amazonaws.com/c1/L8/097/012/LC08_L1TP_097012_20170501_20170515_01_T1/LC08_L1TP_097012_20170501_20170515_01_T1_B11.TIF
(11 rows)
```

