### PR TITLE
WIP: Add JMX remote support to API and tile server

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -45,6 +45,10 @@ Vagrant.configure(2) do |config|
   config.vm.network :forwarded_port, guest: 8181, host: Integer(ENV.fetch("RF_PORT_8181", 8181))
   # grafana ui
   config.vm.network :forwarded_port, guest: 3000, host: Integer(ENV.fetch("RF_PORT_4040", 3000))
+  # jmx api
+  config.vm.network :forwarded_port, guest: 9010, host: Integer(ENV.fetch("RF_PORT_9010", 9010))
+  # jmx tile
+  config.vm.network :forwarded_port, guest: 9020, host: Integer(ENV.fetch("RF_PORT_9020", 9020))
 
   config.vm.provider :virtualbox do |vb|
     vb.memory = 8096

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,6 +60,7 @@ services:
     env_file: .env
     ports:
       - "9000:9000"
+      - "9010:9010"
     volumes:
       - ./app-backend/:/opt/raster-foundry/app-backend/
       - ./.sbt:/root/.sbt
@@ -69,7 +70,15 @@ services:
     environment:
       - AIRFLOW_SERVER_LOCATION=http://airflow.service.rasterfoundry.internal:8080
     entrypoint: ./sbt
-    command: api/run
+    command:
+      - "api/run"
+      - "-Dcom.sun.management.jmxremote.rmi.port=9010"
+      - "-Dcom.sun.management.jmxremote=true"
+      - "-Dcom.sun.management.jmxremote.port=9010"
+      - "-Dcom.sun.management.jmxremote.ssl=false"
+      - "-Dcom.sun.management.jmxremote.authenticate=false"
+      - "-Dcom.sun.management.jmxremote.local.only=false"
+      - "-Djava.rmi.server.hostname=localhost"
 
   tile-server:
     image: openjdk:8-jre
@@ -81,6 +90,7 @@ services:
     env_file: .env
     ports:
       - "9900:9900"
+      - "9020:9020"
     volumes:
       - ./app-backend/:/opt/raster-foundry/app-backend/
       - ./.sbt:/root/.sbt
@@ -88,4 +98,12 @@ services:
       - $HOME/.aws:/root/.aws:ro
     working_dir: /opt/raster-foundry/app-backend/
     entrypoint: ./sbt
-    command: tile/run
+    command:
+      - "tile/run"
+      - "-Dcom.sun.management.jmxremote.rmi.port=9020"
+      - "-Dcom.sun.management.jmxremote=true"
+      - "-Dcom.sun.management.jmxremote.port=9020"
+      - "-Dcom.sun.management.jmxremote.ssl=false"
+      - "-Dcom.sun.management.jmxremote.authenticate=false"
+      - "-Dcom.sun.management.jmxremote.local.only=false"
+      - "-Djava.rmi.server.hostname=localhost"


### PR DESCRIPTION
## Overview

Expose port 9010 (API) and 9020 (tile) all the way outside of the virtual machine. From there, VisualVM can be used to connect to the running JVM via a remote JMX connection.

## Testing Instructions

Reload the Vagrant environment to ensure that the port forwarding rules are applied. Then, open VisualVM and navigate to `File > Add JMX Connection`. Enter `localhost:9020` to connect to the running tile server JVM.