### PR TITLE
[WIP] AST: Linear Operation

### DIFF
--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/ast/package.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/ast/package.scala
@@ -77,8 +77,8 @@ package object ast {
         ContextRDD(kids.head.localMin(kids.tail), kids.map(_.metadata).reduce(_ combine _))
       }
       case Masking(args, _, _, mask) => eval(args.head, rdds).mask(mask)
-      case Linear(args, _, _, f) =>
-        eval(args.head, rdds).withContext(_.mapValues(_.mapDouble(f)))
+      case op: Linear =>
+        eval(op.args.head, rdds).withContext(_.mapValues(_.mapDouble(op.transform)))
     }
 
     /* Guarantee correctness before performing Map Algebra */

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/ast/package.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/ast/package.scala
@@ -77,6 +77,8 @@ package object ast {
         ContextRDD(kids.head.localMin(kids.tail), kids.map(_.metadata).reduce(_ combine _))
       }
       case Masking(args, _, _, mask) => eval(args.head, rdds).mask(mask)
+      case Linear(args, _, _, f) =>
+        eval(args.head, rdds).withContext(_.mapValues(_.mapDouble(f)))
     }
 
     /* Guarantee correctness before performing Map Algebra */

--- a/app-backend/tool/src/main/scala/ast/MapAlgebraAST.scala
+++ b/app-backend/tool/src/main/scala/ast/MapAlgebraAST.scala
@@ -65,10 +65,10 @@ object MapAlgebraAST {
     val symbol = "linear"
 
     lazy val transform: Double => Double = op match {
-      case LAdd => { n => n + constant }
-      case LSub => { n => n - constant }
-      case LMul => { n => n * constant }
-      case LDiv => { n => n / constant }
+      case LinearOp.Add => { n => n + constant }
+      case LinearOp.Sub => { n => n - constant }
+      case LinearOp.Mul => { n => n * constant }
+      case LinearOp.Div => { n => n / constant }
     }
   }
 
@@ -76,27 +76,27 @@ object MapAlgebraAST {
 
   object LinearOp {
     implicit val dec: Decoder[LinearOp] = Decoder.decodeString.emap({
-      case "+" => Right(LAdd)
-      case "-" => Right(LSub)
-      case "*" => Right(LMul)
-      case "/" => Right(LDiv)
+      case "+" => Right(Add)
+      case "-" => Right(Sub)
+      case "*" => Right(Mul)
+      case "/" => Right(Div)
       case _   => Left("failed!")
     })
 
     implicit val enc: Encoder[LinearOp] = new Encoder[LinearOp] {
       final def apply(op: LinearOp) = op match {
-        case LAdd => Json.fromString("+")
-        case LSub => Json.fromString("-")
-        case LMul => Json.fromString("*")
-        case LDiv => Json.fromString("/")
+        case Add => Json.fromString("+")
+        case Sub => Json.fromString("-")
+        case Mul => Json.fromString("*")
+        case Div => Json.fromString("/")
       }
     }
-  }
 
-  case object LAdd extends LinearOp
-  case object LSub extends LinearOp
-  case object LMul extends LinearOp
-  case object LDiv extends LinearOp
+    case object Add extends LinearOp
+    case object Sub extends LinearOp
+    case object Mul extends LinearOp
+    case object Div extends LinearOp
+  }
 
   sealed trait MapAlgebraLeaf extends MapAlgebraAST {
     val `type`: String

--- a/app-backend/tool/src/main/scala/ast/MapAlgebraAST.scala
+++ b/app-backend/tool/src/main/scala/ast/MapAlgebraAST.scala
@@ -60,6 +60,9 @@ object MapAlgebraAST {
   case class Min(args: List[MapAlgebraAST], id: UUID, metadata: Option[NodeMetadata])
       extends Operation { val symbol = "min" }
 
+  case class Linear(args: List[MapAlgebraAST], id: UUID, metadata: Option[NodeMetadata], f: Double => Double)
+    extends UnaryOp { val symbol = "linear" }
+
   sealed trait MapAlgebraLeaf extends MapAlgebraAST {
     val `type`: String
 

--- a/app-backend/tool/src/main/scala/ast/codec/MapAlgebraOperationCodecs.scala
+++ b/app-backend/tool/src/main/scala/ast/codec/MapAlgebraOperationCodecs.scala
@@ -24,6 +24,7 @@ trait MapAlgebraOperationCodecs {
       case Some("min") => ma.as[MapAlgebraAST.Min]
       case Some("max") => ma.as[MapAlgebraAST.Max]
       case Some("classify") => ma.as[MapAlgebraAST.Classification]
+      case Some("linear") => ma.as[MapAlgebraAST.Linear]
       case Some(unrecognized) =>
         Left(DecodingFailure(s"Unrecognized node type: $unrecognized", ma.history))
       case None =>
@@ -49,6 +50,8 @@ trait MapAlgebraOperationCodecs {
         max.asJson
       case classification: MapAlgebraAST.Classification =>
         classification.asJson
+      case linear: MapAlgebraAST.Linear =>
+        linear.asJson
       case operation =>
         throw new InvalidParameterException(s"Encoder for $operation not yet implemented")
     }

--- a/app-backend/tool/src/main/scala/ast/codec/MapAlgebraOperationCodecs.scala
+++ b/app-backend/tool/src/main/scala/ast/codec/MapAlgebraOperationCodecs.scala
@@ -94,4 +94,9 @@ trait MapAlgebraOperationCodecs {
     Decoder.forProduct3("args", "id", "metadata")(MapAlgebraAST.Min.apply)
   implicit lazy val encodeMin: Encoder[MapAlgebraAST.Min] =
     Encoder.forProduct4("apply", "args", "id", "metadata")(op => (op.symbol, op.args, op.id, op.metadata))
+
+  implicit lazy val decodeLinear: Decoder[MapAlgebraAST.Linear] =
+    Decoder.forProduct5("args", "id", "metadata", "constant", "op")(MapAlgebraAST.Linear.apply)
+  implicit lazy val encodeLinear: Encoder[MapAlgebraAST.Linear] =
+    Encoder.forProduct6("apply", "args", "id", "metadata", "constant", "op")(op => (op.symbol, op.args, op.id, op.metadata, op.constant, op.op))
 }

--- a/app-backend/tool/src/main/scala/eval/Interpreter.scala
+++ b/app-backend/tool/src/main/scala/eval/Interpreter.scala
@@ -81,6 +81,8 @@ object Interpreter extends LazyLogging {
       args.map(a => overrideParams(a, overrides)).sequence.map(ks => Min(ks, id, m))
     case Max(args, id, m) =>
       args.map(a => overrideParams(a, overrides)).sequence.map(ks => Max(ks, id, m))
+    case Linear(args, id, m, f) =>
+      args.map(a => overrideParams(a, overrides)).sequence.map(ks => Linear(ks, id, m, f))
   }
 
   /** Interpret an AST with its matched execution parameters, but do so
@@ -167,8 +169,11 @@ object Interpreter extends LazyLogging {
         logger.debug(s"case classification at $id with breakmap ${breaks.toBreakMap}")
         eval(tiles, args.head).classify(breaks.toBreakMap)
 
-      case Masking(args, id, _, mask) =>
+      case Masking(args, _, _, mask) =>
         eval(tiles, args.head).mask(extent, mask)
+
+      case Linear(args, _, _, f) =>
+        eval(tiles, args.head).mapDouble(f)
     }
 
     val pure: Interpreted[Unit] = interpretPure[Unit](ast, sourceMapping)

--- a/app-backend/tool/src/main/scala/eval/Interpreter.scala
+++ b/app-backend/tool/src/main/scala/eval/Interpreter.scala
@@ -69,20 +69,20 @@ object Interpreter extends LazyLogging {
     }
 
     /* Non-overridable Operations */
-    case Addition(args, id, m) =>
-      args.map(a => overrideParams(a, overrides)).sequence.map(ks => Addition(ks, id, m))
-    case Subtraction(args, id, m) =>
-      args.map(a => overrideParams(a, overrides)).sequence.map(ks => Subtraction(ks, id, m))
-    case Multiplication(args, id, m) =>
-      args.map(a => overrideParams(a, overrides)).sequence.map(ks => Multiplication(ks, id, m))
-    case Division(args, id, m) =>
-      args.map(a => overrideParams(a, overrides)).sequence.map(ks => Division(ks, id, m))
-    case Min(args, id, m) =>
-      args.map(a => overrideParams(a, overrides)).sequence.map(ks => Min(ks, id, m))
-    case Max(args, id, m) =>
-      args.map(a => overrideParams(a, overrides)).sequence.map(ks => Max(ks, id, m))
-    case Linear(args, id, m, f) =>
-      args.map(a => overrideParams(a, overrides)).sequence.map(ks => Linear(ks, id, m, f))
+    case op: Addition =>
+      op.args.map(a => overrideParams(a, overrides)).sequence.map(ks => op.copy(args = ks))
+    case op: Subtraction =>
+      op.args.map(a => overrideParams(a, overrides)).sequence.map(ks => op.copy(args = ks))
+    case op: Multiplication =>
+      op.args.map(a => overrideParams(a, overrides)).sequence.map(ks => op.copy(args = ks))
+    case op: Division =>
+      op.args.map(a => overrideParams(a, overrides)).sequence.map(ks => op.copy(args = ks))
+    case op: Min =>
+      op.args.map(a => overrideParams(a, overrides)).sequence.map(ks => op.copy(args = ks))
+    case op: Max =>
+      op.args.map(a => overrideParams(a, overrides)).sequence.map(ks => op.copy(args = ks))
+    case op: Linear =>
+      op.args.map(a => overrideParams(a, overrides)).sequence.map(ks => op.copy(args = ks))
   }
 
   /** Interpret an AST with its matched execution parameters, but do so
@@ -172,8 +172,8 @@ object Interpreter extends LazyLogging {
       case Masking(args, _, _, mask) =>
         eval(tiles, args.head).mask(extent, mask)
 
-      case Linear(args, _, _, f) =>
-        eval(tiles, args.head).mapDouble(f)
+      case op: Linear =>
+        eval(tiles, op.args.head).mapDouble(op.transform)
     }
 
     val pure: Interpreted[Unit] = interpretPure[Unit](ast, sourceMapping)


### PR DESCRIPTION
### TODO

- [x] `Linear` type and JSON codecs
- [x] Interpretation logic in Tile server and Export 
- [ ] Add division-by-zero check in `interpretPure`
- [ ] Param overrides
- [ ] Remove `Constant` type
- [ ] Migrations to change built-in Tools that use Constants

### The Problem

`Constant` tile sounded like a great idea when we came up with it, and its interpretation logic for the Tile server (via `LazyTile`) was quite elegant. However, we a missed big issue with it.

We have it from @notthatbreezy as a requirement that all ASTs should be interpretable for both the Tile server and Exports. In other words:

![ast-sets](https://user-images.githubusercontent.com/229679/27511132-fbf70962-58d2-11e7-9ef7-5966f3811e49.png)

Where:
```
T := the set of ASTs which one can interpret with the Tile server
E := the set of ASTs which one cna interpret for Exports
``` 

We desire the invariant: `T = T∩E = E`

But currently we are not satisfying this invariant for two reasons:

1. An interpretation branch for `Constant` has not been implemented in the Export code
2. Such an implementation is not possible

Why is the second point true? Consider the return type of the eval loop in the Export code:

```scala
eval: (AST, Map[UUID, TileLayerRDD[SpatialKey]]) => TileLayerRDD[SpatialKey]
```
Given that, does the following function exist (anywhere in the mathematical universe)?
```scala
f: Constant => TileLayerRDD[SpatialKey]
```
The answer is *technically* yes, but *practically* no for the purposes of meaningful map algebra in GT and RF. `Constant` on its own has no key space, nor a source of metadata. I hear you thinking:

> Hm but that doesn't matter, because you could just piggy back off the key space / metadata of the other `Source` nodes in the tree.

Maybe yeah as a kind of hack, but that goes out the window with the following legal AST:

```
Constant(uuid, constant, metadata)
```
This is an AST that *would* make sense to interpret on the Tile server (you'd get flat, constant-valued tiles wherever you asked for them), but not with Exports. Where would you even begin?

### The Solution

The answer is to not try and hack around it, or to declare `T = T∩E = E` unnecessary. As an alternative, this PR gets rid of the `Constant` leaf type and introduce the `Linear` operation. Users supply an overridable constant (as before) as well as one of the four core math operators, `+ - * /`. So what was this:

```
Classify ---> Add ---> Source 
              |
              -------> Constant(5)
```
becomes:
```
Classify ---> Linear(+ 5) ---> Source
```

If further motivation is needed, I can offer that previous trees involving `Constant` are type-error-like in a similar way to how Matlab heavily overloads its operators. A la, this is legal Matlab:
```
5 + [1, 2, 3]  // gives [6, 7, 8]
```