### PR TITLE
AST: Masking

### DIFF
--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/ast/package.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/ast/package.scala
@@ -52,7 +52,11 @@ package object ast {
       ast: MapAlgebraAST,
       rdds: Map[UUID, TileLayerRDD[SpatialKey]]
     ): TileLayerRDD[SpatialKey] = ast match {
+      /* --- LEAVES --- */
       case Source(id, _) => rdds(id)
+      case Constant(id, const, _) => ???
+
+      /* --- OPERATIONS --- */
       case Addition(args, _, _) =>
         args.map(eval(_, rdds)).reduce((acc,r) => binary({_ + _}, acc, r))
       case Subtraction(args, _, _) =>
@@ -61,8 +65,8 @@ package object ast {
         args.map(eval(_, rdds)).reduce((acc,r) => binary({_ * _}, acc, r))
       case Division(args, _, _) =>
         args.map(eval(_, rdds)).reduce((acc,r) => binary({_ / _}, acc, r))
-      case Classification(arg :: _, _, _, classMap) =>
-        eval(arg, rdds).withContext(_.color(classMap.toColorMap))
+      case Classification(args, _, _, classMap) =>
+        eval(args.head, rdds).withContext(_.color(classMap.toColorMap))
       case Max(args, _, _) => {
         val kids: List[TileLayerRDD[SpatialKey]] = args.map(eval(_, rdds))
 
@@ -75,7 +79,7 @@ package object ast {
         /* The head call will never fail */
         ContextRDD(kids.head.localMin(kids.tail), kids.map(_.metadata).reduce(_ combine _))
       }
-      case op => throw new Exception(s"Unimplemented Operation given! ${op}")
+      case Masking(args, _, _, mask) => eval(args.head, rdds).mask(mask)
     }
 
     /* Guarantee correctness before performing Map Algebra */

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/ingest/model/OutputDefinition.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/ingest/model/OutputDefinition.scala
@@ -6,6 +6,7 @@ import io.circe.generic.JsonCodec
 import cats.syntax.either._
 
 import com.azavea.rf.datamodel._
+import com.azavea.rf.bridge._
 
 import geotrellis.proj4.CRS
 import geotrellis.raster._

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/ingest/model/SourceDefinition.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/ingest/model/SourceDefinition.scala
@@ -3,6 +3,7 @@ package com.azavea.rf.batch.ingest.model
 import io.circe.generic.JsonCodec
 import com.azavea.rf.batch.util._
 import com.azavea.rf.datamodel._
+import com.azavea.rf.bridge._
 
 import geotrellis.proj4.{CRS, LatLng}
 import geotrellis.raster._

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/ingest/model/package.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/ingest/model/package.scala
@@ -3,7 +3,7 @@ package com.azavea.rf.batch.ingest
 import io.circe._
 import io.circe.syntax._
 
-import com.azavea.rf.datamodel._
+import com.azavea.rf.bridge._
 
 import geotrellis.proj4._
 import geotrellis.raster._
@@ -14,7 +14,6 @@ import geotrellis.vector._
 import cats.syntax.either._
 
 import spray.json._
-import spray.json.DefaultJsonProtocol._
 
 package object model {
   implicit object CRSJsonFormat extends JsonFormat[CRS] {

--- a/app-backend/bridge/build.sbt
+++ b/app-backend/bridge/build.sbt
@@ -1,0 +1,5 @@
+name := "raster-foundry-bridge"
+
+scalacOptions ++= Seq("-feature", "-unchecked", "-deprecation")
+
+addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full)

--- a/app-backend/bridge/src/main/scala/com/azavea/rf/package.scala
+++ b/app-backend/bridge/src/main/scala/com/azavea/rf/package.scala
@@ -1,0 +1,54 @@
+package com.azavea.rf
+
+import scala.util.Try
+
+import cats.syntax.either._
+import geotrellis.proj4.CRS
+import geotrellis.vector.{Extent, MultiPolygon}
+import geotrellis.vector.io._
+import io.circe._
+import io.circe.parser._
+import io.circe.syntax._
+
+// --- //
+
+/** Orphaned typeclass instances for GeoTrellis types, as needed by Raster
+  * Foundry. This is chiefly for Circe codecs, which GeoTrellis itself doesn't
+  * support yet.
+  */
+package object bridge {
+
+  implicit val crsEncoder: Encoder[CRS] =
+    Encoder.encodeString.contramap[CRS] { crs => crs.epsgCode.map { c => s"epsg:$c" }.getOrElse(crs.toProj4String) }
+
+  implicit val crsDecoder: Decoder[CRS] =
+    Decoder.decodeString.emap { str =>
+      Either.catchNonFatal(Try(CRS.fromName(str)) getOrElse CRS.fromString(str)).leftMap(_ => "CRS")
+    }
+
+  implicit val extentEncoder: Encoder[Extent] =
+    new Encoder[Extent] {
+      final def apply(extent: Extent): Json =
+        List(extent.xmin, extent.ymin, extent.xmax, extent.ymax).asJson
+    }
+  implicit val extentDecoder: Decoder[Extent] =
+    Decoder[Json] emap { js =>
+      js.as[List[Double]].map { case List(xmin, ymin, xmax, ymax) =>
+        Extent(xmin, ymin, xmax, ymax)
+      }.leftMap(_ => "Extent")
+    }
+
+  implicit val multipolygonEncoder: Encoder[MultiPolygon] =
+    new Encoder[MultiPolygon] {
+      final def apply(mp: MultiPolygon): Json = {
+        parse(mp.toGeoJson) match {
+          case Right(js: Json) => js
+          case Left(e) => throw e
+        }
+      }
+    }
+
+  implicit val multipolygonDecoder: Decoder[MultiPolygon] = Decoder[Json] map {
+    _.spaces4.parseGeoJson[MultiPolygon]
+  }
+}

--- a/app-backend/build.sbt
+++ b/app-backend/build.sbt
@@ -132,7 +132,7 @@ lazy val apiDependencies = dbDependencies ++ migrationsDependencies ++
 )
 
 lazy val root = Project("root", file("."))
-  .aggregate(api, common, migrations, datamodel, database, batch, tile, tool)
+  .aggregate(api, common, migrations, datamodel, database, batch, tile, tool, bridge)
   .settings(commonSettings:_*)
 
 lazy val api = Project("api", file("api"))
@@ -172,7 +172,7 @@ lazy val migrations = Project("migrations", file("migrations"))
   })
 
 lazy val datamodel = Project("datamodel", file("datamodel"))
-  .dependsOn(tool)
+  .dependsOn(tool, bridge)
   .settings(commonSettings:_*)
   .settings(resolvers += Resolver.bintrayRepo("azavea", "geotrellis"))
   .settings({
@@ -197,7 +197,7 @@ lazy val database = Project("database", file("database"))
   })
 
 lazy val batch = Project("batch", file("batch"))
-  .dependsOn(common, datamodel, database, tool)
+  .dependsOn(common, datamodel, database, tool, bridge)
   .settings(commonSettings:_*)
   .settings(resolvers += Resolver.bintrayRepo("azavea", "geotrellis"))
   .settings({
@@ -271,6 +271,7 @@ lazy val tile = Project("tile", file("tile"))
   .settings(assemblyJarName in assembly := "rf-tile-server.jar")
 
 lazy val tool = Project("tool", file("tool"))
+  .dependsOn(bridge)
   .settings(commonSettings:_*)
   .settings({
     libraryDependencies ++= loggingDependencies ++ Seq(
@@ -283,5 +284,17 @@ lazy val tool = Project("tool", file("tool"))
       Dependencies.circeParser,
       Dependencies.circeOptics,
       Dependencies.scalaCheck
+    )
+  })
+
+
+lazy val bridge = Project("bridge", file("bridge"))
+  .settings(commonSettings:_*)
+  .settings({
+    libraryDependencies ++= loggingDependencies ++ Seq(
+      Dependencies.circeCore,
+      Dependencies.circeGeneric,
+      Dependencies.circeParser,
+      Dependencies.geotrellisVector
     )
   })

--- a/app-backend/build.sbt
+++ b/app-backend/build.sbt
@@ -275,6 +275,8 @@ lazy val tool = Project("tool", file("tool"))
   .settings(commonSettings:_*)
   .settings({
     libraryDependencies ++= loggingDependencies ++ Seq(
+      Dependencies.spark,
+      Dependencies.geotrellisSpark,
       Dependencies.geotrellisRaster,
       Dependencies.geotrellisRasterTestkit,
       Dependencies.shapeless,

--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/AOI.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/AOI.scala
@@ -3,6 +3,7 @@ package com.azavea.rf.datamodel
 import java.sql.Timestamp
 import java.util.{Date, UUID}
 
+import com.azavea.rf.bridge._
 import geotrellis.slick.Projected
 import geotrellis.vector.MultiPolygon
 import io.circe._

--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/ExportOptions.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/ExportOptions.scala
@@ -1,5 +1,6 @@
 package com.azavea.rf.datamodel
 
+import com.azavea.rf.bridge._
 import geotrellis.slick.Projected
 import geotrellis.vector.MultiPolygon
 import geotrellis.proj4.CRS

--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/InputDefinition.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/InputDefinition.scala
@@ -3,6 +3,7 @@ package com.azavea.rf.datamodel
 import java.util.UUID
 
 import cats.implicits._
+import com.azavea.rf.bridge._
 import com.azavea.rf.tool.ast.MapAlgebraAST
 import com.azavea.rf.tool.params.EvalParams
 import geotrellis.vector.MultiPolygon

--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/OutputDefinition.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/OutputDefinition.scala
@@ -1,5 +1,6 @@
 package com.azavea.rf.datamodel
 
+import com.azavea.rf.bridge._
 import geotrellis.proj4.CRS
 import io.circe.generic.JsonCodec
 

--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/Project.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/Project.scala
@@ -3,6 +3,7 @@ package com.azavea.rf.datamodel
 import java.sql.Timestamp
 import java.util.UUID
 
+import com.azavea.rf.bridge._
 import cats.implicits._
 import cats.syntax.either._
 import geotrellis.slick.Projected

--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/Scene.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/Scene.scala
@@ -3,6 +3,7 @@ package com.azavea.rf.datamodel
 import java.sql.Timestamp
 import java.util.UUID
 
+import com.azavea.rf.bridge._
 import geotrellis.vector.Geometry
 import geotrellis.slick.Projected
 

--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/package.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/package.scala
@@ -1,22 +1,23 @@
 package com.azavea.rf
 
 import java.net.URI
-import java.util.UUID
-import java.security.InvalidParameterException
 import java.sql.Timestamp
 import java.time.Instant
+import java.util.UUID
+import java.security.InvalidParameterException
 
 import io.circe._
 import io.circe.parser._
 import io.circe.generic.semiauto._
-import cats.syntax.either._
-import io.circe.syntax._
+
+import com.azavea.rf.bridge._
 
 import geotrellis.vector._
 import geotrellis.vector.io._
 import geotrellis.proj4._
-import geotrellis.slick.Projected
-import scala.util.Try
+import geotrellis.slick._
+
+import cats.syntax.either._
 
 package object datamodel {
 
@@ -41,9 +42,9 @@ package object datamodel {
       "pageSize",
       "results"
     )({
-        pr: PaginatedResponse[A] =>
-        (pr.count, pr.hasPrevious, pr.hasNext, pr.page, pr.pageSize, pr.results)
-      }
+      pr: PaginatedResponse[A] =>
+      (pr.count, pr.hasPrevious, pr.hasNext, pr.page, pr.pageSize, pr.results)
+    }
     )
 
   implicit val timestampEncoder: Encoder[Timestamp] =
@@ -57,8 +58,15 @@ package object datamodel {
     Encoder.encodeString.contramap[UUID](_.toString)
   implicit val uuidDecoder: Decoder[UUID] =
     Decoder.decodeString.emap { str =>
-    Either.catchNonFatal(UUID.fromString(str)).leftMap(_ => "UUID")
-  }
+      Either.catchNonFatal(UUID.fromString(str)).leftMap(_ => "UUID")
+    }
+
+  implicit val uriEncoder: Encoder[URI] =
+    Encoder.encodeString.contramap[URI] { _.toString }
+  implicit val uriDecoder: Decoder[URI] =
+    Decoder.decodeString.emap { str =>
+      Either.catchNonFatal(URI.create(str)).leftMap(_ => "URI")
+    }
 
   implicit val projectedGeometryEncoder: Encoder[Projected[Geometry]] =
     new Encoder[Projected[Geometry]] {
@@ -85,47 +93,7 @@ package object datamodel {
     Projected(js.spaces4.parseGeoJson[Geometry], 4326).reproject(CRS.fromEpsgCode(4326), CRS.fromEpsgCode(3857))(3857)
   }
 
-  implicit val crsEncoder: Encoder[CRS] =
-    Encoder.encodeString.contramap[CRS] { crs => crs.epsgCode.map { c => s"epsg:$c" }.getOrElse(crs.toProj4String) }
-
-  implicit val crsDecoder: Decoder[CRS] =
-    Decoder.decodeString.emap { str =>
-      Either.catchNonFatal(Try(CRS.fromName(str)) getOrElse CRS.fromString(str)).leftMap(_ => "CRS")
-    }
-
-  implicit val extentEncoder: Encoder[Extent] =
-    new Encoder[Extent] {
-      final def apply(extent: Extent): Json =
-        List(extent.xmin, extent.ymin, extent.xmax, extent.ymax).asJson
-    }
-  implicit val extentDecoder: Decoder[Extent] =
-    Decoder[Json] emap { js =>
-      js.as[List[Double]].map { case List(xmin, ymin, xmax, ymax) =>
-        Extent(xmin, ymin, xmax, ymax)
-      }.leftMap(_ => "Extent")
-    }
-
-  implicit val uriEncoder: Encoder[URI] =
-    Encoder.encodeString.contramap[URI] { _.toString }
-  implicit val uriDecoder: Decoder[URI] =
-    Decoder.decodeString.emap { str =>
-      Either.catchNonFatal(URI.create(str)).leftMap(_ => "URI")
-    }
-
-  implicit val multipolygonEncoder: Encoder[MultiPolygon] =
-    new Encoder[MultiPolygon] {
-      final def apply(mp: MultiPolygon): Json = {
-        parse(mp.toGeoJson) match {
-          case Right(js: Json) => js
-          case Left(e) => throw e
-        }
-      }
-    }
-
-  implicit val multipolygonDecoder: Decoder[MultiPolygon] = Decoder[Json] map {
-    _.spaces4.parseGeoJson[MultiPolygon]
-  }
-
   implicit val decodeProjectedMultiPolygon: Decoder[Projected[MultiPolygon]] = deriveDecoder
   implicit val encodeProjectedMultiPolygon: Encoder[Projected[MultiPolygon]] = deriveEncoder
+
 }

--- a/app-backend/tile/src/main/scala/LayerCache.scala
+++ b/app-backend/tile/src/main/scala/LayerCache.scala
@@ -149,12 +149,14 @@ object LayerCache extends Config with LazyLogging {
     voidCache: Boolean = false
   ): OptionT[Future, Histogram[Double]] = {
     val cacheKey = s"histogram-${toolRunId}-${subNode}-${user.id}"
+    val extent: Extent = ???
+
     if (voidCache) histogramCache.delete(cacheKey)
     histogramCache.cachingOptionT(cacheKey) { implicit ec =>
       for {
         (tool, toolRun) <- LayerCache.toolAndToolRun(toolRunId, user, voidCache)
         (ast, params)   <- LayerCache.toolEvalRequirements(toolRunId, subNode, user, voidCache)
-        lztile          <- OptionT(Interpreter.interpretGlobal(ast, params.sources, params.overrides, TileSources.globalSource).map(_.toOption))
+        lztile          <- OptionT(Interpreter.interpretGlobal(ast, params.sources, params.overrides, extent, TileSources.globalSource).map(_.toOption))
         tile            <- OptionT.fromOption[Future](lztile.evaluateDouble)
       } yield {
         val hist = StreamingHistogram.fromTile(tile)

--- a/app-backend/tile/src/main/scala/LayerCache.scala
+++ b/app-backend/tile/src/main/scala/LayerCache.scala
@@ -149,14 +149,14 @@ object LayerCache extends Config with LazyLogging {
     voidCache: Boolean = false
   ): OptionT[Future, Histogram[Double]] = {
     val cacheKey = s"histogram-${toolRunId}-${subNode}-${user.id}"
-    val extent: Extent = ???
 
     if (voidCache) histogramCache.delete(cacheKey)
     histogramCache.cachingOptionT(cacheKey) { implicit ec =>
       for {
         (tool, toolRun) <- LayerCache.toolAndToolRun(toolRunId, user, voidCache)
         (ast, params)   <- LayerCache.toolEvalRequirements(toolRunId, subNode, user, voidCache)
-        lztile          <- OptionT(Interpreter.interpretGlobal(ast, params.sources, params.overrides, extent, TileSources.globalSource).map(_.toOption))
+        (extent, zooms) <- TileSources.fullDataWindow(params.sources)
+        lztile          <- OptionT(Interpreter.interpretGlobal(ast, params.sources, params.overrides, extent, { r => TileSources.globalSource(extent, zooms, r) }).map(_.toOption))
         tile            <- OptionT.fromOption[Future](lztile.evaluateDouble)
       } yield {
         val hist = StreamingHistogram.fromTile(tile)

--- a/app-backend/tile/src/main/scala/LayerCache.scala
+++ b/app-backend/tile/src/main/scala/LayerCache.scala
@@ -155,8 +155,8 @@ object LayerCache extends Config with LazyLogging {
       for {
         (tool, toolRun) <- LayerCache.toolAndToolRun(toolRunId, user, voidCache)
         (ast, params)   <- LayerCache.toolEvalRequirements(toolRunId, subNode, user, voidCache)
-        (extent, zooms) <- TileSources.fullDataWindow(params.sources)
-        lztile          <- OptionT(Interpreter.interpretGlobal(ast, params.sources, params.overrides, extent, { r => TileSources.globalSource(extent, zooms, r) }).map(_.toOption))
+        (extent, zoom)  <- TileSources.fullDataWindow(params.sources)
+        lztile          <- OptionT(Interpreter.interpretGlobal(ast, params.sources, params.overrides, extent, { r => TileSources.globalSource(extent, zoom, r) }).map(_.toOption))
         tile            <- OptionT.fromOption[Future](lztile.evaluateDouble)
       } yield {
         val hist = StreamingHistogram.fromTile(tile)

--- a/app-backend/tile/src/main/scala/tool/TileSources.scala
+++ b/app-backend/tile/src/main/scala/tool/TileSources.scala
@@ -8,15 +8,10 @@ import com.azavea.rf.tool.params._
 
 import com.typesafe.scalalogging.LazyLogging
 import cats.implicits._
-import geotrellis.proj4._
 import geotrellis.raster._
 import geotrellis.slick.Projected
 import geotrellis.spark._
 import geotrellis.spark.io.s3._
-import geotrellis.spark.tiling._
-import spray.json.DefaultJsonProtocol._
-import geotrellis.raster.io._
-import geotrellis.vector.io._
 import geotrellis.spark.io._
 
 import scala.util._

--- a/app-backend/tile/src/main/scala/tool/TileSources.scala
+++ b/app-backend/tile/src/main/scala/tool/TileSources.scala
@@ -7,13 +7,16 @@ import com.azavea.rf.tool.ast._
 import com.azavea.rf.tool.params._
 
 import com.typesafe.scalalogging.LazyLogging
+import cats.data._
 import cats.implicits._
 import geotrellis.raster._
 import geotrellis.slick.Projected
 import geotrellis.spark._
 import geotrellis.spark.io.s3._
 import geotrellis.spark.io._
+import geotrellis.vector.Extent
 
+import java.util.UUID
 import scala.util._
 import scala.concurrent._
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -26,50 +29,80 @@ import scala.concurrent.ExecutionContext.Implicits.global
   */
 object TileSources extends LazyLogging {
 
+  /** Given the data sources for some AST, determine the "data window" for
+    * the entire data set. This ensures that global AST interpretation will behave
+    * correctly, so that valid  histograms can be generated.
+    */
+  def fullDataWindow(
+    rs: Map[UUID, RFMLRaster]
+  )(implicit database: Database): OptionT[Future, (Extent, Map[UUID, Int])] = {
+    rs
+      .values
+      .toStream
+      .map(r => dataWindow(r).map({ case (e, z) => (e, (r.id, z)) }))
+      .sequence
+      .map({ pairs =>
+        val (extents, zooms) = pairs.unzip
+        val extent = extents.reduce(_ combine _)
+
+        (extent, zooms.toMap)
+      })
+  }
+
+  /** Given a reference to a source of data, computes the "data window" of
+    * the entire dataset. The `Int` is the minimally acceptable zoom level at
+    * which one could read a Layer for the purpose of calculating a representative
+    * histogram.
+    */
+  def dataWindow(r: RFMLRaster)(implicit database: Database): OptionT[Future, (Extent, Int)] = r match {
+    case SceneRaster(id, Some(_), _) => {
+      LayerCache.attributeStoreForLayer(id).mapFilter({ case (store, _) =>
+        GlobalSummary.minAcceptableSceneZoom(id, store, 256)  // TODO: 512?
+      })
+    }
+    case ProjectRaster(id, Some(_), _) => GlobalSummary.minAcceptableProjectZoom(id, 256) // TODO: 512?
+
+    /* Don't attempt work for a RFMLRaster which will fail AST validation anyway */
+    case _ => OptionT.none
+  }
+
   /** This source will return the raster for all of zoom level 1 and is
     *  useful for generating a histogram which allows binning values into
     *  quantiles.
     */
-  def globalSource(r: RFMLRaster)(implicit database: Database): Future[Option[Tile]] =
-    r match {
-      case scene @ SceneRaster(sceneId, Some(band), maybeND) =>
-        LayerCache.attributeStoreForLayer(sceneId).mapFilter { case (store, _) =>
-          GlobalSummary.minAcceptableSceneZoom(sceneId, store).flatMap { case (extent, zoom) =>
-            blocking {
-              Try {
-                val layerId = LayerId(sceneId.toString, zoom)
-                S3CollectionLayerReader(store)
-                  .query[SpatialKey, MultibandTile, TileLayerMetadata[SpatialKey]](layerId)
-                  .result
-                  .stitch
-                  .crop(extent)
-                  .tile
-              } match {
-                case Success(tile) =>
-                  Some(tile.interpretAs(maybeND.getOrElse(tile.cellType)))
-                case Failure(e) =>
-                  logger.error(s"Query layer $sceneId at zoom $zoom for $extent: ${e.getMessage}")
-                  None
-              }
-            }
+  def globalSource(
+    extent: Extent,
+    zooms: Map[UUID, Int],
+    r: RFMLRaster
+  )(implicit database: Database): Future[Option[Tile]] = r match {
+    case SceneRaster(id, Some(band), maybeND) =>
+      LayerCache.attributeStoreForLayer(id).mapFilter({ case (store, _) =>
+        blocking {
+          Try {
+            val layerId = LayerId(id.toString, zooms(id))
+
+            S3CollectionLayerReader(store)
+              .query[SpatialKey, MultibandTile, TileLayerMetadata[SpatialKey]](layerId)
+              .result
+              .stitch
+              .crop(extent)
+              .tile
+          } match {
+            case Success(tile) => Option(tile.band(band).interpretAs(maybeND.getOrElse(tile.cellType)))
+            case Failure(e) =>
+              logger.error(s"Query layer $id at zoom ${zooms(id)} for $extent: ${e.getMessage}")
+              None
           }
-        }.map({ mbtile => mbtile.band(band) }).value
+        }
+      }).value
 
-      case scene @ SceneRaster(sceneId, None, _) =>
-        logger.warn(s"Request for $scene does not contain band index")
-        Future.successful(None)
-
-      case project @ ProjectRaster(projId, Some(band), maybeND) =>
-        GlobalSummary.minAcceptableProjectZoom(projId).flatMap { case (extent, zoom) =>
-          Mosaic.rawForExtent(projId, zoom, Some(Projected(extent.toPolygon, 3857)))
-            .map({ tile => tile.band(band).interpretAs(maybeND.getOrElse(tile.cellType)) })
-        }.value
-
-      case project @ ProjectRaster(projId, None, _) =>
-        logger.warn(s"Request for $project does not contain band index")
-        Future.successful(None)
-
+    case ProjectRaster(projId, Some(band), maybeND) => {
+      Mosaic.rawForExtent(projId, zooms(projId), Some(Projected(extent.toPolygon, 3857)))
+        .map({ tile => tile.band(band).interpretAs(maybeND.getOrElse(tile.cellType)) }).value
     }
+
+    case _ => Future.successful(None)
+  }
 
   /** This source provides support for z/x/y TMS tiles */
   def cachedTmsSource(r: RFMLRaster, z: Int, x: Int, y: Int)(implicit database: Database): Future[Option[Tile]] =

--- a/app-backend/tool/src/main/scala/ast/MapAlgebraAST.scala
+++ b/app-backend/tool/src/main/scala/ast/MapAlgebraAST.scala
@@ -1,5 +1,6 @@
 package com.azavea.rf.tool.ast
 
+import geotrellis.vector.MultiPolygon
 import java.util.UUID
 
 import io.circe.generic.JsonCodec

--- a/app-backend/tool/src/main/scala/ast/MapAlgebraAST.scala
+++ b/app-backend/tool/src/main/scala/ast/MapAlgebraAST.scala
@@ -66,9 +66,9 @@ object MapAlgebraAST {
     def withArgs(newArgs: List[MapAlgebraAST]): MapAlgebraAST = Division(newArgs, id, metadata)
   }
 
-  case class Masking(args: List[MapAlgebraAST], id: UUID, metadata: Option[NodeMetadata])
-      extends Operation("mask") {
-    def withArgs(newArgs: List[MapAlgebraAST]): MapAlgebraAST = Masking(newArgs, id, metadata)
+  case class Masking(args: List[MapAlgebraAST], id: UUID, metadata: Option[NodeMetadata], mask: MultiPolygon)
+      extends UnaryOp("mask") {
+    def withArgs(newArgs: List[MapAlgebraAST]): MapAlgebraAST = Masking(newArgs, id, metadata, mask)
   }
 
   case class Classification(args: List[MapAlgebraAST], id: UUID, metadata: Option[NodeMetadata], classMap: ClassMap)

--- a/app-backend/tool/src/main/scala/ast/MapAlgebraAST.scala
+++ b/app-backend/tool/src/main/scala/ast/MapAlgebraAST.scala
@@ -1,11 +1,11 @@
 package com.azavea.rf.tool.ast
 
-import geotrellis.vector.MultiPolygon
 import java.util.UUID
 
 import io.circe.generic.JsonCodec
 import cats.implicits._
 
+import geotrellis.vector.MultiPolygon
 
 /** The ur-type for a recursive representation of MapAlgebra operations */
 sealed trait MapAlgebraAST extends Product with Serializable {

--- a/app-backend/tool/src/main/scala/ast/codec/MapAlgebraOperationCodecs.scala
+++ b/app-backend/tool/src/main/scala/ast/codec/MapAlgebraOperationCodecs.scala
@@ -76,9 +76,9 @@ trait MapAlgebraOperationCodecs {
     Encoder.forProduct4("apply", "args", "id", "metadata")(op => (op.symbol, op.args, op.id, op.metadata))
 
   implicit lazy val decodeMasking: Decoder[MapAlgebraAST.Masking] =
-    Decoder.forProduct3("args", "id", "metadata")(MapAlgebraAST.Masking.apply)
+    Decoder.forProduct4("args", "id", "metadata", "mask")(MapAlgebraAST.Masking.apply)
   implicit lazy val encodeMasking: Encoder[MapAlgebraAST.Masking] =
-    Encoder.forProduct4("apply", "args", "id", "metadata")(op => (op.symbol, op.args, op.id, op.metadata))
+    Encoder.forProduct5("apply", "args", "id", "metadata", "mask")(op => (op.symbol, op.args, op.id, op.metadata, op.mask))
 
   implicit lazy val decodeClassification: Decoder[MapAlgebraAST.Classification] =
     Decoder.forProduct4("args", "id", "metadata", "classMap")(MapAlgebraAST.Classification.apply)

--- a/app-backend/tool/src/main/scala/ast/codec/MapAlgebraOperationCodecs.scala
+++ b/app-backend/tool/src/main/scala/ast/codec/MapAlgebraOperationCodecs.scala
@@ -2,6 +2,7 @@ package com.azavea.rf.tool.ast.codec
 
 import com.azavea.rf.tool.ast._
 import com.azavea.rf.tool.eval._
+import com.azavea.rf.bridge._
 import io.circe._
 import io.circe.syntax._
 

--- a/app-backend/tool/src/main/scala/eval/Interpreter.scala
+++ b/app-backend/tool/src/main/scala/eval/Interpreter.scala
@@ -1,20 +1,22 @@
 package com.azavea.rf.tool.eval
 
-import com.azavea.rf.tool.ast._
-import com.azavea.rf.tool.params._
-import com.azavea.rf.tool.ast.MapAlgebraAST._
-import com.azavea.rf.tool.params.ParamOverride
+import java.util.UUID
+
+import scala.concurrent.{ExecutionContext, Future}
 
 import cats._
 import cats.data._
 import cats.data.Validated._
 import cats.implicits._
-
+import com.azavea.rf.tool.ast._
+import com.azavea.rf.tool.ast.MapAlgebraAST._
+import com.azavea.rf.tool.params._
 import com.typesafe.scalalogging.LazyLogging
+import geotrellis.proj4.WebMercator
 import geotrellis.raster._
-
-import java.util.UUID
-import scala.concurrent.{ExecutionContext, Future}
+import geotrellis.spark.SpatialKey
+import geotrellis.spark.tiling._
+import geotrellis.vector.{Extent, MultiPolygon}
 
 /** This interpreter handles resource resolution and compilation of MapAlgebra ASTs */
 object Interpreter extends LazyLogging {
@@ -22,36 +24,9 @@ object Interpreter extends LazyLogging {
   /** The Interpreted type is either a list of failures or a compiled MapAlgebra operation */
   type Interpreted[A] = ValidatedNel[InterpreterError, A]
 
-  @SuppressWarnings(Array("TraversableHead"))
-  def interpretOperation(op: Operation, eval: MapAlgebraAST => LazyTile): LazyTile = op match {
-    case Addition(args, id, _) =>
-      logger.debug(s"case addition at $id")
-      args.map(eval).reduce(_ + _)
-
-    case Subtraction(args, id, _) =>
-      logger.debug(s"case subtraction at $id")
-      args.map(eval).reduce(_ - _)
-
-    case Multiplication(args, id, _) =>
-      logger.debug(s"case multiplication at $id")
-      args.map(eval).reduce(_ * _)
-
-    case Division(args, id, _) =>
-      logger.debug(s"case division at $id")
-      args.map(eval).reduce(_ / _)
-
-    case Max(args, id, _) =>
-      logger.debug(s"case max at $id")
-      args.map(eval).reduce(_ max _)
-
-    case Min(args, id, _) =>
-      logger.debug(s"case min at $id")
-      args.map(eval).reduce(_ min _)
-
-    case Classification(args, id, _, breaks) =>
-      logger.debug(s"case classification at $id with breakmap ${breaks.toBreakMap}")
-      eval(args.head).classify(breaks.toBreakMap)
-  }
+  val layouts: Array[LayoutDefinition] = (0 to 30).map(n =>
+    ZoomedLayoutScheme.layoutForZoom(n, WebMercator.worldExtent, 256)
+  ).toArray
 
   def overrideParams(
     ast: MapAlgebraAST,
@@ -80,6 +55,19 @@ object Interpreter extends LazyLogging {
       (kids |@| breaks).map({ case (ks, bs) => Classification(ks, id, m, bs) })
     }
 
+    case Masking(args, id, meta, mask) => {
+      val kids: Interpreted[List[MapAlgebraAST]] =
+        args.map(a => overrideParams(a, overrides)).sequence
+
+      val newMask: Interpreted[MultiPolygon] = overrides.get(id) match {
+        case None => Valid(mask)
+        case Some(ParamOverride.Masking(m)) => Valid(m)
+        case Some(_) => Invalid(NonEmptyList.of(InvalidOverride(id)))
+      }
+
+      (kids |@| newMask).map({ case (ks, m) => Masking(ks, id, meta, m) })
+    }
+
     /* Non-overridable Operations */
     case Addition(args, id, m) =>
       args.map(a => overrideParams(a, overrides)).sequence.map(ks => Addition(ks, id, m))
@@ -93,7 +81,6 @@ object Interpreter extends LazyLogging {
       args.map(a => overrideParams(a, overrides)).sequence.map(ks => Min(ks, id, m))
     case Max(args, id, m) =>
       args.map(a => overrideParams(a, overrides)).sequence.map(ks => Max(ks, id, m))
-    case op => Invalid(NonEmptyList.of(UnhandledCase(op.id)))
   }
 
   /** Interpret an AST with its matched execution parameters, but do so
@@ -140,15 +127,49 @@ object Interpreter extends LazyLogging {
     ast: MapAlgebraAST,
     sourceMapping: Map[UUID, RFMLRaster],
     overrides: Map[UUID, ParamOverride],
+    extent: Extent,
     source: RFMLRaster => Future[Option[Tile]]
   )(implicit ec: ExecutionContext): Future[Interpreted[LazyTile]] = {
 
     def eval(tiles: Map[UUID, Tile], ast: MapAlgebraAST): LazyTile = ast match {
+
+      /* --- LEAVES --- */
+
       case Source(id, _) => LazyTile(tiles(id))
       case Constant(_, const, _) => LazyTile.Constant(const)
-      case op: Operation => interpretOperation(op, { tree => eval(tiles, tree) })
-      case unsupported =>
-        throw new java.lang.IllegalStateException(s"Pattern match failure on putative AST: $unsupported")
+
+      /* --- OPERATIONS --- */
+
+      case Addition(args, id, _) =>
+        logger.debug(s"case addition at $id")
+        args.map(eval(tiles, _)).reduce(_ + _)
+
+      case Subtraction(args, id, _) =>
+        logger.debug(s"case subtraction at $id")
+        args.map(eval(tiles, _)).reduce(_ - _)
+
+      case Multiplication(args, id, _) =>
+        logger.debug(s"case multiplication at $id")
+        args.map(eval(tiles, _)).reduce(_ * _)
+
+      case Division(args, id, _) =>
+        logger.debug(s"case division at $id")
+        args.map(eval(tiles, _)).reduce(_ / _)
+
+      case Max(args, id, _) =>
+        logger.debug(s"case max at $id")
+        args.map(eval(tiles, _)).reduce(_ max _)
+
+      case Min(args, id, _) =>
+        logger.debug(s"case min at $id")
+        args.map(eval(tiles, _)).reduce(_ min _)
+
+      case Classification(args, id, _, breaks) =>
+        logger.debug(s"case classification at $id with breakmap ${breaks.toBreakMap}")
+        eval(tiles, args.head).classify(breaks.toBreakMap)
+
+      case Masking(args, id, _, mask) =>
+        eval(tiles, args.head).mask(extent, mask)
     }
 
     val pure: Interpreted[Unit] = interpretPure[Unit](ast, sourceMapping)
@@ -181,7 +202,13 @@ object Interpreter extends LazyLogging {
   )(implicit ec: ExecutionContext): (Int, Int, Int) => Future[Interpreted[LazyTile]] = {
 
     (z: Int, x: Int, y: Int) => {
-      interpretGlobal(ast, sourceMapping, overrides, { raster: RFMLRaster => source(raster, z, x, y) })
+      interpretGlobal(
+        ast,
+        sourceMapping,
+        overrides,
+        layouts(z).mapTransform(SpatialKey(x,y)),
+        { raster: RFMLRaster => source(raster, z, x, y) }
+      )
     }
   }
 }

--- a/app-backend/tool/src/main/scala/eval/Interpreter.scala
+++ b/app-backend/tool/src/main/scala/eval/Interpreter.scala
@@ -131,15 +131,14 @@ object Interpreter extends LazyLogging {
     source: RFMLRaster => Future[Option[Tile]]
   )(implicit ec: ExecutionContext): Future[Interpreted[LazyTile]] = {
 
+    @SuppressWarnings(Array("TraversableHead"))
     def eval(tiles: Map[UUID, Tile], ast: MapAlgebraAST): LazyTile = ast match {
 
       /* --- LEAVES --- */
-
       case Source(id, _) => LazyTile(tiles(id))
       case Constant(_, const, _) => LazyTile.Constant(const)
 
       /* --- OPERATIONS --- */
-
       case Addition(args, id, _) =>
         logger.debug(s"case addition at $id")
         args.map(eval(tiles, _)).reduce(_ + _)

--- a/app-backend/tool/src/main/scala/eval/InterpreterError.scala
+++ b/app-backend/tool/src/main/scala/eval/InterpreterError.scala
@@ -28,6 +28,10 @@ case class UnhandledCase(id: UUID) extends InterpreterError {
   def repr = s"Some branch of Interpreter logic has yet to be implemented: ${id}"
 }
 
+case class UnsubstitutedRef(id: UUID) extends InterpreterError {
+  def repr = s"Unsubstituted Tool reference found: ${id}"
+}
+
 case class NoBandGiven(id: UUID) extends InterpreterError {
   def repr = s"No band value given for Scene ${id}"
 }

--- a/app-backend/tool/src/main/scala/eval/LazyTile.scala
+++ b/app-backend/tool/src/main/scala/eval/LazyTile.scala
@@ -193,49 +193,29 @@ object LazyTile {
       Classify(left.bind(args), f)
   }
 
-  /* TODO: Precompute a BitRaster based on the mask to show where overlaps occur,
-   * that way we can avoid having to calculate a `Point` upon every `get` call,
-   * and avoid having to do JTS intersection tests.
-   */
   case class Masking(left: LazyTile, extent: Extent, mask: MultiPolygon) extends Tree {
-    val xres: Double = (extent.xmax - extent.xmin) / cols
-    val yres: Double = (extent.ymax - extent.ymin) / rows
-
-    /*
     lazy val cellMask: Tile = {
-      val masky = ArrayTile.empty(BitCells, this.cols, this.rows)
+      val masky = ArrayTile.empty(BitCellType, this.cols, this.rows)
+
       RasterExtent(extent, this.cols, this.rows)
-        .foreach(mask)({ (col, row) =>
-          masky.set(col, row, 1)
-        })
+        .foreach(mask)({ (col, row) => masky.set(col, row, 1) })
 
       masky
-    }
-     */
-
-    /* TODO: Inline this */
-//    def inMask2(col: Int, row: Int): Boolean = cellMask.get(col, row) == 1
-
-    /** Is the requested pixel inside the Mask area? */
-    def inMask(col: Int, row: Int): Boolean = {
-      val p = Point(extent.xmin + (col + 0.5) * xres, extent.ymax - (row + 0.5) * yres)
-
-      mask.intersects(p)
     }
 
     /** Perform the NODATA checks ahead of time, in case the underlying Tile
       * is sparse. This will then only check for Mask intersection if the value to
       * give back could be something other than NODATA.
       */
-    def get(col: Int, row: Int) = {
+    def get(col: Int, row: Int): Int = {
       val v: Int = left.get(col, row)
 
-      if (isNoData(v)) v else if (inMask(col, row)) v else NODATA
+      if (isNoData(v)) v else if (cellMask.get(col, row) == 1) v else NODATA
     }
-    def getDouble(col: Int, row: Int) = {
+    def getDouble(col: Int, row: Int): Double = {
       val v: Double = left.getDouble(col, row)
 
-      if (isNoData(v)) v else if (inMask(col, row)) v else Double.NaN
+      if (isNoData(v)) v else if (cellMask.get(col, row) == 1) v else Double.NaN
     }
     def right = LazyTile.Nil
     def bind(args: Map[Var, LazyTile]): LazyTile =

--- a/app-backend/tool/src/main/scala/eval/LazyTile.scala
+++ b/app-backend/tool/src/main/scala/eval/LazyTile.scala
@@ -198,8 +198,8 @@ object LazyTile {
    * and avoid having to do JTS intersection tests.
    */
   case class Masking(left: LazyTile, extent: Extent, mask: MultiPolygon) extends Tree {
-    val xres: Double = cols / (extent.xmax - extent.xmin)
-    val yres: Double = rows / (extent.ymax - extent.ymin)
+    val xres: Double = (extent.xmax - extent.xmin) / cols
+    val yres: Double = (extent.ymax - extent.ymin) / rows
 
     /*
     lazy val cellMask: Tile = {
@@ -218,7 +218,7 @@ object LazyTile {
 
     /** Is the requested pixel inside the Mask area? */
     def inMask(col: Int, row: Int): Boolean = {
-      val p = Point(extent.xmin + col * xres, extent.ymin + row * yres)
+      val p = Point(extent.xmin + (col + 0.5) * xres, extent.ymax - (row + 0.5) * yres)
 
       mask.intersects(p)
     }

--- a/app-backend/tool/src/main/scala/params/EvalParams.scala
+++ b/app-backend/tool/src/main/scala/params/EvalParams.scala
@@ -3,10 +3,14 @@ package com.azavea.rf.tool.params
 import java.util.UUID
 
 import cats.syntax.either._
+import com.azavea.rf.bridge._
 import com.azavea.rf.tool.ast._
+import geotrellis.vector.MultiPolygon
 import io.circe._
 import io.circe.syntax._
 import io.circe.generic.JsonCodec
+
+// --- //
 
 /* Yes, it is correct that all three of these fields can be empty. It is
  * possible to construct a legal AST that will produce results yet has no
@@ -43,6 +47,7 @@ object ParamOverride {
 
   @JsonCodec case class Classification(classMap: ClassMap) extends ParamOverride
   @JsonCodec case class Constant(constant: Double) extends ParamOverride
+  @JsonCodec case class Masking(mask: MultiPolygon) extends ParamOverride
 
   /** Add more possibilities as necessary with the `.orElse` mechanic
     * (the "Alternative" pattern).
@@ -50,12 +55,14 @@ object ParamOverride {
   implicit val dec: Decoder[ParamOverride] = Decoder.instance[ParamOverride]({ po =>
     po.downField("classify").as[Classification]
       .orElse(po.downField("constant").as[Constant])
+      .orElse(po.downField("mask").as[Masking])
   })
 
   implicit val enc: Encoder[ParamOverride] = new Encoder[ParamOverride] {
     def apply(overrides: ParamOverride): Json = overrides match {
       case c: Classification => c.asJson
       case c: Constant => c.asJson
+      case m: Masking => m.asJson
     }
   }
 }

--- a/app-backend/tool/src/test/scala/Generators.scala
+++ b/app-backend/tool/src/test/scala/Generators.scala
@@ -11,6 +11,7 @@ import org.scalacheck.Prop.forAll
 import geotrellis.raster.histogram._
 import geotrellis.raster.render._
 import geotrellis.raster._
+import geotrellis.vector._
 
 import scala.util.Random
 import java.util.UUID
@@ -36,6 +37,13 @@ object Generators {
     dubs <- Gen.containerOfN[List, Double](30, arbitrary[Double])
     ints <- Gen.containerOfN[List, Int](30, arbitrary[Int])
   } yield ClassMap(dubs.zip(ints).toMap)
+
+  /*
+  lazy val genMultiPolygon: Gen[MultiPolygon] = for {
+    xs <- Gen.containerOfN[List, Double](10, arbitrary[Double])
+    ys <- Gen.containerOfN[List, Double](10, arbitrary[Double])
+  } yield MultiPolygon(Polygon(xs.zip(ys) :+ (xs.head, ys.head)))
+   */
 
   lazy val genNodeMetadata: Gen[NodeMetadata] = for {
     label <- Gen.option(arbitrary[String])
@@ -87,7 +95,6 @@ object Generators {
                      MapAlgebraAST.Subtraction.apply _,
                      MapAlgebraAST.Multiplication.apply _,
                      MapAlgebraAST.Division.apply _,
-                     MapAlgebraAST.Masking.apply _,
                      MapAlgebraAST.Max.apply _,
                      MapAlgebraAST.Min.apply _
                    ))
@@ -103,8 +110,20 @@ object Generators {
     cmap <- genClassMap
   } yield MapAlgebraAST.Classification(args, id, nmd, cmap)
 
+  def genMaskingAST(depth: Int) = for {
+    args <- containerOfN[List, MapAlgebraAST](1, genMapAlgebraAST(depth))
+    id <- arbitrary[UUID]
+    nmd <- Gen.option(genNodeMetadata)
+  } yield {
+    val mp = MultiPolygon(Polygon((0, 0), (0, 10), (10, 10), (10, 0), (0, 0)))
+
+    MapAlgebraAST.Masking(args, id, nmd, mp)
+  }
+
+  // TODO: If `genMaskingAST` is included, AST generation diverges!
   def genOpAST(depth: Int) = Gen.frequency(
     (5 -> genBinaryOpAST(depth)),
+//    (2 -> genMaskingAST(depth)),
     (1 -> genClassificationAST(depth))
   )
 
@@ -116,5 +135,4 @@ object Generators {
   def genMapAlgebraAST(depth: Int = 1): Gen[MapAlgebraAST] =
     if (depth >= 100) genLeafAST
     else Gen.frequency((1 -> genOpAST(depth + 1)), (1 -> genLeafAST))
-
 }

--- a/app-backend/tool/src/test/scala/MockInterpreterResources.scala
+++ b/app-backend/tool/src/test/scala/MockInterpreterResources.scala
@@ -27,7 +27,7 @@ trait MockInterpreterResources extends TileBuilders with RasterMatchers {
 
   def tileSource(band: Int) = SceneRaster(UUID.randomUUID, Some(band), None)
 
-  def tile(value: Int): Tile = createValueTile(d = 4, v = value)
+  def tile(value: Int): Tile = createValueTile(d = 256, v = value)
 
   var requests = List.empty[RFMLRaster]
 

--- a/app-backend/tool/src/test/scala/ast/MapAlgebraASTSpec.scala
+++ b/app-backend/tool/src/test/scala/ast/MapAlgebraASTSpec.scala
@@ -1,17 +1,10 @@
 package com.azavea.rf.tool.ast
 
 import com.azavea.rf.tool.ast.MapAlgebraAST._
-import com.azavea.rf.tool.ast.codec._
-import com.azavea.rf.tool.eval._
-
-import org.scalatest._
-import io.circe._
-import io.circe.parser._
-import io.circe.syntax._
-import cats.syntax.either._
 
 import java.util.UUID
 
+import org.scalatest._
 
 class MapAlgebraASTSpec extends FunSpec with Matchers {
 

--- a/app-backend/tool/src/test/scala/ast/codec/MapAlgebraASTCodecSpec.scala
+++ b/app-backend/tool/src/test/scala/ast/codec/MapAlgebraASTCodecSpec.scala
@@ -1,21 +1,12 @@
 package com.azavea.rf.tool.ast.codec
 
-import com.azavea.rf.tool.ast._
-import com.azavea.rf.tool.eval._
-import com.azavea.rf.tool.Generators._
-
-import org.scalacheck._
-import org.scalacheck.Gen._
-import org.scalacheck.Arbitrary.arbitrary
-import org.scalacheck.Prop.forAll
-import org.scalatest.prop._
-import org.scalatest._
-import io.circe._
-import io.circe.parser._
-import io.circe.syntax._
 import cats.syntax.either._
-
-import java.util.UUID
+import com.azavea.rf.tool.Generators._
+import com.azavea.rf.tool.ast._
+import io.circe.syntax._
+import org.scalacheck.Prop.forAll
+import org.scalatest._
+import org.scalatest.prop._
 
 
 class MapAlgebraASTCodecSpec extends PropSpec with Checkers {

--- a/app-backend/tool/src/test/scala/params/EvalParamsSpec.scala
+++ b/app-backend/tool/src/test/scala/params/EvalParamsSpec.scala
@@ -2,7 +2,6 @@ package com.azavea.rf.tool.params
 
 import cats.syntax.either._
 import com.azavea.rf.tool.Generators._
-import io.circe._
 import io.circe.syntax._
 import org.scalacheck.Prop.forAll
 import org.scalatest._


### PR DESCRIPTION
### Overview

This PR implements the `Masking` operation in both the Tile server and in AST Exports.

### TODO

- [x] Reorganize orphan instances from GT
- [x] Extend `Masking` implementation
- [x] `Masking` validation
- [x] Param overrides for `Masking`
- [x] `Masking` Interpretation
  - [x] Tile server
  - [x] Exports
- [x] Demo
- [x] Optimize LazyTile `Masking` with bit Raster

### Demo

![cooler-masking](https://user-images.githubusercontent.com/229679/27659207-7d003f92-5c07-11e7-8e45-c0ab309d010e.png)

### Notes

This introduces a new subpackage called `bridge`. It is a common location for orphaned typeclass instances for GeoTrellis types to live, which helps avoid a circular dependency in this PR.

Closes #2050 
