### PR TITLE
Remove scene list mutation from scene selection modal

### DIFF
--- a/app-frontend/src/app/components/selectedScenesModal/selectedScenesModal.controller.js
+++ b/app-frontend/src/app/components/selectedScenesModal/selectedScenesModal.controller.js
@@ -1,6 +1,7 @@
 export default class SelectedScenesModalController {
     constructor($log, $state, projectService) {
         'ngInject';
+        this.$log = $log;
         this.$state = $state;
         this.projectService = projectService;
         this.scenes = [];

--- a/app-frontend/src/app/components/selectedScenesModal/selectedScenesModal.controller.js
+++ b/app-frontend/src/app/components/selectedScenesModal/selectedScenesModal.controller.js
@@ -23,7 +23,6 @@ export default class SelectedScenesModalController {
         let sceneIds = Array.from(this.selectedScenes.keys());
         this.projectService.addScenes(this.resolve.project.id, sceneIds).then(
             () => {
-                this.resolve.scenes.clear();
                 this.close({ $value: sceneIds });
             },
             (err) => {

--- a/app-frontend/src/app/pages/projects/edit/scenes/scenes.controller.js
+++ b/app-frontend/src/app/pages/projects/edit/scenes/scenes.controller.js
@@ -16,6 +16,7 @@ export default class ProjectsScenesController {
         $event.preventDefault();
         this.projectService.removeScenesFromProject(this.projectId, [scene.id]).then(
             () => {
+                this.$parent.removeHoveredScene();
                 this.$parent.getSceneList();
             },
             () => {


### PR DESCRIPTION
## Overview

This PR fixes the bug that caused the thumbnails of scenes added to a project to remain on the map. The bug was caused by the modal mutating the list of selected scenes before the browse controller has a chance to use that list to remove the thumbnails.

EDIT:
Because it was a tiny fix, I also addressed a bug that caused a deleted scene's footprint to remain on the map.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~

## Notes

We should probably make it a rule of thumb to never modify the data a modal is passed via the `resolve` object and instead pass data back to the calling controller with `close` method. This would put the responsibility of mutating the data on the calling controller rather than the modal.

## Testing Instructions

 * Add scenes to a project, make sure that the thumbnails don't hang around
 * Delete a scene from a project, make sure the footprint doesn't hang around

Closes #1727
Closes #1659 
