### PR TITLE
Change default basemap to light/positron

### DIFF
--- a/app-frontend/config/webpack/global.js
+++ b/app-frontend/config/webpack/global.js
@@ -64,7 +64,7 @@ const basemaps = JSON.stringify({
             }
         }
     },
-    default: 'Aerial'
+    default: 'Light'
 });
 
 module.exports = function (_path) {


### PR DESCRIPTION
## Overview

Change default basemap to light/positron

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~

### Demo

<img width="1680" alt="screen shot 2017-07-18 at 4 19 37 pm" src="https://user-images.githubusercontent.com/16109558/28337850-f5def458-6bd4-11e7-8150-cc6e3d70d8d1.png">


## Testing Instructions

 * Ctrl-C from yarn
 * yarn dev
 * Go to a project or create a new one
 * Check if the basemap is in light/positron mode

Closes #2174 
