### PR TITLE
[Experiment] Add a blocking threadpool for SceneRoutes

### DIFF
--- a/app-backend/tile/src/main/resources/application.conf
+++ b/app-backend/tile/src/main/resources/application.conf
@@ -16,7 +16,7 @@ blocking-io-dispatcher {
   type = Dispatcher
   executor = "thread-pool-executor"
   thread-pool-executor {
-    fixed-pool-size = 32
+    fixed-pool-size = 16
   }
   throughput = 1
 }

--- a/app-backend/tile/src/main/resources/application.conf
+++ b/app-backend/tile/src/main/resources/application.conf
@@ -12,15 +12,13 @@ tile-server {
   cache.enabled = ${?TILESERVER_CACHE_ENABLED}
 }
 
-akka {
-  blocking-scene-routes-dispatcher {
-    type = Dispatcher
-    executor = "thread-pool-executor"
-    thread-pool-executor {
-      fixed-pool-size = 32
-    }
-    throughput = 2 # in order not to blow java heap, can be increased
+blocking-io-dispatcher {
+  type = Dispatcher
+  executor = "thread-pool-executor"
+  thread-pool-executor {
+    fixed-pool-size = 32
   }
+  throughput = 1
 }
 
 kamon {

--- a/app-backend/tile/src/main/resources/application.conf
+++ b/app-backend/tile/src/main/resources/application.conf
@@ -12,6 +12,17 @@ tile-server {
   cache.enabled = ${?TILESERVER_CACHE_ENABLED}
 }
 
+akka {
+  blocking-scene-routes-dispatcher {
+    type = Dispatcher
+    executor = "thread-pool-executor"
+    thread-pool-executor {
+      fixed-pool-size = 32
+    }
+    throughput = 2 # in order not to blow java heap, can be increased
+  }
+}
+
 kamon {
   metric {
     filters {

--- a/app-backend/tile/src/main/scala/Router.scala
+++ b/app-backend/tile/src/main/scala/Router.scala
@@ -17,8 +17,9 @@ class Router extends LazyLogging
   implicit lazy val database = Database.DEFAULT
   implicit val system = AkkaSystem.system
   implicit val materializer = AkkaSystem.materializer
+
   lazy val blockingSceneRoutesDispatcher =
-    system.dispatchers.lookup("blocking-scene-routes-dispatcher")
+    system.dispatchers.lookup("blocking-io-dispatcher")
 
   val toolRoutes = new ToolRoutes()
 

--- a/app-backend/tile/src/main/scala/Router.scala
+++ b/app-backend/tile/src/main/scala/Router.scala
@@ -17,6 +17,8 @@ class Router extends LazyLogging
   implicit lazy val database = Database.DEFAULT
   implicit val system = AkkaSystem.system
   implicit val materializer = AkkaSystem.materializer
+  lazy val blockingSceneRoutesDispatcher =
+    system.dispatchers.lookup("blocking-scene-routes-dispatcher")
 
   val toolRoutes = new ToolRoutes()
 
@@ -39,7 +41,7 @@ class Router extends LazyLogging
           }
         } ~
         tileAuthenticateOption { _ =>
-          SceneRoutes.root
+          SceneRoutes.root(blockingSceneRoutesDispatcher)
         } ~
         pathPrefix("tools") {
           get {

--- a/app-backend/tile/src/main/scala/StitchLayer.scala
+++ b/app-backend/tile/src/main/scala/StitchLayer.scala
@@ -36,9 +36,9 @@ object StitchLayer extends LazyLogging with Config {
     * For non-cached version use [[stitch]] function.
     */
   val stitchCache = HeapBackedMemcachedClient(memcachedClient)
-  def apply(id: UUID, size: Int)(implicit sceneIds: Set[UUID]): OptionT[Future, MultibandTile] =
+  def apply(id: UUID, size: Int): OptionT[Future, MultibandTile] =
     stitchCache.cachingOptionT(s"stitch-{$size}") { implicit ec =>
-      LayerCache.attributeStoreForLayer(id).mapFilter { case (store, _) =>
+      LayerCache.attributeStoreForLayer(id).mapFilter { store =>
         stitch(store, id.toString, size)
       }
     }

--- a/app-backend/tile/src/main/scala/image/GlobalSummary.scala
+++ b/app-backend/tile/src/main/scala/image/GlobalSummary.scala
@@ -54,10 +54,10 @@ object GlobalSummary extends LazyLogging {
   def minAcceptableProjectZoom(
     projId: UUID,
     size: Int = 512
-  )(implicit database: Database, ec: ExecutionContext, sceneIds: Set[UUID]): OptionT[Future, (Extent, Int)] =
+  )(implicit database: Database, ec: ExecutionContext): OptionT[Future, (Extent, Int)] =
     Mosaic.mosaicDefinition(projId, None).semiflatMap({ mosaic =>
       Future.sequence(mosaic.map { case MosaicDefinition(sceneId, _) =>
-        LayerCache.attributeStoreForLayer(sceneId).mapFilter { case (store, _) =>
+        LayerCache.attributeStoreForLayer(sceneId).mapFilter { store =>
           minAcceptableSceneZoom(sceneId, store, 256)
         }.value
       })

--- a/app-backend/tile/src/main/scala/image/Mosaic.scala
+++ b/app-backend/tile/src/main/scala/image/Mosaic.scala
@@ -30,7 +30,7 @@ object Mosaic extends KamonTrace {
 
   def tileLayerMetadata(id: UUID, zoom: Int)(implicit database: Database, sceneIds: Set[UUID]): OptionT[Future, (Int, TileLayerMetadata[SpatialKey])] =
     traceName(s"Mosaic.tileLayerMetadata($id)") {
-      LayerCache.attributeStoreForLayer(id).mapFilter { case (store, pyramidMaxZoom) =>
+      LayerCache.attributeStoreForLayerWithMaxZooms(id).mapFilter { case (store, pyramidMaxZoom) =>
         // because metadata attributes are cached in AttributeStore itself, there is no point caching this function
         val layerName = id.toString
         for (maxZoom <- pyramidMaxZoom.get(layerName)) yield {

--- a/app-backend/tile/src/main/scala/routes/SceneRoutes.scala
+++ b/app-backend/tile/src/main/scala/routes/SceneRoutes.scala
@@ -27,7 +27,7 @@ import scala.util._
 
 object SceneRoutes extends LazyLogging with KamonTraceDirectives {
 
-  def root(implicit blockingDispatcher: MessageDispatcher): Route =
+  def root(implicit dispatcher: MessageDispatcher): Route =
     pathPrefix(JavaUUID) { id =>
       pathPrefix("rgb") {
         traceName("rgb") {
@@ -70,14 +70,12 @@ object SceneRoutes extends LazyLogging with KamonTraceDirectives {
   def layerTile(layer: UUID) =
     pathPrefix(IntNumber / IntNumber / IntNumber).tmap[Future[Option[MultibandTile]]] {
       case (zoom: Int, x: Int, y: Int) =>
-        implicit val sceneIds = Set(layer)
         LayerCache.layerTile(layer, zoom, SpatialKey(x, y)).value
     }
 
   def layerTileAndHistogram(id: UUID) =
     pathPrefix(IntNumber / IntNumber / IntNumber).tmap[(OptionT[Future, MultibandTile], OptionT[Future, Array[Histogram[Double]]])] {
       case (zoom: Int, x: Int, y: Int) =>
-        implicit val sceneIds = Set(id)
         val futureMaybeTile = LayerCache.layerTile(id, zoom, SpatialKey(x, y))
         val futureHistogram = LayerCache.layerHistogram(id, zoom)
         (futureMaybeTile, futureHistogram)
@@ -86,10 +84,9 @@ object SceneRoutes extends LazyLogging with KamonTraceDirectives {
   def pngAsHttpResponse(png: Png): HttpResponse =
     HttpResponse(entity = HttpEntity(ContentType(MediaTypes.`image/png`), png.bytes))
 
-  def imageThumbnailRoute(id: UUID)(implicit blockingDispatcher: MessageDispatcher) =
+  def imageThumbnailRoute(id: UUID)(implicit dispatcher: MessageDispatcher) =
     parameters('size.as[Int].?(256)) { size =>
       complete {
-        implicit val sceneIds = Set(id)
         val futureMaybeTile = StitchLayer(id, size)
         val futureResponse =
           for {
@@ -109,10 +106,9 @@ object SceneRoutes extends LazyLogging with KamonTraceDirectives {
       }
     }
 
-  def imageHistogramRoute(id: UUID)(implicit blockingDispatcher: MessageDispatcher) = {
+  def imageHistogramRoute(id: UUID)(implicit dispatcher: MessageDispatcher) = {
     import DefaultJsonProtocol._
     complete {
-      implicit val sceneIds = Set(id)
       val futureResponse =
         for {
           hist <- LayerCache.layerHistogram(id, 0).value
@@ -130,7 +126,7 @@ object SceneRoutes extends LazyLogging with KamonTraceDirectives {
     }
   }
 
-  def imageRoute(futureMaybeTile: OptionT[Future, MultibandTile])(implicit blockingDispatcher: MessageDispatcher): Route =
+  def imageRoute(futureMaybeTile: OptionT[Future, MultibandTile])(implicit dispatcher: MessageDispatcher): Route =
     complete {
       val futureResponse =
         for {
@@ -154,7 +150,7 @@ object SceneRoutes extends LazyLogging with KamonTraceDirectives {
     index: MultibandTile => Tile,
     defaultColorRamp: Option[ColorRamp] = None,
     defaultBreaks: Option[Array[Double]] = None
-  )(implicit blockingDispatcher: MessageDispatcher): Route = {
+  )(implicit dispatcher: MessageDispatcher): Route = {
     toolParams(defaultColorRamp, defaultBreaks) { params =>
       complete {
         val future =


### PR DESCRIPTION
## Overview

- [x] Remove useless implicit sceneIds: Set[UUID] params (added a special function to get attr store without zooms, created a separate cached for it, in order not to break approach).
- [x] Added a separate threadpool for SceneRoutes

Reason: http://doc.akka.io/docs/akka-http/current/scala/http/handling-blocking-operations-in-akka-http-routes.html

## Testing instructions

Visit projects list page (there should be more than one projects for better experience), after that go on a project page, tiles should load without any delay.