### PR TITLE
Allow Auth0 user impersonation

### DIFF
--- a/app-frontend/src/app/pages/login/login.controller.js
+++ b/app-frontend/src/app/pages/login/login.controller.js
@@ -1,10 +1,20 @@
 export default class LoginController {
-    constructor(authService, $state) {
+    constructor($state, $location, authService) {
         'ngInject';
-        if (authService.verifyAuthCache()) {
-            $state.go('home');
+        this.$state = $state;
+        this.$location = $location;
+        this.authService = authService;
+    }
+
+    $onInit() {
+        const hash = this.$location.hash();
+        if (hash){
+            this.authService.onImpersonation(hash);
+        }
+        if (this.authService.verifyAuthCache()) {
+            this.$state.go('home');
         } else {
-            authService.login();
+            this.authService.login();
         }
     }
 }


### PR DESCRIPTION
## Overview

This PR adds handling for Auth0 user impersonation.

Rather than using a redirect route, this handles the impersonation request from the `login` route.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~

### Notes

Some combination of Auth0 and angular result in the auth params being sent in as a single hash string rather than query params. This required some manual splitting of the params.

This opens up the possibility of someone setting an invalid `id_token` in the hash string. Try/catches have been added to prevent bad JWT formats from causing errors. Instead, a poorly formatted JWT will now redirect to login.

## Testing Instructions

 * Make sure you can login and out normally
 * Go into Auth0 and set the current tenant to the development one
 * Find a user that you want to impersonate and go to their detail page
 * Click 'Sign in As User' and select 'Web' (should be the only option)
 * Select the callback URL that has `/login/` at the end
 * Click the blue button in the  'Client side app' row below

Closes #2153
