### PR TITLE
Check for bad shape extraction

### DIFF
--- a/app-tasks/rf/src/rf/uploads/geotiff/create_footprints.py
+++ b/app-tasks/rf/src/rf/uploads/geotiff/create_footprints.py
@@ -142,9 +142,10 @@ def extract_polygon(mask_tif_path):
 
     mask = np.ma.masked_equal(raster, 0)
     logger.info('Extracting shapes from footprint masks')
-    geoms = shapes(raster, mask=mask.astype('bool'), transform=src_affine, connectivity=4)
+    geoms = list(shapes(raster, mask=mask.astype('bool'), transform=src_affine, connectivity=4))
+    assert len(geoms) > 0, 'Shapes could not be extracted from the footprint masks'
 
-    footprint, value = geoms.next()
+    footprint, value = geoms[0]
     assert value == FILL_VALUE, 'Geometry should be of value %s, got %r' % (
         FILL_VALUE, value)
 

--- a/app-tasks/rf/src/rf/uploads/geotiff/create_footprints.py
+++ b/app-tasks/rf/src/rf/uploads/geotiff/create_footprints.py
@@ -142,10 +142,12 @@ def extract_polygon(mask_tif_path):
 
     mask = np.ma.masked_equal(raster, 0)
     logger.info('Extracting shapes from footprint masks')
-    geoms = list(shapes(raster, mask=mask.astype('bool'), transform=src_affine, connectivity=4))
-    assert len(geoms) > 0, 'Shapes could not be extracted from the footprint masks'
+    geoms = shapes(raster, mask=mask.astype('bool'), transform=src_affine, connectivity=4)
+    try:
+        footprint, value = geoms.next()
+    except StopIteration:
+        raise Exception('Shapes could not be extracted from the footprint mask, the file could be invalid')
 
-    footprint, value = geoms[0]
     assert value == FILL_VALUE, 'Geometry should be of value %s, got %r' % (
         FILL_VALUE, value)
 


### PR DESCRIPTION
## Overview

This PR adds an assertion that should catch a bad shape extraction when generating footprints. This also fixes the unsafe use of a generator which assumed a successful operation.

The rasterio `shapes` generator generates nothing when it cannot successfully extract shapes.  The use of `shapes(...).next()` without catching the possible `StopIteration` exception caused the exception to bubble up to a containing generator, which handles the exception as if it had been raised intentionally. As a result, the airflow task would 'succeed' even in the case of a bad tif.

We probably should not use `next()` like that.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~

## Testing Instructions

 * Ask me for a bad tif that would cause this error
 * Try uploading it and verify that the airflow task instance was marked as a failure
 * Try uploading a good tif and verify that it still works properly
