### PR TITLE
[WIP] Add Kamon metrics tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,23 +11,6 @@ __pycache__/
 # C extensions
 *.so
 
-# Distribution / packaging
-.Python
-env/
-build/
-develop-eggs/
-dist/
-downloads/
-eggs/
-lib/
-lib64/
-parts/
-sdist/
-var/
-*.egg-info/
-.installed.cfg
-*.egg
-
 # PyInstaller
 #  Usually these files are written by a python script from a template
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.
@@ -75,8 +58,6 @@ npm-debug.log
 # MacOS
 .DS_Store
 
-deployment/default.yml
-
 # Scala
 *.class
 *.log
@@ -113,6 +94,7 @@ api-server/.ensime_cache/*
 /.env
 
 .node_modules
+dist/
 
 /data
 /app-tasks/usr/local/airflow/logs/

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -41,6 +41,10 @@ Vagrant.configure(2) do |config|
   config.vm.network :forwarded_port, guest: 8889, host: Integer(ENV.fetch("RF_PORT_8888", 8889))
   # spark driver
   config.vm.network :forwarded_port, guest: 4040, host: Integer(ENV.fetch("RF_PORT_4040", 4040))
+  # graphite ui
+  config.vm.network :forwarded_port, guest: 8181, host: Integer(ENV.fetch("RF_PORT_8181", 8181))
+  # grafana ui
+  config.vm.network :forwarded_port, guest: 3000, host: Integer(ENV.fetch("RF_PORT_4040", 3000))
 
   config.vm.provider :virtualbox do |vb|
     vb.memory = 8096

--- a/app-backend/api/Dockerfile
+++ b/app-backend/api/Dockerfile
@@ -1,8 +1,16 @@
 FROM openjdk:8-jre-alpine
 
+ENV ASPECTJ_WEAVER_VERSION 1.8.10
+
 RUN \
       addgroup -S rf \
-      && adduser -D -S -h /var/lib/rf -s /sbin/nologin -G rf rf
+      && adduser -D -S -h /var/lib/rf -s /sbin/nologin -G rf rf \
+      && apk add --no-cache --virtual .build-deps \
+         ca-certificates \
+         tar \
+         wget \
+      && wget -qO /var/lib/rf/aspectjweaver.jar https://s3.amazonaws.com/rasterfoundry-global-artifacts-us-east-1/aspectjweaver/aspectjweaver-$ASPECTJ_WEAVER_VERSION.jar \
+      && apk del .build-deps
 
 COPY ./target/scala-2.11/rf-server.jar /var/lib/rf/
 

--- a/app-backend/api/src/main/resources/application.conf
+++ b/app-backend/api/src/main/resources/application.conf
@@ -99,6 +99,7 @@ kamon {
   statsd {
     hostname = "statsd"
     port = 8125
+    time-units = "ms"
     simple-metric-key-generator.include-hostname = false
 
     subscriptions {

--- a/app-backend/api/src/main/resources/application.conf
+++ b/app-backend/api/src/main/resources/application.conf
@@ -97,7 +97,7 @@ kamon {
   }
 
   statsd {
-    hostname = "statsite"
+    hostname = "statsd"
     port = 8125
     subscriptions {
       histogram        = [ "**" ]

--- a/app-backend/api/src/main/resources/application.conf
+++ b/app-backend/api/src/main/resources/application.conf
@@ -100,6 +100,7 @@ kamon {
     hostname = "statsd"
     port = 8125
     time-units = "ms"
+    simple-metric-key-generator.application = ${?ENVIRONMENT}.api
     simple-metric-key-generator.include-hostname = false
 
     subscriptions {

--- a/app-backend/api/src/main/resources/application.conf
+++ b/app-backend/api/src/main/resources/application.conf
@@ -111,7 +111,6 @@ kamon {
       akka-actor       = [ "**" ]
       akka-dispatcher  = [ "**" ]
       akka-router      = [ "**" ]
-      system-metric    = [ "**" ]
       akka-http-server = [ "**" ]
     }
   }

--- a/app-backend/api/src/main/resources/application.conf
+++ b/app-backend/api/src/main/resources/application.conf
@@ -99,6 +99,8 @@ kamon {
   statsd {
     hostname = "statsd"
     port = 8125
+    simple-metric-key-generator.include-hostname = false
+
     subscriptions {
       histogram        = [ "**" ]
       min-max-counter  = [ "**" ]

--- a/app-backend/api/src/main/resources/application.conf
+++ b/app-backend/api/src/main/resources/application.conf
@@ -82,3 +82,35 @@ dropbox {
   appSecret = ""
   appSecret = ${?DROPBOX_SECRET}
 }
+
+kamon {
+  metric {
+    filters {
+      trace.includes = [ "**" ]
+    }
+  }
+
+  subscriptions {
+    trace                = [ "**" ]
+    trace-segment        = [ "**" ]
+    akka-http-server     = [ "**" ]
+  }
+
+  statsd {
+    hostname = "statsite"
+    port = 8125
+    subscriptions {
+      histogram        = [ "**" ]
+      min-max-counter  = [ "**" ]
+      gauge            = [ "**" ]
+      counter          = [ "**" ]
+      trace            = [ "**" ]
+      trace-segment    = [ "**" ]
+      akka-actor       = [ "**" ]
+      akka-dispatcher  = [ "**" ]
+      akka-router      = [ "**" ]
+      system-metric    = [ "**" ]
+      akka-http-server = [ "**" ]
+    }
+  }
+}

--- a/app-backend/api/src/main/scala/Main.scala
+++ b/app-backend/api/src/main/scala/Main.scala
@@ -5,9 +5,12 @@ import akka.event.Logging
 import akka.http.scaladsl.Http
 import akka.stream.ActorMaterializer
 
+import kamon.Kamon
+
 import com.azavea.rf.api.utils.Config
 import com.azavea.rf.common.RFRejectionHandler._
 import com.azavea.rf.database.Database
+import scala.util.Try
 
 object AkkaSystem {
   implicit val system = ActorSystem("rf-system")
@@ -22,9 +25,21 @@ object Main extends App
     with Config
     with Router
     with AkkaSystem.LoggerExecutor {
+
+  Kamon.start()
+
   implicit lazy val database = Database.DEFAULT
   implicit val system = AkkaSystem.system
   implicit val materializer = AkkaSystem.materializer
+
+  def terminate(): Unit = {
+    Try(system.terminate())
+    Try(Kamon.shutdown())
+  }
+
+  sys.addShutdownHook {
+    terminate()
+  }
 
   Http().bindAndHandle(routes, httpHost, httpPort)
 

--- a/app-backend/api/src/main/scala/tools/Routes.scala
+++ b/app-backend/api/src/main/scala/tools/Routes.scala
@@ -14,27 +14,54 @@ import com.azavea.rf.tool.ast.codec._
 import com.lonelyplanet.akka.http.extensions.PaginationDirectives
 import de.heikoseeberger.akkahttpcirce.CirceSupport._
 
+import kamon.akka.http.KamonTraceDirectives
+import kamon.akka.http.KamonTraceDirectives.traceName
+
 trait ToolRoutes extends Authentication
     with PaginationDirectives
     with CommonHandlers
+    with KamonTraceDirectives
     with UserErrorHandler {
 
   implicit def database: Database
 
   val toolRoutes: Route = handleExceptions(userExceptionHandler) {
     pathEndOrSingleSlash {
-      get { listTools } ~
-      post { createTool }
+      get {
+        traceName("tools-list") {
+          listTools
+        }
+      } ~
+      post {
+        traceName("tools-create") {
+          createTool
+        }
+      }
     } ~
     pathPrefix(JavaUUID) { toolId =>
       pathEndOrSingleSlash {
-        get { getTool(toolId) } ~
-        put { updateTool(toolId) } ~
-        delete { deleteTool(toolId) }
+        get {
+          traceName("tools-detail") {
+            getTool(toolId)
+          }
+        } ~
+        put {
+          traceName("tools-update") {
+            updateTool(toolId)
+          }
+        } ~
+        delete {
+          traceName("tools-delete") {
+            deleteTool(toolId) }
+        }
       } ~
       pathPrefix("sources") {
         pathEndOrSingleSlash {
-          get { getToolSources(toolId) }
+          get {
+            traceName("tools-sources") {
+              getToolSources(toolId)
+            }
+          }
         }
       }
     }

--- a/app-backend/build.sbt
+++ b/app-backend/build.sbt
@@ -64,6 +64,12 @@ lazy val slickDependencies = List(
     .exclude("postgresql", "postgresql")
 )
 
+lazy val metricsDependencies = List(
+  Dependencies.kamonCore,
+  Dependencies.kamonStatsd,
+  Dependencies.kamonAkkaHttp
+)
+
 lazy val dbDependencies = List(
   Dependencies.hikariCP,
   Dependencies.postgres
@@ -83,7 +89,7 @@ lazy val testDependencies = List(
 )
 
 lazy val apiDependencies = dbDependencies ++ migrationsDependencies ++
-    testDependencies ++ Seq(
+    testDependencies ++ metricsDependencies ++ Seq(
   Dependencies.akka,
   Dependencies.akkahttp,
   Dependencies.akkaHttpCors,
@@ -215,7 +221,8 @@ lazy val tile = Project("tile", file("tile"))
   .enablePlugins(GatlingPlugin)
   .settings(commonSettings:_*)
   .settings({
-    libraryDependencies ++= loggingDependencies ++ testDependencies ++ Seq(
+    libraryDependencies ++= loggingDependencies ++ testDependencies ++
+    metricsDependencies ++ Seq(
       Dependencies.spark,
       Dependencies.geotrellisSpark,
       Dependencies.geotrellisS3,

--- a/app-backend/build.sbt
+++ b/app-backend/build.sbt
@@ -237,9 +237,7 @@ lazy val batch = Project("batch", file("batch"))
 
 import io.gatling.sbt.GatlingPlugin
 lazy val tile = Project("tile", file("tile"))
-  .dependsOn(datamodel)
-  .dependsOn(database)
-  .dependsOn(common % "test->test;compile->compile")
+  .dependsOn(database, datamodel, common % "test->test;compile->compile")
   .dependsOn(tool)
   .dependsOn(batch)
   .enablePlugins(GatlingPlugin)

--- a/app-backend/project/Dependencies.scala
+++ b/app-backend/project/Dependencies.scala
@@ -60,4 +60,8 @@ object Dependencies {
   val dnsJava                 = "dnsjava"                      % "dnsjava"                           % Version.dnsJava
   val dropbox                 = "com.dropbox.core"             % "dropbox-core-sdk"                  % Version.dropbox
   val scalaCheck              = "org.scalacheck"              %% "scalacheck"                        % Version.scalaCheck % "test"
+  val kamonCore               = "io.kamon"                    %% "kamon-core"                        % Version.kamon
+  val kamonAkka               = "io.kamon"                    %% "kamon-akka"                        % Version.kamon
+  val kamonStatsd             = "io.kamon"                    %% "kamon-statsd"                      % Version.kamon
+  val kamonAkkaHttp           = "io.kamon"                    %% "kamon-akka-http"                   % Version.kamonAkkaHttp
 }

--- a/app-backend/project/Version.scala
+++ b/app-backend/project/Version.scala
@@ -40,4 +40,6 @@ object Version {
   val dnsJava            = "2.1.8"
   val dropbox            = "2.1.1"
   val scalaCheck         = "1.13.4"
+  val kamon              = "0.6.7"
+  val kamonAkkaHttp      = "0.6.8"
 }

--- a/app-backend/project/plugins.sbt
+++ b/app-backend/project/plugins.sbt
@@ -5,6 +5,8 @@ resolvers ++= Seq(
 
 resolvers += Classpaths.typesafeResolver
 
+resolvers += Resolver.bintrayIvyRepo("kamon-io", "sbt-plugins")
+
 addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0")
 
 addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.1.10")
@@ -19,3 +21,4 @@ addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.8.2")
 
 addSbtPlugin("io.gatling" % "gatling-sbt" % "2.2.0")
 
+addSbtPlugin("io.kamon" % "sbt-aspectj-runner" % "1.0.1")

--- a/app-backend/tile/Dockerfile
+++ b/app-backend/tile/Dockerfile
@@ -1,8 +1,16 @@
 FROM openjdk:8-jre-alpine
 
+ENV ASPECTJ_WEAVER_VERSION 1.8.10
+
 RUN \
       addgroup -S rf \
-      && adduser -D -S -h /var/lib/rf -s /sbin/nologin -G rf rf
+      && adduser -D -S -h /var/lib/rf -s /sbin/nologin -G rf rf \
+      && apk add --no-cache --virtual .build-deps \
+         ca-certificates \
+         tar \
+         wget \
+      && wget -qO /var/lib/rf/aspectjweaver.jar https://s3.amazonaws.com/rasterfoundry-global-artifacts-us-east-1/aspectjweaver/aspectjweaver-$ASPECTJ_WEAVER_VERSION.jar \
+      && apk del .build-deps
 
 COPY ./target/scala-2.11/rf-tile-server.jar /var/lib/rf/
 

--- a/app-backend/tile/src/main/resources/application.conf
+++ b/app-backend/tile/src/main/resources/application.conf
@@ -25,6 +25,7 @@ kamon {
     hostname = "statsd"
     port = 8125
     time-units = "ms"
+    simple-metric-key-generator.application = ${?ENVIRONMENT}.tile
     simple-metric-key-generator.include-hostname = false
 
     subscriptions {

--- a/app-backend/tile/src/main/resources/application.conf
+++ b/app-backend/tile/src/main/resources/application.conf
@@ -36,7 +36,6 @@ kamon {
       akka-actor       = [ "**" ]
       akka-dispatcher  = [ "**" ]
       akka-router      = [ "**" ]
-      system-metric    = [ "**" ]
       akka-http-server = [ "**" ]
     }
   }

--- a/app-backend/tile/src/main/resources/application.conf
+++ b/app-backend/tile/src/main/resources/application.conf
@@ -24,6 +24,8 @@ kamon {
   statsd {
     hostname = "statsd"
     port = 8125
+    simple-metric-key-generator.include-hostname = false
+
     subscriptions {
       histogram        = [ "**" ]
       min-max-counter  = [ "**" ]

--- a/app-backend/tile/src/main/resources/application.conf
+++ b/app-backend/tile/src/main/resources/application.conf
@@ -24,6 +24,7 @@ kamon {
   statsd {
     hostname = "statsd"
     port = 8125
+    time-units = "ms"
     simple-metric-key-generator.include-hostname = false
 
     subscriptions {

--- a/app-backend/tile/src/main/resources/application.conf
+++ b/app-backend/tile/src/main/resources/application.conf
@@ -7,3 +7,35 @@ tile-server {
   bucket = "rasterfoundry-staging-catalogs-us-east-1"
   bucket = ${?TILE_SERVER_BUCKET}
 }
+
+kamon {
+  metric {
+    filters {
+      trace.includes = [ "**" ]
+    }
+  }
+
+  subscriptions {
+    trace                = [ "**" ]
+    trace-segment        = [ "**" ]
+    akka-http-server     = [ "**" ]
+  }
+
+  statsd {
+    hostname = "statsite"
+    port = 8125
+    subscriptions {
+      histogram        = [ "**" ]
+      min-max-counter  = [ "**" ]
+      gauge            = [ "**" ]
+      counter          = [ "**" ]
+      trace            = [ "**" ]
+      trace-segment    = [ "**" ]
+      akka-actor       = [ "**" ]
+      akka-dispatcher  = [ "**" ]
+      akka-router      = [ "**" ]
+      system-metric    = [ "**" ]
+      akka-http-server = [ "**" ]
+    }
+  }
+}

--- a/app-backend/tile/src/main/resources/application.conf
+++ b/app-backend/tile/src/main/resources/application.conf
@@ -22,7 +22,7 @@ kamon {
   }
 
   statsd {
-    hostname = "statsite"
+    hostname = "statsd"
     port = 8125
     subscriptions {
       histogram        = [ "**" ]

--- a/app-backend/tile/src/main/scala/Main.scala
+++ b/app-backend/tile/src/main/scala/Main.scala
@@ -11,7 +11,9 @@ import akka.http.scaladsl.server._
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.model.{HttpResponse, StatusCodes}
 import geotrellis.spark.io._
+import kamon.Kamon
 
+import scala.util.Try
 
 object AkkaSystem {
   implicit val system = ActorSystem("rf-tiler-system")
@@ -26,10 +28,20 @@ object Main extends App
   with Config
   with AkkaSystem.LoggerExecutor {
 
-  import AkkaSystem._
+  Kamon.start()
 
+  import AkkaSystem._
   val database = Database.DEFAULT
   val router = new Router()
+
+  def terminate(): Unit = {
+    Try(system.terminate())
+    Try(Kamon.shutdown())
+  }
+
+  sys.addShutdownHook {
+    terminate()
+  }
 
   Http().bindAndHandle(router.root, httpHost, httpPort)
 }

--- a/app-tasks/.gitignore
+++ b/app-tasks/.gitignore
@@ -1,0 +1,16 @@
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg

--- a/docker-compose.metrics.yml
+++ b/docker-compose.metrics.yml
@@ -1,0 +1,26 @@
+version: '2.1'
+services:
+  graphite:
+    image: sitespeedio/graphite
+    ports:
+        - "8181:80"
+
+  statsite:
+    image: quay.io/azavea/statsite:0.7.1
+    links:
+      - graphite
+    build:
+      context: ./statsite
+      dockerfile: Dockerfile
+    volumes:
+      - ./statsite/etc/statsite/:/etc/statsite/
+
+  grafana:
+    image: grafana/grafana
+    restart: always
+    ports:
+        - "3000:3000"
+    links:
+        - graphite
+    environment:
+        - GF_SECURITY_ADMIN_PASSWORD=password

--- a/docker-compose.metrics.yml
+++ b/docker-compose.metrics.yml
@@ -3,24 +3,21 @@ services:
   graphite:
     image: sitespeedio/graphite
     ports:
-        - "8181:80"
+      - "8181:80"
 
-  statsite:
-    image: quay.io/azavea/statsite:0.7.1
+  statsd:
+    image: quay.io/azavea/statsd:0.8-alpine
     links:
       - graphite
-    build:
-      context: ./statsite
-      dockerfile: Dockerfile
     volumes:
-      - ./statsite/etc/statsite/:/etc/statsite/
+      - ./statsd/var/lib/statsd/config.js:/var/lib/statsd/config.js
 
   grafana:
     image: grafana/grafana
     restart: always
     ports:
-        - "3000:3000"
+      - "3000:3000"
     links:
-        - graphite
+      - graphite
     environment:
-        - GF_SECURITY_ADMIN_PASSWORD=password
+      - GF_SECURITY_ADMIN_PASSWORD=password

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,7 +56,7 @@ services:
       - postgres:database.service.rasterfoundry.internal
     external_links:
       - airflow-webserver:airflow.service.rasterfoundry.internal
-      - statsite
+      - statsd
     env_file: .env
     ports:
       - "9000:9000"
@@ -77,7 +77,7 @@ services:
       - postgres:database.service.rasterfoundry.internal
       - memcached:tile-cache.service.rasterfoundry.internal
     external_links:
-      - statsite
+      - statsd
     env_file: .env
     ports:
       - "9900:9900"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,6 +56,7 @@ services:
       - postgres:database.service.rasterfoundry.internal
     external_links:
       - airflow-webserver:airflow.service.rasterfoundry.internal
+      - statsite
     env_file: .env
     ports:
       - "9000:9000"
@@ -75,6 +76,8 @@ services:
     links:
       - postgres:database.service.rasterfoundry.internal
       - memcached:tile-cache.service.rasterfoundry.internal
+    external_links:
+      - statsite
     env_file: .env
     ports:
       - "9900:9900"

--- a/scripts/server
+++ b/scripts/server
@@ -21,6 +21,10 @@ then
     then
         docker-compose -f "${DIR}/../docker-compose.yml" \
                        -f "${DIR}/../docker-compose.airflow.yml" up
+    elif [ "${1:-}" = "--with-metrics" ]
+    then
+        docker-compose -f "${DIR}/../docker-compose.yml" \
+                       -f "${DIR}/../docker-compose.metrics.yml" up
     else
         docker-compose up --remove-orphans
     fi

--- a/statsd/var/lib/statsd/config.js
+++ b/statsd/var/lib/statsd/config.js
@@ -1,0 +1,8 @@
+{
+    graphiteHost: "graphite"
+    , graphitePort: 2003
+    , backends: ["./backends/graphite"]
+    , port: 8125
+    , debug: true
+    , debugMessages: true
+}


### PR DESCRIPTION
## Overview

Adds metric tracking to various API and tile endpoints. Also adds
statsite, graphite, grafana for development purposes to track metrics
and compare results over time.

Some things to fix up before merging and giving this a full review:
 - Ensure open up correct ports in Vagrant
 - Figure out how to persist development dashboards
 - Figure out how to filter out unwanted metrics/be more judicious

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~

### Demo
Start servers with `./scripts/server --with-metrics`

Open up `localhost:3000` and configure grafana

![guest-guest-graphite](https://user-images.githubusercontent.com/898060/27541066-88b66252-5a50-11e7-96c4-bca4e5070a14.png)

Make some requests and start testing out grafana and add a dashboard

![sample-dashboard](https://user-images.githubusercontent.com/898060/27541085-9da0b94c-5a50-11e7-836f-c902a3428708.png)

### Notes

This was to evaluate Kamon - either we can edit this and make this mergeable or make a decision to go in a different direction. Certainly need to reduce the number of metrics we're sending though.

## Testing Instructions

 * Forthcoming

Closes #2000 
