### PR TITLE
Add dag run timeout to ingest scenes

### DIFF
--- a/app-tasks/dags/ingest_project_scenes.py
+++ b/app-tasks/dags/ingest_project_scenes.py
@@ -35,7 +35,8 @@ dag = DAG(
     dag_id='ingest_scene',
     default_args=default_args,
     schedule_interval=None,
-    concurrency=int(os.getenv('AIRFLOW_DAG_CONCURRENCY', 24))
+    concurrency=int(os.getenv('AIRFLOW_DAG_CONCURRENCY', 24)),
+    dagrun_timeout=datetime.timedelta(minutes=60)
 )
 
 


### PR DESCRIPTION
## Overview

This commit adds a timeout to set an upper bound for how long an
ingest can run before it fails. This will help prevent large, failed
ingests from blocking other processes from running.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~

### Notes

Generally, ingests should not be taking longer than an hour. The longest task is "wait for status" which is waiting for a job to complete while it's running in EMR. So looking at this graph I think 60 minutes gives us quite a bit of overhead (maybe too much).

![wait-for-status](https://user-images.githubusercontent.com/898060/27091154-52af54ac-502d-11e7-9627-077ef82c144e.png)

## Testing Instructions

 * Spin up locally, verify that ingesting a landsat scene in a project still works
