### PR TITLE
Enable front end color auto correction.

### DIFF
--- a/app-frontend/src/app/pages/projects/edit/color/color.controller.js
+++ b/app-frontend/src/app/pages/projects/edit/color/color.controller.js
@@ -1,18 +1,52 @@
 export default class ProjectsEditColorController {
     constructor( // eslint-disable-line max-params
-        $log, $scope, $q, projectService, layerService, sceneService, $state, mapService,
-        datasourceService
+        $scope, projectService, colorCorrectService
     ) {
         'ngInject';
-        this.projectService = projectService;
-        this.layerService = layerService;
-        this.sceneService = sceneService;
-        this.datasourceService = datasourceService;
-        this.$state = $state;
         this.$scope = $scope;
         this.$parent = $scope.$parent.$ctrl;
-        this.$q = $q;
-        this.$log = $log;
-        this.getMap = () => mapService.getMap('edit');
+        this.projectService = projectService;
+        this.colorCorrectService = colorCorrectService;
+    }
+
+    $onInit() {
+        this.currentBands = null;
+        this.correction = null;
+        this.$parent.sceneListQuery.then(() => {
+            let layer = this.$parent.sceneLayers.values().next();
+            if (layer && layer.value) {
+                layer.value.getColorCorrection().then((correction) => {
+                    this.currentBands = {
+                        redBand: correction.redBand,
+                        greenBand: correction.greenBand,
+                        blueBand: correction.blueBand
+                    };
+                    this.correction = correction;
+                });
+            }
+        });
+    }
+
+    isActiveAutoColorCorrection(correctionType) {
+        if (this.correction) {
+            return this.correction[correctionType].enabled;
+        }
+        return false;
+    }
+
+    setAutoColorCorrection(correctionType) {
+        this.correction[correctionType].enabled = !this.correction[correctionType].enabled;
+        const promise = this.colorCorrectService.bulkUpdate(
+            this.projectService.currentProject.id,
+            Array.from(this.$parent.sceneLayers.keys()),
+            this.correction
+        );
+        this.redrawMosaic(promise);
+    }
+
+    redrawMosaic(promise) {
+        promise.then(() => {
+            this.$parent.layerFromProject();
+        });
     }
 }

--- a/app-frontend/src/app/pages/projects/edit/color/color.html
+++ b/app-frontend/src/app/pages/projects/edit/color/color.html
@@ -17,28 +17,28 @@
     </li>
   </ul>
 </div>
+
 <div class="sidebar-scrollable">
-  <ul class="sidebar-list">
-    <li class="separator">
-      <button class="btn btn-light btn-block"
-              disabled>
-        Auto Tone
-      </button>
-      <i class="icon-info"></i>
-    </li>
-    <li class="separator">
-      <button class="btn btn-light btn-block"
-              disabled>
-        Auto Contrast
-      </button>
-      <i class="icon-info"></i>
-    </li>
-    <li class="separator">
-      <button class="btn btn-light btn-block"
-              disabled>
-        Auto Color
-      </button>
-      <i class="icon-info"></i>
-    </li>
-  </ul>
+  <div class="list-group">
+    <div class="list-group-item">
+      <div>
+        <span title="Auto Contrast"><strong>Auto Contrast</strong></span>
+      </div>
+      <div class="list-group-right">
+        <rf-toggle value="$ctrl.isActiveAutoColorCorrection('equalize')" on-change="$ctrl.setAutoColorCorrection('equalize')">
+          <i class="icon-check"></i>
+        </rf-toggle>
+      </div>
+    </div>
+    <div class="list-group-item">
+      <div>
+        <span title="Auto Color"><strong>Auto Color</strong></span>
+      </div>
+      <div class="list-group-right">
+        <rf-toggle value="$ctrl.isActiveAutoColorCorrection('autoBalance')" on-change="$ctrl.setAutoColorCorrection('autoBalance')">
+          <i class="icon-check"></i>
+        </rf-toggle>
+      </div>
+    </div>
+  </div>
 </div>

--- a/app-frontend/yarn.lock
+++ b/app-frontend/yarn.lock
@@ -4339,11 +4339,11 @@ lodash@3.10.1, lodash@^3.10.0, lodash@^3.10.1, lodash@^3.5.0, lodash@^3.8.0:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
 
-lodash@^4.0.0, lodash@^4.0.1, lodash@^4.2.0, lodash@^4.3.0, lodash@^4.5.0, lodash@~4.5.0:
+lodash@^4.0.0, lodash@^4.0.1, lodash@^4.2.0, lodash@~4.5.0:
   version "4.5.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.5.1.tgz#80e8a074ca5f3893a6b1c10b2a636492d710c316"
 
-lodash@^4.17.2, lodash@^4.17.4:
+lodash@^4.17.2, lodash@^4.17.4, lodash@^4.3.0, lodash@^4.5.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 


### PR DESCRIPTION
## Overview

Enable front end color auto correction.  Turning on "Auto Contrast" will enable "equalize" option of color correction.  Turning on "Auto Color" will enable "autoBalance" option of color correction.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~

### Demo

<img width="1018" alt="color correct" src="https://user-images.githubusercontent.com/16109558/27407675-60f07e12-56a7-11e7-938e-1f679c8850e3.png">

## Testing Instructions

 * On the "Editing Project" page
 * Click "Correction" button
 * Click on checkboxes to select autocorrection types.
 * See the imagery changes on the map.

Closes #1889 
