### PR TITLE
Tune Slick/Hikari database configuration

### DIFF
--- a/app-backend/database/src/main/scala/com/azavea/rf/database/Database.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/Database.scala
@@ -11,6 +11,8 @@ import com.zaxxer.hikari.{HikariConfig, HikariDataSource}
   * @param dbPassword password to use to authenticate user
   */
 class Database(jdbcUrl: String, dbUser: String, dbPassword: String) {
+  private val slickThreadCount = 5
+  private val slickQueueSize = 1000
 
   private val hikariConfig = new HikariConfig()
   // This property is now being manually set because it seemed not
@@ -20,7 +22,13 @@ class Database(jdbcUrl: String, dbUser: String, dbPassword: String) {
   hikariConfig.setJdbcUrl(jdbcUrl)
   hikariConfig.setUsername(dbUser)
   hikariConfig.setPassword(dbPassword)
-  hikariConfig.setLeakDetectionThreshold(3000L)
+  hikariConfig.setConnectionTimeout(1000)
+  hikariConfig.setValidationTimeout(1000)
+  hikariConfig.setIdleTimeout(600000)
+  hikariConfig.setMaxLifetime(1800000)
+  hikariConfig.setLeakDetectionThreshold(0)
+  hikariConfig.setMaximumPoolSize(slickThreadCount * 5)
+  hikariConfig.setMinimumIdle(slickThreadCount)
 
   private val dataSource = new HikariDataSource(hikariConfig)
 
@@ -34,7 +42,7 @@ class Database(jdbcUrl: String, dbUser: String, dbPassword: String) {
   import driver.api._
 
   val db = {
-    val executor = AsyncExecutor("slick", numThreads=5, queueSize=1000)
+    val executor = AsyncExecutor("slick", numThreads=slickThreadCount, queueSize=slickQueueSize)
     driver.api.Database.forDataSource(dataSource, executor)
   }
 }


### PR DESCRIPTION
## Overview

Using the contents of `HikariCPJdbcDataSource` as a starting point, extract what seem like the most important settings, and apply them to our database configuration.

The constant 5 multiplied to slickThreadCount for Hikari pool size mimics the formula used inside of `HikariCPJdbcDataSource`.

## Testing Instructions

Compare settings in this branch against those in [HikariCPJdbcDataSource.scala](https://github.com/slick/slick/blob/3.1.1/slick-hikaricp/src/main/scala/slick/jdbc/hikaricp/HikariCPJdbcDataSource.scala). Also, ensure that `server` still works as expected locally.