### PR TITLE
Remove extra export options

### DIFF
--- a/app-frontend/src/app/core/services/project.service.js
+++ b/app-frontend/src/app/core/services/project.service.js
@@ -47,7 +47,6 @@ export default (app) => {
             this.tokenService = tokenService;
             this.authService = authService;
             this.statusService = statusService;
-            this.exportType = 'S3';
             this.$http = $http;
             this.$location = $location;
             this.$q = $q;
@@ -169,7 +168,7 @@ export default (app) => {
             const defaultSettings = {
                 projectId: project.id,
                 exportStatus: 'NOTEXPORTED',
-                exportType: this.exportType ? this.exportType : 'S3',
+                exportType: 'S3',
                 visibility: 'PRIVATE',
                 exportOptions: finalOptions
             };

--- a/app-frontend/src/app/pages/projects/edit/export/export.html
+++ b/app-frontend/src/app/pages/projects/edit/export/export.html
@@ -77,23 +77,6 @@
     </div>
     <i class="icon-info"></i>
   </li>
-  <li class="separator">
-    <span class="label">Export type</span>
-    <div class="dropdown btn-group fixedwidth" uib-dropdown uib-dropdown-toggle>
-      <a class="btn dropdown-label" >
-       {{$ctrl.exportType.label}}
-      </a>
-      <button type="button" class="btn btn-default dropdown-toggle">
-        <i class="icon-caret-down"></i>
-      </button>
-      <ul class="dropdown-menu dropdown-menu-light" uib-dropdown-menu role="menu">
-        <li ng-repeat="exportType in $ctrl.exportTypes" rol="menuitem">
-          <a ng-click="$ctrl.onExportTypeChange(exportType)">{{exportType.label}}</a>
-        </li>
-      </ul>
-    </div>
-    <i class="icon-info"></i>
-  </li>
 </ul>
 <div class="sidebar-content" ng-if="$ctrl.project">
   <button class="btn btn-primary btn-block" type="button" ng-click="$ctrl.startExport()" ng-if="!$ctrl.isExporting" ng-disabled="!$ctrl.validate()">


### PR DESCRIPTION
## Overview

There are now 3 options for exports: Download, S3 (requires path), and Dropbox

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~

### Demo

![image](https://user-images.githubusercontent.com/4392704/28187296-3ab50c6c-67ec-11e7-84cf-644237e34f00.png)

## Testing Instructions

 * Verify that the 3 options send the correct payload: type and source should correspond to the selection.
Closes #2176
