### PR TITLE
Use tile.band function

### DIFF
--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/ColorCorrect.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/ColorCorrect.scala
@@ -212,7 +212,7 @@ object WhiteBalance {
       cfor(0)(_ < newTile.cols, _ + 1) { col =>
         val bandValues = Array.ofDim[Int](newTile.bandCount)
         cfor(0)(_ < newTile.bandCount, _ + 1) { band =>
-          bandValues(band) = newTile.bands(band).get(col, row)
+          bandValues(band) = newTile.band(band).get(col, row)
         }
         array(col)(row) = f(bandValues)
       }

--- a/app-backend/tile/src/main/scala/tool/TileSources.scala
+++ b/app-backend/tile/src/main/scala/tool/TileSources.scala
@@ -65,7 +65,7 @@ object TileSources extends LazyLogging {
       case project @ ProjectRaster(projId, Some(band)) =>
         GlobalSummary.minAcceptableProjectZoom(projId).flatMap { case (extent, zoom) =>
           Mosaic.rawForExtent(projId, zoom, Some(Projected(extent.toPolygon, 3857)))
-            .map({ tile => tile.bands(band) })
+            .map({ tile => tile.band(band) })
         }.value
 
       case project @ ProjectRaster(projId, None) =>
@@ -79,7 +79,7 @@ object TileSources extends LazyLogging {
     r match {
       case scene @ SceneRaster(sceneId, Some(band)) =>
         LayerCache.layerTile(sceneId, z, SpatialKey(x, y))
-          .map(tile => tile.bands(band)).value
+          .map(tile => tile.band(band)).value
 
       case scene @ SceneRaster(sceneId, None) =>
         logger.warn(s"Request for $scene does not contain band index")
@@ -87,7 +87,7 @@ object TileSources extends LazyLogging {
 
       case project @ ProjectRaster(projId, Some(band)) =>
         Mosaic.raw(projId, z, x, y)
-          .map(tile => tile.bands(band)).value
+          .map(tile => tile.band(band)).value
 
       case project @ ProjectRaster(projId, None) =>
         logger.warn(s"Request for $project does not contain band index")

--- a/app-backend/tool/src/main/scala/eval/LazyTile.scala
+++ b/app-backend/tool/src/main/scala/eval/LazyTile.scala
@@ -138,7 +138,7 @@ object LazyTile {
         case Some(LazyTile.Var(symbol, band)) =>
           LazyTile.Var(symbol, band)
         case Some(Unbound(Some(mbtile))) =>
-          Bound(mbtile.bands(band.getOrElse(0)))
+          Bound(mbtile.band(band.getOrElse(0)))
         case Some(Unbound(None)) =>
           LazyTile.Empty
         case None =>


### PR DESCRIPTION
## Overview

@fosskers pointed out that we were using the `bands` function along with an indexed call into the `Vector` it generates rather than `band`, which should just grab the band immediately from the underlying array. This is a free performance improvement.
