### PR TITLE
Enable changing datasource visibility on datasource detail page

### DIFF
--- a/app-frontend/src/app/core/services/datasource.service.js
+++ b/app-frontend/src/app/core/services/datasource.service.js
@@ -15,10 +15,17 @@ export default (app) => {
                     },
                     get: {
                         method: 'GET',
-                        cache: true
+                        cache: false
                     },
                     create: {
                         method: 'POST'
+                    },
+                    update: {
+                        method: 'PUT',
+                        url: '/api/datasources/:id',
+                        params: {
+                            id: '@id'
+                        }
                     }
                 }
             );
@@ -47,6 +54,10 @@ export default (app) => {
                     return error;
                 }
             );
+        }
+
+        updateDatasource(updatedParams = {}) {
+            return this.Datasource.update(updatedParams).$promise;
         }
     }
 

--- a/app-frontend/src/app/pages/imports/datasources/detail/detail.controller.js
+++ b/app-frontend/src/app/pages/imports/datasources/detail/detail.controller.js
@@ -15,9 +15,11 @@ class DatasourceDetailController {
     loadDatasource() {
         this.isLoadingDatasource = true;
         this.isLoadingDatasourceError = false;
+        this.isDatasourceVisibilityUpdated = false;
         this.datasourceService.get(this.datasourceId).then(
             datasourceResponse => {
                 this.datasource = datasourceResponse;
+                this.isPublic = this.isPublicDatasource();
                 this.initBuffers();
             },
             () => {
@@ -61,6 +63,33 @@ class DatasourceDetailController {
 
     cancel() {
         this.initBuffers();
+    }
+
+    notDefaultDatasource() {
+        if (this.datasource) {
+            return this.datasource.owner !== 'default';
+        }
+        return false;
+    }
+
+    isPublicDatasource() {
+        if (this.datasource) {
+            return this.datasource.visibility === 'PUBLIC';
+        }
+        return false;
+    }
+
+    changeVisibility() {
+        this.datasource.visibility = this.datasource.visibility === 'PUBLIC' ? 'PRIVATE' : 'PUBLIC';
+        this.isPublic = !this.isPublic;
+        this.datasourceService.updateDatasource(this.datasource).then(
+            () => {
+                this.isDatasourceVisibilityUpdated = true;
+            },
+            () => {
+                this.isDatasourceVisibilityUpdated = false;
+            }
+        );
     }
 }
 

--- a/app-frontend/src/app/pages/imports/datasources/detail/detail.html
+++ b/app-frontend/src/app/pages/imports/datasources/detail/detail.html
@@ -31,6 +31,18 @@
             </div>
           </rf-call-to-action-item>
         </div>
+        <div class="cta-row" ng-show="$ctrl.notDefaultDatasource()">
+          <rf-call-to-action-item title="Visibility">
+            <div class="cta-flex-text">
+              <div>
+                <rf-toggle value="$ctrl.isPublic" on-change="$ctrl.changeVisibility()">
+                  <i class="icon-check"></i>
+                </rf-toggle>
+                <span title="Public">Public</span>
+              </div>
+            </div>
+          </rf-call-to-action-item>
+        </div>
       </ui-view>
     </div>
     <div class="column-3">


### PR DESCRIPTION
## Overview

Enable changing datasource visibility on datasource detail page via a checkbox. Default datasources will not have such option exposed though.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~

### Demo

<img width="1680" alt="screen shot 2017-06-27 at 1 58 00 pm" src="https://user-images.githubusercontent.com/16109558/27602498-05ab11fe-5b41-11e7-8ab0-874a4c098c9d.png">


<img width="1680" alt="screen shot 2017-06-27 at 2 00 00 pm" src="https://user-images.githubusercontent.com/16109558/27602505-0b212da8-5b41-11e7-89d8-62b86c9e0178.png">


### Notes

The style of the visibility section may need further edits.


## Testing Instructions

 * Go to the "Imports" and click "Browse Datasources" button 
 * View a default datasource: on its detail page, the visibility section should not show.
 * View your own datasource (if none, create one): on its detail page, the visibility section should show.
 * Change datasource visibility
 * Check XHR if a put request is sent with changed visibility, OR go back and view this page again, OR refresh this page - to see if the new visibility status is reflected on the page.

Closes #2060 
