### PR TITLE
Parse acquisitionDate and cloudCover from upload metadata

### DIFF
--- a/app-tasks/rf/src/rf/uploads/geotiff/create_scenes.py
+++ b/app-tasks/rf/src/rf/uploads/geotiff/create_scenes.py
@@ -10,7 +10,7 @@ from .create_footprints import extract_footprints
 logger = logging.getLogger(__name__)
 
 
-def create_geotiff_scene(tif_path, organizationId, datasource, acquisitionDate=None, cloudCover=None,
+def create_geotiff_scene(tif_path, organizationId, datasource, acquisitionDate=None, cloudCover=0,
                          ingestSizeBytes=0, visibility=Visibility.PRIVATE, tags=[],
                          sceneMetadata=None, name=None, thumbnailStatus=JobStatus.QUEUED,
                          boundaryStatus=JobStatus.QUEUED, ingestStatus=IngestStatus.TOBEINGESTED,

--- a/app-tasks/rf/src/rf/uploads/geotiff/create_scenes.py
+++ b/app-tasks/rf/src/rf/uploads/geotiff/create_scenes.py
@@ -10,7 +10,7 @@ from .create_footprints import extract_footprints
 logger = logging.getLogger(__name__)
 
 
-def create_geotiff_scene(tif_path, organizationId, datasource,
+def create_geotiff_scene(tif_path, organizationId, datasource, acquisitionDate=None, cloudCover=None,
                          ingestSizeBytes=0, visibility=Visibility.PRIVATE, tags=[],
                          sceneMetadata=None, name=None, thumbnailStatus=JobStatus.QUEUED,
                          boundaryStatus=JobStatus.QUEUED, ingestStatus=IngestStatus.TOBEINGESTED,
@@ -51,8 +51,8 @@ def create_geotiff_scene(tif_path, organizationId, datasource,
     sceneKwargs = {
         'sunAzimuth': None,  # TODO: Calculate from acquisitionDate and tif center.
         'sunElevation': None,  # TODO: Same
-        'cloudCover': 0,
-        'acquisitionDate': None,
+        'cloudCover': cloudCover,
+        'acquisitionDate': acquisitionDate,
         'id': str(uuid.uuid4()),
         'thumbnails': None,
         'tileFootprint': tile_footprint,

--- a/app-tasks/rf/src/rf/uploads/geotiff/factories.py
+++ b/app-tasks/rf/src/rf/uploads/geotiff/factories.py
@@ -38,7 +38,7 @@ class GeoTiffS3SceneFactory(object):
         self.visibility = Visibility.PRIVATE
         self.datasource = self._upload.datasource
         self.acquisitionDate = self._upload.metadata.get('acquisitionDate')
-        self.cloudCover = self._upload.metadata.get('cloudCover') or 0
+        self.cloudCover = self._upload.metadata.get('cloudCover', 0)
         self.tags = self._upload.metadata.get('tags') or ['']
 
     def generate_scenes(self):

--- a/app-tasks/rf/src/rf/uploads/geotiff/factories.py
+++ b/app-tasks/rf/src/rf/uploads/geotiff/factories.py
@@ -38,6 +38,7 @@ class GeoTiffS3SceneFactory(object):
         self.visibility = Visibility.PRIVATE
         self.datasource = self._upload.datasource
         self.acquisitionDate = self._upload.metadata.get('acquisitionDate')
+        self.cloudCover = self._upload.metadata.get('cloudCover')
         self.tags = self._upload.metadata.get('tags') or ['']
 
     def generate_scenes(self):
@@ -82,6 +83,7 @@ class GeoTiffS3SceneFactory(object):
             visibility=self.visibility,
             tags=self.tags,
             acquisitionDate=self.acquisitionDate,
+            cloudCover=self.cloudCover,
             name=name,
             owner=self.owner
         )

--- a/app-tasks/rf/src/rf/uploads/geotiff/factories.py
+++ b/app-tasks/rf/src/rf/uploads/geotiff/factories.py
@@ -38,7 +38,7 @@ class GeoTiffS3SceneFactory(object):
         self.visibility = Visibility.PRIVATE
         self.datasource = self._upload.datasource
         self.acquisitionDate = self._upload.metadata.get('acquisitionDate')
-        self.cloudCover = self._upload.metadata.get('cloudCover')
+        self.cloudCover = self._upload.metadata.get('cloudCover') or 0
         self.tags = self._upload.metadata.get('tags') or ['']
 
     def generate_scenes(self):


### PR DESCRIPTION
## Overview

This PR parses `acquisitionDate` and `cloudCover` from upload metadata when creating scenes.

### Checklist

- ~Styleguide updated, if necessary~
- ~Swagger specification updated, if necessary~
- ~Symlinks from new migrations present or corrected for any new migrations~

## Testing Instructions

 * Bring up all ur stuff (server, airflow, frontend)
 * Post the following, filling in a tif in s3, to `/api/uploads/`:

```json
{"files":["s3://<a tif somewhere>"],
 "datasource":"c14c8e97-ba85-4677-ac9c-069cfef1f0b1",
 "fileType":"GEOTIFF",
 "uploadStatus":"UPLOADED",
 "visibility":"PUBLIC",
 "organizationId":"dfac6307-b5ef-43f7-beda-b9f208bb7726",
 "metadata":{"acquisitionDate": null, "cloudCover": 0.1, "garbage": "yeah, garbage"},
 "uploadType":"S3",
 "projectId": null}
```
 * Check the `cloudCover` (and `acquisitionDate`) on the created scene (you can get the id from the bottom of the `process_upload` logs)

Closes #2236
