### PR TITLE
Fix thumbnails caching blow up

### DIFF
--- a/app-backend/tile/src/main/scala/LayerCache.scala
+++ b/app-backend/tile/src/main/scala/LayerCache.scala
@@ -145,6 +145,7 @@ object LayerCache extends Config with LazyLogging with KamonTrace {
                   .stitch
                   .crop(extent)
                   .tile
+                  .resample(256, 256)
               } match {
                 case Success(tile) => Option(tile)
                 case Failure(e) =>


### PR DESCRIPTION
## Overview

It is more a workaround rather than a full solution, as a full solution probably should take in account what zoom level do we want to query thumbnails.

The problem happened due to huge thumbnail size (sometimes col x row result was more than 536832).

Closes #1808
