### PR TITLE
ColorCorrection improvements

### DIFF
--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/ColorCorrect.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/ColorCorrect.scala
@@ -1,300 +1,29 @@
 package com.azavea.rf.datamodel
 
-import java.io._
-
-import io.circe._
-import io.circe.syntax._
-import io.circe.generic.JsonCodec
-
-import spire.syntax.cfor._
-
-import geotrellis.raster._
-import geotrellis.raster.crop._
-import geotrellis.raster.equalization.HistogramEqualization
-import geotrellis.raster.histogram.Histogram
-import geotrellis.raster.sigmoidal.SigmoidalContrast
-import akka.http.scaladsl.server.Directives._
-import akka.http.scaladsl.server._
-
-import scala.math._
-import scala.annotation.tailrec
 import com.azavea.rf.datamodel.color._
 
-object SaturationAdjust {
-  def apply(rgbTile: MultibandTile, chromaFactor: Double): MultibandTile = {
-    scaleTileChroma(rgbTile, chromaFactor)
-  }
+import io.circe.generic.JsonCodec
+import geotrellis.raster._
+import geotrellis.raster.equalization.HistogramEqualization
+import geotrellis.raster.histogram.Histogram
+import org.apache.commons.math3.util.FastMath
+import spire.syntax.cfor._
 
-  /* Convert RGB to Hue, Chroma, Luma https://en.wikipedia.org/wiki/HSL_and_HSV#Lightness */
-  def scaleTileChroma(rgbTile: MultibandTile, chromaFactor: Double): MultibandTile = {
-    val (red, green, blue) = (rgbTile.band(0), rgbTile.band(1), rgbTile.band(2))
-    val (nred, ngreen, nblue) = (
-      ArrayTile.alloc(rgbTile.cellType, rgbTile.cols, rgbTile.rows),
-      ArrayTile.alloc(rgbTile.cellType, rgbTile.cols, rgbTile.rows),
-      ArrayTile.alloc(rgbTile.cellType, rgbTile.cols, rgbTile.rows)
-    )
-    cfor(0)(_ < rgbTile.cols, _ + 1) { col =>
-      cfor(0)(_ < rgbTile.rows, _ + 1) { row =>
-        val (r, g, b) = (red.get(col, row), green.get(col, row), blue.get(col, row))
-        val (hue, chroma, luma) = RGBToHCLuma(r, g, b)
-        val newChroma = scaleChroma(chroma, chromaFactor)
-        val (nr, ng, nb) = HCLumaToRGB(hue, newChroma, luma)
-        nred.set(col, row, nr)
-        ngreen.set(col, row, ng)
-        nblue.set(col, row, nb)
-      }
-    }
-    MultibandTile(nred, ngreen, nblue)
-  }
-
-  // See link for a detailed explanation of what is happening. Basically we are taking the
-  // RGB cube and tilting it on its side so that the black -> white line runs vertically
-  // up the center of the HCL cylinder, then flattening the cube down into a hexagon and then
-  // pretending that that hexagon is actually a cylinder.
-  // https://en.wikipedia.org/wiki/HSL_and_HSV#Lightness
-  def RGBToHCLuma(rByte: Int, gByte: Int, bByte: Int): (Double, Double, Double) = {
-    // RGB come in as unsigned Bytes, but the transformation requires Doubles [0,1]
-    val (r, g, b) = (rByte / 255.0, gByte / 255.0, bByte / 255.0)
-    val colors = List(r, g, b)
-    val max = colors.max
-    val min = colors.min
-    val chroma = max - min
-    val hueSextant = ((chroma, max) match {
-      case (0, _) => 0 // Technically, undefined, but we'll ignore this value in this case.
-      case (_, x) if x == r => ((g - b) / chroma.toDouble) % 6
-      case (_, x) if x == g => ((b - r) / chroma.toDouble) + 2
-      case (_, x) if x == b => ((r - g) / chroma.toDouble) + 4
-    })
-    // Wrap degrees
-    val hue = ((hueSextant * 60.0) % 360) match {
-      case h if h < 0 => h + 360
-      case h if h >= 0 => h
-    }
-    // Perceptually weighted average of "lightness" contribution of sRGB primaries (it's
-    // not clear that we're in sRGB here, but that's the default for most images intended for
-    // display so it's a good guess in the absence of explicit information).
-    val luma = 0.21*r + 0.72*g + 0.07*b
-    (hue, chroma, luma)
-  }
-
-  // Reverse the process above
-  def HCLumaToRGB(hue: Double, chroma: Double, luma: Double): (Int, Int, Int) = {
-    val sextant = hue / 60.0
-    val X = chroma * (1 - Math.abs((sextant % 2) - 1))
-    // Projected color values, i.e., on the flat projection of the RGB cube
-    val (rFlat:Double, gFlat:Double, bFlat:Double) = ((chroma, sextant) match {
-      case (0.0, _) => (0.0, 0.0, 0.0) // Gray (or black / white)
-      case (_, s) if 0 <= s && s < 1 => (chroma, X, 0.0)
-      case (_, s) if 1 <= s && s < 2 => (X, chroma, 0.0)
-      case (_, s) if 2 <= s && s < 3 => (0.0, chroma, X)
-      case (_, s) if 3 <= s && s < 4 => (0.0, X, chroma)
-      case (_, s) if 4 <= s && s < 5 => (X, 0.0, chroma)
-      case (_, s) if 5 <= s && s < 6 => (chroma, 0.0, X)
-    })
-
-    // We can add the same value to each component to move straight up the cylinder from the projected
-    // plane, back to the correct lightness value.
-    val lumaCorrection = luma - (0.21*rFlat + 0.72*gFlat + 0.07*bFlat)
-    val r = clamp8Bit((255 * (rFlat + lumaCorrection)).toInt)
-    val g = clamp8Bit((255 * (gFlat + lumaCorrection)).toInt)
-    val b = clamp8Bit((255 * (bFlat + lumaCorrection)).toInt)
-    (r, g, b)
-  }
-
-  def scaleChroma(chroma: Double, scaleFactor: Double): Double = {
-    // Chroma is a Double in the range [0.0, 1.0]. Scale factor is the same as our other gamma corrections:
-    // a Double in the range [0.0, 2.0].
-    val scaled = math.pow(chroma, 1.0 / scaleFactor)
-    if (scaled < 0.0) 0.0
-    else if (scaled > 1.0) 1.0
-    else scaled
-  }
-
-  @inline def clamp8Bit(z: Int): Int = {
-    if (z < 0) 0
-    else if (z > 255) 255
-    else z
-  }
-}
-
-case class Memo[I <% K, K, O](f: I => O) extends (I => O) {
-  import collection.mutable.{Map => Dict}
-  type Input = I
-  type Key = K
-  type Output = O
-
-  val cache = Dict.empty[K, O]
-  override def apply(x: I) = cache.getOrElseUpdate(x, f(x))
-}
-
-object WhiteBalance {
-  
-  @inline def clamp8Bit(z: Int): Int = {
-    if (z < 0) 0
-    else if (z > 255) 255
-    else z
-  }
-
-  def apply(rgbTiles: List[MultibandTile]): List[MultibandTile] = {
-    val tileAdjs = rgbTiles.par.map(t => tileRgbAdjustments(t)).toList.foldLeft((0.0, 0.0, 0.0))((acc, x) => {
-      (acc._1 + (x._1 / rgbTiles.length), acc._2 + (x._2 / rgbTiles.length), acc._3 + (x._3 / rgbTiles.length))
-    })
-
-    val newTiles =
-      rgbTiles
-        .map(t => MultibandTile(
-          t.band(0).mapIfSet(c => clamp8Bit((c * tileAdjs._1).toInt)),
-          t.band(1).mapIfSet(c => clamp8Bit((c * tileAdjs._2).toInt)),
-          t.band(2).mapIfSet(c => clamp8Bit((c * tileAdjs._3).toInt))))
-        .map(_.convert(UByteConstantNoDataCellType))
-
-    newTiles
-  }
-
-  def tileRgbAdjustments(rgbTile: MultibandTile): (Double, Double, Double) = {
-    try {
-      val resampledTile = rgbTile.resample(128, 128)
-      val newTileAdjs = adjustGrey(resampledTile, (1.0, 1.0, 1.0), 0, false)
-      newTileAdjs
-    } catch {
-      case ex:Exception => {
-        val sw = new StringWriter
-        ex.printStackTrace(new PrintWriter(sw))
-        println(sw.toString)
-        throw ex
-      }
-    }
-  }
-
-  def RgbToYuv(rByte: Int, gByte: Int, bByte: Int): YUV = {
-    type I = (Int, Int, Int)
-    type K = (Int, Int, Int)
-    type O = YUV
-
-    type MemoizedFn = Memo[I, K, O]
-
-    implicit def encode(input: MemoizedFn#Input): MemoizedFn#Key = (input._1, input._2, input._3)
-
-    def rgbToYuv(rb: Int, gb: Int, bb: Int): YUV = {
-      val (r, g, b) = (rb, gb, bb)
-      val W_r = 0.299
-      val W_b = 0.114
-      val W_g = 1 - W_r - W_b
-
-      val Y = W_r*r + W_g*g + W_b*b
-      val U = -0.168736*r + -0.331264*g + 0.5*b
-      val V = 0.5*r + -0.418688*g + -0.081312*b
-
-      YUV(Y,U,V)
-    }
-
-    lazy val f: MemoizedFn = Memo {
-      case (r, g, b) => rgbToYuv(r,g,b)
-      case _ => throw new IllegalArgumentException("Wrong number of arguments")
-    }
-
-    f((rByte, gByte, bByte))
-  }
-  
-  case class AutoBalanceParams (
-    maxIter: Int, gainIncr:Double, doubleStepThreshold:Double, convergenceThreshold:Double, greyThreshold:Double
-  )
-
-  case class YUV (y: Double, u: Double, v: Double)
-
-  val balanceParams = AutoBalanceParams(maxIter=1000, gainIncr=0.01, doubleStepThreshold=0.8, convergenceThreshold=0.001, greyThreshold=0.3)
-
-  def mapBands(mbTile:MultibandTile, f: Array[Int] => Option[YUV]): List[List[Option[YUV]]]  = {
-    val newTile = MultibandTile(mbTile.bands)
-    val array = Array.ofDim[Option[YUV]](newTile.cols, newTile.rows)
-
-    cfor(0)(_ < newTile.rows, _ + 1) { row =>
-      cfor(0)(_ < newTile.cols, _ + 1) { col =>
-        val bandValues = Array.ofDim[Int](newTile.bandCount)
-        cfor(0)(_ < newTile.bandCount, _ + 1) { band =>
-          bandValues(band) = newTile.band(band).get(col, row)
-        }
-        array(col)(row) = f(bandValues)
-      }
-    }
-
-    array.map(_.toList).toList
-  }
-  
-  @tailrec
-  def adjustGrey(rgbTile:MultibandTile, adjustments:(Double, Double, Double), iter:Int, converged:Boolean):(Double, Double, Double) = {
-    if (iter>=balanceParams.maxIter || converged) {
-      adjustments
-    } else {
-      // convert tile to YUV
-      val tileYuv = mapBands(rgbTile, (rgb) => {
-          val bands = rgb.toList.map((i:Int) => if (isData(i)) Some(i) else None)
-          val r :: g :: b :: xs = bands
-          val rgbs = (r, g, b)
-          val yuv = rgbs match {
-            case (Some(rd), Some(gr), Some(bl)) =>  Some(RgbToYuv(rd, gr, bl))
-            case _ => None
-          }
-          yuv
-      })
-      
-      // find grey chromaticity
-      val offGrey = (yuv:YUV) => (abs(yuv.u) + abs(yuv.v)) / yuv.y
-      val greys = tileYuv.map(lst => lst.map(yuv => {
-        for {
-          y <- yuv
-        } yield {
-          if (offGrey(y) < balanceParams.greyThreshold) Some(y) else None
-        }
-      })).flatten
-
-      // calculate average "off-grey"-ness of U & V
-      val uBar = greys.map(yuvs => yuvs.map(mYuv => {
-          mYuv match {
-            case Some(yuv) => yuv.u
-            case _ => 0.0
-          }
-      })).flatten.sum / greys.length
-      
-      val vBar = greys.map(yuvs => yuvs.map(mYuv => {
-          mYuv match {
-            case Some(yuv) => yuv.v
-            case _ => 0.0
-          }
-      })).flatten.sum / greys.length
-
-      // adjust red & blue channels if convergence hasn't been reached
-      val err = if (abs(uBar) > abs(vBar)) uBar else vBar
-      val gainVal = (err match {
-        case x if x < balanceParams.convergenceThreshold => 0
-        case x if x > (balanceParams.doubleStepThreshold * 1) => 2 * balanceParams.gainIncr * signum(err)
-        case _ => balanceParams.gainIncr * err
-      })
-
-      val channelGain = if (abs(vBar) > abs(uBar)) List((1 - gainVal), 1, 1) else List(1, 1, (1 - gainVal))
-      val newAdjustments = (adjustments._1 * channelGain(0), adjustments._2 * channelGain(1), adjustments._3 * channelGain(2))
-
-      val balancedTile = MultibandTile(
-        rgbTile.band(0).mapIfSet(c => clamp8Bit((c*channelGain(0)).toInt)),
-        rgbTile.band(1).mapIfSet(c => clamp8Bit((c*channelGain(1)).toInt)),
-        rgbTile.band(2).mapIfSet(c => clamp8Bit((c*channelGain(2)).toInt)))
-
-      adjustGrey(balancedTile, newAdjustments, iter + 1, if (gainVal == 0) true else false)
-    }
-  }
-
-}
-
+/**
+  * Usage of Approximations.{pow | exp} functions can allow to speed up this function on 10 - 15ms.
+  * We can consider these functions usages in case of real performance issues caused by a long color correction.
+  */
 object ColorCorrect {
-  // TODO: Now that each correction is a separate class, it should be possible to refactor this object to place the
-  // necessary corrections with the classes that enable them. So rather than
-  // ```
-  // val maybeAdjustContrast =
-  //   for (c <- params.brightContrast.contrast)
-  //     yield (mb: MultibandTile) => mb.mapBands { (i, tile) => adjustContrast(tile, c) }
-  // ```
-  //
-  // We would do something like `params.brightContrast.adjustContrast(tile)`
+  import functions.SaturationAdjust._
+  import functions.SigmoidalContrast._
+  // import functions.Approximations
+
+  case class LayerClipping(redMin: Int, redMax: Int, greenMin: Int, greenMax: Int, blueMin: Int, blueMax: Int)
+  sealed trait ClipValue
+  case class ClipBounds(min: Int, max: Int) extends ClipValue
+  case class MaybeClipBounds(maybeMin: Option[Int], maybeMax: Option[Int]) extends ClipValue
+  case class ClippingParams(band: Int, bounds: ClipValue)
+
   @JsonCodec
   case class Params(
     redBand: Int, greenBand: Int, blueBand: Int,
@@ -306,6 +35,8 @@ object ColorCorrect {
     equalize: Equalization,
     autoBalance: AutoWhiteBalance
   ) {
+    def getGamma: Map[Int, Option[Double]] = Map(0 -> gamma.redGamma, 1 -> gamma.greenGamma, 2 -> gamma.blueGamma)
+
     def reorderBands(tile: MultibandTile, hist: Seq[Histogram[Double]]): (MultibandTile, Array[Histogram[Double]]) =
       (tile.subsetBands(redBand, greenBand, blueBand), Array(hist(redBand), hist(greenBand), hist(blueBand)))
 
@@ -315,125 +46,170 @@ object ColorCorrect {
     }
   }
 
+  @inline def normalizeAndClampAndGammaCorrectPerPixel(z: Int, oldMin: Int, oldMax: Int, newMin: Int, newMax: Int, gammaOpt: Option[Double]): Int = {
+    if(isData(z)) {
+      val dNew = newMax - newMin
+      val dOld = oldMax - oldMin
+
+      // When dOld is nothing (normalization is meaningless in this context), we still need to clamp
+      if (dOld == 0) {
+        val v = {
+          if (z > newMax) newMax
+          else if (z < newMin) newMin
+          else z
+        }
+
+        gammaOpt match {
+          case None => v
+          case Some(gamma) => {
+            clampColor {
+              val gammaCorrection = 1 / gamma
+              (255 * FastMath.pow(v / 255.0, gammaCorrection)).toInt
+            }
+          }
+        }
+      } else {
+        val v = {
+          val scaled = (((z - oldMin) * dNew) / dOld) + newMin
+
+          if (scaled > newMax) newMax
+          else if (scaled < newMin) newMin
+          else scaled
+        }
+
+        gammaOpt match {
+          case None => v
+          case Some(gamma) => {
+            clampColor {
+              val gammaCorrection = 1 / gamma
+              (255 * FastMath.pow(v / 255.0, gammaCorrection)).toInt
+            }
+          }
+        }
+      }
+    } else z
+  }
+
+  val rgbBand =
+    (specificBand: Option[Int], allBands: Option[Int], tileDefault: Int) =>
+      specificBand.fold(allBands)(Some(_)).fold(Some(tileDefault))(x => Some(x))
+
+  def complexColorCorrect(rgbTile: MultibandTile, chromaFactor: Option[Double])
+                         (layerNormalizeArgs: Map[Int, ClipBounds], gammas: Map[Int, Option[Double]])
+                         (sigmoidalContrast: SigmoidalContrast)
+                         (colorCorrectArgs: Map[Int, MaybeClipBounds], tileClipping: MultiBandClipping): MultibandTile = {
+    val (red, green, blue) = (rgbTile.band(0), rgbTile.band(1), rgbTile.band(2))
+    val (gr, gg, gb) = (gammas(0), gammas(1), gammas(2))
+    val (nred, ngreen, nblue) = (
+      ArrayTile.alloc(rgbTile.cellType, rgbTile.cols, rgbTile.rows),
+      ArrayTile.alloc(rgbTile.cellType, rgbTile.cols, rgbTile.rows),
+      ArrayTile.alloc(rgbTile.cellType, rgbTile.cols, rgbTile.rows)
+    )
+
+    val ClipBounds(rmin, rmax) = layerNormalizeArgs(0)
+    val ClipBounds(gmin, gmax) = layerNormalizeArgs(1)
+    val ClipBounds(bmin, bmax) = layerNormalizeArgs(2)
+
+    val (rclipMin, rclipMax, rnewMin, rnewMax) = (rmin, rmax, 0, 255)
+    val (gclipMin, gclipMax, gnewMin, gnewMax) = (gmin, gmax, 0, 255)
+    val (bclipMin, bclipMax, bnewMin, bnewMax) = (bmin, bmax, 0, 255)
+
+    val sigmoidal: Double => Double =
+      (sigmoidalContrast.alpha, sigmoidalContrast.beta) match {
+        case (Some(a), Some(b)) => localTransform(rgbTile.cellType, a, b)
+        case _ => identity
+      }
+
+    val (clipr, clipg, clipb): (Int => Int, Int => Int, Int => Int) = {
+      val MaybeClipBounds(mrmin, mrmax) = colorCorrectArgs(0)
+      val MaybeClipBounds(mgmin, mgmax) = colorCorrectArgs(1)
+      val MaybeClipBounds(mbmin, mbmax) = colorCorrectArgs(2)
+
+      val (mrclipMin, mrclipMax) = (rgbBand(mrmin, tileClipping.min, 0).get, rgbBand(mrmax, tileClipping.max, 255).get)
+      val (mgclipMin, mgclipMax) = (rgbBand(mgmin, tileClipping.min, 0).get, rgbBand(mgmax, tileClipping.max, 255).get)
+      val (mbclipMin, mbclipMax) = (rgbBand(mbmin, tileClipping.min, 0).get, rgbBand(mbmax, tileClipping.max, 255).get)
+
+      @inline def clipBands(z: Int, min: Int, max: Int): Int = {
+        if (isData(z) && z > max) 255
+        else if (isData(z) && z < min) 0
+        else z
+      }
+
+      (clipBands(_, mrclipMin, mrclipMax), clipBands(_, mgclipMin, mgclipMax), clipBands(_, mbclipMin, mbclipMax))
+    }
+
+    /** In this case for some reason with this func wrap it works faster ¯\_(ツ)_/¯ (it was micro benchmarked) */
+    lazyWrapper {
+      cfor(0)(_ < rgbTile.cols, _ + 1) { col =>
+        cfor(0)(_ < rgbTile.rows, _ + 1) { row =>
+          val (r, g, b) =
+            (ColorCorrect.normalizeAndClampAndGammaCorrectPerPixel(red.get(col, row), rclipMin, rclipMax, rnewMin, rnewMax, gr),
+              ColorCorrect.normalizeAndClampAndGammaCorrectPerPixel(green.get(col, row), gclipMin, gclipMax, gnewMin, gnewMax, gg),
+              ColorCorrect.normalizeAndClampAndGammaCorrectPerPixel(blue.get(col, row), bclipMin, bclipMax, bnewMin, bnewMax, gb))
+
+          val (nr, ng, nb) = chromaFactor match {
+            case Some(cf) => {
+              val (hue, chroma, luma) = RGBToHCLuma(r, g, b)
+              val newChroma = scaleChroma(chroma, cf)
+              val (nr, ng, nb) = HCLumaToRGB(hue, newChroma, luma)
+              (nr, ng, nb)
+            }
+
+            case _ => (r, g, b)
+          }
+
+          nred.set(col, row, clipr(sigmoidal(nr).toInt))
+          ngreen.set(col, row, clipg(sigmoidal(ng).toInt))
+          nblue.set(col, row, clipb(sigmoidal(nb).toInt))
+        }
+      }
+    }
+
+    MultibandTile(nred, ngreen, nblue)
+  }
+
   def apply(rgbTile: MultibandTile, rgbHist: Array[Histogram[Double]], params: Params): MultibandTile = {
-    val maybeEqualize =
-      if (params.equalize.enabled) Some(HistogramEqualization(_: MultibandTile, rgbHist)) else None
+    var _rgbTile = rgbTile
+    val gammas = params.getGamma
+    if (params.equalize.enabled) _rgbTile = HistogramEqualization(rgbTile, rgbHist)
 
-    case class LayerClipping(redMin: Int, redMax: Int, greenMin: Int, greenMax:Int, blueMin: Int, blueMax: Int)
-    sealed trait ClipValue
-    case class ClipBounds(min: Int, max: Int) extends ClipValue
-    case class MaybeClipBounds(maybeMin: Option[Int], maybeMax: Option[Int]) extends ClipValue
-    case class ClippingParams(band: Int, bounds: ClipValue)
+    val layerRgbClipping = {
+      val range = 1 until 255
+      var isCorrected = true
+      val iMaxMin: Array[(Int, Int)] = Array.ofDim(3)
+      cfor(0)(_ < rgbHist.length, _ + 1) { index =>
+        val hst = rgbHist(index)
+        val imin = hst.minValue().map(_.toInt).getOrElse(0)
+        val imax = hst.maxValue().map(_.toInt).getOrElse(255)
+        iMaxMin(index) = (imin, imax)
+        isCorrected &&= {
+          if (range.contains(hst.minValue().map(_.toInt).getOrElse(0))) true
+          else if (range.contains(hst.maxValue().map(_.toInt).getOrElse(255))) true
+          else false
+        }
+      }
 
-    val layerRgbClipping = (for {
-      (r :: g :: b :: xs) <- Some(rgbHist.toList)
-      isCorrected   <- Some((r :: g :: b :: Nil).foldLeft(true) {(acc, hst) => (
-                          acc && (hst match {
-                            case x if 1 until 255 contains x.minValue().map(_.toInt).getOrElse(0) => true
-                            case x if 1 until 255 contains x.maxValue().map(_.toInt).getOrElse(255) => true
-                            case _ => false
-                          })
-                        )})
-      layerClp      <- if (!isCorrected) {
-                          val getMin = (hst:Histogram[Double]) => hst.minValue().map(_.toInt).getOrElse(0)
-                          val getMax = (hst:Histogram[Double]) => hst.maxValue().map(_.toInt).getOrElse(255)
-                          Some(LayerClipping(getMin(r), getMax(r), getMin(g), getMax(g), getMin(b), getMax(b)))
-                        } else { None }
-    } yield layerClp).getOrElse(LayerClipping(0, 255, 0, 255, 0, 255))
+      if (!isCorrected) {
+        val (rmin, rmax) = iMaxMin(0)
+        val (gmin, gmax) = iMaxMin(1)
+        val (bmin, bmax) = iMaxMin(2)
+        LayerClipping(rmin, rmax, gmin, gmax, bmin, bmax)
+      } else LayerClipping(0, 255, 0, 255, 0, 255)
+    }
 
-    val rgbBand =
-      (specificBand:Option[Int], allBands:Option[Int], tileDefault: Int) =>
-        specificBand.fold(allBands)(Some(_)).fold(Some(tileDefault))(x => Some(x))
-
-    val layerNormalizeArgs = Some(
-      ClippingParams(0, ClipBounds(layerRgbClipping.redMin, layerRgbClipping.redMax))
-        :: ClippingParams(1, ClipBounds(layerRgbClipping.greenMin, layerRgbClipping.greenMax))
-        :: ClippingParams(2, ClipBounds(layerRgbClipping.blueMin, layerRgbClipping.blueMax))
-        :: Nil
+    val layerNormalizeArgs: Map[Int, ClipBounds] = Map(
+      0 -> ClipBounds(layerRgbClipping.redMin, layerRgbClipping.redMax),
+      1 -> ClipBounds(layerRgbClipping.greenMin, layerRgbClipping.greenMax),
+      2 -> ClipBounds(layerRgbClipping.blueMin, layerRgbClipping.blueMax)
     )
 
-    val colorCorrectArgs = Some(
-      ClippingParams(0, MaybeClipBounds(params.bandClipping.redMin, params.bandClipping.redMax))
-        :: ClippingParams(1, MaybeClipBounds(params.bandClipping.greenMin, params.bandClipping.greenMax))
-        :: ClippingParams(2, MaybeClipBounds(params.bandClipping.blueMin, params.bandClipping.blueMax))
-        :: Nil
+    val colorCorrectArgs: Map[Int, MaybeClipBounds] = Map(
+      0 -> MaybeClipBounds(params.bandClipping.redMin, params.bandClipping.redMax),
+      1 -> MaybeClipBounds(params.bandClipping.greenMin, params.bandClipping.greenMax),
+      2 -> MaybeClipBounds(params.bandClipping.blueMin, params.bandClipping.blueMax)
     )
 
-    val maybeClipBands =
-      (clipParams:Option[List[ClippingParams]]) =>
-        for {
-          clipParams <- clipParams
-        } yield {
-          (_:MultibandTile).mapBands { (i, tile) =>
-            (for {
-              args <- clipParams.find(cp => cp.band == i)
-            } yield {
-              args match {
-                case ClippingParams(_, ClipBounds(min, max)) => {
-                  (for {
-                    clipMin <- rgbBand(None, None, min)
-                    clipMax <- rgbBand(None, None, max)
-                    newMin <- Some(0)
-                    newMax <- Some(255)
-                  } yield {
-                    normalizeAndClamp(tile, clipMin, clipMax, newMin, newMax)
-                  })
-                }
-                case ClippingParams(_, MaybeClipBounds(min, max)) => {
-                  (for {
-                    clipMin <- rgbBand(min, params.tileClipping.min, 0)
-                    clipMax <- rgbBand(max, params.tileClipping.max, 255)
-                  } yield {
-                    clipBands(tile, clipMin, clipMax)
-                  })
-                }
-              }
-            }).flatten.getOrElse(tile)
-          }
-        }
-
-    val maybeAdjustGamma =
-      for (c <- params.sigmoidalContrast.alpha)
-        yield (_: MultibandTile).mapBands { (i, tile) =>
-          i match {
-            case 0 => params.gamma.redGamma match {
-              case None => tile
-              case Some(gamma) => gammaCorrect(tile, gamma)
-            }
-            case 1 => params.gamma.greenGamma match {
-              case None => tile
-              case Some(gamma) => gammaCorrect(tile, gamma)
-            }
-            case 2 => params.gamma.blueGamma match {
-              case None => tile
-              case Some(gamma) => gammaCorrect(tile, gamma)
-            }
-            case _ =>
-              sys.error("Too many bands")
-          }
-        }
-
-    val maybeSigmoidal =
-      for (alpha <- params.sigmoidalContrast.alpha; beta <- params.sigmoidalContrast.beta)
-        yield SigmoidalContrast(_: MultibandTile, alpha, beta)
-
-    val maybeAdjustSaturation =
-      for (saturationFactor <- params.saturation.saturation)
-        yield SaturationAdjust(_: MultibandTile, saturationFactor)
-
-
-    // Sequence of transformations to tile, flatten removes None from the list
-    val transformations: List[MultibandTile => MultibandTile] = List(
-      maybeEqualize,
-      maybeClipBands(layerNormalizeArgs),
-      maybeAdjustGamma,
-      maybeAdjustSaturation,
-      maybeSigmoidal,
-      maybeClipBands(colorCorrectArgs)
-    ).flatten
-
-    // Apply tile transformations in order from left to right
-    transformations.foldLeft(rgbTile){ (t, f) => f(t) }
+    complexColorCorrect(_rgbTile, params.saturation.saturation)(layerNormalizeArgs, gammas)(params.sigmoidalContrast)(colorCorrectArgs, params.tileClipping)
   }
 
   @inline def clampColor(z: Int): Int = {
@@ -442,49 +218,5 @@ object ColorCorrect {
     else z
   }
 
-  def maxCellValue(ct: CellType): Int =
-    ct match {
-      case _: FloatCells =>
-        Float.MaxValue.toInt
-      case _: DoubleCells =>
-        Double.MaxValue.toInt
-      case _: BitCells | _: UByteCells | _: UShortCells =>
-        (1 << ct.bits) - 1
-      case _: ByteCells | _: ShortCells | _: IntCells =>
-        ((1 << ct.bits) - 1) - (1 << (ct.bits - 1))
-    }
-
-  def clipBands(tile: Tile, min: Int, max: Int): Tile = {
-    tile.mapIfSet { z =>
-      if (z > max) 255
-      else if (z < min) 0
-      else z
-    }
-  }
-
-  def normalizeAndClamp(tile: Tile, oldMin: Int, oldMax: Int, newMin: Int, newMax: Int): Tile = {
-    val dNew = newMax - newMin
-    val dOld = oldMax - oldMin
-
-    // When dOld is nothing (normalization is meaningless in this context), we still need to clamp
-    if (dOld == 0) tile.mapIfSet { z =>
-      if (z > newMax) newMax
-      else if (z < newMin) newMin
-      else z
-    } else tile.mapIfSet { z =>
-      val scaled = (((z - oldMin) * dNew) / dOld) + newMin
-
-      if (scaled > newMax) newMax
-      else if (scaled < newMin) newMin
-      else scaled
-    }
-  }
-
-  def gammaCorrect(tile: Tile, gamma: Double): Tile =
-    tile.mapIfSet { z =>
-      clampColor {
-        val gammaCorrection = 1 / gamma
-        (255 * math.pow(z / 255.0, gammaCorrection)).toInt
-      }
-    }
+  private def lazyWrapper[T](f: => T): T = f
 }

--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/WhiteBalance.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/WhiteBalance.scala
@@ -1,0 +1,177 @@
+package com.azavea.rf.datamodel
+
+import java.io.{PrintWriter, StringWriter}
+
+import geotrellis.raster.{MultibandTile, UByteConstantNoDataCellType, isData}
+import spire.syntax.cfor.cfor
+
+import scala.annotation.tailrec
+import scala.math.{abs, signum}
+
+case class Memo[I, K, O](f: I => O)(implicit ev: I => K) extends (I => O) {
+  import collection.mutable.{Map => Dict}
+  type Input = I
+  type Key = K
+  type Output = O
+
+  val cache = Dict.empty[K, O]
+  override def apply(x: I) = cache.getOrElseUpdate(x, f(x))
+}
+
+object WhiteBalance {
+
+  @inline def clamp8Bit(z: Int): Int = {
+    if (z < 0) 0
+    else if (z > 255) 255
+    else z
+  }
+
+  def apply(rgbTiles: List[MultibandTile]): List[MultibandTile] = {
+    val tileAdjs = rgbTiles.par.map(t => tileRgbAdjustments(t)).toList.foldLeft((0.0, 0.0, 0.0))((acc, x) => {
+      (acc._1 + (x._1 / rgbTiles.length), acc._2 + (x._2 / rgbTiles.length), acc._3 + (x._3 / rgbTiles.length))
+    })
+
+    val newTiles =
+      rgbTiles
+        .map(t => MultibandTile(
+          t.band(0).mapIfSet(c => clamp8Bit((c * tileAdjs._1).toInt)),
+          t.band(1).mapIfSet(c => clamp8Bit((c * tileAdjs._2).toInt)),
+          t.band(2).mapIfSet(c => clamp8Bit((c * tileAdjs._3).toInt))))
+        .map(_.convert(UByteConstantNoDataCellType))
+
+    newTiles
+  }
+
+  def tileRgbAdjustments(rgbTile: MultibandTile): (Double, Double, Double) = {
+    try {
+      val resampledTile = rgbTile.resample(128, 128)
+      val newTileAdjs = adjustGrey(resampledTile, (1.0, 1.0, 1.0), 0, false)
+      newTileAdjs
+    } catch {
+      case ex:Exception => {
+        val sw = new StringWriter
+        ex.printStackTrace(new PrintWriter(sw))
+        println(sw.toString)
+        throw ex
+      }
+    }
+  }
+
+  def RgbToYuv(rByte: Int, gByte: Int, bByte: Int): YUV = {
+    type I = (Int, Int, Int)
+    type K = (Int, Int, Int)
+    type O = YUV
+
+    type MemoizedFn = Memo[I, K, O]
+
+    implicit def encode(input: MemoizedFn#Input): MemoizedFn#Key = (input._1, input._2, input._3)
+
+    def rgbToYuv(rb: Int, gb: Int, bb: Int): YUV = {
+      val (r, g, b) = (rb, gb, bb)
+      val W_r = 0.299
+      val W_b = 0.114
+      val W_g = 1 - W_r - W_b
+
+      val Y = W_r*r + W_g*g + W_b*b
+      val U = -0.168736*r + -0.331264*g + 0.5*b
+      val V = 0.5*r + -0.418688*g + -0.081312*b
+
+      YUV(Y,U,V)
+    }
+
+    lazy val f: MemoizedFn = Memo {
+      case (r, g, b) => rgbToYuv(r,g,b)
+      case _ => throw new IllegalArgumentException("Wrong number of arguments")
+    }
+
+    f((rByte, gByte, bByte))
+  }
+
+  case class AutoBalanceParams (
+                                 maxIter: Int, gainIncr:Double, doubleStepThreshold:Double, convergenceThreshold:Double, greyThreshold:Double
+                               )
+
+  case class YUV (y: Double, u: Double, v: Double)
+
+  val balanceParams = AutoBalanceParams(maxIter=1000, gainIncr=0.01, doubleStepThreshold=0.8, convergenceThreshold=0.001, greyThreshold=0.3)
+
+  def mapBands(mbTile:MultibandTile, f: Array[Int] => Option[YUV]): List[List[Option[YUV]]]  = {
+    val newTile = MultibandTile(mbTile.bands)
+    val array = Array.ofDim[Option[YUV]](newTile.cols, newTile.rows)
+
+    cfor(0)(_ < newTile.rows, _ + 1) { row =>
+      cfor(0)(_ < newTile.cols, _ + 1) { col =>
+        val bandValues = Array.ofDim[Int](newTile.bandCount)
+        cfor(0)(_ < newTile.bandCount, _ + 1) { band =>
+          bandValues(band) = newTile.band(band).get(col, row)
+        }
+        array(col)(row) = f(bandValues)
+      }
+    }
+
+    array.map(_.toList).toList
+  }
+
+  @tailrec
+  def adjustGrey(rgbTile:MultibandTile, adjustments:(Double, Double, Double), iter:Int, converged:Boolean):(Double, Double, Double) = {
+    if (iter>=balanceParams.maxIter || converged) {
+      adjustments
+    } else {
+      // convert tile to YUV
+      val tileYuv = mapBands(rgbTile, (rgb) => {
+        val bands = rgb.toList.map((i:Int) => if (isData(i)) Some(i) else None)
+        val r :: g :: b :: xs = bands
+        val rgbs = (r, g, b)
+        val yuv = rgbs match {
+          case (Some(rd), Some(gr), Some(bl)) =>  Some(RgbToYuv(rd, gr, bl))
+          case _ => None
+        }
+        yuv
+      })
+
+      // find grey chromaticity
+      val offGrey = (yuv:YUV) => (abs(yuv.u) + abs(yuv.v)) / yuv.y
+      val greys = tileYuv.map(lst => lst.map(yuv => {
+        for {
+          y <- yuv
+        } yield {
+          if (offGrey(y) < balanceParams.greyThreshold) Some(y) else None
+        }
+      })).flatten
+
+      // calculate average "off-grey"-ness of U & V
+      val uBar = greys.map(yuvs => yuvs.map(mYuv => {
+        mYuv match {
+          case Some(yuv) => yuv.u
+          case _ => 0.0
+        }
+      })).flatten.sum / greys.length
+
+      val vBar = greys.map(yuvs => yuvs.map(mYuv => {
+        mYuv match {
+          case Some(yuv) => yuv.v
+          case _ => 0.0
+        }
+      })).flatten.sum / greys.length
+
+      // adjust red & blue channels if convergence hasn't been reached
+      val err = if (abs(uBar) > abs(vBar)) uBar else vBar
+      val gainVal = (err match {
+        case x if x < balanceParams.convergenceThreshold => 0
+        case x if x > (balanceParams.doubleStepThreshold * 1) => 2 * balanceParams.gainIncr * signum(err)
+        case _ => balanceParams.gainIncr * err
+      })
+
+      val channelGain = if (abs(vBar) > abs(uBar)) List((1 - gainVal), 1, 1) else List(1, 1, (1 - gainVal))
+      val newAdjustments = (adjustments._1 * channelGain(0), adjustments._2 * channelGain(1), adjustments._3 * channelGain(2))
+
+      val balancedTile = MultibandTile(
+        rgbTile.band(0).mapIfSet(c => clamp8Bit((c*channelGain(0)).toInt)),
+        rgbTile.band(1).mapIfSet(c => clamp8Bit((c*channelGain(1)).toInt)),
+        rgbTile.band(2).mapIfSet(c => clamp8Bit((c*channelGain(2)).toInt)))
+
+      adjustGrey(balancedTile, newAdjustments, iter + 1, if (gainVal == 0) true else false)
+    }
+  }
+
+}

--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/color/functions/Approximations.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/color/functions/Approximations.scala
@@ -1,0 +1,47 @@
+package com.azavea.rf.datamodel.color.functions
+
+/**
+  * Not very good pow and exponent approximations
+  * consider org.apache.commons.math{3|4}.util.FastMath usage
+  * in cases where these functions can't be applied.
+  *
+  * ApproximationsSpec demonstrates max deviation on SaturationAdjust and SigmoidalContrast domains
+  */
+object Approximations {
+
+  /**
+    * For clarifications
+    * see https://www.reddit.com/r/gamedev/comments/n7na0/fast_approximation_to_mathpow/
+    * and https://martin.ankerl.com/2007/10/04/optimized-pow-approximation-for-java-and-c-c/
+    *
+    */
+  def pow(a: Double, b: Double): Double = { // exponentiation by squaring
+    if(a < 1 && java.lang.Double.isInfinite(b)) return 0d
+    if(a >= 1 && java.lang.Double.isInfinite(b)) return Double.NaN
+    if(java.lang.Double.isNaN(a) || java.lang.Double.isNaN(b)) return Double.NaN
+
+    var r = 1d
+    var exp = b.toInt
+    var base = a
+    while (exp != 0) {
+      if ((exp & 1) != 0) r *= base
+      base *= base
+      exp >>= 1
+    }
+    // use the IEEE 754 trick for the fraction of the exponent
+    val b_faction = b - b.toInt
+    val tmp = java.lang.Double.doubleToLongBits(a)
+    val tmp2 = (b_faction * (tmp - 4606921280493453312L)).toLong + 4606921280493453312L
+    r * java.lang.Double.longBitsToDouble(tmp2)
+  }
+
+  /**
+    * For clarifications
+    * see http://martin.ankerl.com/2007/02/11/optimized-exponential-functions-for-java/
+    *
+    */
+  def exp(value: Double): Double = {
+    val tmp = (1512775 * value + (1072693248 - 60801)).toLong
+    java.lang.Double.longBitsToDouble(tmp << 32)
+  }
+}

--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/color/functions/SaturationAdjust.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/color/functions/SaturationAdjust.scala
@@ -1,0 +1,106 @@
+package com.azavea.rf.datamodel.color.functions
+
+import geotrellis.raster.{ArrayTile, MultibandTile}
+import org.apache.commons.math3.util.FastMath
+import spire.syntax.cfor.cfor
+
+/**
+  * Usage of Approximations.{pow | exp} functions can allow to speed up this function on 10 - 15ms.
+  * We can consider these functions usages in case of real performance issues caused by a long saturation adjust.
+  */
+object SaturationAdjust {
+  def apply(rgbTile: MultibandTile, chromaFactor: Double): MultibandTile = {
+    scaleTileChroma(rgbTile, chromaFactor)
+  }
+
+  /* Convert RGB to Hue, Chroma, Luma https://en.wikipedia.org/wiki/HSL_and_HSV#Lightness */
+  def scaleTileChroma(rgbTile: MultibandTile, chromaFactor: Double): MultibandTile = {
+    val (red, green, blue) = (rgbTile.band(0), rgbTile.band(1), rgbTile.band(2))
+    val (nred, ngreen, nblue) = (
+      ArrayTile.alloc(rgbTile.cellType, rgbTile.cols, rgbTile.rows),
+      ArrayTile.alloc(rgbTile.cellType, rgbTile.cols, rgbTile.rows),
+      ArrayTile.alloc(rgbTile.cellType, rgbTile.cols, rgbTile.rows)
+    )
+    cfor(0)(_ < rgbTile.cols, _ + 1) { col =>
+      cfor(0)(_ < rgbTile.rows, _ + 1) { row =>
+        val (r, g, b) = (red.get(col, row), green.get(col, row), blue.get(col, row))
+        val (hue, chroma, luma) = RGBToHCLuma(r, g, b)
+        val newChroma = scaleChroma(chroma, chromaFactor)
+        val (nr, ng, nb) = HCLumaToRGB(hue, newChroma, luma)
+        nred.set(col, row, nr)
+        ngreen.set(col, row, ng)
+        nblue.set(col, row, nb)
+      }
+    }
+    MultibandTile(nred, ngreen, nblue)
+  }
+
+  // See link for a detailed explanation of what is happening. Basically we are taking the
+  // RGB cube and tilting it on its side so that the black -> white line runs vertically
+  // up the center of the HCL cylinder, then flattening the cube down into a hexagon and then
+  // pretending that that hexagon is actually a cylinder.
+  // https://en.wikipedia.org/wiki/HSL_and_HSV#Lightness
+  def RGBToHCLuma(rByte: Int, gByte: Int, bByte: Int): (Double, Double, Double) = {
+    // RGB come in as unsigned Bytes, but the transformation requires Doubles [0,1]
+    val (r, g, b) = (rByte / 255d, gByte / 255d, bByte / 255d)
+    val colors = List(r, g, b)
+    val max = colors.max
+    val min = colors.min
+    val chroma = max - min
+    val hueSextant = (chroma, max) match {
+      case (0, _) => 0 // Technically, undefined, but we'll ignore this value in this case.
+      case (_, x) if x == r => ((g - b) / chroma.toDouble) % 6
+      case (_, x) if x == g => ((b - r) / chroma.toDouble) + 2
+      case (_, x) if x == b => ((r - g) / chroma.toDouble) + 4
+    }
+    // Wrap degrees
+    val hue = (hueSextant * 60d) % 360 match {
+      case h if h < 0 => h + 360
+      case h if h >= 0 => h
+    }
+    // Perceptually weighted average of "lightness" contribution of sRGB primaries (it's
+    // not clear that we're in sRGB here, but that's the default for most images intended for
+    // display so it's a good guess in the absence of explicit information).
+    val luma = 0.21*r + 0.72*g + 0.07*b
+    (hue, chroma, luma)
+  }
+
+  // Reverse the process above
+  def HCLumaToRGB(hue: Double, chroma: Double, luma: Double): (Int, Int, Int) = {
+    val sextant = hue / 60d
+    val X = chroma * (1 - math.abs((sextant % 2) - 1))
+    // Projected color values, i.e., on the flat projection of the RGB cube
+    val (rFlat: Double, gFlat: Double, bFlat: Double) = (chroma, sextant) match {
+      case (0.0, _) => (0.0, 0.0, 0.0) // Gray (or black / white)
+      case (_, s) if 0 <= s && s < 1 => (chroma, X, 0.0)
+      case (_, s) if 1 <= s && s < 2 => (X, chroma, 0.0)
+      case (_, s) if 2 <= s && s < 3 => (0.0, chroma, X)
+      case (_, s) if 3 <= s && s < 4 => (0.0, X, chroma)
+      case (_, s) if 4 <= s && s < 5 => (X, 0.0, chroma)
+      case (_, s) if 5 <= s && s < 6 => (chroma, 0.0, X)
+    }
+
+    // We can add the same value to each component to move straight up the cylinder from the projected
+    // plane, back to the correct lightness value.
+    val lumaCorrection = luma - (0.21 * rFlat + 0.72 * gFlat + 0.07 * bFlat)
+    val r = clamp8Bit((255 * (rFlat + lumaCorrection)).toInt)
+    val g = clamp8Bit((255 * (gFlat + lumaCorrection)).toInt)
+    val b = clamp8Bit((255 * (bFlat + lumaCorrection)).toInt)
+    (r, g, b)
+  }
+
+  def scaleChroma(chroma: Double, scaleFactor: Double): Double = {
+    // Chroma is a Double in the range [0.0, 1.0]. Scale factor is the same as our other gamma corrections:
+    // a Double in the range [0.0, 2.0].
+    val scaled = FastMath.pow(chroma, 1.0 / scaleFactor)
+    if (scaled < 0.0) 0.0
+    else if (scaled > 1.0) 1.0
+    else scaled
+  }
+
+  @inline def clamp8Bit(z: Int): Int = {
+    if (z < 0) 0
+    else if (z > 255) 255
+    else z
+  }
+}

--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/color/functions/SigmoidalContrast.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/color/functions/SigmoidalContrast.scala
@@ -1,0 +1,85 @@
+package com.azavea.rf.datamodel.color.functions
+
+import geotrellis.raster._
+import org.apache.commons.math3.util.FastMath
+
+/**
+  * Usage of Approximations.{pow | exp} functions can allow to speed up this function on 10 - 15ms.
+  * We can consider these functions usages in case of real performance issues caused by a long sigmoidal contrast.
+  */
+object SigmoidalContrast {
+  /**
+    * @param  cellType   The cell type on which the transform is to act
+    * @param  alpha      The center around-which the stretch is performed (given as a fraction)
+    * @param  beta       The standard deviation in the computation, used to avoid saturating the upper and lower parts of the gamut
+    * @param  intensity  The raw intensity value to be mapped-from
+    * @return            The intensity value produced by the sigmoidal contrast transformation
+    */
+  def transform(cellType: CellType, alpha: Double, beta: Double)(intensity: Double): Double = {
+    val bits = cellType.bits
+
+    val u = cellType match {
+      case _: FloatCells =>
+        (intensity - Float.MinValue) / (Float.MaxValue - Float.MinValue)
+      case _: DoubleCells =>
+        (intensity / 2 - Double.MinValue / 2) / (Double.MaxValue / 2 - Double.MinValue / 2)
+      case _: BitCells | _: UByteCells | _: UShortCells =>
+        intensity / ((1 << bits) - 1)
+      case _: ByteCells | _: ShortCells | _: IntCells =>
+        (intensity + (1 << (bits - 1))) / ((1 << bits) - 1)
+    }
+
+    val numer = 1 / (1 + FastMath.exp(beta * (alpha - u))) - 1 / (1 + FastMath.exp(beta))
+    val denom = 1 / (1 + FastMath.exp(beta * (alpha - 1))) - 1 / (1 + FastMath.exp(beta * alpha))
+    val gu = math.max(0.0, math.min(1.0, numer / denom))
+
+    cellType match {
+      case _: FloatCells =>
+        Float.MaxValue * (2 * gu - 1d)
+      case _: DoubleCells =>
+        Double.MaxValue * (2 * gu - 1d)
+      case _: BitCells | _: UByteCells | _: UShortCells =>
+        ((1 << bits) - 1) * gu
+      case _: ByteCells | _: ShortCells | _: IntCells =>
+        (((1 << bits) - 1) * gu) - (1 << (bits - 1))
+    }
+  }
+
+  /**
+    * Given a singleband [[Tile]] object and the parameters alpha and
+    * beta, perform the sigmoidal contrast computation and return the
+    * result as a tile.
+    *
+    * The approach used is described here:
+    * https://www.imagemagick.org/Usage/color_mods/#sigmoidal
+    *
+    * @param  tile   The input tile
+    * @param  alpha  The center around-which the stretch is performed (given as a fraction)
+    * @param  beta   The standard deviation in the computation, used to avoid saturating the upper and lower parts of the gamut
+    * @return        The output tile
+    */
+  def apply(tile: Tile, alpha: Double, beta: Double): Tile = {
+    val localTransform = transform(tile.cellType, alpha, beta)_
+    tile.mapDouble(localTransform)
+  }
+
+  def localTransform(cellType: CellType, alpha: Double, beta: Double) = transform(cellType, alpha, beta)_
+
+  /**
+    * Given a [[MultibandTile]] object and the parameters alpha and
+    * beta, perform the sigmoidal contrast computation on each band
+    * and return the result as a multiband tile.
+    *
+    * The approach used is described here:
+    * https://www.imagemagick.org/Usage/color_mods/#sigmoidal
+    *
+    * @param  tile   The input multibandtile
+    * @param  alpha  The center around-which the stretch is performed (given as a fraction)
+    * @param  beta   The standard deviation in the computation, used to avoid saturating the upper and lower parts of the gamut
+    * @return        The output tile
+    */
+  def apply(tile: MultibandTile, alpha: Double, beta: Double): MultibandTile = {
+    val localTransform = transform(tile.cellType, alpha, beta)_
+    MultibandTile(tile.bands.map(_.mapDouble(localTransform)))
+  }
+}

--- a/app-backend/datamodel/src/test/scala/com/azavea/rf/datamodel/color/functions/ApproximationsSpec.scala
+++ b/app-backend/datamodel/src/test/scala/com/azavea/rf/datamodel/color/functions/ApproximationsSpec.scala
@@ -1,0 +1,50 @@
+package com.azavea.rf.datamodel.color.functions
+
+import org.apache.commons.math3.util.FastMath
+import org.scalatest._
+
+class ApproximationsSpec extends FunSpec with Matchers {
+  it("Approximations.pow in SaturationAdjust should be +- 0.1 of the FastMath.pow") {
+    // Chroma is a Double in the range [0.0, 1.0]. Scale factor is the same as our other gamma corrections:
+    // a Double in the range [0.0, 2.0].
+    val chromas = 0d to 1d by 0.2
+    val scaleFactors = 0d to 2d by 0.2
+
+    for {
+      chroma <- chromas
+      scaleFactor <- scaleFactors
+    } yield {
+      val fst = Approximations.pow(chroma, 1d / scaleFactor)
+      val snd = FastMath.pow(chroma, 1d / scaleFactor)
+      val thrd = math.pow(chroma, 1d / scaleFactor)
+
+      if(!java.lang.Double.isNaN(fst) && !java.lang.Double.isNaN(snd) && !java.lang.Double.isNaN(thrd)) {
+        fst shouldBe snd +- 0.1
+      } else {
+        java.lang.Double.isNaN(fst) shouldBe java.lang.Double.isNaN(snd)
+        java.lang.Double.isNaN(snd) shouldBe java.lang.Double.isNaN(thrd)
+      }
+    }
+  }
+
+  it("Approximations.exp in SigmoidalContrast should be +- 403 of the FastMath.exp") {
+    val alphas = 0d to 1d by 0.2
+    val betas = 0d to 10d by 0.2
+
+    for {
+      alpha <- alphas
+      beta <- betas
+    } yield {
+      val fst = Approximations.exp(beta * alpha)
+      val snd = FastMath.exp(beta * alpha)
+      val thrd = math.exp(beta * alpha)
+
+      if(!java.lang.Double.isNaN(fst) && !java.lang.Double.isNaN(snd) && !java.lang.Double.isNaN(thrd)) {
+        fst shouldBe snd +- 403
+      } else {
+        java.lang.Double.isNaN(fst) shouldBe java.lang.Double.isNaN(snd)
+        java.lang.Double.isNaN(snd) shouldBe java.lang.Double.isNaN(thrd)
+      }
+    }
+  }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
 
   memcached:
     image: memcached:1.4-alpine
-    command: -I 5242880b
+    command: -m 4096 -c 8192 -I 5242880b
 
   nginx-api:
     image: raster-foundry-nginx-api


### PR DESCRIPTION
## Overview

This PR introduces multiple changes into the tile ColorCorrection function. 

The problem is that ColorCorrection function computation takes 190ms - 360+ms

To resolve this issue were researched two approaches: 

1. through LazyTiles 
2. through reducing cfor loops operations number (every per pixel operation can be done in one loop), reducing `Option` boxing

The first approach didn't work, and / or requires much deeper research, as requires implementation of multiband lazy tiles, as a consequences it was decided to follow through the second approach, as it is more straightforward.

After following the second a problems with slow floating point operations was figured out, standard `math.pow` and `math.exp` are two extremely slow functions. The workaround was to use `commons-math3` library, and `FastMath` functions. However it was not enough (77ms-100ms result seemed to me not enough), and more rough but more fast approximation functions were introduced.

```scala
  /**
    * For clarifications
    * see https://www.reddit.com/r/gamedev/comments/n7na0/fast_approximation_to_mathpow/
    * and https://martin.ankerl.com/2007/10/04/optimized-pow-approximation-for-java-and-c-c/
    *
    */
  def pow(a: Double, b: Double): Double = { // exponentiation by squaring
    if(a < 1 && java.lang.Double.isInfinite(b)) return 0d
    if(a >= 1 && java.lang.Double.isInfinite(b)) return Double.NaN
    if(java.lang.Double.isNaN(a) || java.lang.Double.isNaN(b)) return Double.NaN

    var r = 1d
    var exp = b.toInt
    var base = a
    while (exp != 0) {
      if ((exp & 1) != 0) r *= base
      base *= base
      exp >>= 1
    }
    // use the IEEE 754 trick for the fraction of the exponent
    val b_faction = b - b.toInt
    val tmp = java.lang.Double.doubleToLongBits(a)
    val tmp2 = (b_faction * (tmp - 4606921280493453312L)).toLong + 4606921280493453312L
    r * java.lang.Double.longBitsToDouble(tmp2)
  }

  /**
    * For clarifications
    * see http://martin.ankerl.com/2007/02/11/optimized-exponential-functions-for-java/
    *
    */
  def exp(value: Double): Double = {
    val tmp = (1512775 * value + (1072693248 - 60801)).toLong
    java.lang.Double.longBitsToDouble(tmp << 32)
  }
```
Approximation function usage allowed to achieve `55ms - 68ms` vs FastMath `77ms - 100ms` vs original `190ms - 360+ms` on the same machine in the same conditions.

Functions were tested and `pow` function has max deviation ~= 0.2, `exp` has max deviation ~= 403 on our small function application domain. Tests are in `com.azavea.rf.datamodel.color.functions.ApproximationsSpec`

P.S. During tests at one point I figured out regression after removing logging functions, it turned out that for some reason wrapping `cfors` into:

```scala
def lazyWrapper[T](f: => T): T = f
``` 

Gives some performance improvements.

P.P.S. Old ColorCorrect object was saved in the OldColorCorrect file in the `.old` package.

To follow the development with timings logging use this branch: https://github.com/azavea/raster-foundry/tree/feature/tile-cc-improvements-refactor-new

### Demo

Run [this](https://github.com/azavea/raster-foundry/tree/feature/tile-cc-improvements-refactor-new) branch and see tile server logging.

Closes #2007
