### PR TITLE
Ingest seams fix

### DIFF
--- a/app-backend/batch/src/main/resources/application.conf
+++ b/app-backend/batch/src/main/resources/application.conf
@@ -51,7 +51,7 @@ export-def {
   bucketName  = "export-definitions"
   awsDataproc = "dataproc.rasterfoundry.com."
   sparkJarS3  = "s3://rasterfoundry-global-artifacts-us-east-1/batch"
-  sparkJar    = "rf-batch-8012db8.jar"
+  sparkJar    = "rf-batch-87b97ad.jar"
   sparkClass  = "com.azavea.rf.batch.export.spark.Export"
   sparkMemory = "2G"
 }

--- a/app-backend/project/Version.scala
+++ b/app-backend/project/Version.scala
@@ -2,7 +2,7 @@ object Version {
   val rasterFoundry      = "0.1"
   val akka               = "2.4.3"
   val akkaHttp           = "10.0.3"
-  val geotrellis         = "1.1.0-RC3"
+  val geotrellis         = "1.1.1"
   val hikariCP           = "3.1.1.2"
   val postgres           = "9.4-1201-jdbc41"
   val scala              = "2.11.11"

--- a/app-tasks/dags/ingest_project_scenes.py
+++ b/app-tasks/dags/ingest_project_scenes.py
@@ -49,7 +49,7 @@ dag = DAG(
 batch_job_definition = os.getenv('BATCH_INGEST_JOB_NAME')
 batch_job_queue = os.getenv('BATCH_INGEST_JOB_QUEUE')
 hosted_zone_id = os.getenv('HOSTED_ZONE_ID')
-jar_path = os.getenv('BATCH_JAR_PATH', 'rf-batch-94265f7.jar')
+jar_path = os.getenv('BATCH_JAR_PATH', 'rf-batch-87b97ad.jar')
 
 
 ################################


### PR DESCRIPTION
## Overview

PR adds an additional buffer (2px sized) around chips, to get rid of seams which could appear during the ingest process.

Includes GeoTrellis update up to 1.1.1.

## Testing Instructions

* Run ingest through the UI

Closes #1735
