### PR TITLE
updates tools page, fixes border-radius issue

### DIFF
--- a/app-frontend/src/app/components/tools/toolItem/toolItem.html
+++ b/app-frontend/src/app/components/tools/toolItem/toolItem.html
@@ -1,21 +1,20 @@
-<div class="list-group-item selectable wrap">
-  <img ng-if="$ctrl.toolData.screenshots[0]"
+<div class="panel-body">
+  <div class="row">
+    <div class="column noflex">
+      <img ng-if="$ctrl.toolData.screenshots[0]"
        ng-src="{{$ctrl.toolData.screenshots[0].url}}"
        class="rounded-img item-img">
-  <div ng-if="!$ctrl.toolData.screenshots.length"
-       class="rounded-img item-img image-placeholder"
-       style="height: 75px; width: 75px;">
-  </div>
-  <div>
-    <div class="list-item-header">
-      {{$ctrl.toolData.title}}
+      <div ng-if="!$ctrl.toolData.screenshots.length"
+           class="rounded-img item-img image-placeholder"
+           style="height: 75px; width: 75px;">
+      </div><br>
+      <!-- Temporarily add execute btn until detail page designed -->
+        <a ui-sref="lab.run({toolid: $ctrl.toolData.id})" class="btn btn-primary btn-tiny btn-block">Execute</a>
     </div>
-    <div class="list-item-description">
-      {{$ctrl.toolData.description}}
-    </div>
-    <!-- @TODO: This username will need to be dynamic once other users can create tools -->
-    <div class="list-item-attribution">
-      Uploaded by: Raster Foundry
+    <div class="column">
+      <h4 class="panel-title">{{$ctrl.toolData.title}}</h4>
+      <p>{{$ctrl.toolData.description}}</p>
+      <strong>Created by: Raster Foundry</strong>
     </div>
   </div>
 </div>

--- a/app-frontend/src/app/components/tools/toolSearch/toolSearch.html
+++ b/app-frontend/src/app/components/tools/toolSearch/toolSearch.html
@@ -1,30 +1,15 @@
-<div class="navbar secondary-navbar">
-  <div class="navbar-left">
-    <nav ng-show="$ctrl.$state.$current.name === 'market.tool'">
-      <a href ui-sref="market.search" class="active"> < Back to search results</a>
-    </nav>
-    <nav ng-show="$ctrl.$state.$current.name === 'market.search'">
-      <ng-submit ng-submit="$ctrl.onSearchAction()">
-        <div class="form-group all-in-one input-dark">
-          <label for="search-input">
-            <i class="icon-search"></i>
-          </label>
-          <input type="text"
-                 id="search-input"
-                 class="form-control input-dark"
-                 placeholder="Search for tools"
-                 ng-model="$ctrl.searchText"
-                 ng-keyup="$event.keyCode == 13 && $ctrl.onSearchAction()"/>
-          <button ng-click="$ctrl.clearSearch()" type="button" class="btn btn-link">
-            <i class="icon-cross close"></i>
-          </button>
-        </div>
-      </ng-submit>
-    </nav>
-  </div>
-  <div class="navbar-right">
-    <nav>
-      <a href ui-sref="lab/list">My Tools</a>
-    </nav>
-  </div>
-</div>
+<nav ng-show="$ctrl.$state.$current.name === 'market.search'">
+  <ng-submit ng-submit="$ctrl.onSearchAction()">
+    <div class="form-group search-form">
+      <input type="text"
+             id="search-input"
+             class="form-control"
+             placeholder="Search for tools"
+             ng-model="$ctrl.searchText"
+             ng-keyup="$event.keyCode == 13 && $ctrl.onSearchAction()"/>
+      <button ng-click="$ctrl.onSearchAction()" type="button" class="btn btn-link">
+        <i class="icon-search"></i>
+      </button>
+    </div>
+  </ng-submit>
+</nav>

--- a/app-frontend/src/app/pages/market/market.html
+++ b/app-frontend/src/app/pages/market/market.html
@@ -1,2 +1,1 @@
-<rf-tool-search feature-flag="market-search" on-search="$ctrl.search(text)"></rf-tool-search>
 <ui-view></ui-view>

--- a/app-frontend/src/app/pages/market/search/search.html
+++ b/app-frontend/src/app/pages/market/search/search.html
@@ -1,76 +1,36 @@
-<div class="container column-stretch dashboard-filter wide">
-  <div class="sidebar">
-    <div class="sidebar-scrollable">
-      <div feature-flag="market-search" class="sidebar-category">
-        <div class="sidebar-category-title">
-          Search Terms
-        </div>
-        <div class="sidebar-category-contents">
-          <button class="btn btn-tag"
-                  ng-repeat="searchTerm in $ctrl.searchTerms"
-                  ng-click="$ctrl.removeSearchTerm($index)">
-            {{searchTerm}}
-            <i class="icon-cross" ></i>
-          </button>
-        </div>
-        <div class="sidebar-category-actions">
-          <a href ng-click="$ctrl.clearSearch()">Clear All</a>
-        </div>
-      </div>
-      <div feature-flag="market-search" class="sidebar-separator"></div>
-      <div class="sidebar-category">
-        <div class="sidebar-category-title">
-          Tags
-        </div>
-        <div class="sidebar-category-contents">
-          <div class="sidebar-selection"
-               ng-repeat="tag in $ctrl.toolTagList">
-            <input id="search-tag-{{$id}}" type="checkbox" ng-change="$ctrl.handleTagChange(tag)" ng-checked="tag.selected" ng-model="tag.selected"/>
-            <label for="search-tag-{{$id}}">{{tag.tag}}</label>
-          </div>
-        </div>
-        <div class="sidebar-category-actions">
-          <a href ng-click="$ctrl.viewMoreTags()">View More</a>
-        </div>
-      </div>
-      <div class="sidebar-separator"></div>
-      <div class="sidebar-category">
-        <div class="sidebar-category-title">
-          Category
-        </div>
-        <div class="sidebar-category-contents">
-          <div class="sidebar-selection"
-               ng-repeat="category in $ctrl.toolCategoryList">
-            <input id="search-category-{{$id}}" type="checkbox" ng-change="$ctrl.handleCategoryChange(category)" ng-checked="category.selected" ng-model="category.selected">
-            <label for="search-category-{{$id}}">{{category.category}}</label>
-          </div>
-        </div>
-        <div class="sidebar-category-actions">
-          <a href ng-click="$ctrl.viewMoreCategories()">View More</a>
-        </div>
-      </div>
-    </div>
-  </div>
+<div class="app-content">
+<div class="container dashboard">
   <div class="main">
-    <div class="content">
-      <div class="row stack-sm">
-        <h1 class="h3 page-title">
-          <a>Showing {{$ctrl.pagination.startingItem}} - {{$ctrl.pagination.endingItem}} of {{$ctrl.pagination.count}} results</a>
-        </h1>
+  <div class="row content stack-sm">
+    <div class="column-8">
+       <!-- Dashboard Header -->
+      <div class="dashboard-header">
+        <h1 class="h3">Tools</h1>
+        <div class="flex-fill"></div>
+        <rf-tool-search on-search="$ctrl.search(text)"></rf-tool-search>
+        <a class="btn btn-primary">New tool</a>
       </div>
-      <div class="row stack-sm">
-        <div class="column">
-          <div class="embedded-scrollable">
-            <div class="list-group">
-              <rf-tool-item
-                  ng-repeat="toolData in $ctrl.toolList"
-                  tool-data="toolData"
-                  ng-click="$ctrl.navTool(toolData)"
-              ></rf-tool-item>
-            </div>
-          </div>
-        </div>
+      <!-- Dashboard Header -->
+
+      <!-- Loading indicator -->
+      <div ng-show="$ctrl.loading">
+        <span class="list-placeholder h3">
+          <i class="icon-load"></i>
+        </span>
       </div>
+      <!-- Loading indicator -->
+
+      <p class="font-size-small">Showing {{$ctrl.pagination.startingItem}} - {{$ctrl.pagination.endingItem}} of {{$ctrl.pagination.count}} tools</p>
+
+      <!-- Temporarily removed ng-click until after demo done and detail page designed. -->
+      <rf-tool-item
+          class="panel panel-off-white"
+          ng-repeat="toolData in $ctrl.toolList"
+          tool-data="toolData"
+          ng-click=""
+      ></rf-tool-item>
+
+      <!-- Pagination -->
       <div class="list-group text-center"
            ng-show="!$ctrl.loading && $ctrl.queryResult && $ctrl.pagination.show && !$ctrl.errorMsg">
         <ul uib-pagination
@@ -84,6 +44,110 @@
             ng-change="$ctrl.populateToolList($ctrl.currentPage)">
         </ul>
       </div>
+      <!-- Pagination -->
+    </div>
+
+    <div class="column spacer"></div>
+    <div class="column">
+
+      <!-- Tool Filters -->
+      <div class="aside aside-filters">
+        <section>
+          <!-- The markup for these checkboxes are good, the angular is hacky -->
+          <!-- <label class="checkbox {{active}}"><input type="checkbox"> {{text label}} </label> -->
+          <ul class="list-unstyled">
+            <li>
+              <label class="checkbox" ng-class="{active : isChecked}">
+                <input id="1" type="checkbox" ng-model="isChecked"/>
+                My tools
+              </label>
+            </li>
+            <li>
+              <label class="checkbox" ng-class="{active : isChecked2}">
+                <input id="2" type="checkbox" ng-model="isChecked2"/>
+                Liked
+              </label>
+            </li>
+            <li>
+              <label class="checkbox" ng-class="{active : isChecked3}">
+                <input id="3" type="checkbox" ng-model="isChecked3"/>
+                Public catalog
+              </label>
+            </li>
+          </ul>
+        </section>
+        <section feature-flag="market-search">
+          <h5>
+            Search terms
+            <a href ng-click="$ctrl.clearSearch()" class="pull-right">Clear</a>
+          </h5>
+          <ul class="list-unstyled">
+            <li ng-repeat="searchTerm in $ctrl.searchTerms">
+              <button class="btn btn-tag"
+                      ng-click="$ctrl.removeSearchTerm($index)">
+                {{searchTerm}}
+                <i class="icon-cross"></i>
+              </button>
+            </li>
+          </ul>
+        </section>
+        <section>
+          <h5>Tags</h5>
+
+          <!-- THESE ARE PLACEHOLDER TAGS BECAUSE THERE ARE NONE CURRENTLY -->
+          <ul class="list-unstyled">
+            <li>
+              <label class="checkbox" ng-class="{active : isChecked4}">
+                <input id="tag1" type="checkbox" ng-model="isChecked4"/>
+                Vegetation index
+              </label>
+            </li>
+            <li>
+              <label class="checkbox" ng-class="{active : isChecked5}">
+                <input id="tag2" type="checkbox" ng-model="isChecked5"/>
+                Image classification
+              </label>
+            </li>
+            <li>
+              <label class="checkbox" ng-class="{active : isChecked6}">
+                <input id="tag3" type="checkbox" ng-model="isChecked6"/>
+                Change
+              </label>
+            </li>
+            <li>
+              <label class="checkbox" ng-class="{active : isChecked7}">
+                <input id="tag4" type="checkbox" ng-model="isChecked7"/>
+                Water index
+              </label>
+            </li>
+          </ul>
+          <ul class="list-unstyled">
+            <li ng-repeat="tag in $ctrl.toolTagList">
+              <label for="search-tag-{{$id}}" class="checkbox">
+                <input id="search-tag-{{$id}}" type="checkbox" ng-change="$ctrl.handleTagChange(tag)" ng-checked="tag.selected" ng-model="tag.selected"/>
+                {{tag.tag}}
+              </label>
+            </li>
+            <li><a href ng-click="$ctrl.viewMoreTags()">View More</a></li>
+          </ul>
+        </section>
+
+        <section>
+          <h5>Category</h5>
+          <ul class="list-unstyled">
+            <li ng-repeat="category in $ctrl.toolCategoryList">
+              <label for="search-category-{{$id}}" class="checkbox" ng-class="{active : category.selected}">
+                <input id="search-category-{{$id}}" type="checkbox" ng-checked="category.selected" ng-model="category.selected">
+                {{category.category}}
+              </label>
+            </li>
+            <li><a href ng-click="$ctrl.viewMoreCategories()">View More</a></li>
+          </ul>
+        </section>
+      </div>
+      <!-- Tool Filters -->
     </div>
   </div>
+</div>
+</div>
 </div>

--- a/app-frontend/src/assets/styles/sass/base/_grid.scss
+++ b/app-frontend/src/assets/styles/sass/base/_grid.scss
@@ -82,7 +82,7 @@
 }
 
 .column.noflex {
-  flex: 0;
+  flex: none;
 }
 
 // Individual column vertical aligment

--- a/app-frontend/src/assets/styles/sass/components/_form.scss
+++ b/app-frontend/src/assets/styles/sass/components/_form.scss
@@ -46,7 +46,7 @@ label {
   background-color: #fff;
   background-image: none;
   border: 1px solid $border-color-default;
-  border-radisu: $border-radius-base;
+  border-radius: $border-radius-base;
 
   &:focus {
     border-color: $brand-primary;
@@ -132,7 +132,7 @@ input[type=radio] {
   display: flex;
   flex-direction: row;
   align-items: stretch;
-  border-radisu: $border-radius-base;
+  border-radius: $border-radius-base;
   border: 1px solid $border-color-default;
   background-color: #fff;
 
@@ -167,4 +167,83 @@ input[type=radio] {
 
 .form-group.all-in-one.stacked {
   flex-direction: column;
+}
+
+.form-group.search-form {
+  display: flex;
+  flex-direction: row;
+  align-items: stretch;
+  border-radius: $border-radius-base;
+  border: 1px solid $border-color-default;
+
+  .form-control {
+    border: none;
+    height: 3.2rem;
+  }
+
+  .btn-link {
+    border: none;
+  }
+}
+
+label.checkbox {
+  position: relative;
+  display: flex;
+  align-items: center;
+  font-weight: 500;
+  margin: 0;
+
+  &:after {
+    content: '';
+    order: -1;
+    vertical-align: middle;
+    width: 2rem;
+    height: 2rem;
+    border-radius: 2px;
+    border: 1px solid $shade-light;
+    background: white;
+  }
+
+  &:before {
+    content: '\e803'; // see fontello.css .icon-check:before
+    order: 0;
+    font-family: "fontello";
+    font-style: normal;
+    font-weight: normal;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    margin-left: -17px;
+    position: relative;
+    z-index: 1;
+    visibility: hidden;
+    opacity: 0;
+    transform: scale(.1);
+    transition: .2s ease-in-out opacity, .4s cubic-bezier(0.68, -0.55, 0.27, 1.55) transform;
+  }
+
+  input[type=checkbox] {
+    visibility: hidden;
+    margin-left: -1rem;
+  }
+
+  &.active {
+    color: $brand-primary;
+    transition: .2s ease-in-out color;
+
+    &:after {
+      border-color: $brand-primary;
+    }
+
+    &:before {
+      visibility: visible;
+      opacity: 1;
+      transform: scale(1);
+    }
+  }
+
+  &:hover:not(.active):before {
+    visibility: visible;
+    opacity: .4;
+    transform: scale(1);
+  }
 }

--- a/app-frontend/src/assets/styles/sass/components/_image.scss
+++ b/app-frontend/src/assets/styles/sass/components/_image.scss
@@ -10,7 +10,7 @@ img {
 }
 
 .rounded-img {
-  border-radisu: $border-radius-base;
+  border-radius: $border-radius-base;
 }
 
 .circle-img {

--- a/app-frontend/src/assets/styles/sass/components/_instructions.scss
+++ b/app-frontend/src/assets/styles/sass/components/_instructions.scss
@@ -1,6 +1,6 @@
 .instructions-container {
   border: 1px solid $border-color-default;
-  border-radisu: $border-radius-base;
+  border-radius: $border-radius-base;
   margin: 1rem;
   padding: 2.5rem;
   text-align: center;

--- a/app-frontend/src/assets/styles/sass/components/_modal.scss
+++ b/app-frontend/src/assets/styles/sass/components/_modal.scss
@@ -52,7 +52,7 @@
 .modal-content {
   position: relative;
   background-color: lighten($off-white, 2%);
-  border-radisu: $border-radius-base;
+  border-radius: $border-radius-base;
   background-clip: padding-box;
   outline: 0;
   display: flex;

--- a/app-frontend/src/assets/styles/sass/components/_pagination.scss
+++ b/app-frontend/src/assets/styles/sass/components/_pagination.scss
@@ -25,7 +25,7 @@ $cursor-disabled: default;
   display: inline-block;
   padding-left: 0;
   margin: 2rem 0;
-  border-radisu: $border-radius-base;
+  border-radius: $border-radius-base;
 
   > li {
     display: inline; // Remove list-style and block-level defaults

--- a/app-frontend/src/assets/styles/sass/components/_panel.scss
+++ b/app-frontend/src/assets/styles/sass/components/_panel.scss
@@ -1,6 +1,6 @@
 .panel {
   border: 1px solid #ccc;
-  border-radisu: $border-radius-base;
+  border-radius: $border-radius-base;
   display: block;
   width: 100%;
   margin-bottom: 1rem;
@@ -23,8 +23,18 @@
 .panel-body {
   padding: 2rem;
 
+  .row {
+    margin-bottom: 0;
+  }
+
   .btn {
     margin-top: .5rem;
     margin-bottom: .5rem;
   }
+}
+
+.panel-title {
+  @extend .font-base;
+  font-size: 1.6rem;
+  margin: 0;
 }

--- a/app-frontend/src/assets/styles/sass/components/_slider.scss
+++ b/app-frontend/src/assets/styles/sass/components/_slider.scss
@@ -15,7 +15,7 @@
   }
 
   .rz-bar {
-    border-radisu: $border-radius-base;
+    border-radius: $border-radius-base;
     height: 12px;
     background: $shade-dark;
     display: block;

--- a/app-frontend/src/assets/styles/sass/components/_tooltip.scss
+++ b/app-frontend/src/assets/styles/sass/components/_tooltip.scss
@@ -44,7 +44,7 @@
   color: #fff;
   text-align: center;
   background-color: #586287;
-  border-radisu: $border-radius-base;
+  border-radius: $border-radius-base;
 }
 
 // Arrows

--- a/app-frontend/src/assets/styles/sass/layout/_aside.scss
+++ b/app-frontend/src/assets/styles/sass/layout/_aside.scss
@@ -1,7 +1,7 @@
 aside,
 .aside {
   padding: 2rem;
-  border-radisu: $border-radius-base;
+  border-radius: $border-radius-base;
   border: 1px solid $border-color-default;
 
   a {
@@ -29,5 +29,24 @@ aside,
     margin: 0 -2rem -2rem;
     padding: 2rem;
     background: rgba($shade-light, .1);
+  }
+}
+
+.aside-filters {
+  background: rgba($shade-light, .1);
+  padding: 0 2rem;
+
+  section {
+    padding: 2rem 0;
+    margin: 0;
+    border-bottom: 1px solid $border-color-default;
+
+    &:last-of-type {
+      border-bottom: none;
+    }
+  }
+
+  h5 {
+    margin: 0 0 1rem;
   }
 }

--- a/app-frontend/src/assets/styles/sass/layout/_container.scss
+++ b/app-frontend/src/assets/styles/sass/layout/_container.scss
@@ -23,6 +23,10 @@
     &.dashboard {
       width: 100%;
 	    max-width: 1200px;
+
+      > .row {
+        flex: 1;
+      }
     }
     &.dashboard-filter {
       width: 100%;

--- a/app-frontend/src/assets/styles/sass/layout/_navbar.scss
+++ b/app-frontend/src/assets/styles/sass/layout/_navbar.scss
@@ -55,7 +55,7 @@
     padding: .8rem 1rem;
     margin: 0 1rem;
     border: 1px solid $shade-dark;
-    border-radisu: $border-radius-base;
+    border-radius: $border-radius-base;
 
     i {
       vertical-align: middle;
@@ -88,7 +88,7 @@
     > a.dropdown-toggle {
       padding: .8rem 1rem;
       border: 1px solid $shade-dark;
-      border-radisu: $border-radius-base;
+      border-radius: $border-radius-base;
       color: #fff;
     }
   }

--- a/app-frontend/src/assets/styles/sass/pages/_dashboard.scss
+++ b/app-frontend/src/assets/styles/sass/pages/_dashboard.scss
@@ -15,6 +15,10 @@
       margin-right: 1rem;
     }
   }
+
+  .form-group {
+    margin: 0 1rem;
+  }
 }
 
 .dashboard-header-reveal {
@@ -94,12 +98,13 @@
   ul:not(.dropdown-menu) {
     line-height: 1;
     font-size: 1.3rem;
+    display: block;
   }
 }
 
 .project-preview-container {
   height: 20rem;
-  border-radisu: $border-radius-base;
+  border-radius: $border-radius-base;
 
   &.placeholder {
     background: white;


### PR DESCRIPTION
## Overview

The main reason for the PR is to cleanup the tools page. In doing so, I purposefully removed some functionality and also added some placeholder content in order to support an upcoming demo. 

The second reason for this PR is to fix a spelling error on all `border-radius` specifications in the scss. 

**Misc changes:**
- adds new css flavored checkboxes.
- fixes ie11 flex layout issue


### Demo
<img width="1355" alt="screen shot 2017-06-16 at 9 29 21 am" src="https://user-images.githubusercontent.com/1928955/27228770-f1984a60-5276-11e7-868b-66ad954122b6.png">


### Notes

I removed the click event that goes to tool details page and added the execute button to the tool itself within the list view. This is a temporary change. The tool detail page remains unstyled and isn't ready to be viewed in demos.

The placeholder content I mentioned are the tags that are visible in the filters.


## Testing Instructions

 * go to tools page in navbar.

Closes #1294
