### PR TITLE
Allow for RAW exports of data

### DIFF
--- a/app-backend/api/src/test/scala/exports/ExportSpecHelper.scala
+++ b/app-backend/api/src/test/scala/exports/ExportSpecHelper.scala
@@ -28,10 +28,12 @@ trait ExportSpecHelper { self: ProjectSpecHelper =>
       resolution = 2,
       stitch = false,
       crop = false,
+      raw = false,
       bands = None,
       rasterSize = None,
       crs = None,
-      source = new URI("s3://test")
+      source = new URI("s3://test"),
+      operation = Some("id")
     ).asJson
   )
 

--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/ExportOptions.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/ExportOptions.scala
@@ -13,11 +13,13 @@ case class ExportOptions(
   resolution: Int,
   stitch: Boolean,
   crop: Boolean,
+  raw: Boolean,
   bands: Option[Seq[Int]],
   rasterSize: Option[Int],
   crs: Option[Int],
-  source: URI
+  source: URI,
+  operation: Option[String]
 ) {
-  def render = Render("id", bands)
+  def render = Render(operation.getOrElse("id"), bands)
   def getCrs = crs.map(CRS.fromEpsgCode)
 }

--- a/docs/swagger/spec.yml
+++ b/docs/swagger/spec.yml
@@ -3143,6 +3143,9 @@ definitions:
     type: object
     description: export params
     properties:
+      operation:
+        type: string
+        description: currently a not supported flag, describes a render operation, "id" by defaut.
       bands:
         type: array
         description: bands in the exported geotiffs
@@ -3163,6 +3166,9 @@ definitions:
       crop:
         type: boolean
         description: crop stitched raster by provided mask if possible
+      raw:
+        type: boolean
+        description: make a raw export skipping all color correction steps
   ExportDefinition:
     type: object
     properties:


### PR DESCRIPTION
## Overview

This PR introduces a RAW export param into `ExportOptions`.

### Checklist

- [x] Swagger specification updated, if necessary


## Testing Instructions

* Create an export with this flag.
* Create Export definition out of this Export

More info about testing can be found in this testing issue: https://github.com/azavea/raster-foundry/issues/1874

Closes #1926
