### PR TITLE
Change edit to view on project list and link thumbnails to edit page

### DIFF
--- a/app-frontend/src/app/components/projects/projectItem/projectItem.html
+++ b/app-frontend/src/app/components/projects/projectItem/projectItem.html
@@ -8,26 +8,32 @@
       <div class="column-12">
 
         <!-- IF project has no scenes -->
-        <div class="project-preview-container placeholder"
-             ng-if="!$ctrl.project.scenes"
-             style="background-image: url({{$ctrl.projectPlaceholder}})">
-          <span>This project doesn't have any scenes yet</span>
-        </div>
+        <a ui-sref="projects.edit({projectid: $ctrl.project.id})" style="text-decoration: none">
+          <div class="project-preview-container placeholder"
+               ng-if="!$ctrl.project.scenes"
+               style="background-image: url({{$ctrl.projectPlaceholder}})">
+            <span>This project doesn't have any scenes yet</span>
+          </div>
+        </a>
 
          <!-- IF not all scenes ingested: -->
-        <div class="project-preview-container placeholder"
-             ng-if="$ctrl.project.scenes && $ctrl.status !== 'CURRENT'"
-             style="background-image: url({{$ctrl.projectPlaceholder}})">
-             <span>Preview unavailable</span>
-        </div>
+        <a ui-sref="projects.edit({projectid: $ctrl.project.id})" style="text-decoration: none">
+          <div class="project-preview-container placeholder"
+               ng-if="$ctrl.project.scenes && $ctrl.status !== 'CURRENT'"
+               style="background-image: url({{$ctrl.projectPlaceholder}})">
+               <span>Preview unavailable</span>
+          </div>
+        </a>
 
         <!-- IF using a project's thumbnail: -->
-        <div class="project-preview-container placeholder"
-             ng-if="$ctrl.project.scenes && $ctrl.thumbnailUrl && $ctrl.status === 'CURRENT'"
-             style="background-image: url({{$ctrl.projectPlaceholder}})">
-          <div class="thumbnail"
-               style="background-image: url({{$ctrl.thumbnailUrl}})"></div>
-        </div>
+        <a ui-sref="projects.edit({projectid: $ctrl.project.id})" style="text-decoration: none">
+          <div class="project-preview-container placeholder"
+               ng-if="$ctrl.project.scenes && $ctrl.thumbnailUrl && $ctrl.status === 'CURRENT'"
+               style="background-image: url({{$ctrl.projectPlaceholder}})">
+            <div class="thumbnail"
+                 style="background-image: url({{$ctrl.thumbnailUrl}})"></div>
+          </div>
+        </a>
       </div>
     </div>
     <div class="row">
@@ -44,7 +50,7 @@
       </div>
       <div class="column-6 text-right">
         <a class="btn btn-default" ui-sref="projects.edit({projectid: $ctrl.project.id})">
-          Edit
+          View
         </a>
         <div uib-dropdown ng-if="!$ctrl.isSelectable">
           <button type="button" class="btn btn-default" uib-dropdown-toggle>


### PR DESCRIPTION
## Overview

This PR made changes on project list page.  Buttons are "View" instead of "Edit" now. Clicking on project thumbnails will go to project edit page.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~

### Demo

<img width="1680" alt="screen shot 2017-07-18 at 4 26 28 pm" src="https://user-images.githubusercontent.com/16109558/28338109-e07d6864-6bd5-11e7-8439-06a175993f20.png">


## Testing Instructions

 * Go to the project list page
 * Check if the buttons say "View", and will direct to project edit page
 * Click on thumbnails (no scene projects, uningested scene project, or ingested scene project), check if it goes to project edit page

Closes #2251 
