### PR TITLE
Add nodata specification to ToolRun sources

### DIFF
--- a/app-backend/batch/src/test/scala/com/azavea/rf/batch/export/model/ExportDefinitionSpec.scala
+++ b/app-backend/batch/src/test/scala/com/azavea/rf/batch/export/model/ExportDefinitionSpec.scala
@@ -137,8 +137,8 @@ class ExportDefinitionSpec extends FunSpec with Matchers with BatchSpec {
 
     val params = EvalParams(
       Map(
-        s0.id -> SceneRaster(UUID.randomUUID, Some(5)),
-        s1.id -> SceneRaster(UUID.randomUUID, Some(5))
+        s0.id -> SceneRaster(UUID.randomUUID, Some(5), None),
+        s1.id -> SceneRaster(UUID.randomUUID, Some(5), None)
       ),
       Map.empty
     )
@@ -170,8 +170,8 @@ class ExportDefinitionSpec extends FunSpec with Matchers with BatchSpec {
 
     val params = EvalParams(
       Map(
-        s0.id -> ProjectRaster(UUID.randomUUID, Some(5)),
-        s1.id -> ProjectRaster(UUID.randomUUID, Some(5))
+        s0.id -> ProjectRaster(UUID.randomUUID, Some(5), None),
+        s1.id -> ProjectRaster(UUID.randomUUID, Some(5), None)
       ),
       Map.empty
     )

--- a/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Exports.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Exports.scala
@@ -252,14 +252,14 @@ object Exports extends TableQuery(tag => new Exports(tag)) with LazyLogging {
           case ((sacc, pacc), p: ProjectRaster) => (sacc, p #:: pacc)
         })
 
-    val scenesF: OptionT[Future, Map[UUID, String]] = scenes.map({ case SceneRaster(id, _) =>
+    val scenesF: OptionT[Future, Map[UUID, String]] = scenes.map({ case SceneRaster(id, _, _) =>
       OptionT(Scenes.getScene(id, user)).flatMap(s =>
         OptionT.fromOption(s.ingestLocation.map((s.id, _)))
       )
     }).sequence.map(_.toMap)
 
     val projectsF: OptionT[Future, Map[UUID, List[(UUID, String)]]] =
-      projects.map({ case ProjectRaster(id, _) =>
+      projects.map({ case ProjectRaster(id, _, _) =>
         OptionT(ScenesToProjects.allSceneIngestLocs(id)).map((id, _))
       }).sequence.map(_.toMap)
 

--- a/app-backend/tool/src/main/scala/eval/Interpreter.scala
+++ b/app-backend/tool/src/main/scala/eval/Interpreter.scala
@@ -1,6 +1,7 @@
 package com.azavea.rf.tool.eval
 
 import com.azavea.rf.tool.ast._
+import com.azavea.rf.tool.params._
 import com.azavea.rf.tool.ast.MapAlgebraAST._
 import com.azavea.rf.tool.params.ParamOverride
 

--- a/app-backend/tool/src/test/scala/Generators.scala
+++ b/app-backend/tool/src/test/scala/Generators.scala
@@ -10,6 +10,7 @@ import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.Prop.forAll
 import geotrellis.raster.histogram._
 import geotrellis.raster.render._
+import geotrellis.raster._
 
 import scala.util.Random
 import java.util.UUID
@@ -48,7 +49,16 @@ object Generators {
     band <- arbitrary[Int]
     id <- arbitrary[UUID]
     constructor <- Gen.lzy(Gen.oneOf(SceneRaster.apply _, ProjectRaster.apply _))
-  } yield constructor(id, Some(band))
+    celltype <- Gen.lzy(Gen.oneOf(
+      BitCellType, ByteCellType, UByteCellType, ShortCellType, UShortCellType, IntCellType,
+      FloatCellType, DoubleCellType, ByteConstantNoDataCellType, UByteConstantNoDataCellType,
+      ShortConstantNoDataCellType, UShortConstantNoDataCellType, IntConstantNoDataCellType,
+      FloatConstantNoDataCellType, DoubleConstantNoDataCellType, ByteUserDefinedNoDataCellType(42),
+      UByteUserDefinedNoDataCellType(42), ShortUserDefinedNoDataCellType(42),
+      UShortUserDefinedNoDataCellType(42), IntUserDefinedNoDataCellType(42),
+      FloatUserDefinedNoDataCellType(42), DoubleUserDefinedNoDataCellType(42)
+    ))
+  } yield constructor(id, Some(band), None)
 
   lazy val genEvalParams: Gen[EvalParams] = for {
     astIds  <- containerOfN[List, UUID](12, arbitrary[UUID])

--- a/app-backend/tool/src/test/scala/MockInterpreterResources.scala
+++ b/app-backend/tool/src/test/scala/MockInterpreterResources.scala
@@ -25,7 +25,7 @@ trait MockInterpreterResources extends TileBuilders with RasterMatchers {
 
   def randomSourceAST = MapAlgebraAST.Source(UUID.randomUUID, None)
 
-  def tileSource(band: Int) = SceneRaster(UUID.randomUUID, Some(band))
+  def tileSource(band: Int) = SceneRaster(UUID.randomUUID, Some(band), None)
 
   def tile(value: Int): Tile = createValueTile(d = 4, v = value)
 
@@ -33,9 +33,9 @@ trait MockInterpreterResources extends TileBuilders with RasterMatchers {
 
   val goodSource = (raster: RFMLRaster, z: Int, x: Int, y: Int) => {
     raster match {
-      case r@SceneRaster(id, Some(band)) =>
+      case r@SceneRaster(id, Some(band), maybeND) =>
         requests = raster :: requests
-        Future { Some(tile(band)) }
+        Future { Some(tile(band).interpretAs(maybeND.getOrElse(tile(band).cellType))) }
       case _ => Future.failed(new Exception("can't find that"))
     }
   }

--- a/app-backend/tool/src/test/scala/eval/InterpreterSpec.scala
+++ b/app-backend/tool/src/test/scala/eval/InterpreterSpec.scala
@@ -1,8 +1,9 @@
 package com.azavea.rf.tool.eval
 
 import com.azavea.rf.tool.ast._
-import com.azavea.rf.tool.ast.MapAlgebraAST._
 import com.azavea.rf.tool.eval._
+import com.azavea.rf.tool.params._
+import com.azavea.rf.tool.ast.MapAlgebraAST._
 
 import io.circe._
 import io.circe.syntax._


### PR DESCRIPTION
## Overview

We've been seeing nasty (usually purple) boundaries around tiles produced by Model Lab for some time - the culprit is apparently incorrectly specified metadata pertaining to the `NoData` value. The fix (which we already have) is to properly ingest tiles with a manually configured `OutputDefinition` bearing the appropriate `NoData` specification.

That's probably not good enough. Ingesting things can take a long time and people are bound to mess this up which means that we need to offer an escape hatch for such errors. This PR introduced the machinery necessary to interpret any source (`Project` or `Scene`) with the `NoData` value of a user's choosing. Default geotrellis serialization (`toName` and `fromName` are used in the codecs.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~

### Demo

tired:
```json
  "executionParameters" : {
    "sources" : {
      "df5afa8e-e1ce-4c82-b402-f38cf9a79a59" : {
        "id" : "ac626afa-4f05-4cb7-84cd-a31b77d57959",
        "band" : 4,
        "type" : "project"
      },
      "6cb2a3eb-7070-4c71-9dd4-48f6f12a8fa6" : {
        "id" : "ac626afa-4f05-4cb7-84cd-a31b77d57959",
        "band" : 5,
        "type" : "project"
      }
    }
```
<img width="501" alt="screen shot 2017-06-26 at 5 00 40 pm" src="https://user-images.githubusercontent.com/1977405/27560824-a395f612-5a93-11e7-95bf-63640d16851e.png">


wired:
```json
  "executionParameters" : {
    "sources" : {
      "df5afa8e-e1ce-4c82-b402-f38cf9a79a59" : {
        "id" : "ac626afa-4f05-4cb7-84cd-a31b77d57959",
        "band" : 4,
        "type" : "project",
        "celltype" : "uint16ud0"
      },
      "6cb2a3eb-7070-4c71-9dd4-48f6f12a8fa6" : {
        "id" : "ac626afa-4f05-4cb7-84cd-a31b77d57959",
        "band" : 5,
        "type" : "project",
        "celltype" : "uint16ud0"
      }
    }
  }
```
<img width="502" alt="screen shot 2017-06-26 at 5 00 47 pm" src="https://user-images.githubusercontent.com/1977405/27560846-b9c36870-5a93-11e7-9b1c-9691b702e2f0.png">


Closes #2027
