### PR TITLE
Add redirection and throttling for downloads

### DIFF
--- a/app-backend/api/src/main/scala/exports/Routes.scala
+++ b/app-backend/api/src/main/scala/exports/Routes.scala
@@ -54,7 +54,6 @@ trait ExportRoutes extends Authentication
           get { proxiedFiles(exportId) }
         } ~
         pathPrefix(Segment) { objectKey =>
-          // val url = getFileUrl(exportId, objectKey)
           pathEndOrSingleSlash {
             redirectRoute(exportId, objectKey)
           }

--- a/app-backend/api/src/main/scala/exports/package.scala
+++ b/app-backend/api/src/main/scala/exports/package.scala
@@ -10,8 +10,9 @@ import com.amazonaws.services.s3.AmazonS3URI
 
 import java.time.Duration
 import java.util.Date
-import java.net.{URI, URL}
+import java.net.{URI, URL, URLDecoder}
 import java.sql.Timestamp
+import java.nio.charset.StandardCharsets.UTF_8
 
 package object exports extends Config {
   implicit def listUrlToListString(urls: List[URL]): List[String] = urls.map(_.toString)
@@ -22,6 +23,23 @@ package object exports extends Config {
         case "s3" | "s3a" | "s3n" => Some(S3.getSignedUrls(exportOptions.source))
         case _ => None
       }).getOrElse(Nil)
+    }
+
+    def getObjectKeys(): List[String] = {
+      (exportOptions.source.getScheme match {
+        case "s3" | "s3a" | "s3n" => Some(S3.getObjectKeys(exportOptions.source))
+        case _ => None
+      }).getOrElse(Nil)
+    }
+
+    def getSignedUrl(objectKey: String, duration: Duration = Duration.ofDays(1)): URL = {
+      val amazonURI = new AmazonS3URI(exportOptions.source + "/" + objectKey)
+      val bucket:String = amazonURI.getBucket
+      val key:String = URLDecoder.decode(amazonURI.getKey, UTF_8.toString())
+      (exportOptions.source.getScheme match {
+        case "s3" | "s3a" | "s3n" => Some(S3.getSignedUrl(bucket, key))
+        case _ => None
+      }).getOrElse(new URL(""))
     }
   }
 

--- a/app-frontend/src/app/components/exports/exportDownloadModal/exportDownloadModal.html
+++ b/app-frontend/src/app/components/exports/exportDownloadModal/exportDownloadModal.html
@@ -10,7 +10,7 @@
   </div>
   <div class="modal-body">
     <ul>
-      <li ng-repeat="file in $ctrl.exportFiles"><a ng-href="{{file}}">Download file {{$index + 1}}</a></li>
+      <li ng-repeat="file in $ctrl.exportFiles"><a ng-href="{{file}}" download target="_blank">Download file {{$index + 1}}</a></li>
     </ul>
     <div class="list-group" ng-show="$ctrl.isLoading">
       <span class="list-placeholder">

--- a/app-frontend/src/app/core/services/export.service.js
+++ b/app-frontend/src/app/core/services/export.service.js
@@ -1,7 +1,9 @@
 export default (app) => {
     class ExportService {
-        constructor($resource) {
+        constructor($resource, $q, authService) {
             'ngInject';
+            this.$q = $q;
+            this.authService = authService;
 
             this.Export = $resource(
                 '/api/exports/:id/', {
@@ -19,7 +21,16 @@ export default (app) => {
         }
 
         getFiles(exportObject) {
-            return this.Export.getFiles({ exportId: exportObject.id }).$promise;
+            const token = this.authService.token();
+            return this.$q((resolve, reject) => {
+                const exportFileRequest = this.Export.getFiles({ exportId: exportObject.id }).$promise;
+                exportFileRequest
+                    .then(files => {
+                        resolve(files.map(f => {
+                            return `/api/exports/${exportObject.id}/files/${f}?token=${token}`
+                        }));
+                    });
+            });
         }
     }
 

--- a/app-frontend/src/app/core/services/export.service.js
+++ b/app-frontend/src/app/core/services/export.service.js
@@ -22,12 +22,11 @@ export default (app) => {
 
         getFiles(exportObject) {
             const token = this.authService.token();
-            return this.$q((resolve, reject) => {
-                const exportFileRequest = this.Export.getFiles({ exportId: exportObject.id }).$promise;
-                exportFileRequest
+            return this.$q((resolve) => {
+                this.Export.getFiles({ exportId: exportObject.id })
                     .then(files => {
                         resolve(files.map(f => {
-                            return `/api/exports/${exportObject.id}/files/${f}?token=${token}`
+                            return `/api/exports/${exportObject.id}/files/${f}?token=${token}`;
                         }));
                     });
             });

--- a/docs/swagger/spec.yml
+++ b/docs/swagger/spec.yml
@@ -1673,7 +1673,7 @@ paths:
         - $ref: '#/parameters/uuid'
       responses:
         200:
-          description: List of urls to download exported data
+          description: List of files within an export
           schema:
             type: "array"
             items:
@@ -1681,6 +1681,32 @@ paths:
         404:
           description: |
             UUID parameter does not refer to an export or the user is not able to view the export it refers to or export was not finished successfully yet.
+          schema:
+            $ref: '#/definitions/Error'
+  /exports/{uuid}/files/{filename}:
+    x-resource: Exports
+    get:
+      summary: Download a file from an export
+      tags:
+        - Imagery
+      parameters:
+        - $ref: '#/parameters/uuid'
+        - in: path
+          name: filename
+          type: string
+          description: The filename of the file the user wishes to download. Filenames of an export need to first be fetched.
+      responses:
+        200:
+          description: The content of the reqested file
+          schema:
+            type: file
+        404:
+          description: |
+            UUID does not reference an export that exists, the user has access to, and has finished successfully. The filename may not exist
+          schema:
+            $ref: '#/definitions/Error'
+        503:
+          description: The request rate has been exceeded.
           schema:
             $ref: '#/definitions/Error'
 

--- a/docs/swagger/spec.yml
+++ b/docs/swagger/spec.yml
@@ -1691,8 +1691,9 @@ paths:
         - Imagery
       parameters:
         - $ref: '#/parameters/uuid'
-        - in: path
-          name: filename
+        - name: filename
+          required: true
+          in: path
           type: string
           description: The filename of the file the user wishes to download. Filenames of an export need to first be fetched.
       responses:

--- a/nginx/etc/nginx/conf.d/api.conf
+++ b/nginx/etc/nginx/conf.d/api.conf
@@ -1,3 +1,5 @@
+limit_req_zone $binary_remote_addr zone=download:10m rate=1r/m;
+
 server {
     listen 80 default_server;
     server_name app.staging.rasterfoundry.com app.rasterfoundry.com;
@@ -15,6 +17,16 @@ server {
     include /etc/nginx/includes/api-security-headers.conf;
 
     location /api {
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Forwarded-For $remote_addr;
+        proxy_redirect off;
+
+        proxy_pass http://api-server-upstream;
+    }
+
+    location ~ ^\/api\/exports\/.*\/files\/.* {
+        limit_req zone=download burst=5;
+
         proxy_set_header Host $http_host;
         proxy_set_header X-Forwarded-For $remote_addr;
         proxy_redirect off;

--- a/nginx/etc/nginx/conf.d/api.conf
+++ b/nginx/etc/nginx/conf.d/api.conf
@@ -1,4 +1,4 @@
-limit_req_zone $binary_remote_addr zone=download:10m rate=1r/m;
+limit_req_zone $binary_remote_addr zone=download:10m rate=1r/s;
 
 server {
     listen 80 default_server;
@@ -24,8 +24,8 @@ server {
         proxy_pass http://api-server-upstream;
     }
 
-    location ~ ^\/api\/exports\/.*\/files\/.* {
-        limit_req zone=download burst=5;
+    location ~* ^\/api\/exports\/.*\/files\/.* {
+        limit_req zone=download burst=5 nodelay;
 
         proxy_set_header Host $http_host;
         proxy_set_header X-Forwarded-For $remote_addr;


### PR DESCRIPTION
## Overview

This PR adds redirection and throttling for downloading the imagery resulting from exports. It addresses three areas:
- API server: added endpoint and handling for redirecting an export download to an S3 signed URL via a 302
- Front-end: adjusted the export service and download modal to handle the new scheme for getting the files of an export as well as query param authentication
- NGINX - added rate limiting to the api-server's conf file

### Checklist

~- [ ] Styleguide updated, if necessary~
- [x] Swagger specification updated, if necessary
~- [ ] Symlinks from new migrations present or corrected for any new migrations~

### Notes

The throttle rate is ridiculous right now (1 req/min) and I'll adjust it before we merge once we decide on a reasonable value.

I think the throttling is going to apply across files, so trying to download 2 different files within a minute (with the current throttle rate) would not succeed. This may be OK when we adjust to a more sensible value, it may not be.

## Testing Instructions

 * Export some stuff
 * Once the exports succeed, try downloading the export files
 * Make sure you can download the tiffs, but not more frequently than 1 per minute.

Closes #2134
