### PR TITLE
Enable S3 import on front-end

### DIFF
--- a/app-frontend/src/app/components/scenes/sceneImportModal/sceneImportModal.html
+++ b/app-frontend/src/app/components/scenes/sceneImportModal/sceneImportModal.html
@@ -1,6 +1,6 @@
 <div class="modal-scrollable-body modal-sidebar-header">
   <div class="modal-header">
-    <button type="button" class="close" aria-label="Close" ng-click="$ctrl.dismiss()">
+    <button type="button" class="close" aria-label="Close" ng-click="$ctrl.handleClose()">
       <span aria-hidden="true">&times;</span>
     </button>
     <h4 class="modal-title" ng-if="!$ctrl.resolve.project">
@@ -62,16 +62,14 @@
           <rf-box-select-item
           class="small"
           ng-class="{selected: $ctrl.importType === 'local'}"
+          ng-click="$ctrl.setImportType('local')"
         >
           <div class="text-center"><strong>Local Files</strong></div>
         </rf-box-select-item>
         <rf-box-select-item
-          class="small disabled"
-        >
-          <div class="text-center"><strong>URI</strong></div>
-        </rf-box-select-item>
-        <rf-box-select-item
-          class="small disabled"
+          class="small"
+          ng-class="{selected: $ctrl.importType === 'S3'}"
+          ng-click="$ctrl.setImportType('S3')"
         >
           <div class="text-center"><strong>AWS S3</strong></div>
         </rf-box-select-item>
@@ -80,6 +78,27 @@
         >
           <div class="text-center"><strong>DropBox</strong></div>
         </rf-box-select-item>
+      </div>
+      <div ng-if="$ctrl.importType === 'S3'">
+        <p>
+          Enter the the S3 bucket and prefix to indicate where your imagery is located.
+          The import process will import any imagery found in that location into Raster Foundry.
+        </p>
+        <form>
+          <div class="form-group">
+            <label for="name">S3 Bucket</label>
+            <input id="name" type="url" class="form-control"
+                  placeholder="S3 Bucket" ng-model="$ctrl.s3Config.bucket">
+          </div>
+          <div class="form-group color-danger"
+              ng-if="$ctrl.showProjectCreateError && $ctrl.projectCreateErrorText"
+          >
+              {{$ctrl.projectCreateErrorText}}
+          </div>
+        </form>
+      </div>
+      <div ng-if="$ctrl.currentError" class="color-danger text-center">
+        {{$ctrl.currentError.data}}
       </div>
     </div>
   </div>
@@ -178,6 +197,13 @@
   </div>
 
   <!--Body for IMPORT_SUCCESS-->
+  <div class="modal-body" ng-if="$ctrl.currentStepIs('S3_UPLOAD')">
+    <div class="content">
+      <h3 class="no-margin text-center">Processing your S3 import</h3>
+    </div>
+  </div>
+
+  <!--Body for IMPORT_SUCCESS-->
   <div class="modal-body" ng-if="$ctrl.currentStepIs('IMPORT_SUCCESS')">
     <div class="content">
       <h3 class="no-margin">Success!</h3>
@@ -190,43 +216,28 @@
   </div>
 
   <!--Default Footer-->
-  <div
-    ng-if="$ctrl.currentStepIsNot(['UPLOAD_PROGRESS', 'IMPORT_SUCCESS', 'DATASOURCE_SELECT'])"
-    class="modal-footer"
-  >
+  <div class="modal-footer">
     <button type="button" class="btn pull-left"
-            ng-click="$ctrl.closeWithData(1)">
+            ng-if="$ctrl.allowClose()"
+            ng-click="$ctrl.handleClose()">
       Cancel
     </button>
 
     <button type="button" class="btn"
-            ng-if="$ctrl.hasPreviousStep()"
-            ng-click="$ctrl.gotoPreviousStep()">
+            ng-if="$ctrl.hasPrevious()"
+            ng-click="$ctrl.handlePrevious()"
+            ng-disabled="!$ctrl.allowPrevious()">
       Back
     </button>
     <button type="button" class="btn btn-primary"
+            ng-if="$ctrl.hasNext()"
             ng-click="$ctrl.handleNext()"
-            ng-disabled="!$ctrl.allowNext">
+            ng-disabled="!$ctrl.allowNext()">
       Next
     </button>
-  </div>
-
-  <!--Footer for UPLOAD_PROGRESS-->
-  <div ng-if="$ctrl.currentStepIs(['UPLOAD_PROGRESS'])" class="modal-footer">
-  </div>
-
-  <!--Footer for DATASOURCE_SELECT-->
-  <div ng-if="$ctrl.currentStepIs(['DATASOURCE_SELECT'])" class="modal-footer">
-    <button type="button" class="btn pull-left"
-            ng-click="$ctrl.closeWithData(1)">
-      Cancel
-    </button>
-  </div>
-
-  <!--Footer for SUCCESS-->
-  <div ng-if="$ctrl.currentStepIs('IMPORT_SUCCESS')" class="modal-footer">
     <button type="button" class="btn btn-primary"
-            ng-click="$ctrl.closeWithData(1)">
+            ng-if="$ctrl.allowDone()"
+            ng-click="$ctrl.handleDone()">
       Done
     </button>
   </div>

--- a/app-frontend/src/app/core/services/upload.service.js
+++ b/app-frontend/src/app/core/services/upload.service.js
@@ -13,7 +13,7 @@ export default (app) => {
                     },
                     credentials: {
                         method: 'GET',
-                        url: '/api/uploads/:id/credentials'
+                        url: `${BUILDCONFIG.API_HOST}/api/uploads/:id/credentials`
                     },
                     update: {
                         method: 'PUT'


### PR DESCRIPTION
## Overview

This PR enables the S3 import option on the front-end. The user can now select the S3 type within the import process and enter an bucket and prefix to upload all imagery at that location.

This PR also refactors the state handling of the modal. As the flow became more complex and different steps required different validation procedures it was necessary to transition to a more explicit method of handling each modal state where each state could designate code to be run upon entering the state along with logic for displaying and enabling/disabling buttons.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~

### Demo

![image](https://user-images.githubusercontent.com/2442245/27882877-73901776-619c-11e7-9412-5778403e1cca.png)

### Notes

This is only an initial front-end implementation and because the back-end does not exist to support it, this does not actually work yet. Some processing logic will need to be added when the backend is finalized.

## Testing Instructions

 * Make sure local file imports work as before and that button validation states make sense (since this was all refactored)
* Test out the S3 option and see that button validation states make sense

Closes #2152
