### PR TITLE
Use HTTPs for aerial map tiles

### DIFF
--- a/app-frontend/config/webpack/global.js
+++ b/app-frontend/config/webpack/global.js
@@ -39,7 +39,7 @@ const basemaps = JSON.stringify({
             }
         },
         Aerial: {
-            url: 'http://{s}.{base}.maps.cit.api.here.com/maptile/2.1/{type}/{mapID}/hybrid.day/{z}/{x}/{y}/{size}/{format}?app_id={app_id}&app_code={app_code}&lg={language}',
+            url: 'https://{s}.{base}.maps.cit.api.here.com/maptile/2.1/{type}/{mapID}/hybrid.day/{z}/{x}/{y}/{size}/{format}?app_id={app_id}&app_code={app_code}&lg={language}',
             properties: {
                 attribution: 'Map &copy; 1987-2014 <a href="http://developer.here.com">HERE</a>',
                 subdomains: '1234',


### PR DESCRIPTION
Fixes issue where aerial tiles do not load because of CSP problems because the scheme was http