### PR TITLE
Move webpack manifest plugin to prod only

### DIFF
--- a/app-frontend/config/webpack/environments/production.js
+++ b/app-frontend/config/webpack/environments/production.js
@@ -4,11 +4,15 @@
  no-console: 0
  */
 
+const path = require('path');
 const webpack = require('webpack');
 const CleanWebpackPlugin = require('clean-webpack-plugin');
 const WebpackFailPlugin = require('webpack-fail-plugin');
+const Manifest = require('manifest-revision-webpack-plugin');
 
 module.exports = function (_path) {
+    let rootAssetPath = _path + 'src';
+
     return {
         context: _path,
         debug: false,
@@ -24,6 +28,10 @@ module.exports = function (_path) {
                 root: _path,
                 verbose: true,
                 dry: false
+            }),
+            new Manifest(path.join(_path + '/config', 'manifest.json'), {
+                rootAssetPath: rootAssetPath,
+                ignorePaths: ['.DS_Store']
             }),
             new webpack.DefinePlugin({
                 'process.env': {

--- a/app-frontend/config/webpack/environments/production.js
+++ b/app-frontend/config/webpack/environments/production.js
@@ -29,7 +29,7 @@ module.exports = function (_path) {
                 verbose: true,
                 dry: false
             }),
-            new Manifest(path.join(_path + '/config', 'manifest.json'), {
+            new Manifest(path.join(_path + '/dist', 'manifest.json'), {
                 rootAssetPath: rootAssetPath,
                 ignorePaths: ['.DS_Store']
             }),

--- a/app-frontend/config/webpack/global.js
+++ b/app-frontend/config/webpack/global.js
@@ -8,7 +8,6 @@
 const path = require('path');
 const webpack = require('webpack');
 const autoprefixer = require('autoprefixer-core');
-const Manifest = require('manifest-revision-webpack-plugin');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 
@@ -210,10 +209,6 @@ module.exports = function (_path) {
                 async: true,
                 children: true,
                 minChunks: Infinity
-            }),
-            new Manifest(path.join(_path + '/config', 'manifest.json'), {
-                rootAssetPath: rootAssetPath,
-                ignorePaths: ['.DS_Store']
             }),
             new ExtractTextPlugin(
                 'assets/styles/css/[name]' +


### PR DESCRIPTION
## Overview

The manifest plugin has been the cause for our web-pack crashes numerous times now, specifically whenever we make changes to files that have no changes. It's not something we should need in development. This PR moves the plugin to run on prod only.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~

## Testing Instructions

 * Run the web-pack server locally
 * Make sure it starts up
 * Save some unchanged files, be sure the server remains running
 * Run `./scripts/cibuild` and ensure that it can be run successfully
