### PR TITLE
Feature/tnation/jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -77,8 +77,8 @@ node {
 
         dir('raster-foundry-deployment') {
           wrap([$class: 'AnsiColorBuildWrapper']) {
-            sh './scripts/infra plan'
-            sh './scripts/infra apply'
+            sh 'docker-compose -f docker-compose.ci.yml run --rm terraform ./scripts/infra plan'
+            sh 'docker-compose -f docker-compose.ci.yml run --rm terraform ./scripts/infra apply'
           }
         }
       }

--- a/deployment/ansible/group_vars/jenkins
+++ b/deployment/ansible/group_vars/jenkins
@@ -3,6 +3,4 @@ docker_users:
   - "{{ ansible_user }}"
   - "{{ jenkins_name }}"
 
-terraform_version: "0.9.6"
-
 java_version: "7u121*"

--- a/deployment/ansible/raster-foundry-jenkins.yml
+++ b/deployment/ansible/raster-foundry-jenkins.yml
@@ -9,7 +9,6 @@
 
   roles:
     - { role: azavea.ntp }
-    - { role: azavea.terraform }
     - { role: raster-foundry.aws-cli }
     - { role: raster-foundry.docker }
     - { role: raster-foundry.shellcheck }

--- a/deployment/ansible/roles.yml
+++ b/deployment/ansible/roles.yml
@@ -15,6 +15,3 @@
 
 - src: azavea.ntp
   version: 0.1.1
-
-- src: azavea.terraform
-  version: 0.3.1


### PR DESCRIPTION
## Overview

azavea/raster-foundry-deployment#66 added a Docker based deployment setup, which removes the need to install `terraform` on Jenkins. This PR removes the `terraform` installation from Ansible, and modifies the `Jenkinsfile` to run the deployment step using `docker-compose` instead of invoking `scripts/infra` directly.
### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~

### Demo

N/A

### Notes

The current docker-compose setup uses `AWS_PROFILE` and mounts the Jenkins `~/.aws` directory into the container (this directory didn't exist and needed to be re-created out-of-band for this PR). It might be worth it to store `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` in the Jenkins credential store and pass them to `docker-compose run -e`

## Testing Instructions

- http://jenkins.staging.rasterfoundry.com/job/raster-foundry/job/raster-foundry/job/feature%252Ftnation%252Fjenkinsfile/2/console

Closes #2208 
