### PR TITLE
Install Docker v17

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -9,6 +9,8 @@ if ["up", "provision", "status"].include?(ARGV.first)
   AnsibleGalaxyHelper.install_dependent_roles("deployment/ansible")
 end
 
+ANSIBLE_VERSION = "2.3.1.0"
+
 Vagrant.configure(2) do |config|
   config.vm.box = "ubuntu/trusty64"
 
@@ -54,11 +56,11 @@ Vagrant.configure(2) do |config|
 
   config.vm.provision "shell" do |s|
     s.inline = <<-SHELL
-      if [ ! -x /usr/local/bin/ansible ]; then
+      if [ ! -x /usr/local/bin/ansible ] || ! ansible --version | grep #{ANSIBLE_VERSION}; then
         sudo apt-get update -qq
         sudo apt-get install python-pip python-dev -y
         sudo pip install paramiko==1.16.0
-        sudo pip install ansible==2.0.2.0
+        sudo pip install ansible==#{ANSIBLE_VERSION}
       fi
 
       cd /opt/raster-foundry/deployment/ansible && \

--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -1,8 +1,8 @@
 ---
 aws_cli_version: "1.10.47"
 
-docker_version: "1.12.*"
-docker_compose_version: "1.9.0"
+docker_version: "17.*"
+docker_compose_version: "1.13.0"
 
 shellcheck_version: "0.3.*"
 

--- a/deployment/ansible/raster-foundry.yml
+++ b/deployment/ansible/raster-foundry.yml
@@ -8,6 +8,7 @@
       apt: update_cache=yes cache_valid_time=3600
 
   roles:
+    - { role: "azavea.python-security", when: 'ansible_python_version | version_compare("2.7.9", "<")' }
     - role: "raster-foundry.docker"
     - role: "raster-foundry.aws-cli"
 

--- a/deployment/ansible/roles.yml
+++ b/deployment/ansible/roles.yml
@@ -1,8 +1,11 @@
 - src: azavea.docker
-  version: 2.2.0
+  version: 4.0.0
+
+- src: azavea.python-security
+  version: 0.1.0
 
 - src: azavea.pip
-  version: 0.1.1
+  version: 1.0.0
 
 - src: azavea.jenkins
   version: 1.1.1

--- a/deployment/ansible/roles/raster-foundry.docker/defaults/main.yml
+++ b/deployment/ansible/roles/raster-foundry.docker/defaults/main.yml
@@ -1,2 +1,0 @@
----
-docker_compose_version: "1.7.1"

--- a/deployment/vagrant/ansible_galaxy_helper.rb
+++ b/deployment/vagrant/ansible_galaxy_helper.rb
@@ -18,7 +18,7 @@ module AnsibleGalaxyHelper
     ansible_roles_spec = File.join(ansible_directory, "roles.yml")
 
     YAML.load_file(ansible_roles_spec).each do |role|
-      role_name = role["src"]
+      role_name = role["name"] ? role["name"] : role["src"]
       role_version = role["version"]
       role_path = File.join(ansible_directory, "roles", role_name)
       galaxy_metadata = galaxy_install_info(role_path)


### PR DESCRIPTION
## Overview

This PR installs the necessary resources to follow the new installation instructions for `docker v17`.

Changes:
- Bump Version to `v17`.
    - Bump `azavea.docker` version to `4.0.0` (not released yet)
    - This requires the addition of the `azavea.python-security` role, which installs python modules necessary to allow Ansible to interact with servers that use have SNI enabled. 
- Bump `docker-compose` version to `1.13.*`.
    - Remove the old `docker-py` module, which causes errors when installed alongside `docker-compose`. See docker/docker-py#1395
- Update Ansible to `2.3.1`, and add a check to ensure that the right version is installed.
- Modify `ansible_galaxy_helper.rb` to use the Ansible rolespec `name` attribute if it's available when installing roles. I initially did this for convenience while testing some `ansible-docker` and `ansible-python-security` changes, but I think it's a useful addition.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~

### Demo

N/A

### Notes

Once this is reviewed in Development, changes will be applied to CI.

## Testing Instructions
```bash
$ vagrant provision
$ vagrant ssh -c "docker-compose --version; docker --version"
$ vagrant ssh -c "docker-compose --version; docker --version"                            
docker-compose version 1.13.0, build 1719ceb
Docker version 17.03.1-ce, build c6d412e
```
Connects #1958 
Requires azavea/ansible-docker#14
Requires azavea/ansible-python-security#1