### PR TITLE
Correctly produce histograms for small projects

### DIFF
--- a/app-backend/common/src/main/scala/cache/HeapBackedMemcachedClient.scala
+++ b/app-backend/common/src/main/scala/cache/HeapBackedMemcachedClient.scala
@@ -32,6 +32,14 @@ class HeapBackedMemcachedClient(
       .maximumSize(Config.memcached.heapMaxEntries)
       .build[String, Future[Any]]()
 
+
+  /** Clear the specified value within this cache */
+  def delete(key: String) = {
+    client.delete(key)
+    onHeapCache.invalidate(key)
+  }
+
+
   /**
     * Returns the value associated with `cacheKey` in the memcached, obtaining that value from
     * `mappingFunction` if necessary. This method provides a simple substitute for the

--- a/app-backend/tile/src/main/scala/Router.scala
+++ b/app-backend/tile/src/main/scala/Router.scala
@@ -45,6 +45,7 @@ class Router extends LazyLogging
             tileAuthenticateOption { _ =>
               toolRoutes.tms(TileSources.cachedTmsSource) ~
               toolRoutes.validate ~
+              toolRoutes.histogram ~
               toolRoutes.preflight
             }
           }

--- a/app-backend/tile/src/main/scala/image/GlobalSummary.scala
+++ b/app-backend/tile/src/main/scala/image/GlobalSummary.scala
@@ -1,0 +1,97 @@
+package com.azavea.rf.tile.image
+
+import com.azavea.rf.tile._
+import com.azavea.rf.tile.tool.TileSources
+import com.azavea.rf.datamodel.{Tool, ToolRun, User, MosaicDefinition}
+import com.azavea.rf.tool.eval._
+import com.azavea.rf.tool.ast._
+import com.azavea.rf.tool.params._
+import com.azavea.rf.tool.ast.MapAlgebraAST
+import com.azavea.rf.common._
+import com.azavea.rf.common.cache._
+import com.azavea.rf.common.cache.kryo.KryoMemcachedClient
+import com.azavea.rf.database.Database
+import com.azavea.rf.database.tables._
+
+import io.circe._
+import io.circe.syntax._
+import geotrellis.raster._
+import geotrellis.raster.render._
+import geotrellis.raster.histogram._
+import geotrellis.raster.io._
+import geotrellis.vector.io._
+import geotrellis.spark.io._
+import geotrellis.spark._
+import geotrellis.proj4._
+import geotrellis.spark.io.s3.{S3InputFormat, S3AttributeStore, S3CollectionLayerReader, S3ValueReader}
+import com.github.blemale.scaffeine.{Scaffeine, Cache => ScaffeineCache}
+import geotrellis.vector.Extent
+import com.typesafe.scalalogging.LazyLogging
+import spray.json.DefaultJsonProtocol._
+import cats._
+import cats.data._
+import cats.implicits._
+
+import java.security.InvalidParameterException
+import java.util.UUID
+import scala.concurrent._
+import scala.concurrent.duration._
+import scala.util._
+
+
+object GlobalSummary extends LazyLogging {
+
+  /** Get the [[RasterExtent]] which describes the meaningful subset of a layer from metadata */
+  private def getDefinedRasterExtent(md: TileLayerMetadata[_]): RasterExtent = {
+    val re = RasterExtent(md.layout.extent,
+      md.layout.tileLayout.totalCols.toInt,
+      md.layout.tileLayout.totalRows.toInt
+    )
+    val gb = re.gridBoundsFor(md.extent)
+    re.rasterExtentFor(gb).toRasterExtent
+  }
+
+  /** Get the minimum zoom level for a single scene from which a histogram can be constructed without
+    *  losing too much information (too much being defined by the 'size' threshold)
+    */
+  def minAcceptableSceneZoom(sceneId: UUID, store: AttributeStore, size: Int = 512): Option[(Extent, Int)] = {
+    def startZoom(zoom: Int): Option[(Extent, Int)] = {
+      val currentId = LayerId(sceneId.toString, zoom)
+      val metadata = Try { store.readMetadata[TileLayerMetadata[SpatialKey]](currentId) }.toOption
+      metadata.flatMap { meta =>
+        val re = getDefinedRasterExtent(meta)
+        logger.debug(s"Data Extent: ${meta.extent.reproject(WebMercator, LatLng).toGeoJson()}")
+        logger.debug(s"$currentId has (${re.cols},${re.rows}) pixels")
+        if (re.cols >= size || re.rows >= size) Some((meta.extent, currentId.zoom))
+        else startZoom(zoom + 1).orElse(Some(meta.extent, currentId.zoom))
+      }
+    }
+    startZoom(1)
+  }
+
+  /** Get the minimum zoom level for a project from which a histogram can be constructed without
+    *  losing too much information (too much being defined by the 'size' threshold)
+    */
+  def minAcceptableProjectZoom(
+    projId: UUID,
+    size: Int = 512
+  )(implicit database: Database, ec: ExecutionContext): OptionT[Future, (Extent, Int)] =
+    Mosaic.mosaicDefinition(projId, None).semiflatMap({ mosaic =>
+      Future.sequence(mosaic.map { case MosaicDefinition(sceneId, _) =>
+        LayerCache.attributeStoreForLayer(sceneId).mapFilter { case (store, _) =>
+          minAcceptableSceneZoom(sceneId, store, 256)
+        }.value
+      })
+    }).map({ zoomsAndExtents =>
+      zoomsAndExtents.flatten.reduce({ (agg, next) =>
+        val e1 = agg._1
+        val e2 = next._1
+        (Extent(
+          e1.xmin min e2.xmin,
+          e1.ymin min e2.ymin,
+          e1.xmax max e2.xmax,
+          e1.ymax max e2.ymax
+        ), agg._2 max next._2)
+      })
+    })
+}


### PR DESCRIPTION
## Overview

Initially, it appeared as though non-landsat imagery was not appearing on tool endpoints. Further investigation indicated that this was a red herring: the small test cases being used to test non-landsat behavior were being retrieved from S3 without trouble, they just failed to be associated with accurate histograms. The problem with histogram generation was related to the fact that, prior to this PR, they were generated from the least resolution zoom level available - a zoom level which, for small datasets, might collapse the entire raster to a single pixel.

This PR sophisticates the search for the appropriate zoom level by iterating up in zoom levels until one which has enough cells is found. 

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~

### Demo

<img width="484" alt="screen shot 2017-06-13 at 5 00 25 pm" src="https://user-images.githubusercontent.com/1977405/27104366-04c9b69c-505a-11e7-948f-c673945cce5f.png">

### Notes

- In addition to the main set of fixes provided here, cache invalidation was added in the course of debugging and can be kicked off in preflight with the `voidCache=true` query parameter.
- The threshold is parametric and perhaps it would be useful to expose this parameter in certain instances (if we need more fully correct histograms for certain purposes)
- It should be noted that `Project` histograms might have difficulties with the current solution in certain instances. This is because the least resolute zoom level which provides sufficient data is the level for which histograms are produced - this means that larger datasets will have disproportionately large effects (which is maybe desirable behavior but which might make it difficult to reason about histogram output)


Closes #1906
