### PR TITLE
Add overrides.js.template for overriding select webpack global vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Frontend theming should only be used if you intend on forking and white labeling
  - Edit `app-frontend/src/assets/styles/sass/app.scss` and uncomment the two blocks of code which reference theme files. This will turn the theme files _on_.
  - All theme overrides will then be written inside of `app-frontend/src/assets/styles/sass/theme`
      - app-wide variables for changing fonts, colors, etc. are located in `app-frontend/src/assets/styles/sass/theme/settings`.
+     - app-wide variables for changing build options, basemaps, and app name are located in `app-frontend/config/webpack/overrides.js`. To start, copy the template file located in the same directory. Variables currently available for configuration are pre-populated at the top of the file.
      - `_core.scss` should contain the bulk of style overrides which `/settings/` does **not** cover.
      - **Tip:** You can mimic the main application `scss` structure inside of `/theme/` and `@import` the files into `_core.scss`
  - WIP: we are still working out the kinks for icon fonts and branding assets.

--- a/app-frontend/.gitignore
+++ b/app-frontend/.gitignore
@@ -5,3 +5,4 @@ coverage/
 .idea/
 .tmp/
 config/manifest.json
+config/webpack/overrides.js

--- a/app-frontend/config/webpack/environments/development.js
+++ b/app-frontend/config/webpack/environments/development.js
@@ -1,7 +1,6 @@
 'use strict';
 /* globals module process */
-/* no-console: 0
- */
+/* no-console: 0 */
 
 
 const webpack = require('webpack');

--- a/app-frontend/config/webpack/global.js
+++ b/app-frontend/config/webpack/global.js
@@ -17,6 +17,29 @@ const DEVELOPMENT = NODE_ENV === 'production' ? false : true;
 const stylesLoader = 'css-loader?sourceMap!postcss-loader!sass-loader?' +
         'outputStyle=expanded&sourceMap=true&sourceMapContents=true';
 
+const basemaps = JSON.stringify({
+    layers: {
+        Light: {
+            url: 'https://cartodb-basemaps-{s}.global.ssl.fastly.net/light_all/{z}/{x}/{y}.png',
+            properties: {
+                attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">' +
+                    'OpenStreetMap</a> &copy;<a href="http://cartodb.com/attributions">CartoDB</a>',
+                maxZoom: 30
+            },
+            default: true
+        },
+        Dark: {
+            url: 'https://cartodb-basemaps-{s}.global.ssl.fastly.net/dark_all/{z}/{x}/{y}.png',
+            properties: {
+                attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">' +
+                    'OpenStreetMap</a> &copy;<a href="http://cartodb.com/attributions">CartoDB</a>',
+                maxZoom: 30
+            }
+        }
+    },
+    default: 'Light'
+});
+
 module.exports = function (_path) {
     let rootAssetPath = _path + 'src';
 
@@ -202,6 +225,12 @@ module.exports = function (_path) {
                 template: path.join(_path, 'src', 'tpl-index.html'),
                 heapLoad: DEVELOPMENT ? '2743344218' : '3505855839',
                 development: DEVELOPMENT
+            }),
+            new webpack.DefinePlugin({
+                'BUILDCONFIG': {
+                    APP_NAME: '\'RasterFoundry\'',
+                    BASEMAPS: basemaps
+                }
             })
         ]
     };

--- a/app-frontend/config/webpack/overrides.js.template
+++ b/app-frontend/config/webpack/overrides.js.template
@@ -1,0 +1,40 @@
+'use strict';
+/* globals module */
+/* no-console: 0 */
+
+const webpack = require('webpack');
+
+const basemaps = JSON.stringify({
+    layers: {
+        Light: {
+            url: 'https://cartodb-basemaps-{s}.global.ssl.fastly.net/light_all/{z}/{x}/{y}.png',
+            properties: {
+                attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">' +
+                    'OpenStreetMap</a> &copy;<a href="http://cartodb.com/attributions">CartoDB</a>',
+                maxZoom: 30
+            }
+        },
+        Dark: {
+            url: 'https://cartodb-basemaps-{s}.global.ssl.fastly.net/dark_all/{z}/{x}/{y}.png',
+            properties: {
+                attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">' +
+                    'OpenStreetMap</a> &copy;<a href="http://cartodb.com/attributions">CartoDB</a>',
+                maxZoom: 30
+            }
+        }
+    },
+    default: 'Light'
+});
+
+module.exports = function () {
+    return {
+        plugins: [
+            new webpack.DefinePlugin({
+                'BUILDCONFIG': {
+                    APP_NAME: '\'RasterFoundry?\'',
+                    BASEMAPS: basemaps
+                }
+            })
+        ]
+    };
+};

--- a/app-frontend/package.json
+++ b/app-frontend/package.json
@@ -119,6 +119,7 @@
     "url-loader": "~0.5.6",
     "webpack": "~1.12.12",
     "webpack-dev-server": "1.16.2",
+    "webpack-merge": "4.1.0",
     "yarn": "^0.24.3"
   },
   "engines": {

--- a/app-frontend/webpack.config.js
+++ b/app-frontend/webpack.config.js
@@ -4,11 +4,15 @@
           no-console: 0
  */
 
-const _ = require('lodash');
+const fs = require('fs');
+const merge = require('webpack-merge');
+
 const configs = {
 
     // global section
     global: require(__dirname + '/config/webpack/global'),
+    overrides: fs.existsSync(__dirname + '/config/webpack/overrides.js') ?
+        require(__dirname + '/config/webpack/overrides') : null,
 
     // config by enviroments
     production: require(__dirname + '/config/webpack/environments/production'),
@@ -24,7 +28,8 @@ let load = function () {
     console.log('Current Environment: ', ENV);
 
     // load config file by environment
-    return configs && _.merge(
+    return configs && merge(
+        configs.overrides ? configs.overrides(__dirname) : null,
         configs.global(__dirname),
         configs[ENV](__dirname)
     );

--- a/app-frontend/yarn.lock
+++ b/app-frontend/yarn.lock
@@ -4343,7 +4343,7 @@ lodash@^4.0.0, lodash@^4.0.1, lodash@^4.2.0, lodash@^4.3.0, lodash@^4.5.0, lodas
   version "4.5.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.5.1.tgz#80e8a074ca5f3893a6b1c10b2a636492d710c316"
 
-lodash@^4.17.2:
+lodash@^4.17.2, lodash@^4.17.4:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
@@ -7139,6 +7139,12 @@ webpack-dev-server@1.16.2:
 webpack-fail-plugin@^1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/webpack-fail-plugin/-/webpack-fail-plugin-1.0.6.tgz#a135ee070a258548837f921d452004c695889ee7"
+
+webpack-merge@4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/webpack-merge/-/webpack-merge-4.1.0.tgz#6ad72223b3e0b837e531e4597c199f909361511e"
+  dependencies:
+    lodash "^4.17.4"
 
 webpack@~1.12.12:
   version "1.12.15"


### PR DESCRIPTION
## Overview

Allow use of an optional overrides.js webpack configuration file which is ignored by git
Replace use of _.merge with more intelligent merging

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~

## Testing Instructions

 * Copy `app-frontend/config/webpack/overrides.js.template` into `app-frontend/config/webpackoverrides.js`
* To test overriding, replace the default basemap property in the file and start the file (webpack must be restarted to see changes

Closes https://github.com/azavea/raster-foundry/issues/1885
