### PR TITLE
Disable running tests during assembly

### DIFF
--- a/app-backend/build.sbt
+++ b/app-backend/build.sbt
@@ -269,6 +269,7 @@ lazy val tile = Project("tile", file("tile"))
     case _ => MergeStrategy.first
   })
   .settings(assemblyJarName in assembly := "rf-tile-server.jar")
+  .settings(test in assembly := {})
 
 lazy val tool = Project("tool", file("tool"))
   .settings(commonSettings:_*)


### PR DESCRIPTION
## Overview

Our tiler tests require the database to be available in order to run, but we
don't want to have that requirement during JAR assembly. This prevents
tests from running during the assembly task, which makes the database no
longer necessary.

### Checklist

- [ ] ~Styleguide updated, if necessary~
- [ ] ~Swagger specification updated, if necessary~
- [ ] ~Symlinks from new migrations present or corrected for any new migrations~

## Testing Instructions

 * From `develop`, run the command from #1915 (including `--no-deps`). It should run `AuthSpec` tests which will fail because no database is available.
 * Check out this branch and re-run the command. Tests from `com.azavea.rf.tile.AuthSpec` should no longer be run and the command should succeed even when the `--no-deps` parameter is included.

Closes #1915 