### PR TITLE
Angular Service to Query Planet API

### DIFF
--- a/app-frontend/src/app/services/services.module.js
+++ b/app-frontend/src/app/services/services.module.js
@@ -17,6 +17,7 @@ require('./settings/featureFlag.directive')(shared);
 require('./vendor/rollbarWrapper.service')(shared);
 require('./vendor/dropbox.service')(shared);
 require('./vendor/intercom.service')(shared);
+require('./vendor/planetLabs.service.js')(shared);
 require('./vendor/aws-sdk-s3.module.js');
 
 // projects

--- a/app-frontend/src/app/services/vendor/planetLabs.service.js
+++ b/app-frontend/src/app/services/vendor/planetLabs.service.js
@@ -1,0 +1,63 @@
+export default (app) => {
+    class PlanetLabsService {
+        constructor(
+            $log, $http
+        ) {
+            'ngInject';
+            this.$log = $log;
+            this.$http = $http;
+        }
+
+        sendHttpRequest(req) {
+            return this.$http(req).then(
+                (response) => {
+                    return response;
+                },
+                (error) => {
+                    return error;
+                }
+            );
+        }
+
+        filterScenes(apiKey, requestBody) {
+            let req = {
+                'method': 'POST',
+                'url': 'https://api.planet.com/data/v1/quick-search',
+                'headers': {
+                    'Content-Type': 'application/json',
+                    'Authorization': 'Basic ' + apiKey
+                },
+                data: requestBody
+            };
+
+            return this.sendHttpRequest(req);
+        }
+
+        getFilteredScenesNextPage(apiKey, link) {
+            let req = {
+                'method': 'GET',
+                'url': link,
+                'headers': {
+                    'Authorization': 'Basic ' + apiKey
+                }
+            };
+
+            return this.sendHttpRequest(req);
+        }
+
+        getThumbnail(apiKey, link) {
+            let req = {
+                'method': 'GET',
+                'url': link,
+                'headers': {
+                    'Authorization': 'Basic ' + apiKey,
+                    'Content-Type': 'arraybuffer'
+                }
+            };
+
+            return this.sendHttpRequest(req);
+        }
+    }
+
+    app.service('planetLabsService', PlanetLabsService);
+};


### PR DESCRIPTION
## Overview

This PR has two commits.  The first one is the angular service for querying the planet labs API in order to filter scenes and get scene thumbnails.  The filters match RF filters.  The second commit is a simple testing UI to make sure the service works as intended.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~

### Demo

<img width="1680" alt="filter request" src="https://user-images.githubusercontent.com/16109558/28338884-45a5aa4c-6bd8-11e7-9d16-e50f88e9adc1.png">


### Notes

The service is in charge of sending requests to different planet API endpoints.  Request body should be constructed in the controller (as in the test UI - second commit).  The controller will pass different request bodies to the service to filter scenes based on different criteria.


## Testing Instructions

 * Change `YOUR_PLANET_API_KEY`(line 35 of planetlabs.controller.js) to your own planet labs API Key
 * Go to `/projects/edit/:project_id/planetlabs` and use this UI to test if the service work as intended.  This UI is only for simply testing the service.
 * Use the not-so-fancy filters on the sidebar to apply/change/remove filters.  They will trigger API calls from the service to get scene information. Check the requests and responses in the Network to see if they are correct.  Check if you can get the thumbnail (in png format) of the first scene from the responses as well.
<img width="1680" alt="filter response" src="https://user-images.githubusercontent.com/16109558/28339589-90dad7a6-6bda-11e7-9e58-a5a02d8359b8.png">

 * Use geojson.io to check if the geo filter/bbox filter actually works (by simply copying and pasting a response from a geo filter).
<img width="1680" alt="geo" src="https://user-images.githubusercontent.com/16109558/28339680-e46101fc-6bda-11e7-8f96-fac58626b03a.png">

 * Click on the next page button at the bottom to get scenes on the next page within the same set of filters.
<img width="1680" alt="next page scene list response" src="https://user-images.githubusercontent.com/16109558/28339749-22230c74-6bdb-11e7-9d0d-1351a6b222be.png">


Closes #2141 
