### PR TITLE
Increase Airflow parallelism

### DIFF
--- a/app-tasks/usr/local/airflow/airflow.cfg
+++ b/app-tasks/usr/local/airflow/airflow.cfg
@@ -45,13 +45,13 @@ sql_alchemy_pool_recycle = 3600
 parallelism = ${AIRFLOW_PARALLELISM}
 
 # The number of task instances allowed to run concurrently by the scheduler
-dag_concurrency = 24
+dag_concurrency = 16
 
 # Are DAGs paused by default at creation
 dags_are_paused_at_creation = False
 
 # The maximum number of active DAG runs per DAG
-max_active_runs_per_dag = 24
+max_active_runs_per_dag = 16
 
 # Whether to load the examples that ship with Airflow. It's good to
 # get started, but you probably want to set this to False in a production
@@ -174,4 +174,4 @@ scheduler_heartbeat_sec = 5
 # The scheduler can run multiple threads in parallel to schedule dags.
 # This defines how many threads will run. However airflow will never
 # use more threads than the amount of cpu cores available.
-max_threads = 1
+max_threads = 2

--- a/docker-compose.airflow.yml
+++ b/docker-compose.airflow.yml
@@ -21,12 +21,12 @@ services:
       - redis:cache.service.rasterfoundry.internal
     environment:
       - AIRFLOW_HOME=/usr/local/airflow
-      - AIRFLOW_PARALLELISM=2
+      - AIRFLOW_PARALLELISM=8
       - AIRFLOW_FERNET_KEY=secret
       - AIRFLOW_BASE_URL=http://localhost:8080
       - AIRFLOW_WEBSERVER_WORKERS=1
       - AIRFLOW_SECRET_KEY=secret
-      - AIRFLOW_CELERY_CONCURRENCY=4
+      - AIRFLOW_CELERY_CONCURRENCY=2
       - RF_HOST=http://rasterfoundry.com:9000
     ports:
       - "8080:8080"
@@ -48,12 +48,12 @@ services:
       - AIRFLOW_HOME=/usr/local/airflow
       - AIRFLOW_REMOTE_LOG_FOLDER=
       - AIRFLOW_REMOTE_LOG_CONN_ID=
-      - AIRFLOW_PARALLELISM=2
+      - AIRFLOW_PARALLELISM=8
       - AIRFLOW_FERNET_KEY=secret
       - AIRFLOW_BASE_URL=http://localhost:8080
       - AIRFLOW_WEBSERVER_WORKERS=1
       - AIRFLOW_SECRET_KEY=secret
-      - AIRFLOW_CELERY_CONCURRENCY=4
+      - AIRFLOW_CELERY_CONCURRENCY=2
       - RF_HOST=http://rasterfoundry.com:9000
     ports:
       - "5555:5555"
@@ -80,12 +80,12 @@ services:
       - AIRFLOW_HOME=/usr/local/airflow
       - AIRFLOW_REMOTE_LOG_FOLDER=
       - AIRFLOW_REMOTE_LOG_CONN_ID=
-      - AIRFLOW_PARALLELISM=32
+      - AIRFLOW_PARALLELISM=8
       - AIRFLOW_FERNET_KEY=secret
       - AIRFLOW_BASE_URL=http://localhost:8080
       - AIRFLOW_WEBSERVER_WORKERS=1
       - AIRFLOW_SECRET_KEY=secret
-      - AIRFLOW_CELERY_CONCURRENCY=4
+      - AIRFLOW_CELERY_CONCURRENCY=2
       - PYTHONPATH=/opt/raster-foundry/app-tasks/rf/src/
       - RF_HOST=http://rasterfoundry.com:9000
     command: airflow scheduler
@@ -112,12 +112,12 @@ services:
       - AIRFLOW_HOME=/usr/local/airflow
       - AIRFLOW_REMOTE_LOG_FOLDER=
       - AIRFLOW_REMOTE_LOG_CONN_ID=
-      - AIRFLOW_PARALLELISM=32
+      - AIRFLOW_PARALLELISM=8
       - AIRFLOW_FERNET_KEY=secret
       - AIRFLOW_BASE_URL=http://localhost:8080
       - AIRFLOW_WEBSERVER_WORKERS=1
       - AIRFLOW_SECRET_KEY=secret
-      - AIRFLOW_CELERY_CONCURRENCY=4
+      - AIRFLOW_CELERY_CONCURRENCY=2
       - RF_HOST=http://rasterfoundry.com:9000
     command: airflow worker
 
@@ -142,11 +142,11 @@ services:
       - AIRFLOW_HOME=/usr/local/airflow
       - AIRFLOW_REMOTE_LOG_FOLDER=
       - AIRFLOW_REMOTE_LOG_CONN_ID=
-      - AIRFLOW_PARALLELISM=32
+      - AIRFLOW_PARALLELISM=8
       - AIRFLOW_FERNET_KEY=secret
       - AIRFLOW_BASE_URL=http://localhost:8080
       - AIRFLOW_WEBSERVER_WORKERS=1
       - AIRFLOW_SECRET_KEY=secret
-      - AIRFLOW_CELERY_CONCURRENCY=4
+      - AIRFLOW_CELERY_CONCURRENCY=2
       - RF_HOST=http://rasterfoundry.com:9000
     command: airflow worker -q spark


### PR DESCRIPTION
## Overview

All of the changes to `docker-compose.airflow.yml` pertain only to the development environment. They are mainly aimed at keeping proportions closer to what they are in the default Airflow configuration.

Changes directly to the Airflow configuration file are to better align with the Airflow defaults based on the version we are currently running. The only one that should have a direct impact to AWS environments is `max_threads` for the scheduler. All other changes to resolve this issue were made via configuration settings that get passed through the environment.

Closes #1760 

## Testing Instructions

Navigate to the Flower UI for staging and production. Click through one of the workers and note the **Max concurrency** value. It should be **2**:

- https://flower.staging.rasterfoundry.com/
- https://flower.rasterfoundry.com/

In addition, kick off two ingests by creating two projects via the staging UI. Monitor Airflow to ensure that they are both being processed.