### PR TITLE
Use https for base of landsat URLs

### DIFF
--- a/app-backend/batch/src/main/resources/application.conf
+++ b/app-backend/batch/src/main/resources/application.conf
@@ -41,8 +41,8 @@ landsat8 {
   usgsLandsatUrl   = "https://landsat.usgs.gov/landsat/metadata_service/bulk_metadata_files/LANDSAT_8.csv"
   usgsLandsatUrlC1 = "https://landsat.usgs.gov/landsat/metadata_service/bulk_metadata_files/LANDSAT_8_C1.csv"
   awsRegion        = "us-west-2"
-  awsLandsatBase   = "http://landsat-pds.s3.amazonaws.com/"
-  awsLandsatBaseC1 = "http://landsat-pds.s3.amazonaws.com/c1/"
+  awsLandsatBase   = "https://landsat-pds.s3.amazonaws.com/"
+  awsLandsatBaseC1 = "https://landsat-pds.s3.amazonaws.com/c1/"
   bucketName       = "landsat-pds"
 }
 


### PR DESCRIPTION

## Overview
Uses `https` for base landsat URLs

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~

### Demo

Note the thumbnail URLs for the most recent imported versions are SSL

![verify-ssl](https://user-images.githubusercontent.com/898060/27231512-d56b3708-5280-11e7-9698-cfc63a5c2de5.png)

## Testing Instructions

 * Rebuild batch jar
 * Load airflow worker in shell: `./scripts/console airflow-worker bash`
 * Load Landsat 8 data for a day: `java -cp /opt/raster-foundry/jars/rf-batch.jar com.azavea.rf.batch.Main import_landsat8 2017-06-13`
 * Verify new Landsat 8 thumbnails use `https` in UI after starting scripts server

Closes #1975
