### PR TITLE
Improve Airflow DAG/Task Logging

### DIFF
--- a/app-tasks/dags/aoi-monitoring/find_aoi_projects_to_update.py
+++ b/app-tasks/dags/aoi-monitoring/find_aoi_projects_to_update.py
@@ -10,14 +10,17 @@ from airflow.operators.python_operator import PythonOperator
 
 from rf.utils.exception_reporting import wrap_rollbar
 
-rf_logger = logging.getLogger('rf')
-ch = logging.StreamHandler()
-ch.setLevel(logging.INFO)
 formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+ch = logging.StreamHandler()
+
+ch.setLevel(logging.INFO)
 ch.setFormatter(formatter)
-rf_logger.addHandler(ch)
+
+logging.getLogger('rf').addHandler(ch)
+logging.getLogger().addHandler(ch)
 
 logger = logging.getLogger(__name__)
+
 
 default_args = {
     'owner': 'raster-foundry',

--- a/app-tasks/dags/aoi-monitoring/update_aoi_projects.py
+++ b/app-tasks/dags/aoi-monitoring/update_aoi_projects.py
@@ -9,14 +9,17 @@ from airflow.exceptions import AirflowException
 
 from rf.utils.exception_reporting import wrap_rollbar
 
-rf_logger = logging.getLogger('rf')
-ch = logging.StreamHandler()
-ch.setLevel(logging.INFO)
 formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+ch = logging.StreamHandler()
+
+ch.setLevel(logging.INFO)
 ch.setFormatter(formatter)
-rf_logger.addHandler(ch)
+
+logging.getLogger('rf').addHandler(ch)
+logging.getLogger().addHandler(ch)
 
 logger = logging.getLogger(__name__)
+
 
 default_args = {
     'owner': 'raster-foundry',

--- a/app-tasks/dags/aoi-monitoring/update_aoi_projects.py
+++ b/app-tasks/dags/aoi-monitoring/update_aoi_projects.py
@@ -9,6 +9,9 @@ from airflow.exceptions import AirflowException
 
 from rf.utils.exception_reporting import wrap_rollbar
 
+from utils import failure_callback
+
+
 formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
 ch = logging.StreamHandler()
 
@@ -60,5 +63,6 @@ PythonOperator(
     provide_context=True,
     python_callable=update_aoi_project,
     execution_timeout=datetime.timedelta(seconds=60),
+    on_failure_callback=failure_callback,
     dag=dag
 )

--- a/app-tasks/dags/export_project.py
+++ b/app-tasks/dags/export_project.py
@@ -13,6 +13,9 @@ from airflow.operators import PythonOperator
 from airflow.exceptions import AirflowException
 from rf.utils.exception_reporting import wrap_rollbar
 
+from utils import failure_callback
+
+
 formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
 ch = logging.StreamHandler()
 
@@ -133,6 +136,7 @@ create_export_definition_task = PythonOperator(
     task_id='create_export_definition',
     provide_context=True,
     python_callable=create_export_definition_op,
+    on_failure_callback=failure_callback,
     dag=dag
 )
 
@@ -140,6 +144,7 @@ wait_for_status_task = PythonOperator(
     task_id='wait_for_status',
     provide_context=True,
     python_callable=wait_for_status_op,
+    on_failure_callback=failure_callback,
     dag=dag
 )
 

--- a/app-tasks/dags/import_landsat8_scenes.py
+++ b/app-tasks/dags/import_landsat8_scenes.py
@@ -1,10 +1,13 @@
 """Task for scheduled finding new Landsat 8 scenes to ingest"""
 
-from datetime import datetime, timedelta
+from datetime import datetime
 import os
 
 from airflow.operators.bash_operator import BashOperator
 from airflow.models import DAG
+
+from utils import failure_callback
+
 
 schedule = None if os.getenv('ENVIRONMENT') == 'development' else '@daily'
 start_date = datetime(2016, 11, 6)
@@ -26,5 +29,6 @@ landsat8_finder = BashOperator(
     task_id='import_new_landsat8_scenes',
     provide_context=True,
     bash_command=bash_cmd,
+    on_failure_callback=failure_callback,
     dag=dag
 )

--- a/app-tasks/dags/import_sentinel2_scenes.py
+++ b/app-tasks/dags/import_sentinel2_scenes.py
@@ -4,6 +4,9 @@ from airflow.operators.bash_operator import BashOperator
 from airflow.models import DAG
 from datetime import datetime, timedelta
 
+from utils import failure_callback
+
+
 seven_days_ago = datetime.combine(
     datetime.today() - timedelta(7), datetime.min.time())
 
@@ -25,5 +28,6 @@ sentinel2_importer = BashOperator(
     task_id='import_sentinel2',
     provide_context=True,
     bash_command=bash_cmd,
+    on_failure_callback=failure_callback,
     dag=dag
 )

--- a/app-tasks/dags/ingest_project_scenes.py
+++ b/app-tasks/dags/ingest_project_scenes.py
@@ -16,6 +16,9 @@ from rf.ingest import create_landsat8_ingest, create_ingest_definition
 from rf.uploads.landsat8.settings import datasource_id as landsat_id
 from rf.utils.exception_reporting import wrap_rollbar
 
+from utils import failure_callback
+
+
 formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
 ch = logging.StreamHandler()
 
@@ -231,6 +234,7 @@ create_ingest_definition_task = PythonOperator(
     task_id='create_ingest_definition',
     provide_context=True,
     python_callable=create_ingest_definition_op,
+    on_failure_callback=failure_callback,
     dag=dag
 )
 
@@ -239,6 +243,7 @@ launch_spark_ingest_task = PythonOperator(
     task_id='launch_spark_ingest',
     provide_context=True,
     python_callable=launch_spark_ingest_job_op,
+    on_failure_callback=failure_callback,
     dag=dag
 )
 
@@ -246,6 +251,7 @@ wait_for_status_task = PythonOperator(
     task_id='wait_for_status',
     provide_context=True,
     python_callable=wait_for_status_op,
+    on_failure_callback=failure_callback,
     dag=dag
 )
 

--- a/app-tasks/dags/ingest_project_scenes.py
+++ b/app-tasks/dags/ingest_project_scenes.py
@@ -16,14 +16,17 @@ from rf.ingest import create_landsat8_ingest, create_ingest_definition
 from rf.uploads.landsat8.settings import datasource_id as landsat_id
 from rf.utils.exception_reporting import wrap_rollbar
 
-rf_logger = logging.getLogger('rf')
-ch = logging.StreamHandler()
-ch.setLevel(logging.INFO)
 formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+ch = logging.StreamHandler()
+
+ch.setLevel(logging.INFO)
 ch.setFormatter(formatter)
-rf_logger.addHandler(ch)
+
+logging.getLogger('rf').addHandler(ch)
+logging.getLogger().addHandler(ch)
 
 logger = logging.getLogger(__name__)
+
 
 default_args = {
     'owner': 'raster-foundry',

--- a/app-tasks/dags/process_upload.py
+++ b/app-tasks/dags/process_upload.py
@@ -48,21 +48,30 @@ def process_upload(*args, **kwargs):
     upload = Upload.from_id(upload_id)
     upload.update_upload_status('Processing')
 
+    logger.info('Processing upload (%s) for user %s with files %s',
+                upload.id, upload.owner, upload.files)
+
     try:
         factory = GeoTiffS3SceneFactory(upload)
         scenes = factory.generate_scenes()
+        logger.info('Creating scene objects for upload %s, preparing to POST to API', upload.id)
+
         created_scenes = [scene.create() for scene in scenes]
+        logger.info('Successfully created %s scenes (%s)', len(created_scenes), [s.id for s in created_scenes])
 
         if upload.projectId:
-            logger.info("Upload specified a project. Linking scenes to project.")
+            logger.info('Upload specified a project. Linking scenes to project %s', upload.projectId)
             scene_ids = [scene.id for scene in created_scenes]
             batch_scene_to_project_url = '{HOST}/api/projects/{PROJECT}/scenes'.format(HOST=HOST, PROJECT=upload.projectId)
             session = get_session()
             response = session.post(batch_scene_to_project_url, json=scene_ids)
             response.raise_for_status()
         upload.update_upload_status('Complete')
-        logger.info('Finished importing scenes')
+        logger.info('Finished importing scenes for upload (%s) for user %s with files %s',
+                     upload.id, upload.owner, upload.files)
     except:
+        logger.error('Failed to process upload (%s) for user %s with files %s',
+                     upload.id, upload.owner, upload.files)
         upload.update_upload_status('Failed')
         raise
 

--- a/app-tasks/dags/process_upload.py
+++ b/app-tasks/dags/process_upload.py
@@ -11,6 +11,9 @@ from rf.uploads.geotiff.factories import GeoTiffS3SceneFactory
 from rf.utils.io import get_session
 from rf.utils.exception_reporting import wrap_rollbar
 
+from utils import failure_callback
+
+
 # Logging Setup
 formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
 ch = logging.StreamHandler()
@@ -80,5 +83,6 @@ process_upload_op = PythonOperator(
     task_id='process_upload',
     python_callable=process_upload,
     provide_context=True,
+    on_failure_callback=failure_callback,
     dag=dag
 )

--- a/app-tasks/dags/process_upload.py
+++ b/app-tasks/dags/process_upload.py
@@ -11,15 +11,18 @@ from rf.uploads.geotiff.factories import GeoTiffS3SceneFactory
 from rf.utils.io import get_session
 from rf.utils.exception_reporting import wrap_rollbar
 
-
-rf_logger = logging.getLogger('rf')
-ch = logging.StreamHandler()
-ch.setLevel(logging.INFO)
+# Logging Setup
 formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+ch = logging.StreamHandler()
+
+ch.setLevel(logging.INFO)
 ch.setFormatter(formatter)
-rf_logger.addHandler(ch)
+
+logging.getLogger('rf').addHandler(ch)
+logging.getLogger().addHandler(ch)
 
 logger = logging.getLogger(__name__)
+
 
 args = {
     'start_date': datetime(2017, 2, 21)
@@ -38,7 +41,7 @@ HOST = os.getenv('RF_HOST')
 def process_upload(*args, **kwargs):
     """Import scenes for a given upload"""
 
-    logging.info('Processing geotiff uploads...')
+    logger.info('Processing geotiff uploads...')
     conf = kwargs['dag_run'].conf
 
     upload_id = conf.get('uploadId')

--- a/app-tasks/dags/utils.py
+++ b/app-tasks/dags/utils.py
@@ -1,0 +1,46 @@
+import logging
+import os
+
+import rollbar
+
+logger = logging.getLogger(__name__)
+
+environment = os.getenv('ENVIRONMENT')
+rollbar_token = os.getenv('ROLLBAR_SERVER_TOKEN')
+
+# Avoid use of threads by default in case the worker exits before sending message
+rollbar.init(rollbar_token, environment, handler='blocking')
+
+
+def failure_callback(context):
+    """Failure callback used to send notifications to rollbar for failed task instances
+
+    Args:
+        context (dict): contextual information passed by airflow to the callback
+    """
+
+    dag_run = context['dag_run']
+    task = context['task']
+
+    task_id = task.task_id
+    dag_id = dag_run.dag_id
+    dag_run_id = dag_run.run_id
+
+    message = 'Task {} failed for DAG {} (DAG run: {})'.format(
+        task_id, dag_id, dag_run_id
+    )
+    notify_rollbar(message)
+
+
+def notify_rollbar(message):
+    """Function to notify rollbar of an error if configured
+
+    Args:
+        message (str): message to send to rollbar
+    """
+
+    if all([environment, rollbar_token]):
+        rollbar.report_message(message)
+    else:
+        logger.warning('Both ENVIRONMENT and ROLLBAR_SERVER_TOKEN must be set to log exceptions to rollbar')
+        logger.error(message)


### PR DESCRIPTION
## Overview

There are a few issues with our Airflow logging that this PR starts to solve:
 1. Not every log making it to stdout
 2. Lack of contextual/user information in logs when tracking down failures
 3. Notifications to Rollbar for failed task instances

The first problem is actually a little tough to solve in an elegant way because Airflow uses the root logger everywhere, so the only solution is to add another handler (stream handler) to the root logger and deal with all the logs now.

The second problem is solved by updating the logs to include additional context, including upload ids, scene ids, and user ids where relevant.

The third problem is solved by adding a failure callback that sends a notification to rollbar in the event of a failed task instance so that an issue can be created and triaged.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~

### Demo

New logs in airflow (demonstrating the new contextual information):

```

*** Log file isn't local.
*** Fetching here: http://07b3c70fefce:8793/log/process_upload/process_upload/2017-06-22T13:26:05.054860

[2017-06-22 13:26:14,426] {models.py:154} INFO - Filling up the DagBag from /opt/raster-foundry/app-tasks/dags/process_upload.py
[2017-06-22 13:26:14,580] {credentials.py:674} INFO - Found credentials in shared credentials file: ~/.aws/credentials
[2017-06-22 13:26:14,755] {__init__.py:281} WARNING - Rollbar already initialized. Ignoring re-init.
[2017-06-22 13:26:15,828] {models.py:154} INFO - Filling up the DagBag from /opt/raster-foundry/app-tasks/dags/process_upload.py
[2017-06-22 13:26:15,965] {credentials.py:674} INFO - Found credentials in shared credentials file: ~/.aws/credentials
[2017-06-22 13:26:16,076] {__init__.py:281} WARNING - Rollbar already initialized. Ignoring re-init.
[2017-06-22 13:26:16,102] {models.py:1196} INFO - 
--------------------------------------------------------------------------------
Starting attempt 1 of 1
--------------------------------------------------------------------------------

[2017-06-22 13:26:16,113] {models.py:1219} INFO - Executing <Task(PythonOperator): process_upload> on 2017-06-22 13:26:05.054860
[2017-06-22 13:26:16,129] {process_upload.py:47} INFO - Processing geotiff uploads...
[2017-06-22 13:26:16,222] {process_upload.py:55} INFO - Processing upload (07c6068f-4b2d-4fd4-ae18-024a891fc848) for user auth0|59318a9d2fbbca3e16bcfc92 with files [u's3://rasterfoundry-development-data-us-east-1/user-uploads/auth0|59318a9d2fbbca3e16bcfc92/07c6068f-4b2d-4fd4-ae18-024a891fc848/ebee-test-flight-nz233reals.tif']
[2017-06-22 13:26:16,222] {process_upload.py:60} INFO - Creating scene objects for upload 07c6068f-4b2d-4fd4-ae18-024a891fc848, preparing to POST to API
[2017-06-22 13:26:16,239] {connectionpool.py:735} INFO - Starting new HTTPS connection (1): s3.amazonaws.com
[2017-06-22 13:26:16,352] {connectionpool.py:735} INFO - Starting new HTTPS connection (2): s3.amazonaws.com
[2017-06-22 13:26:16,353] {connectionpool.py:735} INFO - Starting new HTTPS connection (3): s3.amazonaws.com
[2017-06-22 13:26:16,355] {connectionpool.py:735} INFO - Starting new HTTPS connection (4): s3.amazonaws.com
[2017-06-22 13:26:16,356] {connectionpool.py:735} INFO - Starting new HTTPS connection (5): s3.amazonaws.com
[2017-06-22 13:26:21,829] {create_scenes.py:41} INFO - Generating Scene from /tmp/tmpq_uFl3
[2017-06-22 13:26:22,003] {create_footprints.py:169} INFO - Beginning process to extract footprint for image:/tmp/tmpq_uFl3
[2017-06-22 13:26:22,005] {create_footprints.py:186} INFO - Running GDAL command: gdal_translate /tmp/tmpq_uFl3 /tmp/tmpAuIg4D/tmpLwjxhX.TIF -outsize 512 542
[2017-06-22 13:26:22,187] {create_footprints.py:35} INFO - Creating masks to extract footprints
[2017-06-22 13:26:22,220] {create_footprints.py:144} INFO - Extracting shapes from footprint masks
[2017-06-22 13:26:22,224] {create_footprints.py:87} INFO - Transforming footprint coordinates
[2017-06-22 13:26:22,226] {create_footprints.py:144} INFO - Extracting shapes from footprint masks
[2017-06-22 13:26:22,230] {create_footprints.py:87} INFO - Transforming footprint coordinates
[2017-06-22 13:26:22,234] {create_thumbnails.py:70} INFO - Performing thumbnail resampling
[2017-06-22 13:26:22,408] {create_thumbnails.py:76} INFO - Performing thumbnail warping
[2017-06-22 13:26:22,501] {create_thumbnails.py:97} INFO - Creating thumbnail files
[2017-06-22 13:26:23,308] {create_thumbnails.py:139} INFO - Uploading thumbnails to S3
[2017-06-22 13:26:23,323] {connectionpool.py:735} INFO - Starting new HTTPS connection (1): s3.amazonaws.com
[2017-06-22 13:26:24,779] {process_upload.py:63} INFO - Successfully created scenes 1 ([u'5dcc2799-4186-426b-9364-5ebc1cdbfe78'])
[2017-06-22 13:26:24,779] {process_upload.py:66} INFO - Upload specified a project. Linking scenes to project 31b4627f-9112-4299-a390-5a4b41a073e7
[2017-06-22 13:26:25,285] {process_upload.py:74} INFO - Finished importing scenes for upload (07c6068f-4b2d-4fd4-ae18-024a891fc848) for user auth0|59318a9d2fbbca3e16bcfc92 with files [u's3://rasterfoundry-development-data-us-east-1/user-uploads/auth0|59318a9d2fbbca3e16bcfc92/07c6068f-4b2d-4fd4-ae18-024a891fc848/ebee-test-flight-nz233reals.tif']
[2017-06-22 13:26:25,286] {python_operator.py:67} INFO - Done. Returned value was: None
```

Same logs from `docker-compose -f docker-compose.airflow.yml logs` illustrating that the same logs now go to `stdout`:

```
airflow-worker_1        | --------------------------------------------------------------------------------
airflow-worker_1        | Starting attempt 1 of 1
airflow-worker_1        | --------------------------------------------------------------------------------
airflow-worker_1        | 
airflow-worker_1        | 2017-06-22 13:26:16,113 - root - INFO - Executing <Task(PythonOperator): process_upload> on 2017-06-22 13:26:05.054860
airflow-worker_1        | 2017-06-22 13:26:16,129 - unusual_prefix_process_upload - INFO - Processing geotiff uploads...
airflow-worker_1        | 2017-06-22 13:26:16,222 - unusual_prefix_process_upload - INFO - Processing upload (07c6068f-4b2d-4fd4-ae18-024a891fc848) for user auth0|59318a9d2f
bbca3e16bcfc92 with files [u's3://rasterfoundry-development-data-us-east-1/user-uploads/auth0|59318a9d2fbbca3e16bcfc92/07c6068f-4b2d-4fd4-ae18-024a891fc848/ebee-test-flight-
nz233reals.tif']
airflow-worker_1        | 2017-06-22 13:26:16,222 - unusual_prefix_process_upload - INFO - Creating scene objects for upload 07c6068f-4b2d-4fd4-ae18-024a891fc848, preparing 
to POST to API
airflow-worker_1        | 2017-06-22 13:26:16,239 - botocore.vendored.requests.packages.urllib3.connectionpool - INFO - Starting new HTTPS connection (1): s3.amazonaws.com
airflow-worker_1        | 2017-06-22 13:26:16,352 - botocore.vendored.requests.packages.urllib3.connectionpool - INFO - Starting new HTTPS connection (2): s3.amazonaws.com
airflow-worker_1        | 2017-06-22 13:26:16,353 - botocore.vendored.requests.packages.urllib3.connectionpool - INFO - Starting new HTTPS connection (3): s3.amazonaws.com
airflow-worker_1        | 2017-06-22 13:26:16,355 - botocore.vendored.requests.packages.urllib3.connectionpool - INFO - Starting new HTTPS connection (4): s3.amazonaws.com
airflow-worker_1        | 2017-06-22 13:26:16,356 - botocore.vendored.requests.packages.urllib3.connectionpool - INFO - Starting new HTTPS connection (5): s3.amazonaws.com
airflow-worker_1        | [2017-06-22 13:26:20,650] {_internal.py:87} INFO - 172.21.0.6 - - [22/Jun/2017 13:26:20] "GET /log/process_upload/process_upload/2017-06-22T13:26:0
5.054860 HTTP/1.1" 200 -
airflow-worker_1        | 2017-06-22 13:26:21,829 - rf.uploads.geotiff.create_scenes - INFO - Generating Scene from /tmp/tmpq_uFl3
airflow-worker_1        | 2017-06-22 13:26:21,829 - rf.uploads.geotiff.create_scenes - INFO - Generating Scene from /tmp/tmpq_uFl3
airflow-worker_1        | 2017-06-22 13:26:22,003 - rf.uploads.geotiff.create_footprints - INFO - Beginning process to extract footprint for image:/tmp/tmpq_uFl3
airflow-worker_1        | 2017-06-22 13:26:22,003 - rf.uploads.geotiff.create_footprints - INFO - Beginning process to extract footprint for image:/tmp/tmpq_uFl3
airflow-worker_1        | 2017-06-22 13:26:22,005 - rf.uploads.geotiff.create_footprints - INFO - Running GDAL command: gdal_translate /tmp/tmpq_uFl3 /tmp/tmpAuIg4D/tmpLwjxh
X.TIF -outsize 512 542
airflow-worker_1        | 2017-06-22 13:26:22,005 - rf.uploads.geotiff.create_footprints - INFO - Running GDAL command: gdal_translate /tmp/tmpq_uFl3 /tmp/tmpAuIg4D/tmpLwjxh
X.TIF -outsize 512 542
airflow-worker_1        | Input file size is 4393, 4657
airflow-worker_1        | 0...10...20...30...40...50...60...70...80...90...100 - done.
airflow-worker_1        | 2017-06-22 13:26:22,187 - rf.uploads.geotiff.create_footprints - INFO - Creating masks to extract footprints
airflow-worker_1        | 2017-06-22 13:26:22,187 - rf.uploads.geotiff.create_footprints - INFO - Creating masks to extract footprints
airflow-worker_1        | /usr/local/bin/rf/uploads/geotiff/create_footprints.py:46: NodataShadowWarning: The dataset's nodata attribute is shadowing the alpha band. All mas
ks will be determined by the nodata attribute
airflow-worker_1        |   mask = sieve(src.dataset_mask(), size=40)
airflow-worker_1        | /usr/local/bin/rf/uploads/geotiff/create_footprints.py:191: DeprecationWarning: 'src.affine' is deprecated.  Please switch to 'src.transform'. See 
https://github.com/mapbox/rasterio/issues/86 for details.
```

Sample Rollbar message from a task failure:

![ex-rollbar](https://user-images.githubusercontent.com/898060/27436744-34ef63b4-572e-11e7-88c7-13dc5a2c9830.png)

## Testing Instructions

 * Start up server: `./scripts/server --with-airflow`
 * Create a new project and upload some data, observe logs in stdout and in airflow match, verify additional context is in logs

Closes #1994 
Closes https://github.com/azavea/raster-foundry-clients/issues/25 
