### PR TITLE
Update projects AoI fields

### DIFF
--- a/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Projects.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Projects.scala
@@ -310,12 +310,14 @@ object Projects extends TableQuery(tag => new Projects(tag)) with LazyLogging {
                          .filter(_.id === projectId)
     } yield (
       updateProject.modifiedAt, updateProject.modifiedBy, updateProject.name, updateProject.description,
-      updateProject.visibility, updateProject.tileVisibility, updateProject.tags
+      updateProject.visibility, updateProject.tileVisibility, updateProject.tags, updateProject.aoiCadenceMillis,
+      updateProject.aoisLastChecked
     )
     database.db.run {
-      updateProjectQuery.update((
-        updateTime, user.id, project.name, project.description, project.visibility, project.tileVisibility, project.tags
-      ))
+      updateProjectQuery.update(
+        (updateTime, user.id, project.name, project.description, project.visibility, project.tileVisibility, project.tags,
+         project.aoiCadenceMillis, project.aoisLastChecked)
+      )
     } map {
       case 1 => 1
       case c => throw new IllegalStateException(s"Error updating project: update result expected to be 1, was $c")


### PR DESCRIPTION
## Overview

This PR adds a couple AoI field to the `Project` type's DB update handler, so that they will be persisted.

### Checklist

~~- [ ] Styleguide updated, if necessary~~
~~- [ ] Swagger specification updated, if necessary~~
~~- [ ] Symlinks from new migrations present or corrected for any new migrations~~


## Testing Instructions

 * bounce the API server
 * `PUT` to `api/projects/[project id]` with new values in the `aoiCadenceMillis` and `aoiLastChecked` fields
 * check that the request ends with a `204` response and that the DB reflects the change in values

Closes #1816 
