### PR TITLE
Permission issues during the export job fix

### DIFF
--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/util/S3.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/util/S3.scala
@@ -109,9 +109,17 @@ object S3 {
 
   /** Set credentials in case Hadoop configuration files don't specify S3 credentials. */
   def setCredentials(conf: Configuration, credentialsProviderChain: AWSCredentialsProvider = new DefaultAWSCredentialsProviderChain): Configuration = {
-    conf.set("fs.s3.impl", classOf[org.apache.hadoop.fs.s3native.NativeS3FileSystem].getName)
-    conf.set("fs.s3.awsAccessKeyId", credentialsProviderChain.getCredentials.getAWSAccessKeyId)
-    conf.set("fs.s3.awsSecretAccessKey", credentialsProviderChain.getCredentials.getAWSSecretKey)
+
+    /**
+      * Identify whether function is called on EMR
+      * fs.AbstractFileSystem.s3a.impl is a specific key which should be set on EMR
+      *
+      * */
+    if(conf.isKeyUnset("fs.AbstractFileSystem.s3a.impl")) {
+      conf.set("fs.s3.impl", classOf[org.apache.hadoop.fs.s3native.NativeS3FileSystem].getName)
+      conf.set("fs.s3.awsAccessKeyId", credentialsProviderChain.getCredentials.getAWSAccessKeyId)
+      conf.set("fs.s3.awsSecretAccessKey", credentialsProviderChain.getCredentials.getAWSSecretKey)
+    }
     conf
   }
 }

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/util/package.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/util/package.scala
@@ -11,11 +11,16 @@ import geotrellis.spark.io.s3.util.S3RangeReader
 import com.amazonaws.auth._
 import com.amazonaws.services.s3.{AmazonS3URI, AmazonS3Client => AWSAmazonS3Client}
 import org.apache.commons.io.IOUtils
+import org.apache.hadoop.conf.Configuration
 
 import java.io._
 import java.net._
 
 package object util {
+  implicit class ConfigurationMethods(conf: Configuration) {
+    def isKeyUnset(key: String): Boolean = conf.get(key) == null
+  }
+
   implicit class InputStreamMethods(is: InputStream) {
     def toJson = {
       val lines = scala.io.Source.fromInputStream(is).getLines


### PR DESCRIPTION
## Overview

AWS EMR has some specific settings, which should be used as is. 
Export job (and other jobs) overrided some specific settings provided by environment which caused permissions issues (potentially not export job was effected).

## Test instructions 

Run it on EMR and locally.

Local test command example (should finish successfully): 

```bash
docker-compose -f docker-compose.spark.yml run spark-driver \
  --driver-memory 2G \
  --class com.azavea.rf.batch.export.spark.Export \
  /opt/rf/jars/rf-batch.jar -j s3://rasterfoundry-development-data-us-east-1/export-definitions/f1911a7a-cba5-4c5e-9f15-61b8ca411791.json
```

Closes #1925
