### PR TITLE
Improve error when operation lacks 'apply'

### DIFF
--- a/app-backend/tool/src/main/scala/ast/codec/MapAlgebraCodec.scala
+++ b/app-backend/tool/src/main/scala/ast/codec/MapAlgebraCodec.scala
@@ -16,6 +16,8 @@ trait MapAlgebraCodec
     ma._symbol match {
       case Some(_) =>
         ma.as[MapAlgebraAST.Operation]
+      case None if (ma._fields.contains("args")) =>
+        Left(DecodingFailure("Unrecognized node type: $ma", ma.history))
       case None =>
         ma.as[MapAlgebraAST.Source]
     }

--- a/app-backend/tool/src/main/scala/ast/package.scala
+++ b/app-backend/tool/src/main/scala/ast/package.scala
@@ -14,7 +14,7 @@ package object ast extends MapAlgebraCodec {
     def _label: Option[String] = root.metadata.label.string.getOption(self)
     def _symbol: Option[String] = root.selectDynamic("apply").string.getOption(self)
 
-    def _fields: Option[Seq[String]] = root.obj.getOption(self).map(_.fields)
+    def _fields: Seq[String] = root.obj.getOption(self).map(_.fields).getOrElse(Seq())
   }
 
   implicit class CirceMapAlgebraHCursorMethods(val self: HCursor) {
@@ -23,7 +23,7 @@ package object ast extends MapAlgebraCodec {
     def _label: Option[String] = self.value._label
     def _symbol: Option[String] = self.value._symbol
 
-    def _fields: Option[Seq[String]] = self.value._fields
+    def _fields: Seq[String] = self.value._fields
   }
 
   implicit class MapAlgebraASTHelperMethods(val self: MapAlgebraAST) {

--- a/app-backend/tool/src/test/scala/eval/InterpreterSpec.scala
+++ b/app-backend/tool/src/test/scala/eval/InterpreterSpec.scala
@@ -84,7 +84,7 @@ class InterpreterSpec
     val lt = Await.result(ret, 10.seconds)
 
     requests should be (empty)
-    lt should be (Invalid(NEL.of(MissingParameter(src2.id), RasterRetrievalError(src1.id, theTileSource.id))))
+    lt should be (Invalid(NEL.of(RasterRetrievalError(src1.id, theTileSource.id), MissingParameter(src2.id))))
   }
 
   it("interpretPure - simple") {
@@ -349,7 +349,7 @@ class InterpreterSpec
     val op = Await.result(ret, 10.seconds) match {
       case Valid(lazytile) =>
         val maybeTile = lazytile.evaluateDouble
-        requests.length should be (2)
+        requests.length should be (4)
         maybeTile.get.getDouble(0, 0) should be (-4.0/6.0)
       case i@Invalid(_) =>
         fail(s"$i")


### PR DESCRIPTION
## Overview

This PR provides a slight improvement on the detail offered when an operation is missing its 'apply' field.
