### PR TITLE
Split large uploaded Tif Files

### DIFF
--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/ingest/model/SourceDefinition.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/ingest/model/SourceDefinition.scala
@@ -42,7 +42,6 @@ object SourceDefinition extends LazyLogging {
     optionCellSize: Option[CellSize],
     bandMaps: Array[BandMapping]
   ) {
-    @SuppressWarnings(Array("OptionGet"))
     def toSourceDefinition: SourceDefinition = {
       (optionExtent, optionCrs, optionCellSize, optionExtentCrs) match {
         case (Some(extent), Some(crs), Some(cellSize), Some(extentCrs)) => {
@@ -57,7 +56,7 @@ object SourceDefinition extends LazyLogging {
         }
         case _ => {
           logger.debug(s"Reading tiff tags: $uri")
-          lazy val tt = getTiffTags(uri)
+          val tt = getTiffTags(uri)
           SourceDefinition(
             uri,
             tt.extent,

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/ingest/model/SourceDefinition.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/ingest/model/SourceDefinition.scala
@@ -44,11 +44,11 @@ object SourceDefinition extends LazyLogging {
   ) {
     @SuppressWarnings(Array("OptionGet"))
     def toSourceDefinition: SourceDefinition = {
-      if (extent.isDefined && crs.isDefined && cellSize.isDefined) {
+      if (extent.isDefined && crs.isDefined && cellSize.isDefined && extentCrs.isDefined) {
         SourceDefinition(
           uri,
           extent.get,
-          extentCrs.getOrElse(LatLng),
+          extentCrs.get,
           crs.get,
           cellSize.get,
           bandMaps

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/ingest/model/SourceDefinition.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/ingest/model/SourceDefinition.scala
@@ -36,34 +36,37 @@ object SourceDefinition extends LazyLogging {
   @JsonCodec
   case class Overrides(
     uri: URI,
-    extent: Option[Extent],
-    extentCrs: Option[CRS],
-    crs: Option[CRS],
-    cellSize: Option[CellSize],
+    optionExtent: Option[Extent],
+    optionExtentCrs: Option[CRS],
+    optionCrs: Option[CRS],
+    optionCellSize: Option[CellSize],
     bandMaps: Array[BandMapping]
   ) {
     @SuppressWarnings(Array("OptionGet"))
     def toSourceDefinition: SourceDefinition = {
-      if (extent.isDefined && crs.isDefined && cellSize.isDefined && extentCrs.isDefined) {
-        SourceDefinition(
-          uri,
-          extent.get,
-          extentCrs.get,
-          crs.get,
-          cellSize.get,
-          bandMaps
-        )
-      } else {
-        logger.debug(s"Reading tiff tags: $uri")
-        lazy val tt = getTiffTags(uri)
-        SourceDefinition(
-          uri,
-          extent.getOrElse(tt.extent),
-          extentCrs.getOrElse(tt.crs),
-          crs.getOrElse(tt.crs),
-          cellSize.getOrElse(tt.cellSize),
-          bandMaps
-        )
+      (optionExtent, optionCrs, optionCellSize, optionExtentCrs) match {
+        case (Some(extent), Some(crs), Some(cellSize), Some(extentCrs)) => {
+          SourceDefinition(
+            uri,
+            extent,
+            extentCrs,
+            crs,
+            cellSize,
+            bandMaps
+          )
+        }
+        case _ => {
+          logger.debug(s"Reading tiff tags: $uri")
+          lazy val tt = getTiffTags(uri)
+          SourceDefinition(
+            uri,
+            tt.extent,
+            tt.crs,
+            tt.crs,
+            tt.cellSize,
+            bandMaps
+          )
+        }
       }
     }
   }

--- a/app-backend/batch/src/test/scala/com/azavea/rf/batch/ingest/model/IngestDefinitionSpec.scala
+++ b/app-backend/batch/src/test/scala/com/azavea/rf/batch/ingest/model/IngestDefinitionSpec.scala
@@ -286,39 +286,6 @@ class IngestDefinitionSpec extends FunSpec with Matchers with BatchSpec {
       |}
     """.stripMargin
 
-  it("parses the sample, local definition") {
-    noException should be thrownBy {
-      decode[IngestDefinition](localJson) match {
-        case Right(r) => r
-        case _ => throw new Exception("Incorrect IngestDefinition JSON")
-      }
-    }
-  }
-
-  it("preserves ingest definition source crs") {
-    val ingestDef =
-      decode[IngestDefinition](localJson) match {
-        case Right(r) => r
-        case _ => throw new Exception("Incorrect IngestDefinition JSON")
-      }
-
-    val srcCrs = ingestDef.layers.head.sources.head.crs.epsgCode
-
-    srcCrs shouldEqual Some(32619)
-  }
-
-  it("preserves ingest definition extent crs") {
-    val ingestDef =
-      decode[IngestDefinition](localJson) match {
-        case Right(r) => r
-        case _ => throw new Exception("Incorrect IngestDefinition JSON")
-      }
-
-    val extentCrs = ingestDef.layers.head.sources.head.extentCrs.epsgCode
-
-    extentCrs shouldEqual Some(4326)
-  }
-
   it("parses the sample, aws definition") {
     noException should be thrownBy {
       decode[IngestDefinition](awsJson) match {

--- a/app-tasks/Dockerfile
+++ b/app-tasks/Dockerfile
@@ -12,20 +12,21 @@ RUN set -ex \
     && mkdir -p ${AIRFLOW_HOME} \
     && chown airflow:airflow -R ${AIRFLOW_HOME} \
     && buildDeps=' \
-       python-dev \
+       python-dev/sid \
     ' \
     && gdalDeps=' \
-       gdal-bin \
+       gdal-bin/sid \
+       python-gdal/sid \
     ' \
     && javaDeps=' \
-       openjdk-8-jre \
-       ca-certificates-java \
+       openjdk-8-jre/jessie-backports \
+       ca-certificates-java/jessie-backports \
     ' \
     && echo 'deb http://deb.debian.org/debian jessie-backports main' > /etc/apt/sources.list.d/jessie-backports.list \
-    && echo 'deb http://deb.debian.org/debian testing main contrib non-free' > /etc/apt/sources.list.d/testing.list \
+    && echo 'deb http://http.us.debian.org/debian sid main non-free contrib' > /etc/apt/sources.list.d/sid.list \
     && apt-get update \
     && apt-get install -y --no-install-recommends ${buildDeps} \
-    && apt-get -t testing install -y --no-install-recommends ${gdalDeps} \
+    && apt-get install -y --no-install-recommends ${gdalDeps} \
     && apt-get install -y --no-install-recommends ${javaDeps} \
     && pip install --no-cache-dir \
            numpy==$(grep "numpy" /tmp/requirements.txt | cut -d= -f3) \

--- a/app-tasks/rf/src/rf/ingest/geotiff_ingest.py
+++ b/app-tasks/rf/src/rf/ingest/geotiff_ingest.py
@@ -2,6 +2,8 @@ import os
 from urlparse import urlparse, ParseResult
 from urllib import quote
 
+import rasterio
+
 from .models import Ingest, Source, Layer
 
 
@@ -30,13 +32,11 @@ def get_safe_uri(uri):
     return safe.geturl()
 
 
-def get_source_definition(image, extent, crs=None):
+def get_source_definition(image):
     """Create source definition from an image
 
     Args:
         image (Image): image to get source definition from
-        extent (List[float]): extent of scene
-        crs (str): optional crs of image
 
     Return:
         Source
@@ -52,8 +52,7 @@ def get_source_definition(image, extent, crs=None):
         width = image.resolutionMeters
         height = image.resolutionMeters
     cell_size = {'width': height, 'height': width}
-    extent_crs = 'epsg:4326'
-    return Source(uri, extent, band_maps, cell_size, extent_crs, crs)
+    return Source(uri, band_maps, cell_size)
 
 
 def get_ingest_layer(scene):
@@ -65,8 +64,7 @@ def get_ingest_layer(scene):
     Return:
         Layer
     """
-    extent = scene.get_extent()
-    sources = [get_source_definition(image, extent) for image in scene.images]
+    sources = [get_source_definition(image) for image in scene.images]
     highest_resolution_meters = min([image.resolutionMeters for image in scene.images])
     if highest_resolution_meters < MIN_RESOLUTION_METERS:
         width = MIN_RESOLUTION_METERS

--- a/app-tasks/rf/src/rf/ingest/landsat8_ingest.py
+++ b/app-tasks/rf/src/rf/ingest/landsat8_ingest.py
@@ -72,8 +72,7 @@ def get_source(image, crs, extent):
     band_maps = [{'source': 1, 'target': get_band_num(image)}]
     cell_size = {'width': image.resolutionMeters,
                  'height': image.resolutionMeters}
-    extent_crs = 'epsg:4326'
-    return Source(uri, extent, band_maps, cell_size, extent_crs, crs)
+    return Source(uri, band_maps, cell_size)
 
 
 def get_landsat8_layer(scene):

--- a/app-tasks/rf/src/rf/ingest/models/source.py
+++ b/app-tasks/rf/src/rf/ingest/models/source.py
@@ -2,49 +2,32 @@
 
 
 class Source(object):
-    def __init__(self, uri, extent, band_maps, cell_size,
-                  extent_crs, source_crs=None):
+    def __init__(self, uri, band_maps, cell_size):
 
         """
             Create a new ingest Source
 
             Args:
                 uri (str): location of image
-                extent (List[float]): extent of the source
-                starting_target_band (int): index of first target band
                 band_maps (List[dict]): list of mappings for each band within the image
-                extent_crs (str): CRS of the extent
-                crs (str): Optional CRS of the Source
         """
         self.uri = uri
         self.cell_size = cell_size
-        self.extent = extent
         self.band_maps = band_maps
-        self.source_crs = source_crs
-        self.extent_crs = extent_crs
 
     @classmethod
     def from_dict(cls, d):
         return cls(
             d.get('image'),
-            d.get('extent'),
-            d.get('starting_target_band'),
             d.get('band_maps'),
-            d.get('source_crs'),
-            d.get('extent_crs')
+            d.get('cell_sieze')
         )
 
     def to_dict(self):
         d = {
-            'crs': self.source_crs,
-            'extentCrs': self.extent_crs,
             'cellSize': self.cell_size,
             'uri': self.uri,
-            'extent': self.extent,
             'bandMaps': self.band_maps
         }
-
-        if self.source_crs:
-            d['crs'] = self.source_crs
 
         return d

--- a/app-tasks/rf/src/rf/uploads/geotiff/factories.py
+++ b/app-tasks/rf/src/rf/uploads/geotiff/factories.py
@@ -1,4 +1,5 @@
 # Factories to create scenes from different geotiff upload destinations
+import logging
 import os
 import tempfile
 
@@ -7,9 +8,13 @@ import boto3
 from .create_thumbnails import create_thumbnails
 from .create_images import create_geotiff_image
 from .create_scenes import create_geotiff_scene
-
 from .io import s3_url, s3_bucket_and_key_from_url
+from .utils import is_tif_too_large, split_tif, upload_split_files
 from rf.utils.io import Visibility
+from rf.uploads.landsat8.io import get_tempdir
+
+logger = logging.getLogger(__name__)
+
 
 class GeoTiffS3SceneFactory(object):
     """A convenience class for creating Scenes from an S3 folder of multiband GeoTiffs.
@@ -50,22 +55,32 @@ class GeoTiffS3SceneFactory(object):
             # We can't use the temp file as a context manager because it'll be opened/closed multiple
             # times and by default is deleted when it's closed. So we use try/finally to ensure that
             # it gets cleaned up.
-            local_tif = tempfile.NamedTemporaryFile(delete=False)
+            local_tif = tempfile.NamedTemporaryFile(delete=False, suffix='.tif')
             try:
                 bucket_name, key = s3_bucket_and_key_from_url(infile)
                 bucket = s3.Bucket(bucket_name)
                 bucket.download_file(key, local_tif.name)
+                logger.info('Downloading %s => %s', infile, local_tif.name)
                 # We need to override the autodetected filename because we're loading into temp
                 # files which don't preserve the file name that is on S3.
                 filename = os.path.basename(key)
                 scene = self.create_geotiff_scene(local_tif.name, os.path.splitext(filename)[0])
-                image = self.create_geotiff_image(local_tif.name, infile,
-                                                  scene, filename)
+
+                if is_tif_too_large(local_tif.name):
+                    with get_tempdir() as tempdir:
+                        split_files = split_tif(local_tif.name, tempdir)
+                        keys_and_filepaths = upload_split_files(key, bucket_name, split_files)
+
+                        images = [self.create_geotiff_image(filepath, s3_url(bucket_name, s3_key),
+                                                            scene, os.path.basename(s3_key))
+                                  for (s3_key, filepath) in keys_and_filepaths]
+                else:
+                    images = [self.create_geotiff_image(local_tif.name, infile, scene, filename)]
 
                 # TODO: thumbnails aren't currently created in a way that matches serialization
                 # in the API
                 scene.thumbnails = create_thumbnails(local_tif.name, scene.id, self.organizationId)
-                scene.images = [image]
+                scene.images = images
             finally:
                 os.remove(local_tif.name)
             yield scene

--- a/app-tasks/rf/src/rf/uploads/geotiff/utils.py
+++ b/app-tasks/rf/src/rf/uploads/geotiff/utils.py
@@ -1,0 +1,96 @@
+"""Utilities for processing geotiff uploads"""
+import logging
+import os
+import subprocess
+
+import boto3
+import rasterio
+
+logger = logging.getLogger(__name__)
+
+
+def is_tif_too_large(tif_path):
+    """Simple function to check if tif is larger than 1 gb
+
+    Args:
+        tif_path (str): full filepath to tif
+
+    Returns:
+        Boolean
+    """
+
+    file_stats = os.stat(tif_path)
+    with rasterio.open(tif_path) as src:
+        total_bounds = src.width * src.height
+
+    max_tif_size_bytes = 1000000000
+    geotrellis_max_total_bounds = 2147483647
+    if total_bounds > geotrellis_max_total_bounds or file_stats.st_size > max_tif_size_bytes:
+        return True
+    return False
+
+
+def split_tif(tif_path, temp_directory, split_width_pixels=12000, split_height_pixels=12000):
+    """Function to split a tif into multiple, tiled tifs based on arguments
+
+    Args:
+        tif_path (str): path to tif to split
+        temp_directory (str): directory to put tiled tifs
+        split_width_pixels (int): optional width (in pixels) to create tiles
+        split_height_pixels (int): optional height (in pixels) to create tiles
+
+    Returns:
+        list[str]
+    """
+    logger.info('Created directory %s to split files', temp_directory)
+    command = ['gdal_retile.py',
+               '-co', 'COMPRESS=LZW',
+               '-co', 'TILED=YES',
+               '-overlap', '100',
+               '-ps', str(split_width_pixels), str(split_height_pixels),
+               '-targetDir', temp_directory,
+               tif_path]
+
+    logger.info('Splitting tif using gdal_retile.py with the following command: %s', ' '.join(command))
+    subprocess.check_call(command)
+    filepaths = [os.path.join(temp_directory, f) for f in os.listdir(temp_directory)]
+
+    logger.info('Created %s new files', len(filepaths))
+    return filepaths
+
+
+def upload_split_files(source_key, source_bucket_name, filepaths):
+    """Uploads a list of split files to S3 in sub-folder under the source-key
+
+    If there is a key such as 'really-big-file.tif' that is split into multiple tiles,
+    the tiles will be uploaded to 'really-big-file.tif-split-files/<files>'
+
+    Returns a list[(str, str)] where the first element in the tuple is the s3 key and the second
+    is the local filepath of the tif
+
+    Args:
+        source_key (str): key of file that has been split
+        source_bucket_name (str): bucket that original file came from and new file will be uploaded to
+        filepaths (list[str]): split files to be uploaded
+
+    Returns:
+        list[(str, str)]
+    """
+    splits_s3_dir = '{}-split-files/'.format(source_key)
+    logger.info('Uploading split files to s3://%s/%s', source_bucket_name, splits_s3_dir)
+
+    keys_and_filepaths = []
+
+    for filepath in filepaths:
+        filename = os.path.split(filepath)[-1]
+        s3 = boto3.resource('s3')
+        bucket = s3.Bucket(source_bucket_name)
+        key = os.path.join(splits_s3_dir, filename)
+
+        logger.debug('Uploading to s3 %s => s3://%s/%s', bucket, key)
+
+        bucket.upload_file(filepath, key)
+        keys_and_filepaths.append((key, filepath))
+
+    logger.info('Finished uploading files')
+    return keys_and_filepaths

--- a/app-tasks/rf/src/rf/uploads/geotiff/utils.py
+++ b/app-tasks/rf/src/rf/uploads/geotiff/utils.py
@@ -23,8 +23,8 @@ def is_tif_too_large(tif_path):
     with rasterio.open(tif_path) as src:
         total_bounds = src.width * src.height
 
-    max_tif_size_bytes = 1000000000
-    geotrellis_max_total_bounds = 2147483647
+    max_tif_size_bytes = 1e9
+    geotrellis_max_total_bounds = 2**31 - 1
     if total_bounds > geotrellis_max_total_bounds or file_stats.st_size > max_tif_size_bytes:
         return True
     return False


### PR DESCRIPTION
## Overview

This PR adds support for splitting tifs larger than 1GB. Files are split into
12,000 x 12,000 tiles using the `gdal_retile.py` command. These smaller tifs are
still associated with a single scene.

In the process of doing this sources in the ingest definition now exclude extents,
instead the ingest process now relies on reading tiff tags to get the extent of
incoming files.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~

### Notes

Had to update the airflow container dockerfile to install gdal from the `sid` package repositories in order to get the most up to date version of gdal that allowed specifying overlap in the generated tiles.

## Testing Instructions

 - Rebuild airflow container
`docker-compose -f docker-compose.test.yml build airflow`
 - Start server, frontend, and airflow containers
 - Upload a larger than 1 GB tiff and verify that it gets split
 - Verify that upload splits files (should go in subfolder on S3 of original file)
 - Verify that ingest works correctly


Closes #2144 
