### PR TITLE
Minor Fixes/Frontend Customization for API Server

### DIFF
--- a/app-frontend/config/webpack/global.js
+++ b/app-frontend/config/webpack/global.js
@@ -252,7 +252,8 @@ module.exports = function (_path) {
             new webpack.DefinePlugin({
                 'BUILDCONFIG': {
                     APP_NAME: '\'RasterFoundry\'',
-                    BASEMAPS: basemaps
+                    BASEMAPS: basemaps,
+                    API_HOST: '\'\''
                 }
             })
         ]

--- a/app-frontend/config/webpack/overrides.js.template
+++ b/app-frontend/config/webpack/overrides.js.template
@@ -32,7 +32,8 @@ module.exports = function () {
             new webpack.DefinePlugin({
                 'BUILDCONFIG': {
                     APP_NAME: '\'RasterFoundry?\'',
-                    BASEMAPS: basemaps
+                    BASEMAPS: basemaps,
+                    API_HOST: '\'https://app.rasterfoundry.com\''
                 }
             })
         ]

--- a/app-frontend/src/app/core/services/aoi.service.js
+++ b/app-frontend/src/app/core/services/aoi.service.js
@@ -1,9 +1,11 @@
+/* globals BUILDCONFIG */
+
 export default (app) => {
     class aoiService {
         constructor($resource) {
             'ngInject';
             this.AOI = $resource(
-                '/api/areas-of-interest/:id', {id: '@id'}, {
+                `${BUILDCONFIG.API_HOST}/api/areas-of-interest/:id`, {id: '@id'}, {
                     update: {
                         method: 'PUT'
                     }

--- a/app-frontend/src/app/core/services/auth.service.js
+++ b/app-frontend/src/app/core/services/auth.service.js
@@ -1,3 +1,5 @@
+/* globals BUILDCONFIG */
+
 /* globals Auth0Lock heap */
 
 import assetLogo from '../../../assets/images/logo-raster-foundry.png';
@@ -25,7 +27,7 @@ export default (app) => {
 
             this.pendingReauth = null;
 
-            this.User = $resource('/api/users/:id', {
+            this.User = $resource(`${BUILDCONFIG.API_HOST}/api/users/:id`, {
                 id: '@id'
             }, {
                 query: {

--- a/app-frontend/src/app/core/services/colorCorrect.service.js
+++ b/app-frontend/src/app/core/services/colorCorrect.service.js
@@ -1,10 +1,14 @@
+/* globals BUILDCONFIG */
+
 export default (app) => {
     class ColorCorrectService {
         constructor($resource) {
             'ngInject';
 
+            let BASE_URL = BUILDCONFIG.API_HOST;
+
             this.colorCorrect = $resource(
-                '/api/projects/:projectId/mosaic/:sceneId/', {}, {
+                `${BASE_URL}/api/projects/:projectId/mosaic/:sceneId/`, {}, {
                     get: {
                         method: 'GET',
                         cache: false,
@@ -26,7 +30,7 @@ export default (app) => {
             );
 
             this.bulkColorCorrect = $resource(
-                '/api/projects/:projectId/mosaic/bulk-update-color-corrections/', {}, {
+                `${BASE_URL}/api/projects/:projectId/mosaic/bulk-update-color-corrections/`, {}, {
                     create: {
                         method: 'POST',
                         params: {

--- a/app-frontend/src/app/core/services/datasource.service.js
+++ b/app-frontend/src/app/core/services/datasource.service.js
@@ -1,3 +1,5 @@
+/* globals BUILDCONFIG */
+
 export default (app) => {
     class DatasourceService {
         constructor($resource, authService) {
@@ -6,7 +8,7 @@ export default (app) => {
             this.authService = authService;
 
             this.Datasource = $resource(
-                '/api/datasources/:id/', {
+                `${BUILDCONFIG.API_HOST}/api/datasources/:id/`, {
                     id: '@properties.id'
                 }, {
                     query: {

--- a/app-frontend/src/app/core/services/dropbox.service.js
+++ b/app-frontend/src/app/core/services/dropbox.service.js
@@ -1,3 +1,5 @@
+/* globals BUILDCONFIG */
+
 /* globals _ document */
 export default (app) => {
     class DropboxService {
@@ -6,7 +8,7 @@ export default (app) => {
 
             this.authService = authService;
             this.DropboxSetup = $resource(
-                '/api/users/dropbox-setup', {}, {
+                `${BUILDCONFIG.API_HOST}/api/users/dropbox-setup`, {}, {
                     confirm: {
                         method: 'POST'
                     }

--- a/app-frontend/src/app/core/services/export.service.js
+++ b/app-frontend/src/app/core/services/export.service.js
@@ -1,15 +1,17 @@
+/* globals BUILDCONFIG */
+
 export default (app) => {
     class ExportService {
         constructor($resource) {
             'ngInject';
 
             this.Export = $resource(
-                '/api/exports/:id/', {
+                `${BUILDCONFIG.API_HOST}/api/exports/:id/`, {
                     id: '@properties.id'
                 }, {
                     getFiles: {
                         isArray: true,
-                        url: '/api/exports/:exportId/files',
+                        url: `${BUILDCONFIG.API_HOST}/api/exports/:exportId/files`,
                         params: {
                             exportId: '@exportId'
                         }

--- a/app-frontend/src/app/core/services/featureFlags.provider.js
+++ b/app-frontend/src/app/core/services/featureFlags.provider.js
@@ -1,3 +1,5 @@
+/* globals BUILDCONFIG */
+
 function updateFlagsAndGetAll(newFlags) {
     let flagsList = angular.isArray(newFlags) ? newFlags : Object.values(newFlags);
     flagsList.forEach(flag => {
@@ -76,7 +78,7 @@ export default app => {
         constructor($resource) {
             'ngInject';
 
-            this.PerUserFeatureFlag = $resource('/feature-flags/');
+            this.PerUserFeatureFlag = $resource(`${BUILDCONFIG.API_HOST}/feature-flags/`);
         }
 
         load() {

--- a/app-frontend/src/app/core/services/feed.service.js
+++ b/app-frontend/src/app/core/services/feed.service.js
@@ -1,3 +1,5 @@
+/* globals BUILDCONFIG */
+
 export default (app) => {
     class FeedService {
         constructor($resource, $q, $http) {
@@ -11,7 +13,7 @@ export default (app) => {
             return this.$q((resolve, reject) => {
                 this.$http({
                     method: 'GET',
-                    url: '/api/feed'
+                    url: `${BUILDCONFIG.API_HOST}/api/feed`
                 }).then(response => {
                     let raw = response.data;
                     try {

--- a/app-frontend/src/app/core/services/gridLayer.service.js
+++ b/app-frontend/src/app/core/services/gridLayer.service.js
@@ -1,3 +1,5 @@
+/* globals BUILDCONFIG */
+
 import Konva from 'konva';
 export default (app) => {
     /** Service to create a Leaflet grid layer for scenes
@@ -16,7 +18,7 @@ export default (app) => {
          * @returns {promise} API response for scene grid
          */
         requestGrid(coords, params) {
-            let url = `/api/scene-grid/${coords.z}/${coords.x}/${coords.y}/`;
+            let url = `${BUILDCONFIG.API_HOST}/api/scene-grid/${coords.z}/${coords.x}/${coords.y}/`;
             return this.$http.get(url, {params: params});
         }
 

--- a/app-frontend/src/app/core/services/organization.service.js
+++ b/app-frontend/src/app/core/services/organization.service.js
@@ -1,10 +1,12 @@
+/* globals BUILDCONFIG */
+
 export default (app) => {
     class OrganizationService {
         constructor($resource) {
             'ngInject';
 
             this.Organization = $resource(
-                '/api/organizations/:id/', {
+                `${BUILDCONFIG.API_HOST}/api/organizations/:id/`, {
                     id: '@properties.id'
                 }, {
                     query: {

--- a/app-frontend/src/app/core/services/project.service.js
+++ b/app-frontend/src/app/core/services/project.service.js
@@ -1,3 +1,5 @@
+/* globals BUILDCONFIG */
+
 /* global L */
 const availableProcessingOptions = [
     {
@@ -56,7 +58,7 @@ export default (app) => {
             this.tileServer = `${APP_CONFIG.tileServerLocation}`;
 
             this.Project = $resource(
-                '/api/projects/:id/', {
+                `${BUILDCONFIG.API_HOST}/api/projects/:id/`, {
                     id: '@properties.id'
                 }, {
                     query: {
@@ -75,14 +77,14 @@ export default (app) => {
                     },
                     updateProject: {
                         method: 'PUT',
-                        url: '/api/projects/:id',
+                        url: `${BUILDCONFIG.API_HOST}/api/projects/:id`,
                         params: {
                             id: '@id'
                         }
                     },
                     addScenes: {
                         method: 'POST',
-                        url: '/api/projects/:projectId/scenes/',
+                        url: `${BUILDCONFIG.API_HOST}/api/projects/:projectId/scenes/`,
                         params: {
                             projectId: '@projectId'
                         },
@@ -91,7 +93,7 @@ export default (app) => {
                     projectScenes: {
                         method: 'GET',
                         cache: false,
-                        url: '/api/projects/:projectId/scenes',
+                        url: `${BUILDCONFIG.API_HOST}/api/projects/:projectId/scenes`,
                         params: {
                             projectId: '@projectId',
                             pending: '@pending'
@@ -100,14 +102,14 @@ export default (app) => {
                     projectAois: {
                         method: 'GET',
                         cache: false,
-                        url: '/api/projects/:projectId/areas-of-interest',
+                        url: `${BUILDCONFIG.API_HOST}/api/projects/:projectId/areas-of-interest`,
                         params: {
                             projectId: '@projectId'
                         }
                     },
                     removeScenes: {
                         method: 'DELETE',
-                        url: '/api/projects/:projectId/scenes/',
+                        url: `${BUILDCONFIG.API_HOST}/api/projects/:projectId/scenes/`,
                         params: {
                             projectId: '@projectId'
                         }
@@ -118,21 +120,22 @@ export default (app) => {
                     },
                     listExports: {
                         method: 'GET',
-                        url: '/api/exports?project=:project',
+                        url: `${BUILDCONFIG.API_HOST}/api/exports?project=:project`,
                         params: {
                             project: '@project'
                         }
                     },
                     createAOI: {
                         method: 'POST',
-                        url: '/api/projects/:projectId/areas-of-interest/',
+                        url: `${BUILDCONFIG.API_HOST}/api/projects/:projectId/areas-of-interest/`,
                         params: {
                             projectId: '@projectId'
                         }
                     },
                     approveScene: {
                         method: 'POST',
-                        url: '/api/projects/:projectId/scenes/:sceneId/accept',
+                        url: `${BUILDCONFIG.API_HOST}` +
+                            '/api/projects/:projectId/scenes/:sceneId/accept',
                         params: {
                             projectId: '@projectId',
                             sceneId: '@sceneId'
@@ -334,7 +337,7 @@ export default (app) => {
         removeScenesFromProject(projectId, scenes) {
             return this.$http({
                 method: 'DELETE',
-                url: `/api/projects/${projectId}/scenes/`,
+                url: `${BUILDCONFIG.API_HOST}/api/projects/${projectId}/scenes/`,
                 data: scenes,
                 headers: {'Content-Type': 'application/json;charset=utf-8'}
             });
@@ -366,7 +369,7 @@ export default (app) => {
         }
 
         getBaseURL() {
-            let host = this.$location.host();
+            let host = BUILDCONFIG.API_HOST || this.$location.host();
             let protocol = this.$location.protocol();
             let port = this.$location.port();
             let formattedPort = port !== 80 && port !== 443 ? ':' + port : '';

--- a/app-frontend/src/app/core/services/scene.service.js
+++ b/app-frontend/src/app/core/services/scene.service.js
@@ -1,10 +1,12 @@
+/* globals BUILDCONFIG */
+
 export default (app) => {
     class SceneService {
         constructor($resource) {
             'ngInject';
 
             this.Scene = $resource(
-                '/api/scenes/:id/', {
+                `${BUILDCONFIG.API_HOST}/api/scenes/:id/`, {
                     id: '@properties.id'
                 }, {
                     query: {

--- a/app-frontend/src/app/core/services/token.service.js
+++ b/app-frontend/src/app/core/services/token.service.js
@@ -1,3 +1,5 @@
+/* globals BUILDCONFIG */
+
 export default (app) => {
     class TokenService {
         constructor($resource, $q, $log) {
@@ -6,7 +8,7 @@ export default (app) => {
             this.$log = $log;
 
             this.ApiToken = $resource(
-                '/api/tokens/:id', {
+                `${BUILDCONFIG.API_HOST}/api/tokens/:id`, {
                     id: '@id'
                 }, {
                     query: {
@@ -21,7 +23,7 @@ export default (app) => {
             );
 
             this.MapToken = $resource(
-                '/api/map-tokens/:id', {
+                `${BUILDCONFIG.API_HOST}/api/map-tokens/:id`, {
                     id: '@id'
                 }, {
                     create: {

--- a/app-frontend/src/app/core/services/tool.service.js
+++ b/app-frontend/src/app/core/services/tool.service.js
@@ -1,3 +1,5 @@
+/* globals BUILDCONFIG */
+
 export default (app) => {
     class ToolService {
         constructor($resource, $http, authService) {
@@ -5,7 +7,7 @@ export default (app) => {
             this.$http = $http;
             this.authService = authService;
             this.Tool = $resource(
-                '/api/tools/:id/', {
+                `${BUILDCONFIG.API_HOST}/api/tools/:id/`, {
                     id: '@properties.id'
                 }, {
                     query: {
@@ -19,7 +21,7 @@ export default (app) => {
                 }
             );
             this.ToolRun = $resource(
-                '/api/tool-runs/:id/', {
+                `${BUILDCONFIG.API_HOST}/api/tool-runs/:id/`, {
                     id: '@properties.id'
                 }, {
                     create: {

--- a/app-frontend/src/app/core/services/toolCategory.service.js
+++ b/app-frontend/src/app/core/services/toolCategory.service.js
@@ -1,10 +1,12 @@
+/* globals BUILDCONFIG */
+
 export default (app) => {
     class ToolCategoryService {
         constructor($resource) {
             'ngInject';
 
             this.ToolCategory = $resource(
-                '/api/tool-categories/:id/', {
+                `${BUILDCONFIG.API_HOST}/api/tool-categories/:id/`, {
                     id: '@properties.id'
                 }, {
                     query: {

--- a/app-frontend/src/app/core/services/toolTag.service.js
+++ b/app-frontend/src/app/core/services/toolTag.service.js
@@ -1,10 +1,12 @@
+/* globals BUILDCONFIG */
+
 export default (app) => {
     class ToolTagService {
         constructor($resource) {
             'ngInject';
 
             this.ToolTag = $resource(
-                '/api/tool-tags/:id/', {
+                `${BUILDCONFIG.API_HOST}/api/tool-tags/:id/`, {
                     id: '@properties.id'
                 }, {
                     query: {

--- a/app-frontend/src/app/core/services/upload.service.js
+++ b/app-frontend/src/app/core/services/upload.service.js
@@ -1,9 +1,11 @@
+/* globals BUILDCONFIG */
+
 export default (app) => {
     class UploadService {
         constructor($resource) {
             'ngInject';
             this.Upload = $resource(
-                '/api/uploads/:id', {
+                `${BUILDCONFIG.API_HOST}/api/uploads/:id`, {
                     id: '@id'
                 }, {
                     create: {

--- a/app-frontend/src/app/index.bootstrap.js
+++ b/app-frontend/src/app/index.bootstrap.js
@@ -1,4 +1,4 @@
-/* global document */
+/* globals document BUILDCONFIG */
 
 // index.html page to dist folder
 import '!!file-loader?name=[name].[ext]!../favicon.ico';
@@ -19,7 +19,8 @@ angular.element(document).ready(function () {
         },
         resolve: {
             APP_CONFIG: ['$http', ($http) => {
-                return $http.get('/config').then(
+                let url = `${BUILDCONFIG.API_HOST}/config`;
+                return $http.get(url).then(
                     (result) => result,
                     (error) => ({error: error})
                 );

--- a/app-tasks/dags/ingest_project_scenes.py
+++ b/app-tasks/dags/ingest_project_scenes.py
@@ -163,7 +163,7 @@ def create_ingest_definition_op(*args, **kwargs):
     logger.info('Beginning to create ingest definition for scene %s for user %s...',
                 scene_id, scene.owner)
 
-    if scene.ingestStatus != IngestStatus.TOBEINGESTED:
+    if scene.ingestStatus != IngestStatus.TOBEINGESTED and scene.ingestStatus != IngestStatus.FAILED:
         raise Exception('Scene is no longer waiting to be ingested, error error')
 
     scene.ingestStatus = IngestStatus.INGESTING

--- a/app-tasks/dags/ingest_project_scenes.py
+++ b/app-tasks/dags/ingest_project_scenes.py
@@ -225,6 +225,8 @@ def wait_for_status_op(*args, **kwargs):
     logger.info('Setting scene %s ingest status to %s', scene.id, scene.ingestStatus)
     scene.update()
     logger.info('Successfully updated scene %s\'s ingest status', scene.id)
+    if scene.ingestStatus == IngestStatus.FAILED:
+        raise AirflowException('Failed to ingest {} for user {}'.format(scene_id, scene.owner))
 
 
 ################################


### PR DESCRIPTION
## Overview

Still prevents accidentally kicking off the same ingest multiple times

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~

## Testing

### Rerun Failed Jobs
 - Start servers with airflow
 - Open psql shell: `./scripts/psql`
 - Set ingest status to failed for scene:
  `UPDATE scenes SET ingest_status = 'FAILED' WHERE id = '57e69503-61e1-4d8a-8dd6-eef465fd502e';`
 - Kick off ingest for scene by posting the following json to `http://localhost:8080/api/dag-runs/ingest_scene`:
  `{'sceneId': '57e69503-61e1-4d8a-8dd6-eef465fd502e'}`
 - Observe that job proceeds as normal

### Set Different API Host for Frontend
 - cp `app-frontend/config/webpack/overrides.js.template` to `app-frontend/config/webpack/overrides.js`
 - open up `localhost:9091` and open developer tools, observe requests go to `app.rasterfoundry.com`
 - sign in with user and test that application functions as expected

Closes #2181 
Closes #2148 