### PR TITLE
Fix path for API spec publishing

### DIFF
--- a/scripts/deploy-docs
+++ b/scripts/deploy-docs
@@ -24,12 +24,12 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
                 echo "Syncing docs to ${RF_DOCS_BUCKET} (dryrun)"
                 aws s3 cp --dryrun \
                     "${DIR}/../docs/swagger/spec.yml" \
-                    "s3://${RF_DOCS_BUCKET}/spec"
+                    "s3://${RF_DOCS_BUCKET}/spec/"
             else
                 echo "Syncing docs to ${RF_DOCS_BUCKET}"
                 aws s3 cp \
                     "${DIR}/../docs/swagger/spec.yml" \
-                    "s3://${RF_DOCS_BUCKET}/spec"
+                    "s3://${RF_DOCS_BUCKET}/spec/"
             fi
         else
             echo "ERROR: No RF_DOCS_BUCKET found."


### PR DESCRIPTION
## Overview

When publishing the API spec, ensure that the target path has a trailing slash so that `spec.yml` gets placed at the root of the path vs. the creation of an object named `spec` at the same level of the `spec/` subdirectory.

Fixes https://github.com/azavea/raster-foundry/issues/1955

## Testing Instructions

First, execute `deploy-docs`, which gets invoked by `cipublish`:

```bash
vagrant@vagrant-ubuntu-trusty-64:/opt/raster-foundry$ RF_DEBUG=1 RF_DOCS_BUCKET="rasterfoundry-staging-docs-site-us-east-1" ./scripts/deploy-docs 
++ dirname ./scripts/deploy-docs
+ DIR=./scripts
+ '[' ./scripts/deploy-docs = ./scripts/deploy-docs ']'
+ '[' '' = --help ']'
+ [[ -n rasterfoundry-staging-docs-site-us-east-1 ]]
+ '[' '' = --dryrun ']'
+ echo 'Syncing docs to rasterfoundry-staging-docs-site-us-east-1'
Syncing docs to rasterfoundry-staging-docs-site-us-east-1
+ aws s3 cp ./scripts/../docs/swagger/spec.yml s3://rasterfoundry-staging-docs-site-us-east-1/spec/
upload: docs/swagger/spec.yml to s3://rasterfoundry-staging-docs-site-us-east-1/spec/spec.yml
```

Then, use `curl` and `grep` to determine if it is up-to-date based on the most recent changes:

```bash
$ curl -s "https://spec.staging.rasterfoundry.com" | grep "/projects/{uuid}/areas-of-interest/"
  /projects/{uuid}/areas-of-interest/:
```