### PR TITLE
Feature/jis/dropbox export frontend

### DIFF
--- a/app-backend/api/src/main/scala/user/Routes.scala
+++ b/app-backend/api/src/main/scala/user/Routes.scala
@@ -21,6 +21,7 @@ import com.typesafe.scalalogging.LazyLogging
 import scala.collection.JavaConverters._
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
+import scala.util.{Failure, Success}
 
 
 /**
@@ -115,9 +116,7 @@ trait UserRoutes extends Authentication
         dbxAuthRequest.redirectURI, session, queryParams
       )
       logger.debug("Auth finish from Dropbox successful")
-      Users.storeDropboxAccessToken(user.id, authFinish.getAccessToken)
-      logger.debug(s"Sent access code for user ${user.id} to database")
-      complete(StatusCodes.OK)
+      complete(Users.storeDropboxAccessToken(user.id, authFinish.getAccessToken))
     }
   }
 

--- a/app-backend/api/src/main/scala/user/Routes.scala
+++ b/app-backend/api/src/main/scala/user/Routes.scala
@@ -21,7 +21,6 @@ import com.typesafe.scalalogging.LazyLogging
 import scala.collection.JavaConverters._
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
-import scala.util.{Failure, Success}
 
 
 /**

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/export/spark/Export.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/export/spark/Export.scala
@@ -208,7 +208,7 @@ object Export extends SparkJob with Config with LazyLogging {
     conf: HadoopConfiguration
   ): Unit = {
     def path(key: SpatialKey): ExportDefinition => String = { ed =>
-      s"${ed.output.getURLDecodedSource}/${ed.input.resolution}-${key.col}-${key.row}-${ed.id}.tiff"
+      s"/${ed.output.getURLDecodedSource}/${ed.input.resolution}-${key.col}-${key.row}-${ed.id}.tiff"
     }
 
     rdd.foreachPartition({ iter =>

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/export/spark/Export.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/export/spark/Export.scala
@@ -167,7 +167,7 @@ object Export extends SparkJob with Config with LazyLogging {
   }
 
   private def singlePath(ed: ExportDefinition): String =
-    s"${ed.output.getURLDecodedSource}/${ed.input.resolution}-${ed.id}-${UUID.randomUUID()}.tiff"
+    s"/${ed.output.getURLDecodedSource}/${ed.input.resolution}-${ed.id}-${UUID.randomUUID()}.tiff"
 
   /** Write a single GeoTiff to some target. */
   private def writeGeoTiff[T <: CellGrid, G <: GeoTiff[T]](

--- a/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Exports.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Exports.scala
@@ -9,7 +9,6 @@ import com.azavea.rf.tool.ast._
 import com.azavea.rf.tool.params._
 
 import cats.data._
-import cats.syntax._
 import cats.implicits._
 import com.lonelyplanet.akka.http.extensions.PageRequest
 import com.typesafe.scalalogging.LazyLogging

--- a/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Users.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Users.scala
@@ -156,6 +156,12 @@ object Users extends TableQuery(tag => new Users(tag)) with LazyLogging {
     database.db.run(updateAction)
   }
 
+  def getDropboxAccessToken(userId: String)(implicit database: DB): Future[Option[Option[String]]] = {
+    val filtAction = Users.filter(_.id === userId).map(_.dropboxCredential).result.headOption
+    logger.debug(s"Attempting to retrieve access token for user $userId")
+    database.db.run(filtAction)
+  }
+
   def updateUser(user: User, id: String)(implicit database: DB): Future[Int] = {
     val now = new Timestamp((new java.util.Date).getTime)
     val updateQuery = for {

--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/ExportDefinition.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/ExportDefinition.scala
@@ -6,7 +6,7 @@ import java.util.UUID
 
 /** The top level structure defining an export job
   *
-  * @param id The UUID which identifies this particular ingest job
+  * @param id The UUID which identifies this particular export job
   * @param input [[InputDefinition]] with inforamation about input data for an export job
   * @param output [[OutputDefinition]] with inforamation about output data for an export job
   */

--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/OutputDefinition.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/OutputDefinition.scala
@@ -25,5 +25,6 @@ case class OutputDefinition(
   source: URI,
   dropboxCredential: Option[String]
 ) {
-  def getURLDecodedSource: String = URLDecoder.decode(source.toString, "UTF-8")
+  def getURLDecodedSource: String =
+    URLDecoder.decode(source.toString, "UTF-8").replace("dropbox:///", "")
 }

--- a/app-frontend/src/app/components/projects/projectExportModal/projectExportModal.controller.js
+++ b/app-frontend/src/app/components/projects/projectExportModal/projectExportModal.controller.js
@@ -45,7 +45,7 @@ export default class ProjectExportModalController {
 
     createExport() {
         let extraOptions = this.exportType.label === 'Dropbox' ?
-            { source: `dropbox:///raster-foundry/${this.projectId}` } :
+            { source: `dropbox:///raster-foundry/${this.projectId}.tif` } :
             {};
         this.projectService
             .export(this.projectId, this.zoom, this.exportType.label, extraOptions)

--- a/app-frontend/src/app/components/projects/projectExportModal/projectExportModal.controller.js
+++ b/app-frontend/src/app/components/projects/projectExportModal/projectExportModal.controller.js
@@ -9,6 +9,12 @@ export default class ProjectExportModalController {
         this.maxZoom = 30;
         this.projectId = this.resolve.project.id;
         this.zoom = this.resolve.zoom;
+        this.exportType = 'S3';
+        this.exportTypes = [
+            {active: true, label: 'S3'},
+            {active: false, label: 'Dropbox'}
+        ];
+        this.exportDestination = null;
         this.exportSuccess = false;
         this.exportFailure = false;
         this.zoomSlider = {
@@ -21,13 +27,28 @@ export default class ProjectExportModalController {
         };
     }
 
+    onExportTypeChange(newExportType) {
+        let newLabel = newExportType.label;
+        this.exportTypes.forEach(exportType => {
+            if (exportType.label === newLabel) {
+                exportType.active = true;
+                this.exportType = exportType;
+            } else {
+                exportType.active = false;
+            }
+        });
+    }
+
     exportNotStarted() {
         return !this.exportSuccess && !this.exportFailure;
     }
 
     createExport() {
+        let extraOptions = this.exportType.label === 'Dropbox' ?
+            { source: `dropbox:///raster-foundry/${this.projectId}` } :
+            {};
         this.projectService
-            .export(this.projectId, this.zoom)
+            .export(this.projectId, this.zoom, this.exportType.label, extraOptions)
             .then(
                 () => {
                     // @TODO: should we do something with the export object that we get back here?

--- a/app-frontend/src/app/components/projects/projectExportModal/projectExportModal.controller.js
+++ b/app-frontend/src/app/components/projects/projectExportModal/projectExportModal.controller.js
@@ -14,7 +14,6 @@ export default class ProjectExportModalController {
             {active: true, label: 'S3'},
             {active: false, label: 'Dropbox'}
         ];
-        this.exportDestination = null;
         this.exportSuccess = false;
         this.exportFailure = false;
         this.zoomSlider = {

--- a/app-frontend/src/app/components/projects/projectExportModal/projectExportModal.controller.js
+++ b/app-frontend/src/app/components/projects/projectExportModal/projectExportModal.controller.js
@@ -11,8 +11,8 @@ export default class ProjectExportModalController {
         this.zoom = this.resolve.zoom;
         this.exportType = 'S3';
         this.exportTypes = [
-            {active: true, label: 'S3'},
-            {active: false, label: 'Dropbox'}
+            {label: 'S3'},
+            {label: 'Dropbox'}
         ];
         this.exportSuccess = false;
         this.exportFailure = false;
@@ -30,10 +30,7 @@ export default class ProjectExportModalController {
         let newLabel = newExportType.label;
         this.exportTypes.forEach(exportType => {
             if (exportType.label === newLabel) {
-                exportType.active = true;
                 this.exportType = exportType;
-            } else {
-                exportType.active = false;
             }
         });
     }

--- a/app-frontend/src/app/components/projects/projectExportModal/projectExportModal.html
+++ b/app-frontend/src/app/components/projects/projectExportModal/projectExportModal.html
@@ -14,7 +14,27 @@
   <!-- Body for export start -->
   <div class="modal-body" ng-if="$ctrl.exportNotStarted()">
     <div class="content">
-      <h4 class="modal-content-header">Export zoom level</h4>
+      <h4 class="modal-content-header">Export Options</h4>
+        <div>
+          <p>
+              Select what type of export to perform. A Dropbox export will send your
+              exported file to Dropbox, if you've connected your Dropbox account. Otherwise,
+              export this project to S3. To set up Dropbox, visit your account settings.
+          </p>
+          <div class="form-group">
+          <label>Export Type</label>
+          <div class="form-group">
+            <div class="btn-group inline">
+              <button class="btn btn-primary"
+                      ng-repeat="exportType in $ctrl.exportTypes"
+                      ng-click="$ctrl.onExportTypeChange(exportType)"
+                      ng-class="{'active': exportType.active}">
+              {{exportType.label}}
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
       <div class="form-group">
         <div>
           <p>

--- a/app-frontend/src/app/core/services/project.service.js
+++ b/app-frontend/src/app/core/services/project.service.js
@@ -166,7 +166,7 @@ export default (app) => {
             const defaultSettings = {
                 projectId: project.id,
                 exportStatus: 'NOTEXPORTED',
-                exportType: this.exportType ? exportType : 'S3',
+                exportType: this.exportType ? this.exportType : 'S3',
                 visibility: 'PRIVATE',
                 exportOptions: finalOptions
             };

--- a/app-frontend/src/app/core/services/project.service.js
+++ b/app-frontend/src/app/core/services/project.service.js
@@ -45,6 +45,7 @@ export default (app) => {
             this.tokenService = tokenService;
             this.authService = authService;
             this.statusService = statusService;
+            this.exportType = 'S3';
             this.$http = $http;
             this.$location = $location;
             this.$q = $q;
@@ -165,7 +166,7 @@ export default (app) => {
             const defaultSettings = {
                 projectId: project.id,
                 exportStatus: 'NOTEXPORTED',
-                exportType: exportType ? exportType : 'S3',
+                exportType: this.exportType ? exportType : 'S3',
                 visibility: 'PRIVATE',
                 exportOptions: finalOptions
             };

--- a/app-frontend/src/app/core/services/project.service.js
+++ b/app-frontend/src/app/core/services/project.service.js
@@ -165,7 +165,7 @@ export default (app) => {
             const defaultSettings = {
                 projectId: project.id,
                 exportStatus: 'NOTEXPORTED',
-                exportType: 'S3',
+                exportType: exportType ? exportType : 'S3',
                 visibility: 'PRIVATE',
                 exportOptions: finalOptions
             };

--- a/app-frontend/src/app/pages/projects/edit/export/export.controller.js
+++ b/app-frontend/src/app/pages/projects/edit/export/export.controller.js
@@ -140,7 +140,7 @@ export default class ExportController {
 
     getExportSource() {
         return this.getCurrentExportType().exportType === 'Dropbox' ?
-            {source: `dropbox://${this.project.id}`} :
+            {source: `dropbox:///${this.project.id}`} :
             {};
     }
 

--- a/app-frontend/src/app/pages/projects/edit/export/export.html
+++ b/app-frontend/src/app/pages/projects/edit/export/export.html
@@ -77,6 +77,23 @@
     </div>
     <i class="icon-info"></i>
   </li>
+  <li class="separator">
+    <span class="label">Export type</span>
+    <div class="dropdown btn-group fixedwidth" uib-dropdown uib-dropdown-toggle>
+      <a class="btn dropdown-label" >
+       {{$ctrl.exportType.label}}
+      </a>
+      <button type="button" class="btn btn-default dropdown-toggle">
+        <i class="icon-caret-down"></i>
+      </button>
+      <ul class="dropdown-menu dropdown-menu-light" uib-dropdown-menu role="menu">
+        <li ng-repeat="exportType in $ctrl.exportTypes" rol="menuitem">
+          <a ng-click="$ctrl.onExportTypeChange(exportType)">{{exportType.label}}</a>
+        </li>
+      </ul>
+    </div>
+    <i class="icon-info"></i>
+  </li>
 </ul>
 <div class="sidebar-content" ng-if="$ctrl.project">
   <button class="btn btn-primary btn-block" type="button" ng-click="$ctrl.startExport()" ng-if="!$ctrl.isExporting" ng-disabled="!$ctrl.validate()">


### PR DESCRIPTION
## Overview

This PR adds Dropbox as an export option to the frontend. It also fixes some things that were broken in the backend.

### Checklist

- ~Styleguide updated, if necessary~
- ~Swagger specification updated, if necessary~
- ~Symlinks from new migrations present or corrected for any new migrations~

### Notes

There's a new TODO around where `OptionT`s in a for comprehension failed for extremely mysterious reasons. @fosskers said he'd take a look at that section in an upcoming PR.

## Testing Instructions

 * bring up the server, the frontend, and airflow
 * sign in to dropbox
 * add dropbox integration to your raster foundry session from account management
 * start an export for a project at a pretty low zoom level (you'll be running spark locally later and don't want memory errors)
 * click `Dropbox` for export type
 * wait a minute. The export will fail because the export job doesn't appear to have a way to specify a different `rf-batch-*.jar`. That's fine.
 * From `app-backend` outside the vm, `./sbt batch/assembly`
 * Go somewhere with access to that jar, access to your `~/.aws/credentials`, and `spark-submit` available
 * `env AWS_PROFILE=raster-foundry spark-submit --verbose  --master=local[4] --class com.azavea.rf.batch.export.spark.Export --driver-memory 4G PATH/TO/YOUR/rf-batch-*.jar -j s3://rasterfoundry-development-data-us-east-1/export-definitions/<YOUR EXPORT DEFINITION>.json`
 * check out your sweet new tifs in your dropbox `Apps/raster-foundry-staging/<stuff>.tif`

Closes #2018
Closes #2048
