### PR TITLE
Add Constant LazyTile

### DIFF
--- a/app-backend/tool/src/main/scala/ast/codec/MapAlgebraCodec.scala
+++ b/app-backend/tool/src/main/scala/ast/codec/MapAlgebraCodec.scala
@@ -9,7 +9,8 @@ import java.security.InvalidParameterException
 
 trait MapAlgebraCodec
     extends MapAlgebraOperationCodecs
-       with MapAlgebraUtilityCodecs {
+      with MapAlgebraLeafCodecs
+      with MapAlgebraUtilityCodecs {
 
   /** TODO: Add codec paths besides `raster source` and `operation` when supported */
   implicit def mapAlgebraDecoder = Decoder.instance[MapAlgebraAST] { ma =>
@@ -17,7 +18,7 @@ trait MapAlgebraCodec
       case Some(_) =>
         ma.as[MapAlgebraAST.Operation]
       case None =>
-        ma.as[MapAlgebraAST.Source]
+        ma.as[MapAlgebraAST.MapAlgebraLeaf]
     }
   }
 
@@ -25,8 +26,8 @@ trait MapAlgebraCodec
     final def apply(ast: MapAlgebraAST): Json = ast match {
       case operation: MapAlgebraAST.Operation =>
         operation.asJson
-      case source: MapAlgebraAST.Source =>
-        source.asJson
+      case leaf: MapAlgebraAST.MapAlgebraLeaf =>
+        leaf.asJson
       case _ =>
         throw new InvalidParameterException(s"Unrecognized AST: $ast")
     }

--- a/app-backend/tool/src/main/scala/ast/codec/MapAlgebraLeafCodecs.scala
+++ b/app-backend/tool/src/main/scala/ast/codec/MapAlgebraLeafCodecs.scala
@@ -19,7 +19,7 @@ trait MapAlgebraLeafCodecs {
       case Some("const") =>
         ma.as[MapAlgebraAST.Constant]
       case _ =>
-        throw new InvalidParameterException(s"Unrecognized AST: $ma")
+        Left(DecodingFailure(s"Unrecognized leaf node: $ma", ma.history))
     }
   }
 

--- a/app-backend/tool/src/main/scala/ast/codec/MapAlgebraLeafCodecs.scala
+++ b/app-backend/tool/src/main/scala/ast/codec/MapAlgebraLeafCodecs.scala
@@ -1,0 +1,47 @@
+package com.azavea.rf.tool.ast.codec
+
+import com.azavea.rf.tool.ast._
+
+import io.circe._
+import io.circe.syntax._
+
+import java.security.InvalidParameterException
+
+trait MapAlgebraLeafCodecs {
+  implicit def mapAlgebraDecoder: Decoder[MapAlgebraAST]
+  implicit def mapAlgebraEncoder: Encoder[MapAlgebraAST]
+
+  /** TODO: Add codec paths besides `raster source` and `operation` when supported */
+  implicit def mapAlgebraLeafDecoder = Decoder.instance[MapAlgebraAST.MapAlgebraLeaf] { ma =>
+    ma._type match {
+      case Some("src") =>
+        ma.as[MapAlgebraAST.Source]
+      case Some("const") =>
+        ma.as[MapAlgebraAST.Constant]
+      case _ =>
+        throw new InvalidParameterException(s"Unrecognized AST: $ma")
+    }
+  }
+
+  implicit def mapAlgebraLeafEncoder: Encoder[MapAlgebraAST.MapAlgebraLeaf] = new Encoder[MapAlgebraAST.MapAlgebraLeaf] {
+    final def apply(ast: MapAlgebraAST.MapAlgebraLeaf): Json = ast match {
+      case src: MapAlgebraAST.Source =>
+        src.asJson
+      case const: MapAlgebraAST.Constant =>
+        const.asJson
+      case _ =>
+        throw new InvalidParameterException(s"Unrecognized AST: $ast")
+    }
+  }
+
+  implicit lazy val decodeSource: Decoder[MapAlgebraAST.Source] =
+    Decoder.forProduct2("id", "metadata")(MapAlgebraAST.Source.apply)
+  implicit lazy val encodeSource: Encoder[MapAlgebraAST.Source] =
+    Encoder.forProduct3("type", "id", "metadata")(op => (op.`type`, op.id, op.metadata))
+
+  implicit lazy val decodeConstant: Decoder[MapAlgebraAST.Constant] =
+    Decoder.forProduct3("id", "constant", "metadata")(MapAlgebraAST.Constant.apply)
+  implicit lazy val encodeConstant: Encoder[MapAlgebraAST.Constant] =
+    Encoder.forProduct4("type", "id", "constant", "metadata")(op => (op.`type`, op.id, op.constant, op.metadata))
+}
+

--- a/app-backend/tool/src/main/scala/eval/LazyTile.scala
+++ b/app-backend/tool/src/main/scala/eval/LazyTile.scala
@@ -243,4 +243,16 @@ object LazyTile {
     def bind(args: Map[Var, LazyTile]): LazyTile =
       DualCombine(left.bind(args), right.bind(args), f, g)
   }
+
+  case class Constant(value: Double) extends Tree {
+    def get(col: Int, row: Int) = value.toInt
+    def getDouble(col: Int, row: Int) = value
+    def left = LazyTile.Nil
+    def right = LazyTile.Nil
+    // These overrides allows us to evaluate a tile which consists of this value
+    override def cols: Int = 256
+    override def rows: Int = 256
+    def bind(args: Map[Var, LazyTile]): LazyTile =
+      this
+  }
 }

--- a/app-backend/tool/src/test/scala/Generators.scala
+++ b/app-backend/tool/src/test/scala/Generators.scala
@@ -61,6 +61,12 @@ object Generators {
     nmd <- Gen.option(genNodeMetadata)
   } yield MapAlgebraAST.Source(id, nmd)
 
+  lazy val genConstantAST = for {
+    id <- arbitrary[UUID]
+    const <- arbitrary[Int]
+    nmd <- Gen.option(genNodeMetadata)
+  } yield MapAlgebraAST.Constant(id, const, nmd)
+
   def genBinaryOpAST(depth: Int) = for {
     constructor <- Gen.lzy(Gen.oneOf(
                      MapAlgebraAST.Addition.apply _,
@@ -92,7 +98,7 @@ object Generators {
     *  See: http://stackoverflow.com/questions/19829293/scalacheck-arbitrary-implicits-and-recursive-generators
     */
   def genMapAlgebraAST(depth: Int = 1): Gen[MapAlgebraAST] =
-    if (depth >= 100) genSourceAST
+    if (depth >= 100) genConstantAST
     else Gen.frequency((1 -> genOpAST(depth + 1)), (1 -> genSourceAST))
 
 }

--- a/app-backend/tool/src/test/scala/eval/InterpreterSpec.scala
+++ b/app-backend/tool/src/test/scala/eval/InterpreterSpec.scala
@@ -355,4 +355,27 @@ class InterpreterSpec
         fail(s"$i")
     }
   }
+
+  it("should evaluate using constant tiles") {
+    requests = Nil
+    val forty = Constant(UUID.randomUUID, 40, None)
+    val two = Constant(UUID.randomUUID, 2, None)
+    val lifeUniverseEtc = forty + two
+    val tms = Interpreter.interpretTMS(
+      ast = lifeUniverseEtc,
+      sourceMapping = Map(),
+      source = goodSource
+    )
+    println("Simple Constant calculation: ", lifeUniverseEtc.asJson.noSpaces)
+
+    val ret = tms(0, 1, 1)
+    val op = Await.result(ret, 10.seconds) match {
+      case Valid(lazytile) =>
+        val maybeTile = lazytile.evaluateDouble
+        requests.length should be (0)
+        maybeTile.get.getDouble(0, 0) should be (42)
+      case i@Invalid(_) =>
+        fail(s"$i")
+    }
+  }
 }


### PR DESCRIPTION
## Overview

Many calculations require specification of constant values to serve as coefficients. Accomplishing this requires the implementation of "tiles" which return a single value regardless of `col` and `row`. `MapAlgebraAST.Constant` in this PR provides this behavior

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~


### Notes

The issue for this task mentions the need to update these `Constant` values from `ToolRun`s (rather than just tools). This requirement is not being ignored: it is general enough that we're implementing it in such a way that it will handle this and other similar cases

## Testing Instructions

 * Run the tests

Closes #2008
