### PR TITLE
Install GDAL 2.1 in Airflow worker container image

### DIFF
--- a/app-tasks/Dockerfile
+++ b/app-tasks/Dockerfile
@@ -14,19 +14,19 @@ RUN set -ex \
     && buildDeps=' \
        python-dev \
     ' \
+    && gdalDeps=' \
+       gdal-bin \
+    ' \
     && javaDeps=' \
        openjdk-8-jre \
+       ca-certificates-java \
     ' \
-    && gdal=' \
-       gdal-bin \
-       libgdal1h \
-       libgdal-dev \
-    ' \
-    && echo "deb http://ftp.debian.org/debian jessie-backports main" > /etc/apt/sources.list.d/backports.list \
+    && echo 'deb http://deb.debian.org/debian jessie-backports main' > /etc/apt/sources.list.d/jessie-backports.list \
+    && echo 'deb http://deb.debian.org/debian testing main contrib non-free' > /etc/apt/sources.list.d/testing.list \
     && apt-get update \
-    && apt-get -t jessie-backports install -y --no-install-recommends ca-certificates-java \
-    && apt-get install -y --no-install-recommends ${buildDeps} ${gdal} ${javaDeps} \
-    && update-java-alternatives -s java-1.8.0-openjdk-amd64 \
+    && apt-get install -y --no-install-recommends ${buildDeps} \
+    && apt-get -t testing install -y --no-install-recommends ${gdalDeps} \
+    && apt-get install -y --no-install-recommends ${javaDeps} \
     && pip install --no-cache-dir \
            numpy==$(grep "numpy" /tmp/requirements.txt | cut -d= -f3) \
     && pip install --no-cache-dir -r /tmp/requirements.txt \


### PR DESCRIPTION
## Overview

Make use of the `testing` Debian repository to gain access to newer version of the `gdal-bin` package (and its associated dependencies).

Fixes #1930 

## Testing Instructions

After pulling down this branch, execute the following command to create a new version of the Airflow container image:

```bash
vagrant@vagrant-ubuntu-trusty-64:/opt/raster-foundry$ GIT_COMMIT="latest" docker-compose \
  -f docker-compose.yml \
  -f docker-compose.airflow.yml \
  -f docker-compose.test.yml \
  build airflow
```

From there, download a TIF that is known to break GDAL < 2.1 into the root of the project directory and launch an instance of the container image. Once inside, execute the `gdalwarp` command that was previously failing:

```bash
airflow@273b8f34addc:/usr/local/airflow$ gdalwarp --version
GDAL 2.1.2, released 2016/10/24
vagrant@vagrant-ubuntu-trusty-64:/opt/raster-foundry$ docker run --rm -ti -v ${PWD}:/joker raster-foundry-airflow:latest /bin/bash                                                
airflow@273b8f34addc:/usr/local/airflow$ gdalwarp /joker/Elia-orig.tif /joker/Elia.tif -t_srs "EPSG:3857"                                                                         
Processing input file /joker/Elia-orig.tif. 
Using internal nodata values (e.g. 0) for image /joker/Elia-orig.tif.                    
0...10...20...30...40...50...60...70...80...90...100 - done.
```