### PR TITLE
Include scene post body params

### DIFF
--- a/docs/swagger/spec.yml
+++ b/docs/swagger/spec.yml
@@ -2974,8 +2974,6 @@ definitions:
         source:
           type: string
           description: for uploads of type S3 and Dropbox, the location of the files to import. If files are specified, this field is ignored
-        sceneMetadata:
-          $ref: '#/definitions/UploadMetadata'
   Upload:
     allOf:
     - $ref: '#/definitions/BaseModel'
@@ -2989,15 +2987,6 @@ definitions:
             type: string
         metadata:
           type: object
-  UploadMetadata:
-    type: object
-    properties:
-      sceneCloudCover:
-        type: number
-        format: float32
-      sceneAcquisitionDate:
-        type: string
-        format: datetime
   UploadPaginated:
     allOf:
     - $ref: '#/definitions/PaginatedResponse'

--- a/docs/swagger/spec.yml
+++ b/docs/swagger/spec.yml
@@ -4,7 +4,7 @@ info:
   description: An application to find, view, and analyze geospatial data at any scale
   version: "0.1.0"
 
-host: localhost:9000
+host: app.rasterfoundry.com
 
 schemes:
   - http
@@ -497,6 +497,12 @@ paths:
       summary: Create a scene
       tags:
         - Imagery
+      parameters:
+        - name: scene
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/Scene'
       responses:
         201:
           description: Successfully created a new scene
@@ -2968,6 +2974,8 @@ definitions:
         source:
           type: string
           description: for uploads of type S3 and Dropbox, the location of the files to import. If files are specified, this field is ignored
+        sceneMetadata:
+          $ref: '#/definitions/UploadMetadata'
   Upload:
     allOf:
     - $ref: '#/definitions/BaseModel'
@@ -2981,6 +2989,15 @@ definitions:
             type: string
         metadata:
           type: object
+  UploadMetadata:
+    type: object
+    properties:
+      sceneCloudCover:
+        type: number
+        format: float32
+      sceneAcquisitionDate:
+        type: string
+        format: datetime
   UploadPaginated:
     allOf:
     - $ref: '#/definitions/PaginatedResponse'
@@ -3096,7 +3113,6 @@ definitions:
   CombinedSceneQueryParams:
     type: object
     description: Combined query parameters for filtering scenes
-    discriminator: type
     properties:
       orgParams:
         $ref: '#/definitions/OrgParams'


### PR DESCRIPTION
## Overview

This PR includes post body parameters for posting to `/scenes/` and removes
an erroneous `discriminator` on `CombinedSceneQueryParams`. These are necessary
for the docs site to understand what's going on with scenes and for `bravado` to construct
`post_scenes` calls correctly in the python client.

### Checklist

- ~Styleguide updated, if necessary~
- [x] Swagger specification updated, if necessary
- ~Symlinks from new migrations present or corrected for any new migrations~

## Testing Instructions

 * Tested as azavea/raster-foundry-python-client/pull/13

Closes #2262 
