### PR TITLE
Account for `Constant` tiles in Export AST evaluation

### DIFF
--- a/app-backend/tool/src/main/scala/eval/InterpreterError.scala
+++ b/app-backend/tool/src/main/scala/eval/InterpreterError.scala
@@ -32,6 +32,10 @@ case class UnsubstitutedRef(id: UUID) extends InterpreterError {
   def repr = s"Unsubstituted Tool reference found: ${id}"
 }
 
+case class NoSourceLeaves(id: UUID) extends InterpreterError {
+  def repr = s"The Operation ${id} has only Constant leaves"
+}
+
 case class NoBandGiven(id: UUID) extends InterpreterError {
   def repr = s"No band value given for Scene ${id}"
 }

--- a/app-backend/tool/src/test/scala/eval/InterpreterSpec.scala
+++ b/app-backend/tool/src/test/scala/eval/InterpreterSpec.scala
@@ -372,30 +372,6 @@ class InterpreterSpec
     }
   }
 
-  it("should evaluate using constant tiles") {
-    requests = Nil
-    val forty = Constant(UUID.randomUUID, 40, None)
-    val two = Constant(UUID.randomUUID, 2, None)
-    val lifeUniverseEtc = forty + two
-    val tms = Interpreter.interpretTMS(
-      ast = lifeUniverseEtc,
-      sourceMapping = Map(),
-      overrides = Map.empty,
-      source = goodSource
-    )
-    println("Simple Constant calculation: ", lifeUniverseEtc.asJson.noSpaces)
-
-    val ret = tms(0, 1, 1)
-    val op = Await.result(ret, 10.seconds) match {
-      case Valid(lazytile) =>
-        val maybeTile = lazytile.evaluateDouble
-        requests.length should be (0)
-        maybeTile.get.getDouble(0, 0) should be (42)
-      case i@Invalid(_) =>
-        fail(s"$i")
-    }
-  }
-
   it("should evaluate masking") {
     import geotrellis.proj4._
     requests = Nil


### PR DESCRIPTION
See #2119 .

New AST conditions:

- A full AST must have at least one `Source` leaf
- Subtrees *can* have only `Constant`s as their leaves, unless they are `Unary` operations like `Classification` or `Masking`

Visually:

**Illegal**
![illegal0](https://user-images.githubusercontent.com/229679/27882585-133cc960-6182-11e7-8881-9059052d93e0.png)

**Legal**
![legal0](https://user-images.githubusercontent.com/229679/27882592-1b11901c-6182-11e7-9f03-e1c77d81b623.png)

**Legal**
![legal1](https://user-images.githubusercontent.com/229679/27882667-688bd082-6182-11e7-9d8a-572b1bb6a7ad.png)

**Illegal**
![illegal1](https://user-images.githubusercontent.com/229679/27882672-6f8a12c2-6182-11e7-8e4f-4012fd4ac29f.png)
