### PR TITLE
Fix Nginx HTTP virtual host collision

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       - ./nginx/srv/dist/:/srv/dist/
       - ./nginx/etc/nginx/nginx.conf:/etc/nginx/nginx.conf
       - ./nginx/etc/nginx/includes/:/etc/nginx/includes/
-      - ./nginx/etc/nginx/conf.d/api.conf:/etc/nginx/conf.d/api.conf
+      - ./nginx/etc/nginx/conf.d/api.conf:/etc/nginx/conf.d/default.conf
 
   nginx-tiler:
     image: raster-foundry-nginx-tiler
@@ -48,7 +48,7 @@ services:
       - ./nginx/srv/dist/:/srv/dist/
       - ./nginx/etc/nginx/nginx.conf:/etc/nginx/nginx.conf
       - ./nginx/etc/nginx/includes/:/etc/nginx/includes/
-      - ./nginx/etc/nginx/conf.d/tiler.conf:/etc/nginx/conf.d/tiler.conf
+      - ./nginx/etc/nginx/conf.d/tiler.conf:/etc/nginx/conf.d/default.conf
 
   api-server:
     image: openjdk:8-jre

--- a/nginx/Dockerfile.airflow
+++ b/nginx/Dockerfile.airflow
@@ -4,4 +4,4 @@ RUN mkdir -p /etc/nginx/includes
 
 COPY etc/nginx/nginx.conf /etc/nginx/nginx.conf
 COPY etc/nginx/includes/*.conf /etc/nginx/includes/
-COPY etc/nginx/conf.d/airflow.conf /etc/nginx/conf.d/
+COPY etc/nginx/conf.d/airflow.conf /etc/nginx/conf.d/default.conf

--- a/nginx/Dockerfile.api
+++ b/nginx/Dockerfile.api
@@ -7,4 +7,4 @@ RUN chown nginx:nginx -R /srv/dist/
 
 COPY etc/nginx/nginx.conf /etc/nginx/nginx.conf
 COPY etc/nginx/includes/*.conf /etc/nginx/includes/
-COPY etc/nginx/conf.d/api.conf /etc/nginx/conf.d/
+COPY etc/nginx/conf.d/api.conf /etc/nginx/conf.d/default.conf

--- a/nginx/Dockerfile.tiler
+++ b/nginx/Dockerfile.tiler
@@ -4,4 +4,4 @@ RUN mkdir -p /etc/nginx/includes
 
 COPY etc/nginx/nginx.conf /etc/nginx/nginx.conf
 COPY etc/nginx/includes/*.conf /etc/nginx/includes/
-COPY etc/nginx/conf.d/tiler.conf /etc/nginx/conf.d/
+COPY etc/nginx/conf.d/tiler.conf /etc/nginx/conf.d/default.conf

--- a/nginx/etc/nginx/conf.d/airflow.conf
+++ b/nginx/etc/nginx/conf.d/airflow.conf
@@ -1,5 +1,5 @@
 server {
-    listen 80;
+    listen 80 default_server;
     server_name airflow.staging.rasterfoundry.com flower.staging.rasterfoundry.com airflow.rasterfoundry.com flower.rasterfoundry.com;
     return 301 https://$host$request_uri;
 }
@@ -9,7 +9,7 @@ upstream airflow-webserver-upstream {
 }
 
 server {
-    listen 443;
+    listen 443 default_server;
     server_name airflow.staging.rasterfoundry.com airflow.rasterfoundry.com;
 
     include /etc/nginx/includes/airflow-security-headers.conf;

--- a/nginx/etc/nginx/conf.d/api.conf
+++ b/nginx/etc/nginx/conf.d/api.conf
@@ -1,5 +1,5 @@
 server {
-    listen 80;
+    listen 80 default_server;
     server_name app.staging.rasterfoundry.com app.rasterfoundry.com;
     return 301 https://$host$request_uri;
 }

--- a/nginx/etc/nginx/conf.d/tiler.conf
+++ b/nginx/etc/nginx/conf.d/tiler.conf
@@ -1,5 +1,5 @@
 server {
-    listen 80;
+    listen 80 default_server;
     server_name tiles.staging.rasterfoundry.com tiles.rasterfoundry.com;
     return 301 https://$host$request_uri;
 }
@@ -9,7 +9,7 @@ upstream tile-server-upstream {
 }
 
 server {
-    listen 443;
+    listen 443 default_server;
     server_name tiles.staging.rasterfoundry.com tiles.rasterfoundry.com localhost;
 
     include /etc/nginx/includes/tiler-security-headers.conf;


### PR DESCRIPTION
## Overview

The Nginx container image comes with a default virtual host configuration at `/etc/nginx/conf.d/default.conf`. Ensure that we overwrite it with our virtual host configuration so that there aren't any unexpected conflicts between them.

Also, in scenarios where we know that we want a set of virtual hosts per Nginx instance, ensure that we set the `default_server` for each port combination. This will cause Nginx to raise an error in the even that multiple virtual hosts define that they are the default within a single instance's configuration.

## Testing Instructions

Within your VM, rebuild the Nginx container images with `bootstrap` and ensure that `server` works:

```bash
vagrant@vagrant-ubuntu-trusty-64:/opt/raster-foundry$ ./scripts/bootstrap
vagrant@vagrant-ubuntu-trusty-64:/opt/raster-foundry$ ./scripts/server
```