### PR TITLE
Feature/jis/dropbox finish auth endpoint

### DIFF
--- a/app-backend/api/src/main/scala/user/DropboxUser.scala
+++ b/app-backend/api/src/main/scala/user/DropboxUser.scala
@@ -1,0 +1,6 @@
+package com.azavea.rf.api.user
+
+import io.circe.generic.JsonCodec
+
+@JsonCodec
+case class DropboxAuthRequest(authorizationCode: String)

--- a/app-backend/api/src/main/scala/user/DropboxUser.scala
+++ b/app-backend/api/src/main/scala/user/DropboxUser.scala
@@ -22,7 +22,8 @@ case class DropboxAuthRequest(
   *
   * get returns a random 16 byte string that we're using
   * to pretend we set state in the /authorize request.
-  * set and clear do nothing.
+  * set and clear are around just to make the interface
+  * happy
   */
 class DummySessionStore extends DbxSessionStore {
 

--- a/app-backend/api/src/main/scala/user/DropboxUser.scala
+++ b/app-backend/api/src/main/scala/user/DropboxUser.scala
@@ -1,6 +1,46 @@
 package com.azavea.rf.api.user
 
+import com.dropbox.core.DbxSessionStore
 import io.circe.generic.JsonCodec
 
+import scala.beans.BeanProperty
+import scala.util.Random
+import java.util.Base64
+
 @JsonCodec
-case class DropboxAuthRequest(authorizationCode: String)
+case class DropboxAuthRequest(
+  authorizationCode: String,
+  redirectURI: String
+)
+
+/** Mock a DbxSessionStore.
+  *
+  * To implement the DbxSessionStore interface, we need
+  * get, set, and clear. The Dropbox SDK is really happy
+  * if we're using the servlet API, but since we're not,
+  * we have this dumb class instead.
+  *
+  * get returns a random 16 byte string that we're using
+  * to pretend we set state in the /authorize request.
+  * set and clear do nothing.
+  */
+class DummySessionStore extends DbxSessionStore {
+
+  @BeanProperty
+  var token:String = ""
+
+  def get: String = {
+    val s = this.getToken()
+    s match {
+      case "" =>
+        val bytes: Array[Byte] =
+          Array.fill(16)((Random.nextInt(255) - 128).toByte)
+        val encoder = Base64.getEncoder()
+        this.setToken(encoder.encodeToString(bytes))
+        this.getToken()
+      case _ => s
+    }
+  }
+  def set(s: String): Unit = this.setToken(s)
+  def clear: Unit = ()
+}

--- a/app-backend/api/src/main/scala/user/Routes.scala
+++ b/app-backend/api/src/main/scala/user/Routes.scala
@@ -114,8 +114,9 @@ trait UserRoutes extends Authentication
       val authFinish = webAuth.finishFromRedirect(
         dbxAuthRequest.redirectURI, session, queryParams
       )
-      logger.info("authFinish created")
+      logger.debug("Auth finish from Dropbox successful")
       Users.storeDropboxAccessToken(userId, authFinish.getAccessToken)
+      logger.debug(s"Sent access code for user $userId to database")
       complete(StatusCodes.OK)
     }
   }

--- a/app-backend/api/src/main/scala/utils/QueryParameters.scala
+++ b/app-backend/api/src/main/scala/utils/QueryParameters.scala
@@ -28,7 +28,7 @@ trait QueryParametersCommon extends QueryParameterDeserializers {
     orgQueryParams & userQueryParameters & timestampQueryParameters
   ).as(ProjectQueryParameters.apply _)
 
-def aoiQueryParameters = (
+  def aoiQueryParameters = (
     orgQueryParams & userQueryParameters & timestampQueryParameters
   ).as(AoiQueryParameters.apply _)
 

--- a/app-backend/database/src/main/scala/com/azavea/rf/database/QueryParameters.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/QueryParameters.scala
@@ -251,3 +251,8 @@ case class ExportQueryParameters(
   project: Option[UUID] = None,
   exportStatus: Iterable[String] = Seq[String]()
 )
+
+@JsonCodec
+case class DropboxAuthQueryParameters(
+  code: Option[String] = None
+)

--- a/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Users.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Users.scala
@@ -65,7 +65,7 @@ object Users extends TableQuery(tag => new Users(tag)) with LazyLogging {
       val hasNext = (page.offset + 1) * page.limit < totalUsers // 0 indexed page offset
       val hasPrevious = page.offset > 0
       PaginatedResponse(totalUsers, hasPrevious, hasNext,
-        page.offset, page.limit, users)
+                        page.offset, page.limit, users)
     }
   }
 
@@ -148,6 +148,12 @@ object Users extends TableQuery(tag => new Users(tag)) with LazyLogging {
     database.db.run {
       getUserAction.headOption
     }
+  }
+
+  def storeDropboxAccessToken(userId: String, token: String)(implicit database: DB): Future[Int] = {
+    val updateAction = Users.filter(_.id === userId).map(_.dropboxCredential).update(Some(token))
+    logger.debug(s"Attempting to store access token for user $userId")
+    database.db.run(updateAction)
   }
 
   def updateUser(user: User, id: String)(implicit database: DB): Future[Int] = {

--- a/app-frontend/src/app/core/services/dropbox.service.js
+++ b/app-frontend/src/app/core/services/dropbox.service.js
@@ -6,7 +6,7 @@ export default (app) => {
 
             this.authService = authService;
             this.DropboxSetup = $resource(
-                '/api/users/:userid/dropbox-setup', {}, {
+                '/api/users/dropbox-setup', {}, {
                     confirm: {
                         method: 'POST'
                     }

--- a/docs/swagger/spec.yml
+++ b/docs/swagger/spec.yml
@@ -135,6 +135,21 @@ paths:
           description: Unexpected error
           schema:
             $ref: '#/definitions/Error'
+  /users/dropbox-setup/:
+    x-resource: Users
+    post:
+      summary: Store a dropbox access token for a user from an authorization code
+      tags:
+        - Users
+      parameters:
+          - $ref: '#/parameters/uuid'
+          - name: DropboxAuthRequest
+            in: body
+            schema:
+              $ref: '#/definitions/DropboxAuthRequest'
+      responses:
+        200:
+          description: Dropbox access token successfully fetched
   /users/me/:
     x-resource: Users
     get:
@@ -205,25 +220,6 @@ paths:
           description: Update successful (No Content)
         default:
           description: Unexpected error
-          schema:
-            $ref: '#/definitions/Error'
-  /users/{uuid}/dropbox-setup/:
-    x-resource: Users
-    post:
-      summary: Store a dropbox access token for a user from an authorization code
-      tags:
-        - Users
-      parameters:
-          - $ref: '#/parameters/uuid'
-          - name: DropboxAuthRequest
-            in: body
-            schema:
-              $ref: '#/definitions/DropboxAuthRequest'
-      responses:
-        200:
-          description: Dropbox access token successfully fetched
-        404:
-          description: User not found
           schema:
             $ref: '#/definitions/Error'
   /organizations/:

--- a/docs/swagger/spec.yml
+++ b/docs/swagger/spec.yml
@@ -142,7 +142,6 @@ paths:
       tags:
         - Users
       parameters:
-          - $ref: '#/parameters/uuid'
           - name: DropboxAuthRequest
             in: body
             schema:

--- a/docs/swagger/spec.yml
+++ b/docs/swagger/spec.yml
@@ -207,6 +207,26 @@ paths:
           description: Unexpected error
           schema:
             $ref: '#/definitions/Error'
+  /users/{uuid}/dropbox-setup/:
+    x-resource: Users
+    post:
+      summary: Store a dropbox access token for a user from an authorization code
+      tags:
+        - Users
+      parameters:
+          - $ref: '#/parameters/uuid'
+          - name: authorizationCode
+            in: body
+            required: true
+            schema:
+              type: string
+      responses:
+        200:
+          description: Dropbox access token successfully fetched
+        404:
+          description: User not found
+          schema:
+            $ref: '#/definitions/Error'
   /organizations/:
     x-resource: Organizations
     get:
@@ -1670,7 +1690,6 @@ paths:
             $ref: '#/definitions/Error'
 
 parameters:
-
   orderingBase:
     name: ordering
     in: query

--- a/docs/swagger/spec.yml
+++ b/docs/swagger/spec.yml
@@ -215,16 +215,10 @@ paths:
         - Users
       parameters:
           - $ref: '#/parameters/uuid'
-          - name: authorizationCode
+          - name: DropboxAuthRequest
             in: body
-            required: true
             schema:
-              type: string
-          - name: redirectURI
-            in: body
-            required: true
-            schema:
-              type: string
+              $ref: '#/definitions/DropboxAuthRequest'
       responses:
         200:
           description: Dropbox access token successfully fetched
@@ -2103,6 +2097,13 @@ definitions:
         format: uuid
       colorCorrection:
         $ref: '#/definitions/ColorCorrection'
+  DropboxAuthRequest:
+    type: object
+    properties:
+      authorizationCode:
+        type: string
+      redirectURI:
+        type: string
   AOI:
     type: object
     properties:

--- a/docs/swagger/spec.yml
+++ b/docs/swagger/spec.yml
@@ -220,6 +220,11 @@ paths:
             required: true
             schema:
               type: string
+          - name: redirectURI
+            in: body
+            required: true
+            schema:
+              type: string
       responses:
         200:
           description: Dropbox access token successfully fetched


### PR DESCRIPTION
## Overview

This PR adds a `/api/users/<user id>/dropbox-setup/` route to fetch a dropbox credential for
a user.

### Checklist

- [x] ~Styleguide updated, if necessary~
- [x] Swagger specification updated, if necessary
- [x] ~Symlinks from new migrations present or corrected for any new migrations~

## Testing Instructions

 * Manually set `dbxKey` and `dbxSecret` in user routes to `app key` and `app secret` from the `raster-foundry` app in the rf dropbox account
 * start up the server
 * Sign into dropbox
 * Hit our [authorize endpoint](https://www.dropbox.com/oauth2/authorize?client_id=ej47wp89mk6asie&response_type=code) and copy the code
 * `http :9000/api/users/{your user id}/dropbox-setup/ authorizationCode=<the code> Authorization:"Bearer xxxxxx"`
 * `./scripts/psql`
 * `select id, dropbox_credential from users where dropbox_credential is not null`
 * :taco:

Closes #1878 
