### PR TITLE
AST: Overrides for "extra params"

### DIFF
--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/export/spark/Export.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/export/spark/Export.scala
@@ -50,7 +50,7 @@ object Export extends SparkJob with Config with LazyLogging {
     projLocs: Map[UUID, List[(UUID, String)]],
     conf: HadoopConfiguration
   )(implicit sc: SparkContext): Unit = {
-    interpretRDD(ast, params.sources, ed.input.resolution, sceneLocs, projLocs) match {
+    interpretRDD(ast, params.sources, params.overrides, ed.input.resolution, sceneLocs, projLocs) match {
       case Invalid(errs) => throw InterpreterException(errs)
       case Valid(rdd) => {
 

--- a/app-backend/tile/src/main/scala/LayerCache.scala
+++ b/app-backend/tile/src/main/scala/LayerCache.scala
@@ -152,7 +152,7 @@ object LayerCache extends Config with LazyLogging {
       for {
         (tool, toolRun) <- LayerCache.toolAndToolRun(toolRunId, user, voidCache)
         (ast, params)   <- LayerCache.toolEvalRequirements(toolRunId, subNode, user, voidCache)
-        lztile          <- OptionT(Interpreter.interpretGlobal(ast, params.sources, TileSources.globalSource).map(_.toOption))
+        lztile          <- OptionT(Interpreter.interpretGlobal(ast, params.sources, params.overrides, TileSources.globalSource).map(_.toOption))
         tile            <- OptionT.fromOption[Future](lztile.evaluateDouble)
       } yield {
         val hist = StreamingHistogram.fromTile(tile)

--- a/app-backend/tile/src/main/scala/routes/ToolRoutes.scala
+++ b/app-backend/tile/src/main/scala/routes/ToolRoutes.scala
@@ -121,7 +121,7 @@ class ToolRoutes(implicit val database: Database) extends Authentication
                   (toolRun, tool) <- LayerCache.toolAndToolRun(toolRunId, user)
                   (ast, params)   <- LayerCache.toolEvalRequirements(toolRunId, nodeId, user)
                   tile            <- OptionT({
-                                       val tms = Interpreter.interpretTMS(ast, params.sources, source)
+                                       val tms = Interpreter.interpretTMS(ast, params.sources, params.overrides, source)
                                        logger.debug(s"Attempting to retrieve TMS tile at $z/$x/$y")
                                        tms(z, x, y).map {
                                          case Valid(op) => op.evaluateDouble

--- a/app-backend/tool/src/main/scala/ast/codec/MapAlgebraCodec.scala
+++ b/app-backend/tool/src/main/scala/ast/codec/MapAlgebraCodec.scala
@@ -35,4 +35,3 @@ trait MapAlgebraCodec
 }
 
 object MapAlgebraCodec extends MapAlgebraCodec
-

--- a/app-backend/tool/src/main/scala/eval/Interpreter.scala
+++ b/app-backend/tool/src/main/scala/eval/Interpreter.scala
@@ -59,7 +59,13 @@ object Interpreter extends LazyLogging {
     /* Can't override data Sources */
     case s: Source => Valid(s)
 
-    /* Operations which can be overridden */
+    /* Nodes which can be overridden */
+    case c: Constant => overrides.get(c.id) match {
+      case None => Valid(c)
+      case Some(ParamOverride.Constant(const)) => Valid(c.copy(constant = const))
+      case Some(_) => Invalid(NonEmptyList.of(InvalidOverride(c.id)))
+    }
+
     case Classification(args, id, m, b) => {
       val kids: Interpreted[List[MapAlgebraAST]] =
         args.map(a => overrideParams(a, overrides)).sequence

--- a/app-backend/tool/src/main/scala/eval/InterpreterError.scala
+++ b/app-backend/tool/src/main/scala/eval/InterpreterError.scala
@@ -49,6 +49,10 @@ case class ASTDecodeError(id: UUID, msg: DecodingFailure) extends InterpreterErr
   def repr = s"Unable to decode the AST associated with ToolRun ${id}: ${msg}"
 }
 
+case class InvalidOverride(id: UUID) extends InterpreterError {
+  def repr = s"Node ${id} was given an incompatible override value"
+}
+
 object InterpreterError {
   implicit val encodeInterpreterErrors: Encoder[InterpreterError] =
     new Encoder[InterpreterError] {

--- a/app-backend/tool/src/main/scala/params/EvalParams.scala
+++ b/app-backend/tool/src/main/scala/params/EvalParams.scala
@@ -41,19 +41,21 @@ sealed trait ParamOverride
 
 object ParamOverride {
 
-  @JsonCodec
-  case class Classification(classMap: ClassMap) extends ParamOverride
+  @JsonCodec case class Classification(classMap: ClassMap) extends ParamOverride
+  @JsonCodec case class Constant(constant: Double) extends ParamOverride
 
   /** Add more possibilities as necessary with the `.orElse` mechanic
     * (the "Alternative" pattern).
     */
   implicit val dec: Decoder[ParamOverride] = Decoder.instance[ParamOverride]({ po =>
     po.downField("classify").as[Classification]
+      .orElse(po.downField("constant").as[Constant])
   })
 
   implicit val enc: Encoder[ParamOverride] = new Encoder[ParamOverride] {
     def apply(overrides: ParamOverride): Json = overrides match {
       case c: Classification => c.asJson
+      case c: Constant => c.asJson
     }
   }
 }

--- a/app-backend/tool/src/main/scala/params/EvalParams.scala
+++ b/app-backend/tool/src/main/scala/params/EvalParams.scala
@@ -5,19 +5,48 @@ import java.util.UUID
 import cats.syntax.either._
 import com.azavea.rf.tool.ast._
 import io.circe._
+import io.circe.syntax._
+import io.circe.generic.JsonCodec
 
-case class EvalParams(sources: Map[UUID, RFMLRaster] = Map(), metadata: Map[UUID, NodeMetadata] = Map())
+case class EvalParams(
+  sources: Map[UUID, RFMLRaster] = Map(),
+  metadata: Map[UUID, NodeMetadata] = Map(),
+  overrides: Map[UUID, ParamOverride] = Map()
+)
 
 object EvalParams {
+
   implicit val encodeEvalParams: Encoder[EvalParams] =
     Encoder.forProduct2("sources", "metadata")(ep => (ep.sources, ep.metadata))
 
   implicit val decodeEvalParams: Decoder[EvalParams] = new Decoder[EvalParams] {
     final def apply(c: HCursor): Decoder.Result[EvalParams] = {
-      val sources = c.get[Map[UUID, RFMLRaster]]("sources").getOrElse(Map())
-      val overrides = c.get[Map[UUID, NodeMetadata]]("metadata").getOrElse(Map())
+      val sources = c.get[Map[UUID, RFMLRaster]]("sources").getOrElse(Map.empty)
+      val metas = c.get[Map[UUID, NodeMetadata]]("metadata").getOrElse(Map.empty)
+      val overrides = c.get[Map[UUID, ParamOverride]]("overrides").getOrElse(Map.empty)
 
-      Right(EvalParams(sources, overrides))
+      Right(EvalParams(sources, metas, overrides))
+    }
+  }
+}
+
+sealed trait ParamOverride
+
+object ParamOverride {
+
+  @JsonCodec
+  case class Classification(classMap: ClassMap) extends ParamOverride
+
+  /** Add more possibilities as necessary with the `.orElse` mechanic
+    * (the "Alternative" pattern).
+    */
+  implicit val dec: Decoder[ParamOverride] = Decoder.instance[ParamOverride]({ po =>
+    po.downField("classify").as[Classification]
+  })
+
+  implicit val enc: Encoder[ParamOverride] = new Encoder[ParamOverride] {
+    def apply(overrides: ParamOverride): Json = overrides match {
+      case c: Classification => c.asJson
     }
   }
 }

--- a/app-backend/tool/src/main/scala/params/EvalParams.scala
+++ b/app-backend/tool/src/main/scala/params/EvalParams.scala
@@ -21,7 +21,7 @@ case class EvalParams(
 object EvalParams {
 
   implicit val encodeEvalParams: Encoder[EvalParams] =
-    Encoder.forProduct2("sources", "metadata")(ep => (ep.sources, ep.metadata))
+    Encoder.forProduct3("sources", "metadata", "overrides")(ep => (ep.sources, ep.metadata, ep.overrides))
 
   implicit val decodeEvalParams: Decoder[EvalParams] = new Decoder[EvalParams] {
     final def apply(c: HCursor): Decoder.Result[EvalParams] = {

--- a/app-backend/tool/src/main/scala/params/EvalParams.scala
+++ b/app-backend/tool/src/main/scala/params/EvalParams.scala
@@ -8,6 +8,10 @@ import io.circe._
 import io.circe.syntax._
 import io.circe.generic.JsonCodec
 
+/* Yes, it is correct that all three of these fields can be empty. It is
+ * possible to construct a legal AST that will produce results yet has no
+ * external data sources.
+ */
 case class EvalParams(
   sources: Map[UUID, RFMLRaster] = Map(),
   metadata: Map[UUID, NodeMetadata] = Map(),
@@ -30,6 +34,9 @@ object EvalParams {
   }
 }
 
+/** A sum type which allows us hold override values of varying types in the
+  * same `Map` in a type safe way.
+  */
 sealed trait ParamOverride
 
 object ParamOverride {

--- a/app-backend/tool/src/test/scala/eval/InterpreterSpec.scala
+++ b/app-backend/tool/src/test/scala/eval/InterpreterSpec.scala
@@ -31,6 +31,7 @@ class InterpreterSpec
     val tms = Interpreter.interpretTMS(
       ast = src1 - src2,
       sourceMapping = Map(src1.id -> tileSource(4), src2.id -> tileSource(5)),
+      overrides = Map.empty,
       source = goodSource
     )
 
@@ -53,6 +54,7 @@ class InterpreterSpec
     val tms = Interpreter.interpretTMS(
       ast = src1 - src2,
       sourceMapping = Map(src1.id -> tileSource(4)),
+      overrides = Map.empty,
       source = goodSource
     )
 
@@ -77,6 +79,7 @@ class InterpreterSpec
     val tms = Interpreter.interpretTMS(
       ast = src1 - src2,
       sourceMapping = Map(src1.id -> theTileSource),
+      overrides = Map.empty,
       source = badSource
     )
 
@@ -117,6 +120,7 @@ class InterpreterSpec
     val tms = Interpreter.interpretTMS(
       ast = srcAST.classify(breakmap),
       sourceMapping = Map(srcAST.id -> tileSource(4)),
+      overrides = Map.empty,
       source = goodSource
     )
     println("Classification node: ", srcAST.classify(breakmap).asJson.noSpaces)
@@ -140,6 +144,7 @@ class InterpreterSpec
     val tms = Interpreter.interpretTMS(
       ast = srcAST.classify(breakmap),
       sourceMapping = Map(srcAST.id -> tileSource(4)),
+      overrides = Map.empty,
       source = goodSource
     )
 
@@ -161,6 +166,7 @@ class InterpreterSpec
     val tms = Interpreter.interpretTMS(
       ast = src1 - src2,
       sourceMapping = Map(src1.id -> tileSource(1), src2.id -> tileSource(5)),
+      overrides = Map.empty,
       source = goodSource
     )
     println("Subtraction node: ", (src1 - src2).asJson.noSpaces)
@@ -186,6 +192,7 @@ class InterpreterSpec
     val tms = Interpreter.interpretTMS(
       ast = ast,
       sourceMapping = Map(src1.id -> tileSource(5), src2.id -> tileSource(4), src3.id -> tileSource(1)),
+      overrides = Map.empty,
       source = goodSource
     )
 
@@ -207,6 +214,7 @@ class InterpreterSpec
     val tms = Interpreter.interpretTMS(
       ast = src1 / src2,
       sourceMapping = Map(src1.id -> tileSource(4), src2.id -> tileSource(5)),
+      overrides = Map.empty,
       source = goodSource
     )
     println("Division node: ", (src1 / src2).asJson.noSpaces)
@@ -231,6 +239,7 @@ class InterpreterSpec
     val tms = Interpreter.interpretTMS(
       ast = ast,
       sourceMapping = Map(src1.id -> tileSource(1), src2.id -> tileSource(5), src3.id -> tileSource(4)),
+      overrides = Map.empty,
       source = goodSource
     )
 
@@ -252,6 +261,7 @@ class InterpreterSpec
     val tms = Interpreter.interpretTMS(
       ast = src1 * src2,
       sourceMapping = Map(src1.id -> tileSource(4), src2.id -> tileSource(5)),
+      overrides = Map.empty,
       source = goodSource
     )
     println("Multiplication node: ", (src1 * src2).asJson.noSpaces)
@@ -274,6 +284,7 @@ class InterpreterSpec
     val tms = Interpreter.interpretTMS(
       ast = src1 + src2,
       sourceMapping = Map(src1.id -> tileSource(4), src2.id -> tileSource(5)),
+      overrides = Map.empty,
       source = goodSource
     )
     println("Addition node: ", (src1 + src2).asJson.noSpaces)
@@ -296,6 +307,7 @@ class InterpreterSpec
     val tms = Interpreter.interpretTMS(
       ast = src1.max(src2),
       sourceMapping = Map(src1.id -> tileSource(1), src2.id -> tileSource(5)),
+      overrides = Map.empty,
       source = goodSource
     )
     println("LocalMax node: ", (src1.max(src2)).asJson.noSpaces)
@@ -318,6 +330,7 @@ class InterpreterSpec
     val tms = Interpreter.interpretTMS(
       ast = src1.min(src2),
       sourceMapping = Map(src1.id -> tileSource(1), src2.id -> tileSource(5)),
+      overrides = Map.empty,
       source = goodSource
     )
     println("LocalMin node: ", (src1.min(src2)).asJson.noSpaces)
@@ -341,6 +354,7 @@ class InterpreterSpec
     val tms = Interpreter.interpretTMS(
       ast = ndvi,
       sourceMapping = Map(nir.id -> tileSource(1), red.id -> tileSource(5)),
+      overrides = Map.empty,
       source = goodSource
     )
     println("Simple NDVI calculation: ", ndvi.asJson.noSpaces)
@@ -364,6 +378,7 @@ class InterpreterSpec
     val tms = Interpreter.interpretTMS(
       ast = lifeUniverseEtc,
       sourceMapping = Map(),
+      overrides = Map.empty,
       source = goodSource
     )
     println("Simple Constant calculation: ", lifeUniverseEtc.asJson.noSpaces)

--- a/app-backend/tool/src/test/scala/params/EvalParamsSpec.scala
+++ b/app-backend/tool/src/test/scala/params/EvalParamsSpec.scala
@@ -1,19 +1,12 @@
 package com.azavea.rf.tool.params
 
-import com.azavea.rf.tool.ast._
-import com.azavea.rf.tool.eval._
-import com.azavea.rf.tool.Generators._
-
-import org.scalacheck.Prop.forAll
-import org.scalatest.prop._
-import org.scalatest._
-import io.circe._
-import io.circe.parser._
-import io.circe.syntax._
 import cats.syntax.either._
-
-import scala.util.Random
-import java.util.UUID
+import com.azavea.rf.tool.Generators._
+import io.circe._
+import io.circe.syntax._
+import org.scalacheck.Prop.forAll
+import org.scalatest._
+import org.scalatest.prop._
 
 
 class EvalParamsSpec extends PropSpec with Matchers with Checkers {


### PR DESCRIPTION
### Overview
This PR lays the ground work for being able to replace at "run time" the "extra params" of AST `Operation` nodes that have any (like the `breaks` field in `Classification`).

### JSON Samples

The newly extended form of `EvalParams`, which are embedded in `ToolRun`. Nothing about `ToolRun` itself had to change in this PR.

```json
 {
   "sources" : {
     "ae3d5e1b-6333-4b2c-a365-f58b62ca1b16" : {
       "id" : "cd9840de-8806-4dc3-ac78-c9072edf5a02",
       "band" : 5,
       "type" : "scene"
     },
     "a4d64cc5-e3d0-48ac-91ea-5f545fa85ac7" : {
       "id" : "bce1b792-8bb0-4bf1-92a9-ffcf95506201",
       "band" : 5,
       "type" : "scene"
     },
     "e5a58572-4a50-440d-9084-a38e1d2914b1" : {
       "id" : "9e0ae12f-5ff0-46e4-b67c-c57b087ab9f4",
       "band" : 5,
       "type" : "scene"
     }
   },
   "metadata" : {

   },
   "overrides" : {
     "ae3d5e1b-6333-4b2c-a365-f58b62ca1b16" : {
       "constant" : 5.0
     },
     "e5a58572-4a50-440d-9084-a38e1d2914b1" : {
       "classMap" : {
         "classifications" : {
           "0.5" : 3,
           "0.0" : 1,
           "0.75" : 4,
           "1.0" : 5,
           "0.25" : 2
         },
         "options" : {
           "boundaryType" : "lessThanOrEqualTo",
           "ndValue" : -2147483648,
           "fallback" : -2147483648
         }
       }
     }
   }
 }
```

Closes #1991 
