### PR TITLE
Fix possible undefined project state

### DIFF
--- a/app-frontend/src/app/pages/projects/edit/edit.controller.js
+++ b/app-frontend/src/app/pages/projects/edit/edit.controller.js
@@ -47,6 +47,7 @@ export default class ProjectsEditController {
                         this.projectUpdateListeners.forEach((wait) => {
                             wait.resolve(project);
                         });
+                        this.getSceneList();
                         if (this.project.isAOIProject) {
                             this.getPendingSceneList();
                         }
@@ -55,7 +56,6 @@ export default class ProjectsEditController {
                         this.loadingProject = false;
                     }
                 );
-                this.getSceneList();
             } else {
                 this.$state.go('projects.list');
             }


### PR DESCRIPTION
## Overview

This PR addresses a possible undefined project situation on the project edit page. This is an async bug that was caused by referencing `this.project` within the controller without a guarantee that it was defined. The results were that some projects would seemingly not have color-modes defined.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~

## Testing Instructions

 * Go to the project edit page for a project
 * Clear cache and hard reload and see that there are no errors and that all color-modes defined for the relevant datasources are shown.

Closes #2117
