### PR TITLE
[Experiment] Add a blocking thread pool for blocking Futures

### DIFF
--- a/app-backend/common/src/main/scala/cache/HeapBackedMemcachedClient.scala
+++ b/app-backend/common/src/main/scala/cache/HeapBackedMemcachedClient.scala
@@ -58,7 +58,7 @@ class HeapBackedMemcachedClient(
     * @param mappingFunction  the function to compute a value
     * @return the current (existing or computed) value associated with the specified key
     */
-  def caching[T](cacheKey: String)(mappingFunction: ExecutionContext => Future[T])(implicit ec: ExecutionContext): Future[T] = {
+  def caching[T](cacheKey: String)(mappingFunction: ExecutionContext => Future[T]): Future[T] = {
     if(options.enabled) {
       val sanitizedKey = HeapBackedMemcachedClient.sanitizeKey(cacheKey)
       if(options.heapEnabled) {
@@ -68,10 +68,10 @@ class HeapBackedMemcachedClient(
       } else {
         client.getOrElseUpdate[T](sanitizedKey, mappingFunction(options.ec), options.memcachedTTL)(options.ec)
       }
-    } else mappingFunction(ec)
+    } else mappingFunction(options.ec)
   }
 
-  def cachingOptionT[T](cacheKey: String)(mappingFunction: ExecutionContext => OptionT[Future, T])(implicit ec: ExecutionContext): OptionT[Future, T] = {
+  def cachingOptionT[T](cacheKey: String)(mappingFunction: ExecutionContext => OptionT[Future, T]): OptionT[Future, T] = {
     if(options.enabled) {
       val sanitizedKey = HeapBackedMemcachedClient.sanitizeKey(cacheKey)
       val futureOption =
@@ -84,7 +84,7 @@ class HeapBackedMemcachedClient(
         }
 
       OptionT(futureOption)
-    } else mappingFunction(ec)
+    } else mappingFunction(options.ec)
   }
 }
 

--- a/app-backend/common/src/main/scala/cache/HeapBackedMemcachedClient.scala
+++ b/app-backend/common/src/main/scala/cache/HeapBackedMemcachedClient.scala
@@ -58,7 +58,7 @@ class HeapBackedMemcachedClient(
     * @param mappingFunction  the function to compute a value
     * @return the current (existing or computed) value associated with the specified key
     */
-  def caching[T](cacheKey: String)(mappingFunction: ExecutionContext => Future[T]): Future[T] = {
+  def caching[T](cacheKey: String)(mappingFunction: ExecutionContext => Future[T])(implicit ec: ExecutionContext): Future[T] = {
     if(options.enabled) {
       val sanitizedKey = HeapBackedMemcachedClient.sanitizeKey(cacheKey)
       if(options.heapEnabled) {
@@ -68,10 +68,10 @@ class HeapBackedMemcachedClient(
       } else {
         client.getOrElseUpdate[T](sanitizedKey, mappingFunction(options.ec), options.memcachedTTL)(options.ec)
       }
-    } else mappingFunction(options.ec)
+    } else mappingFunction(ec)
   }
 
-  def cachingOptionT[T](cacheKey: String)(mappingFunction: ExecutionContext => OptionT[Future, T]): OptionT[Future, T] = {
+  def cachingOptionT[T](cacheKey: String)(mappingFunction: ExecutionContext => OptionT[Future, T])(implicit ec: ExecutionContext): OptionT[Future, T] = {
     if(options.enabled) {
       val sanitizedKey = HeapBackedMemcachedClient.sanitizeKey(cacheKey)
       val futureOption =
@@ -84,7 +84,7 @@ class HeapBackedMemcachedClient(
         }
 
       OptionT(futureOption)
-    } else mappingFunction(options.ec)
+    } else mappingFunction(ec)
   }
 }
 

--- a/app-backend/tile/src/main/resources/application.conf
+++ b/app-backend/tile/src/main/resources/application.conf
@@ -13,7 +13,7 @@ tile-server {
 }
 
 akka {
-  loglevel = "DEBUG"
+  loglevel = "ALL"
 }
 
 blocking-io-dispatcher {

--- a/app-backend/tile/src/main/resources/application.conf
+++ b/app-backend/tile/src/main/resources/application.conf
@@ -12,11 +12,15 @@ tile-server {
   cache.enabled = ${?TILESERVER_CACHE_ENABLED}
 }
 
+akka {
+  loglevel = "DEBUG"
+}
+
 blocking-io-dispatcher {
   type = Dispatcher
   executor = "thread-pool-executor"
   thread-pool-executor {
-    fixed-pool-size = 32
+    fixed-pool-size = 16
   }
   throughput = 1
 }

--- a/app-backend/tile/src/main/resources/application.conf
+++ b/app-backend/tile/src/main/resources/application.conf
@@ -12,15 +12,13 @@ tile-server {
   cache.enabled = ${?TILESERVER_CACHE_ENABLED}
 }
 
-akka {
-  blocking-scene-routes-dispatcher {
-    type = Dispatcher
-    executor = "thread-pool-executor"
-    thread-pool-executor {
-      fixed-pool-size = 32
-    }
-    throughput = 2 # in order not to blow java heap, can be increased
+blocking-io-dispatcher {
+  type = Dispatcher
+  executor = "thread-pool-executor"
+  thread-pool-executor {
+    fixed-pool-size = 32
   }
+  throughput = 1
 }
 
 kamon {

--- a/app-backend/tile/src/main/resources/application.conf
+++ b/app-backend/tile/src/main/resources/application.conf
@@ -12,6 +12,17 @@ tile-server {
   cache.enabled = ${?TILESERVER_CACHE_ENABLED}
 }
 
+akka {
+  blocking-scene-routes-dispatcher {
+    type = Dispatcher
+    executor = "thread-pool-executor"
+    thread-pool-executor {
+      fixed-pool-size = 32
+    }
+    throughput = 2 # in order not to blow java heap, can be increased
+  }
+}
+
 kamon {
   metric {
     filters {

--- a/app-backend/tile/src/main/resources/application.conf
+++ b/app-backend/tile/src/main/resources/application.conf
@@ -13,7 +13,7 @@ tile-server {
 }
 
 akka {
-  loglevel = "ALL"
+  loglevel = "ERROR"
 }
 
 blocking-io-dispatcher {

--- a/app-backend/tile/src/main/scala/LayerCache.scala
+++ b/app-backend/tile/src/main/scala/LayerCache.scala
@@ -87,7 +87,7 @@ object LayerCache extends Config with LazyLogging with KamonTrace {
       )
     }
 
-  def layerHistogram(layerId: UUID, zoom: Int)(implicit ec: ExecutionContext): OptionT[Future, Array[Histogram[Double]]] =
+  def layerHistogram(layerId: UUID, zoom: Int): OptionT[Future, Array[Histogram[Double]]] =
     traceName(s"LayerCache.layerHistogram($layerId)") {
       histogramCache.cachingOptionT(s"histogram-$layerId-$zoom") { implicit ec =>
         attributeStoreForLayer(layerId).map { store =>
@@ -98,7 +98,7 @@ object LayerCache extends Config with LazyLogging with KamonTrace {
       }
     }
 
-  def layerTile(layerId: UUID, zoom: Int, key: SpatialKey)(implicit ec: ExecutionContext): OptionT[Future, MultibandTile] =
+  def layerTile(layerId: UUID, zoom: Int, key: SpatialKey): OptionT[Future, MultibandTile] =
     traceName(s"LayerCache.layerTile($layerId)") {
       tileCache.cachingOptionT(s"tile-$layerId-$zoom-${key.col}-${key.row}") { implicit ec =>
         attributeStoreForLayer(layerId).mapFilter { store =>
@@ -118,7 +118,7 @@ object LayerCache extends Config with LazyLogging with KamonTrace {
       }
     }
 
-  def layerTileForExtent(layerId: UUID, zoom: Int, extent: Extent)(implicit ec: ExecutionContext): OptionT[Future, MultibandTile] =
+  def layerTileForExtent(layerId: UUID, zoom: Int, extent: Extent): OptionT[Future, MultibandTile] =
     traceName(s"LayerCache.layerTileForExtent($layerId)") {
       tileCache.cachingOptionT(s"extent-tile-$layerId-$zoom-$extent") { implicit ec =>
         attributeStoreForLayer(layerId).mapFilter { store =>
@@ -150,7 +150,7 @@ object LayerCache extends Config with LazyLogging with KamonTrace {
     subNode: Option[UUID],
     user: User,
     voidCache: Boolean = false
-  )(implicit ec: ExecutionContext): OptionT[Future, Histogram[Double]] = traceName(s"LayerCache.modelLayerGlobalHistogram($toolRunId)") {
+  ): OptionT[Future, Histogram[Double]] = traceName(s"LayerCache.modelLayerGlobalHistogram($toolRunId)") {
     val cacheKey = s"histogram-${toolRunId}-${subNode}-${user.id}"
 
     if (voidCache) histogramCache.delete(cacheKey)
@@ -185,7 +185,7 @@ object LayerCache extends Config with LazyLogging with KamonTrace {
     toolRunId: UUID,
     user: User,
     voidCache: Boolean = false
-  )(implicit ec: ExecutionContext): OptionT[Future, (Tool.WithRelated, ToolRun)] =
+  ): OptionT[Future, (Tool.WithRelated, ToolRun)] =
     traceName(s"LayerCache.toolAndToolRun($toolRunId)") {
       astCache.cachingOptionT(s"tool+run-$toolRunId-${user.id}") { implicit ec =>
         traceName(s"LayerCache.toolAndToolRun($toolRunId) (no cache)") {
@@ -205,7 +205,7 @@ object LayerCache extends Config with LazyLogging with KamonTrace {
     subNode: Option[UUID],
     user: User,
     voidCache: Boolean = false
-  )(implicit ec: ExecutionContext): OptionT[Future, (MapAlgebraAST, EvalParams)] =
+  ): OptionT[Future, (MapAlgebraAST, EvalParams)] =
     traceName(s"LayerCache.toolEvalRequirements($toolRunId)") {
       val cacheKey = s"ast+params-$toolRunId-${subNode}-${user.id}"
       if (voidCache) histogramCache.delete(cacheKey)
@@ -251,7 +251,7 @@ object LayerCache extends Config with LazyLogging with KamonTrace {
     subNode: Option[UUID],
     user: User,
     voidCache: Boolean = false
-  )(implicit ec: ExecutionContext): OptionT[Future, ColorMap] = traceName(s"LayerCache.toolRunColorMap($toolRunId)") {
+  ): OptionT[Future, ColorMap] = traceName(s"LayerCache.toolRunColorMap($toolRunId)") {
     val cacheKey = s"colormap-$toolRunId-${subNode}-${user.id}"
     if (voidCache) astCache.delete(cacheKey)
     astCache.cachingOptionT(cacheKey) { implicit ec =>

--- a/app-backend/tile/src/main/scala/Router.scala
+++ b/app-backend/tile/src/main/scala/Router.scala
@@ -19,11 +19,7 @@ class Router extends LazyLogging
 
   implicit val defaultDespatcher = system.dispatchers.defaultGlobalDispatcher
 
-  lazy val blockingMosaicRoutesDispatcher =
-    system.dispatchers.lookup("blocking-io-dispatcher")
   lazy val blockingSceneRoutesDispatcher =
-    system.dispatchers.lookup("blocking-io-dispatcher")
-  lazy val blockingToolRoutesDispatcher =
     system.dispatchers.lookup("blocking-io-dispatcher")
 
   val toolRoutes = new ToolRoutes()
@@ -35,7 +31,7 @@ class Router extends LazyLogging
       pathPrefix("tiles") {
         pathPrefix(JavaUUID) { projectId =>
           tileAccessAuthorized(projectId) {
-            case true => MosaicRoutes.mosaicProject(projectId)(database, blockingMosaicRoutesDispatcher)
+            case true => MosaicRoutes.mosaicProject(projectId)
             case _ => reject(AuthorizationFailedRejection)
           }
         } ~
@@ -52,7 +48,7 @@ class Router extends LazyLogging
         pathPrefix("tools") {
           get {
             tileAuthenticateOption { _ =>
-              TileSources.root(toolRoutes)(database, blockingToolRoutesDispatcher)
+              TileSources.root(toolRoutes)
             }
           }
         }

--- a/app-backend/tile/src/main/scala/Router.scala
+++ b/app-backend/tile/src/main/scala/Router.scala
@@ -17,6 +17,8 @@ class Router extends LazyLogging
   implicit lazy val database = Database.DEFAULT
   implicit val system = AkkaSystem.system
   implicit val materializer = AkkaSystem.materializer
+  lazy val blockingSceneRoutesDispatcher =
+    system.dispatchers.lookup("blocking-scene-routes-dispatcher")
 
   val toolRoutes = new ToolRoutes()
 
@@ -39,7 +41,7 @@ class Router extends LazyLogging
           }
         } ~
         tileAuthenticateOption { _ =>
-          SceneRoutes.root
+          SceneRoutes.root(blockingSceneRoutesDispatcher)
         } ~
         pathPrefix("tools") {
           get {

--- a/app-backend/tile/src/main/scala/StitchLayer.scala
+++ b/app-backend/tile/src/main/scala/StitchLayer.scala
@@ -16,7 +16,6 @@ import cats.implicits._
 
 import java.util.UUID
 import scala.concurrent._
-import scala.concurrent.ExecutionContext.Implicits.global
 import scala.util.{Failure, Success, Try}
 
 object StitchLayer extends LazyLogging with Config {
@@ -36,9 +35,9 @@ object StitchLayer extends LazyLogging with Config {
     * For non-cached version use [[stitch]] function.
     */
   val stitchCache = HeapBackedMemcachedClient(memcachedClient)
-  def apply(id: UUID, size: Int)(implicit sceneIds: Set[UUID]): OptionT[Future, MultibandTile] =
+  def apply(id: UUID, size: Int)(implicit ec: ExecutionContext): OptionT[Future, MultibandTile] =
     stitchCache.cachingOptionT(s"stitch-{$size}") { implicit ec =>
-      LayerCache.attributeStoreForLayer(id).mapFilter { case (store, _) =>
+      LayerCache.attributeStoreForLayer(id).mapFilter { store =>
         stitch(store, id.toString, size)
       }
     }

--- a/app-backend/tile/src/main/scala/image/GlobalSummary.scala
+++ b/app-backend/tile/src/main/scala/image/GlobalSummary.scala
@@ -54,10 +54,10 @@ object GlobalSummary extends LazyLogging {
   def minAcceptableProjectZoom(
     projId: UUID,
     size: Int = 512
-  )(implicit database: Database, ec: ExecutionContext, sceneIds: Set[UUID]): OptionT[Future, (Extent, Int)] =
+  )(implicit database: Database, ec: ExecutionContext): OptionT[Future, (Extent, Int)] =
     Mosaic.mosaicDefinition(projId, None).semiflatMap({ mosaic =>
       Future.sequence(mosaic.map { case MosaicDefinition(sceneId, _) =>
-        LayerCache.attributeStoreForLayer(sceneId).mapFilter { case (store, _) =>
+        LayerCache.attributeStoreForLayer(sceneId).mapFilter { store =>
           minAcceptableSceneZoom(sceneId, store, 256)
         }.value
       })

--- a/app-backend/tile/src/main/scala/routes/SceneRoutes.scala
+++ b/app-backend/tile/src/main/scala/routes/SceneRoutes.scala
@@ -27,11 +27,11 @@ import scala.util._
 
 object SceneRoutes extends LazyLogging with KamonTraceDirectives {
 
-  def root(implicit blockingDispatcher: MessageDispatcher): Route =
+  def root(implicit dispatcher: MessageDispatcher): Route =
     pathPrefix(JavaUUID) { id =>
       pathPrefix("rgb") {
         traceName("rgb") {
-          layerTileAndHistogram(id) { (futureMaybeTile, _) =>
+          layerTileAndHistogram(id)(implicitly[ExecutionContext]) { (futureMaybeTile, _) =>
             imageRoute(futureMaybeTile)
           }
         } ~
@@ -67,17 +67,15 @@ object SceneRoutes extends LazyLogging with KamonTraceDirectives {
       }
     }
 
-  def layerTile(layer: UUID) =
+  def layerTile(layer: UUID)(implicit ec: ExecutionContext) =
     pathPrefix(IntNumber / IntNumber / IntNumber).tmap[Future[Option[MultibandTile]]] {
       case (zoom: Int, x: Int, y: Int) =>
-        implicit val sceneIds = Set(layer)
         LayerCache.layerTile(layer, zoom, SpatialKey(x, y)).value
     }
 
-  def layerTileAndHistogram(id: UUID) =
+  def layerTileAndHistogram(id: UUID)(implicit ec: ExecutionContext) =
     pathPrefix(IntNumber / IntNumber / IntNumber).tmap[(OptionT[Future, MultibandTile], OptionT[Future, Array[Histogram[Double]]])] {
       case (zoom: Int, x: Int, y: Int) =>
-        implicit val sceneIds = Set(id)
         val futureMaybeTile = LayerCache.layerTile(id, zoom, SpatialKey(x, y))
         val futureHistogram = LayerCache.layerHistogram(id, zoom)
         (futureMaybeTile, futureHistogram)
@@ -86,10 +84,9 @@ object SceneRoutes extends LazyLogging with KamonTraceDirectives {
   def pngAsHttpResponse(png: Png): HttpResponse =
     HttpResponse(entity = HttpEntity(ContentType(MediaTypes.`image/png`), png.bytes))
 
-  def imageThumbnailRoute(id: UUID)(implicit blockingDispatcher: MessageDispatcher) =
+  def imageThumbnailRoute(id: UUID)(implicit dispatcher: MessageDispatcher) =
     parameters('size.as[Int].?(256)) { size =>
       complete {
-        implicit val sceneIds = Set(id)
         val futureMaybeTile = StitchLayer(id, size)
         val futureResponse =
           for {
@@ -109,10 +106,9 @@ object SceneRoutes extends LazyLogging with KamonTraceDirectives {
       }
     }
 
-  def imageHistogramRoute(id: UUID)(implicit blockingDispatcher: MessageDispatcher) = {
+  def imageHistogramRoute(id: UUID)(implicit dispatcher: MessageDispatcher) = {
     import DefaultJsonProtocol._
     complete {
-      implicit val sceneIds = Set(id)
       val futureResponse =
         for {
           hist <- LayerCache.layerHistogram(id, 0).value
@@ -130,7 +126,7 @@ object SceneRoutes extends LazyLogging with KamonTraceDirectives {
     }
   }
 
-  def imageRoute(futureMaybeTile: OptionT[Future, MultibandTile])(implicit blockingDispatcher: MessageDispatcher): Route =
+  def imageRoute(futureMaybeTile: OptionT[Future, MultibandTile])(implicit dispatcher: MessageDispatcher): Route =
     complete {
       val futureResponse =
         for {
@@ -154,7 +150,7 @@ object SceneRoutes extends LazyLogging with KamonTraceDirectives {
     index: MultibandTile => Tile,
     defaultColorRamp: Option[ColorRamp] = None,
     defaultBreaks: Option[Array[Double]] = None
-  )(implicit blockingDispatcher: MessageDispatcher): Route = {
+  )(implicit dispatcher: MessageDispatcher): Route = {
     toolParams(defaultColorRamp, defaultBreaks) { params =>
       complete {
         val future =


### PR DESCRIPTION
## Overview

- [x] Remove useless `implicit sceneIds: Set[UUID]` params (added a special function to get attr store without zooms, created a separate cached for it, in order not to break approach).
- [x] Remove all `blocking {}` function calls
- [x] Remove global execution context usages

Reason: http://doc.akka.io/docs/akka-http/current/scala/http/handling-blocking-operations-in-akka-http-routes.html

## Testing instructions

Visit projects list page (there should be more than one projects for better experience), after that go on a project page, tiles should load without any delay.