### PR TITLE
Rebuild node-sass after yarn install

### DIFF
--- a/app-frontend/package.json
+++ b/app-frontend/package.json
@@ -16,6 +16,7 @@
     "clean": "rimraf dist/*",
     "build-nginx": "rimraf ../nginx/srv/dist/* && yarn run build && cp -R dist/* ../nginx/srv/dist/",
     "dev": "cross-env NODE_ENV=development webpack-dev-server",
+    "postinstall": "npm rebuild node-sass",
     "sort-packages": "sort-package-json",
     "start": "yarn run dev",
     "test": "karma start karma.conf.js",


### PR DESCRIPTION
## Overview

Occasionally, CI builds will fail because`node-sass` is missing the linux binding in the `vendor` directory:
```bash
ModuleBuildError: Module build failed: Error: ENOENT: no such file or directory, scandir '/opt/raster-foundry/app-frontend/node_modules/node-sass/vendor'
    at Error (native)
    at Object.fs.readdirSync (fs.js:951:18)
    at Object.getInstalledBinaries (/opt/raster-foundry/app-frontend/node_modules/node-sass/lib/extensions.js:121:13)
    at foundBinariesList (/opt/raster-foundry/app-frontend/node_modules/node-sass/lib/errors.js:20:15)
    at foundBinaries (/opt/raster-foundry/app-frontend/node_modules/node-sass/lib/errors.js:15:5)
    at Object.module.exports.missingBinary (/opt/raster-foundry/app-frontend/node_modules/node-sass/lib/errors.js:45:5)
    at module.exports (/opt/raster-foundry/app-frontend/node_modules/node-sass/lib/binding.js:15:30)
    at Object.<anonymous> (/opt/raster-foundry/app-frontend/node_modules/node-sass/lib/index.js:14:35)
    at Module._compile (module.js:570:32)
    at Object.Module._extensions..js (module.js:579:10)
    at Module.load (module.js:487:32)
    at tryModuleLoad (module.js:446:12)
```

The official solution for this issue is to run `npm rebuild node-sass`, as documented in [sass/node-sass#1579](https://github.com/sass/node-sass/issues/1579#issuecomment-227662011). This [comment](https://github.com/sass/node-sass/issues/1579#issuecomment-306585762) suggests a  yarn `postinstall` step to rebuild `node-sass`, which is the approach I took in this PR.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~

### Demo

N/A

### Notes

Another potential option was to install the missing binary directly, as explained [here](https://github.com/sass/node-sass/issues/1162#issuecomment-141832833). I felt that this was too hacky, and didn't fit as cleanly into the `cibuild` process.


## Testing Instructions

 * See [Jenkins](http://jenkins.staging.rasterfoundry.com/job/raster-foundry/job/raster-foundry/job/feature%252Ftnation%252Fnode-sass/10/console) build output

Closes #1385 
