### PR TITLE
Add compressed project-item

### DIFF
--- a/app-frontend/src/app/components/projects/projectItem/projectItem.component.js
+++ b/app-frontend/src/app/components/projects/projectItem/projectItem.component.js
@@ -4,10 +4,12 @@ import projectItemTpl from './projectItem.html';
 const rfProjectItem = {
     templateUrl: projectItemTpl,
     controller: 'ProjectItemController',
+    transclude: true,
     bindings: {
         project: '<',
         selected: '&',
-        onSelect: '&'
+        onSelect: '&',
+        slim: '<'
     }
 };
 

--- a/app-frontend/src/app/components/projects/projectItem/projectItem.html
+++ b/app-frontend/src/app/components/projects/projectItem/projectItem.html
@@ -1,76 +1,86 @@
 <div class="panel-body">
-  <rf-status-tag ng-if="$ctrl.status" entity-type="project" status="$ctrl.status"></rf-status-tag>
-  <a href ui-sref="projects.detail({projectid: $ctrl.project.id})" class="h4">
-    <h4 class="project-title" data-title="{{$ctrl.project.name}}">{{$ctrl.project.name}}</h4>
-  </a>
-  <div class="row">
-    <div class="column-12">
+  <ng-container ng-if="!$ctrl.slim">
+    <rf-status-tag ng-if="$ctrl.status" entity-type="project" status="$ctrl.status"></rf-status-tag>
+    <a href ui-sref="projects.detail({projectid: $ctrl.project.id})" class="h4">
+      <h4 class="project-title" data-title="{{$ctrl.project.name}}">{{$ctrl.project.name}}</h4>
+    </a>
+    <div class="row">
+      <div class="column-12">
 
-      <!-- IF project has no scenes -->
-      <div class="project-preview-container placeholder" 
-           ng-if="!$ctrl.project.scenes"
-           style="background-image: url({{$ctrl.projectPlaceholder}})">
-        <span>This project doesn't have any scenes yet</span>
-      </div>
+        <!-- IF project has no scenes -->
+        <div class="project-preview-container placeholder"
+             ng-if="!$ctrl.project.scenes"
+             style="background-image: url({{$ctrl.projectPlaceholder}})">
+          <span>This project doesn't have any scenes yet</span>
+        </div>
 
-       <!-- IF not all scenes ingested: -->
-      <div class="project-preview-container placeholder"
-           ng-if="$ctrl.project.scenes && $ctrl.status !== 'CURRENT'"
-           style="background-image: url({{$ctrl.projectPlaceholder}})">
-           <span>Preview unavailable</span>
-      </div>
+         <!-- IF not all scenes ingested: -->
+        <div class="project-preview-container placeholder"
+             ng-if="$ctrl.project.scenes && $ctrl.status !== 'CURRENT'"
+             style="background-image: url({{$ctrl.projectPlaceholder}})">
+             <span>Preview unavailable</span>
+        </div>
 
-      <!-- IF using a project's thumbnail: -->
-      <div class="project-preview-container placeholder"
-           ng-if="$ctrl.project.scenes && $ctrl.thumbnailUrl && $ctrl.status === 'CURRENT'"
-           style="background-image: url({{$ctrl.projectPlaceholder}})">
-        <div class="thumbnail"
-             style="background-image: url({{$ctrl.thumbnailUrl}})"></div>
+        <!-- IF using a project's thumbnail: -->
+        <div class="project-preview-container placeholder"
+             ng-if="$ctrl.project.scenes && $ctrl.thumbnailUrl && $ctrl.status === 'CURRENT'"
+             style="background-image: url({{$ctrl.projectPlaceholder}})">
+          <div class="thumbnail"
+               style="background-image: url({{$ctrl.thumbnailUrl}})"></div>
+        </div>
       </div>
     </div>
-  </div>
-  <div class="row">
-    <div class="column-6">
-      <ul class="list-unstyled color-dark">
-        <li>
-          <ng-pluralize count="$ctrl.project.scenes"
-                        when="{'one': '1 Scene',
-                              'other': '{} Scenes'}">
-          </ng-pluralize>
-        </li>
-        <li>Edited {{$ctrl.project.modifiedAt | date : 'shortDate'}}</li>
-      </ul>
-    </div>
-    <div class="column-6 text-right">
-      <a class="btn btn-default" ui-sref="projects.edit({projectid: $ctrl.project.id})">
-        Edit
-      </a>
-      <div uib-dropdown ng-if="!$ctrl.isSelectable">
-        <button type="button" class="btn btn-default" uib-dropdown-toggle>
-          <i class="icon-caret-down"></i>
-        </button>
-        <ul class="dropdown-menu dropdown-menu-light" uib-dropdown-menu role="menu">
-          <li role="menuitem">
-            <a href ui-sref="projects.detail({projectid: $ctrl.project.id})">
-              <i class="icon-color-correct"></i>Project Details
-            </a>
+    <div class="row">
+      <div class="column-6">
+        <ul class="list-unstyled color-dark">
+          <li>
+            <ng-pluralize count="$ctrl.project.scenes"
+                          when="{'one': '1 Scene',
+                                'other': '{} Scenes'}">
+            </ng-pluralize>
           </li>
-          <li role="menuitem">
-            <a href ui-sref="projects.edit.browse({projectid: $ctrl.project.id})">
-              <i class="icon-project"></i>Add Scenes
-            </a>
-          </li>
-          <li role="menuitem">
-            <a href ng-click="$ctrl.publishModal()"><i class="icon-share"></i>Share</a>
-          </li>
-          <li class="divider"></li>
-          <li role="menuitem">
-            <a href class="color-danger" ng-click="$ctrl.deleteModal()">
-              <i class="icon-trash"></i>Delete
-            </a>
-          </li>
+          <li>Edited {{$ctrl.project.modifiedAt | date : 'shortDate'}}</li>
         </ul>
       </div>
+      <div class="column-6 text-right">
+        <a class="btn btn-default" ui-sref="projects.edit({projectid: $ctrl.project.id})">
+          Edit
+        </a>
+        <div uib-dropdown ng-if="!$ctrl.isSelectable">
+          <button type="button" class="btn btn-default" uib-dropdown-toggle>
+            <i class="icon-caret-down"></i>
+          </button>
+          <ul class="dropdown-menu dropdown-menu-light" uib-dropdown-menu role="menu">
+            <li role="menuitem">
+              <a href ui-sref="projects.detail({projectid: $ctrl.project.id})">
+                <i class="icon-color-correct"></i>Project Details
+              </a>
+            </li>
+            <li role="menuitem">
+              <a href ui-sref="projects.edit.browse({projectid: $ctrl.project.id})">
+                <i class="icon-project"></i>Add Scenes
+              </a>
+            </li>
+            <li role="menuitem">
+              <a href ng-click="$ctrl.publishModal()"><i class="icon-share"></i>Share</a>
+            </li>
+            <li class="divider"></li>
+            <li role="menuitem">
+              <a href class="color-danger" ng-click="$ctrl.deleteModal()">
+                <i class="icon-trash"></i>Delete
+              </a>
+            </li>
+          </ul>
+        </div>
+      </div>
     </div>
-  </div>
+  </ng-container>
+
+  <ng-container ng-if="$ctrl.slim">
+    <div class="row">
+      <h4 class="project-title flex-fill" data-title="{{$ctrl.project.name}}">{{$ctrl.project.name}}</h4>
+      <ng-transclude>
+      </ng-transclude>
+    </div>
+  </ng-container>
 </div>

--- a/app-frontend/src/app/components/projects/projectSelectModal/projectSelectModal.html
+++ b/app-frontend/src/app/components/projects/projectSelectModal/projectSelectModal.html
@@ -14,8 +14,9 @@
     <div class="list-group">
       <rf-project-item
           project="project"
-          ng-click="$ctrl.setSelected(project)"
-          ng-repeat="project in $ctrl.projectList track by project.id">
+          ng-repeat="project in $ctrl.projectList track by project.id"
+          slim="true">
+          <button class="btn btn-default" ng-click="$ctrl.setSelected(project)">Select</button>
       </rf-project-item>
     </div>
     <div class="list-group" ng-show="$ctrl.loading">

--- a/app-frontend/src/assets/styles/sass/_shame.scss
+++ b/app-frontend/src/assets/styles/sass/_shame.scss
@@ -1396,3 +1396,7 @@ table.upload-info {
 .picture-description {
   flex: 1;
 }
+.list-group rf-project-item .panel-body{
+  background: $off-white;
+  margin-bottom: 1rem;
+}


### PR DESCRIPTION
## Overview

This PR adds an attribute to the `projectItem` component, `slim`. When slim is set to true, the project item is displayed in a way that is more suitable for use in a list. This PR also utilizes this attribute to improve the display of the projects in the lab project selection modal.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~

### Demo

<img width="922" alt="screen shot 2017-06-19 at 11 59 49 am" src="https://user-images.githubusercontent.com/2442245/27294235-dc50cdd6-54e6-11e7-84fa-a5c98e832ab6.png">

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.


## Testing Instructions

* Open a tool in the lab and test the source selection
