### PR TITLE
Use Memcached for AttributeStore

### DIFF
--- a/app-backend/tile/src/main/resources/application.conf
+++ b/app-backend/tile/src/main/resources/application.conf
@@ -6,10 +6,6 @@ tile-server {
 
   bucket = "rasterfoundry-staging-catalogs-us-east-1"
   bucket = ${?TILE_SERVER_BUCKET}
-
-  # in memory tileserver cache
-  cache.enabled = true
-  cache.enabled = ${?TILESERVER_CACHE_ENABLED}
 }
 
 kamon {

--- a/app-backend/tile/src/main/scala/package.scala
+++ b/app-backend/tile/src/main/scala/package.scala
@@ -1,8 +1,6 @@
 package com.azavea.rf
 
 import spray.json._
-import spray.json.DefaultJsonProtocol._
-import com.github.blemale.scaffeine.{Cache => ScaffeineCache}
 
 import java.util.UUID
 
@@ -14,11 +12,5 @@ package object tile {
       case _ =>
         deserializationError("Failed to parse UUID string ${js} to java UUID")
     }
-  }
-
-  implicit class withLayerCacheMethods[K, V](cache: ScaffeineCache[K, V]) extends Config {
-    def take(key: K, mappingFunction: K => V): V =
-      if (withCaching) cache.get(key, mappingFunction)
-      else mappingFunction(key)
   }
 }


### PR DESCRIPTION
## Overview

Uses `HeapBackedMemcachedClient` for attribute store instead of `Scaffeine`.
This PR removes `TILESERVER_CACHE_ENABLED` env var.

Depends on #2222
