### PR TITLE
Adjust Ingest Parallelism on Data Size

### DIFF
--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/ingest/CommandLine.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/ingest/CommandLine.scala
@@ -11,6 +11,7 @@ object CommandLine {
     overwrite: Boolean = false,
     windowSize: Int = 1024,
     partitionsPerFile: Int = 8,
+    partitionsSize: Int = 50, // partition size in mb to calculate repartitioning
     statusBucket: String = "rasterfoundry-dataproc-ingest-status-us-east-1"
   )
 
@@ -46,7 +47,11 @@ object CommandLine {
 
     opt[Int]('p',"partitionsPerFile")
       .action( (s, conf) => conf.copy(partitionsPerFile = s) )
-      .text("Number of RDD partitions to create per each source file")
+      .text("Min number of RDD partitions to create per each source file")
+
+    opt[Int]('z',"partitionsSize")
+      .action( (s, conf) => conf.copy(partitionsSize = s) )
+      .text("Partition size to calculate repartitioning (object size / partition size)")
 
     opt[String]('b',"statusBucket")
       .action( (s, conf) => conf.copy(statusBucket = s) )

--- a/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Exports.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Exports.scala
@@ -50,7 +50,7 @@ class Exports(_tableTag: Tag) extends Table[Export](_tableTag, "exports")
   val toolRunId: Rep[Option[UUID]] = column[Option[UUID]]("toolrun_id")
   val exportOptions: Rep[Json] = column[Json]("export_options")
 
-  lazy val projectsFk = foreignKey("exports_project_id_fkey", projectId, Projects)(r => r.id, onUpdate=ForeignKeyAction.NoAction, onDelete=ForeignKeyAction.Cascade)
+  lazy val projectsFk = foreignKey("exports_project_id_fkey", projectId, Projects)(r => r.id.?, onUpdate=ForeignKeyAction.NoAction, onDelete=ForeignKeyAction.Cascade)
   lazy val organizationsFk = foreignKey("exports_organization_id_fkey", organizationId, Organizations)(r => r.id, onUpdate=ForeignKeyAction.NoAction, onDelete=ForeignKeyAction.NoAction)
   lazy val createdByUserFK = foreignKey("exports_created_by_fkey", createdBy, Users)(r => r.id, onUpdate=ForeignKeyAction.NoAction, onDelete=ForeignKeyAction.NoAction)
   lazy val modifiedByUserFK = foreignKey("exports_modified_by_fkey", modifiedBy, Users)(r => r.id, onUpdate=ForeignKeyAction.NoAction, onDelete=ForeignKeyAction.NoAction)


### PR DESCRIPTION
## Overview

PR adds logic to get inputs partitions number basing on its size.

### Checklist

- [x] Test

### Notes

Tested on a local RF instance, on jobs launched via airflow on EMR. 
P.S. On a prod / dev systems [this](https://github.com/azavea/raster-foundry/blob/develop/app-tasks/dags/ingest_project_scenes.py#L45) line should be renamed as well.

Closes #1880
