### PR TITLE
adds readme section on theming and font family variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,19 @@ To run tests you can do one of the following (in order of speed):
  - Run `yarn run test` outside the VM (or `yarn run test-watch`)
  - Run `./scripts/test` inside the VM (will also run additional project tests)
 
+#### Frontend Theming
+
+Frontend theming should only be used if you intend on forking and white labeling the application. Theming of the frontend application can be done easily with a few tweaks to the `scss`. To get theming working correctly, follow these instructions: 
+
+ - Edit `app-frontend/src/assets/styles/sass/app.scss` and uncomment the two blocks of code which reference theme files. This will turn the theme files _on_.
+ - All theme overrides will then be written inside of `app-frontend/src/assets/styles/sass/theme`
+     - app-wide variables for changing fonts, colors, etc. are located in `app-frontend/src/assets/styles/sass/theme/settings`.
+     - `_core.scss` should contain the bulk of style overrides which `/settings/` does **not** cover.
+     - **Tip:** You can mimic the main application `scss` structure inside of `/theme/` and `@import` the files into `_core.scss`
+ - WIP: we are still working out the kinks for icon fonts and branding assets.
+
+Due to active development to Raster Foundry, some aspects of theming might break and will need active maintenance. 
+
 ## Ports
 
 The Vagrant configuration maps the following host ports to services running in the virtual machines. Ports can be overridden for individual developers using environment variables

--- a/app-frontend/src/assets/styles/sass/_shame.scss
+++ b/app-frontend/src/assets/styles/sass/_shame.scss
@@ -67,7 +67,7 @@ div.image-placeholder {
   padding: 4px 7px;
   opacity: .9;
   transition: .1s ease-in-out opacity;
-  font-family: 'Open Sans', sans-serif;
+  font-family: $font-base;
   max-width: 400px;
 
   &:hover {

--- a/app-frontend/src/assets/styles/sass/app.scss
+++ b/app-frontend/src/assets/styles/sass/app.scss
@@ -1,7 +1,7 @@
 /* * * *
  * Theme settings
  * Overrides the default settings
- * uncomment @import if using
+ * uncomment @import if using theming
  * * * */
 /* @import
  "theme/settings/colors",
@@ -90,7 +90,7 @@
 /* * * *
  * Theme styles
  * Overrides default styles
- * uncomment @import if using
+ * uncomment @import if using theming
  * * * */
 /* @import
   "theme/core"; */

--- a/app-frontend/src/assets/styles/sass/base/_base.scss
+++ b/app-frontend/src/assets/styles/sass/base/_base.scss
@@ -4,7 +4,7 @@
 
 html { 
 	font-size: 62.5%; 
-	font-family: 'Open Sans', sans-serif;
+	font-family: $font-base;
   height: 100%;
 }
 

--- a/app-frontend/src/assets/styles/sass/base/_typography.scss
+++ b/app-frontend/src/assets/styles/sass/base/_typography.scss
@@ -8,7 +8,7 @@
 @include heading-tags {
   margin-bottom: 1rem;
   line-height: 1.1;
-  font-family: 'Titillium Web', sans-serif;
+  font-family: $font-header;
   color: $shade-dark;
 }
 
@@ -59,11 +59,11 @@ p, .p {
 }
 
 .font-base {
-  font-family: 'Open Sans', sans-serif;
+  font-family: $font-base;
 }
 
 .font-alt {
-  font-family: 'Titillium Web', sans-serif;
+  font-family: $font-header;
 }
 
 .text-uppercase {

--- a/app-frontend/src/assets/styles/sass/settings/_variables.scss
+++ b/app-frontend/src/assets/styles/sass/settings/_variables.scss
@@ -28,6 +28,13 @@ $column-padding: 1rem !default;
 
 
 /* * * *
+ * Fonts
+ * * * */
+$font-base: 'Open Sans', sans-serif !default;
+$font-header: 'Titillium Web', sans-serif !default;
+
+
+/* * * *
  * Borders 
  * * * */
 // Border Radius

--- a/app-frontend/src/assets/styles/sass/theme/settings/_variables.scss
+++ b/app-frontend/src/assets/styles/sass/theme/settings/_variables.scss
@@ -28,6 +28,13 @@ $column-padding: 1rem;
 
 
 /* * * *
+ * Fonts
+ * * * */
+$font-base: 'Open Sans', sans-serif;
+$font-header: 'Titillium Web', sans-serif;
+
+
+/* * * *
  * Borders 
  * * * */
 // Border Radius


### PR DESCRIPTION
## Overview

- Update the README to walkthrough using the theme files. **Note:** this will need to be updated as we introduce the branding config file.
- Replaces hard decorations of font families with variables which can be changed in the theme file.

~### Checklist~

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
