### PR TITLE
Fix scene removal from project on project details page

### DIFF
--- a/app-frontend/src/app/pages/projects/detail/scenes/scenes.controller.js
+++ b/app-frontend/src/app/pages/projects/detail/scenes/scenes.controller.js
@@ -67,4 +67,21 @@ export default class ProjectDetailScenesController {
             }
         });
     }
+
+    removeScene(scene, event) {
+        if (event) {
+            event.stopPropagation();
+            event.preventDefault();
+        }
+        this.projectService.removeScenesFromProject(this.project.id, [ scene.id ]).then(
+            () => {
+                this.populateSceneList(this.currentPage);
+            },
+            (err) => {
+                // later on, use toasts or something instead of a debug message
+                this.$log.debug('Error removing scenes from project.', err);
+                this.populateSceneList(this.currentPage);
+            }
+        );
+    }
 }


### PR DESCRIPTION
## Overview

This PR serves as a quick fix to make scene removal from a project from the project details page.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~

## Testing Instructions

 * Make sure you can delete a scene from a project from the scene details page.

Closes #2179 