### PR TITLE
Omit port from Dropbox OAuth redirect URL

### DIFF
--- a/app-frontend/src/app/pages/settings/connections/connections.controller.js
+++ b/app-frontend/src/app/pages/settings/connections/connections.controller.js
@@ -52,7 +52,7 @@ class ConnectionsController {
 
         let offsets = calculateOffsets(500, 500);
         let origin = `${this.$location.protocol()}://${this.$location.host()}` +
-            `${this.$location.port() ? ':' + this.$location.port() : ''}`;
+            `${this.$location.port() !== 443 ? ':' + this.$location.port() : ''}`;
         let dropboxOauthUrl = 'https://dropbox.com/oauth2/authorize?response_type=code' +
             `&client_id=${this.config.dropboxClientId}` +
             `&redirect_uri=${origin}/callback`;


### PR DESCRIPTION
## Overview

This change omits the trailing port number in the Dropbox authorization workflow `redirect_uri` when served over HTTPS.

Fixes https://github.com/azavea/raster-foundry/issues/1993

## Testing Instructions

I built the static bundle and Nginx container image locally, then pushed it to ECR using the tag that's currently deployed. After cycling the API task instance, the new image went live.

You should not be able to connect Dropbox by navigating to https://app.staging.rasterfoundry.com/settings/connections and completing the authorization workflow.