### PR TITLE
Add impersonation info to Heap

### DIFF
--- a/app-frontend/src/app/core/services/auth.service.js
+++ b/app-frontend/src/app/core/services/auth.service.js
@@ -180,7 +180,11 @@ export default (app) => {
                    ) {
                     heap.identify(profile.email);
                     this.getCurrentUser().then((user) => {
-                        heap.addUserProperties({organization: user.organizationId});
+                        heap.addUserProperties({
+                            'organization': user.organizationId,
+                            'impersonated': profile.impersonated || false,
+                            'impersonator': profile.impersonated ? profile.impersonator.email : null
+                        });
                         heap.addEventProperties({'Logged In': 'true'});
                     });
                 }


### PR DESCRIPTION
## Overview

This PR pulls impersonation info into Heap if it is available.

It works but it seems to only fully show in heap after log-out.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~


## Testing Instructions

 * This can be confirmed by removing the `if` around the heap script in `tpl-index.html` and then impersonating a user and then logging out.

Closes #2203
