### PR TITLE
Disable third party services in dev

### DIFF
--- a/app-backend/common/src/main/scala/Rollbar.scala
+++ b/app-backend/common/src/main/scala/Rollbar.scala
@@ -104,11 +104,13 @@ trait RollbarNotifier extends LazyLogging {
   }
 
   def sendError(payload: JsObject): Unit = {
-    Http().singleRequest(
-      HttpRequest(HttpMethod("POST", false, false, RequestEntityAcceptance.Expected),
-        uri = this.url,
-        entity = HttpEntity(ContentTypes.`application/json`,
-          payload.toString))
-    )
+    if (this.environment != "development") {
+      Http().singleRequest(
+        HttpRequest(HttpMethod("POST", false, false, RequestEntityAcceptance.Expected),
+          uri = this.url,
+          entity = HttpEntity(ContentTypes.`application/json`,
+            payload.toString))
+      )
+    }
   }
 }

--- a/app-frontend/config/webpack/global.js
+++ b/app-frontend/config/webpack/global.js
@@ -200,7 +200,8 @@ module.exports = function (_path) {
             new HtmlWebpackPlugin({
                 filename: 'index.html',
                 template: path.join(_path, 'src', 'tpl-index.html'),
-                heapLoad: DEVELOPMENT ? '2743344218' : '3505855839'
+                heapLoad: DEVELOPMENT ? '2743344218' : '3505855839',
+                development: DEVELOPMENT
             })
         ]
     };

--- a/app-frontend/src/app/core/services/rollbarWrapper.service.js
+++ b/app-frontend/src/app/core/services/rollbarWrapper.service.js
@@ -8,14 +8,16 @@ export default (app) => {
         }
 
         init(user = {}) {
-            this.Rollbar.configure({
-                accessToken: this.accessToken,
-                captureUncaught: true,
-                payload: {
-                    environment: this.env,
-                    person: user
-                }
-            });
+            if (this.env !== 'development') {
+                this.Rollbar.configure({
+                    accessToken: this.accessToken,
+                    captureUncaught: true,
+                    payload: {
+                        environment: this.env,
+                        person: user
+                    }
+                });
+            }
         }
     }
 

--- a/app-frontend/src/tpl-index.html
+++ b/app-frontend/src/tpl-index.html
@@ -15,10 +15,12 @@
     <script src="{%=o.htmlWebpackPlugin.files.chunks[chunk].entry %}" defer></script>
     {% } %}
 
-    <script type="text/javascript">
-     window.heap=window.heap||[],heap.load=function(e,t){window.heap.appid=e,window.heap.config=t=t||{};var r=t.forceSSL||"https:"===document.location.protocol,a=document.createElement("script");a.type="text/javascript",a.async=!0,a.src=(r?"https:":"http:")+"//cdn.heapanalytics.com/js/heap-"+e+".js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(a,n);for(var o=function(e){return function(){heap.push([e].concat(Array.prototype.slice.call(arguments,0)))}},p=["addEventProperties","addUserProperties","clearEventProperties","identify","removeEventProperty","setEventProperties","track","unsetEventProperty"],c=0;c<p.length;c++)heap[p[c]]=o(p[c])};
-     heap.load("{%=o.htmlWebpackPlugin.options.heapLoad %}");
-    </script>
+    {% if (!o.htmlWebpackPlugin.options.development) { %}
+      <script type="text/javascript">
+       window.heap=window.heap||[],heap.load=function(e,t){window.heap.appid=e,window.heap.config=t=t||{};var r=t.forceSSL||"https:"===document.location.protocol,a=document.createElement("script");a.type="text/javascript",a.async=!0,a.src=(r?"https:":"http:")+"//cdn.heapanalytics.com/js/heap-"+e+".js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(a,n);for(var o=function(e){return function(){heap.push([e].concat(Array.prototype.slice.call(arguments,0)))}},p=["addEventProperties","addUserProperties","clearEventProperties","identify","removeEventProperty","setEventProperties","track","unsetEventProperty"],c=0;c<p.length;c++)heap[p[c]]=o(p[c])};
+       heap.load("{%=o.htmlWebpackPlugin.options.heapLoad %}");
+      </script>
+    {% } %}
 </head>
 <body>
     <!--[if lt IE 10]>


### PR DESCRIPTION
## Overview

This PR disables Rollbar and Heap in our development environment.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~

## Notes

Our heap data from staging and production use the same environment because our `NODE_ENV`, which is all we have available at the point of build, does not get a proper `staging` value.

We'll want to figure out how to get our Heap app codes into the ENV so that it is configurable.

## Testing Instructions

 * Induce a JS error, see that the error is not sent to Rollbar
 * Check that no requests are being sent to Heap
 * You can alter the value of `DEVELOPMENT` here: https://github.com/azavea/raster-foundry/compare/feature/ak/disable-third-party-services-in-dev?expand=1#diff-38b5978d33ff92244185afccc98d04cdR204 to `false` and see that the Heap requests are then being sent.

Closes #1607
