### PR TITLE
Add Node header component

### DIFF
--- a/app-frontend/src/app/components/tools/diagramNodeHeader/diagramNodeHeader.component.js
+++ b/app-frontend/src/app/components/tools/diagramNodeHeader/diagramNodeHeader.component.js
@@ -1,0 +1,10 @@
+import diagramNodeHeaderTpl from './diagramNodeHeader.html';
+
+export default {
+    templateUrl: diagramNodeHeaderTpl,
+    controller: 'DiagramNodeHeaderController',
+    bindings: {
+        model: '<',
+        invalid: '<'
+    }
+};

--- a/app-frontend/src/app/components/tools/diagramNodeHeader/diagramNodeHeader.controller.js
+++ b/app-frontend/src/app/components/tools/diagramNodeHeader/diagramNodeHeader.controller.js
@@ -1,0 +1,48 @@
+export default class DiagramNodeHeaderController {
+    constructor($document, $scope) {
+        'ngInject';
+        this.$document = $document;
+        this.$scope = $scope;
+    }
+
+    $onInit() {
+    }
+
+    $onChanges(changes) {
+        if (changes.model && changes.model.currentValue) {
+            this.cellType = this.model.get('cellType');
+            this.cellTitle = this.model.get('title');
+            this.menuItems = this.model.get('contextMenu');
+        }
+    }
+
+    isFunctionType() {
+        return this.cellType === 'Function';
+    }
+
+    toggleMenu() {
+        let initialClick = true;
+        const onClick = () => {
+            if (!initialClick) {
+                this.showMenu = false;
+                this.$document.off('click', this.clickListener);
+                this.$scope.$evalAsync();
+            } else {
+                initialClick = false;
+            }
+        };
+        if (!this.showMenu) {
+            this.showMenu = true;
+            this.clickListener = onClick;
+            this.$document.on('click', onClick);
+        } else {
+            this.showMenu = false;
+            this.$document.off('click', this.clickListener);
+            delete this.clickListener;
+        }
+    }
+
+    setHeight(height) {
+        this.model.set('size', {width: 300, height: height});
+    }
+}

--- a/app-frontend/src/app/components/tools/diagramNodeHeader/diagramNodeHeader.html
+++ b/app-frontend/src/app/components/tools/diagramNodeHeader/diagramNodeHeader.html
@@ -1,0 +1,32 @@
+<div class="node-header">
+  <div class="node-header-colorblock"
+       ng-class="{'node-type-input': $ctrl.cellType === 'Input',
+              'node-type-function': $ctrl.cellType === 'Function'}">
+  </div>
+  <div class="node-dropdown"
+       ng-click="$ctrl.toggleMenu($event)">
+    <div class="node-dropdown-icon"></div>
+    <div class="node-dropdown-menu" ng-show="$ctrl.showMenu">
+      <ul>
+        <li ng-repeat="menuItem in $ctrl.menuItems"
+            ng-click="menuItem.callback($event, $ctrl.model)"
+            ng-class="{'divider': menuItem.type === 'divider'}"
+        >{{menuItem.label}}
+        </li>
+      </ul>
+    </div>
+  </div>
+  <div class="node-header-text">
+    <div class="node-header-type">
+      <span class="icon-info"
+            ng-if="$ctrl.isFunctionType()"></span>
+      {{$ctrl.cellType}}
+    </div>
+    <div class="node-header-label">
+      {{$ctrl.cellTitle}}
+    </div>
+  </div>
+  <div class="node-status">
+    <span class="icon-warning color-warning" ng-if="$ctrl.invalid">
+  </div>
+</div>

--- a/app-frontend/src/app/components/tools/diagramNodeHeader/diagramNodeHeader.module.js
+++ b/app-frontend/src/app/components/tools/diagramNodeHeader/diagramNodeHeader.module.js
@@ -1,0 +1,18 @@
+import angular from 'angular';
+import DiagramNodeHeaderComponent from './diagramNodeHeader.component.js';
+import DiagramNodeHeaderController from './diagramNodeHeader.controller.js';
+
+const DiagramNodeHeaderModule = angular.module(
+    'components.tools.diagramNodeHeader',
+    []
+);
+
+DiagramNodeHeaderModule.component(
+    'rfDiagramNodeHeader', DiagramNodeHeaderComponent
+);
+
+DiagramNodeHeaderModule.controller(
+    'DiagramNodeHeaderController', DiagramNodeHeaderController
+);
+
+export default DiagramNodeHeaderModule;

--- a/app-frontend/src/app/index.components.js
+++ b/app-frontend/src/app/index.components.js
@@ -26,6 +26,7 @@ export default angular.module('index.components', [
     require('./components/tools/toolItem/toolItem.module.js').name,
     require('./components/tools/diagramContainer/diagramContainer.module.js').name,
     require('./components/tools/diagramContainer2/diagramContainer.module.js').name,
+    require('./components/tools/diagramNodeHeader/diagramNodeHeader.module.js').name,
 
     // map components
     require('./components/map/mapContainer/mapContainer.module.js').name,

--- a/app-frontend/src/assets/styles/sass/_shame.scss
+++ b/app-frontend/src/assets/styles/sass/_shame.scss
@@ -1610,4 +1610,129 @@ rf-export-item {
   background: white;
   /* Make sure events are propagated to the JointJS element so, e.g. dragging works.*/
   pointer-events: none;
+  display: flex;
+  flex-direction: column;
+  border-radius: 5px;
+}
+
+.node-header {
+  border-radius: 5px 5px 0 0;
+  display: flex;
+  background: rgba(249, 249, 249, 1);
+  pointer-events: none;
+  position: relative;
+}
+
+.node-dropdown {
+  width: 1em;
+  padding: .75em;
+  pointer-events: auto;
+  position: relative;
+  cursor: pointer;
+}
+
+.node-dropdown-icon {
+  width: .4em;
+  height: .4em;
+  border-radius: 50%;
+  background-color: $shade-light;
+  box-shadow: 0px .75em 0px $shade-light, 0px 1.5em 0px $shade-light;
+}
+
+.node-header-text {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  padding: .25em .25em .5em .5em;
+  .node-header-type {
+    display: flex;
+    flex-direction: row;
+    color: $gray-lighter;
+
+    [class^="icon-"]:before, [class*=" icon-"]:before {
+      width: 1em;
+      margin-right: 0em;
+      margin-left: 0em;
+    }
+  }
+
+  .node-header-label {
+    font-weight: 700;
+    color: rgba(73, 78, 105, 1);
+  }
+}
+
+.node-status {
+  padding: .25em;
+}
+
+
+.node-header-colorblock {
+  border-radius: 5px 0 0 0;
+  width: 1em;
+  &.node-type-input {
+    background: $blue;
+  }
+  &.node-type-function {
+    background: $green;
+  }
+}
+
+.node-body {
+  flex: 1;
+  cursor: auto;
+  pointer-events: auto;
+}
+
+.node-dropdown-menu {
+  position: absolute;
+  left: 2.1em;
+  top: -1em;
+
+  width: 13em;
+  background: white;
+
+  border-radius: 2px;
+  border: 1px solid $shade-light;
+
+  &::after {
+    content: "";
+    position: absolute;
+    left: -10px;
+    top: 2em;
+    width: 0;
+    height: 0;
+    border-top: 10px solid transparent;
+    border-bottom: 10px solid transparent;
+    border-right: 10px solid $shade-light;
+  }
+
+  ul {
+    font-weight: 700;
+    list-style: none;
+    margin: 0;
+    padding: .5em 0 0 0;
+  }
+  li {
+    padding: 0 1em .5em 1em;
+    &:hover {
+      color: $shade-dark;
+    }
+    &.disabled {
+      color: $gray-lightest;
+      &:hover {
+        color: $gray-lightest;
+      }
+    }
+  }
+  .divider {
+    height: 1px;
+    margin: 0 .5em 0.5em .5em;
+    overflow: hidden;
+    border-bottom: 1px solid $gray-lightest;
+  }
+}
+
+.joint-element {
+  cursor: drag;
 }

--- a/app-frontend/src/assets/styles/sass/settings/_colors.scss
+++ b/app-frontend/src/assets/styles/sass/settings/_colors.scss
@@ -29,3 +29,6 @@ $danger: #F98094 !default;  // pinkish-red
 $green: #81C784 !default;
 $yellow: #FFCA28 !default;
 $red: #E57373 !default;
+
+$blue: rgba(56, 139, 186, 1);
+$green: rgba(169, 206, 33, 1);


### PR DESCRIPTION
## Overview

Add a node header component for use in tool runs

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~

### Demo

![image](https://user-images.githubusercontent.com/4392704/28035568-194d7228-6583-11e7-9e49-d92040834410.png)

### Notes

At this point, we should have feature parity with  the original tool runs.
The warning icon is currently hardcoded to show on all input nodes, since the body component for them is not implemented yet.
I created `setHeight()` preemptively so when we need to use it, we can. It doesn't cause the graph to re-flow in response.

## Testing Instructions
* Verify that you can drag the nodes by the title bar, but not the body
* Verify that the dropdown menu & all options work as expected

Closes #2157 
