### PR TITLE
Add annotation route and page for projects

### DIFF
--- a/app-frontend/src/app/index.module.js
+++ b/app-frontend/src/app/index.module.js
@@ -74,6 +74,7 @@ const App = angular.module(
         require('./pages/projects/edit/aoi-approve/aoi-approve.module.js').name,
         require('./pages/projects/edit/aoi-parameters/aoi-parameters.module.js').name,
         require('./pages/projects/edit/export/export.module.js').name,
+        require('./pages/projects/edit/annotate/annotate.module.js').name,
 
         require('./pages/imports/imports.module.js').name,
         require('./pages/imports/datasources/datasources.module.js').name,

--- a/app-frontend/src/app/index.routes.js
+++ b/app-frontend/src/app/index.routes.js
@@ -29,6 +29,7 @@ import projectMaskingDrawTpl from './pages/projects/edit/masking/draw/draw.html'
 import aoiApproveTpl from './pages/projects/edit/aoi-approve/aoi-approve.html';
 import aoiParametersTpl from './pages/projects/edit/aoi-parameters/aoi-parameters.html';
 import exportTpl from './pages/projects/edit/export/export.html';
+import annotateTpl from './pages/projects/edit/annotate/annotate.html';
 
 import settingsTpl from './pages/settings/settings.html';
 import profileTpl from './pages/settings/profile/profile.html';
@@ -149,6 +150,12 @@ function projectEditStates($stateProvider) {
             url: '/export',
             templateUrl: exportTpl,
             controller: 'ExportController',
+            controllerAs: '$ctrl'
+        })
+        .state('projects.edit.annotate', {
+            url: '/annotate',
+            templateUrl: annotateTpl,
+            controller: 'AnnotateController',
             controllerAs: '$ctrl'
         });
 }

--- a/app-frontend/src/app/pages/projects/edit/annotate/annotate.controller.js
+++ b/app-frontend/src/app/pages/projects/edit/annotate/annotate.controller.js
@@ -1,0 +1,10 @@
+export default class AnnotateController {
+    constructor( // eslint-disable-line max-params
+        $log, $state, $scope
+    ) {
+        'ngInject';
+        this.$log = $log;
+        this.$state = $state;
+        this.$scope = $scope;
+    }
+}

--- a/app-frontend/src/app/pages/projects/edit/annotate/annotate.html
+++ b/app-frontend/src/app/pages/projects/edit/annotate/annotate.html
@@ -1,0 +1,23 @@
+<div class="sidebar-header">
+<a class="btn sidebar-header-nav-btn" ui-sref="projects.edit">
+  <i class="icon-arrow-left"></i>
+</a>
+<h5 class="sidebar-title">Annotations</h5>
+</div>
+<div class="sidebar-project">
+  <ul class="sidebar-list">
+    <li>
+      <div class="label">
+        <span class="text">This is some text about annotating.</span>
+      </div>
+      <div class="list-group-right column-6 nogutter btn-group">
+        <button class="btn btn-primary btn-block" type="button">
+          Import
+        </button>
+        <button class="btn btn-primary btn-block" type="button">
+          Export
+        </button>
+      </div>
+    </li>
+  </ul>
+</div>

--- a/app-frontend/src/app/pages/projects/edit/annotate/annotate.module.js
+++ b/app-frontend/src/app/pages/projects/edit/annotate/annotate.module.js
@@ -1,0 +1,10 @@
+import angular from 'angular';
+import AnnotateController from './annotate.controller.js';
+
+const AnnotateModule = angular.module('pages.projects.edit.annotate', []);
+
+AnnotateModule.controller(
+    'AnnotateController', AnnotateController
+);
+
+export default AnnotateModule;

--- a/app-frontend/src/app/pages/projects/edit/edit.html
+++ b/app-frontend/src/app/pages/projects/edit/edit.html
@@ -63,6 +63,22 @@
           <i class="icon-info"></i>
         </div>
 
+        <!-- Annotations -->
+        <div
+          class="list-group-item"
+          feature-flag='annotations'>
+          <label>Annotations</label>
+          <div class="list-group-right column-6 nogutter">
+            <button class="btn btn-light btn-block"
+                    type="button"
+                    ui-sref="projects.edit.annotate">
+              Annotate project
+            </button>
+          </div>
+          <i class="icon-info"></i>
+        </div>
+        <!-- Annotations -->
+
         <!-- Sharing -->
         <div class="list-group-item">
           <label>Sharing</label>


### PR DESCRIPTION
## Overview

This PR adds an annotation section and button to the project edit page. Clicking the button will go to the annotate page, which currently has: a link to go back to project edit page, placeholder texts about annotating, buttons to import and export geojson annotations (will add functionalities in later PRs).

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~

### Demo

<img width="1680" alt="screen shot 2017-07-19 at 1 56 13 pm" src="https://user-images.githubusercontent.com/16109558/28381907-5de16828-6c8a-11e7-8ed9-bb952ec0edf7.png">

<img width="1680" alt="screen shot 2017-07-19 at 1 56 16 pm" src="https://user-images.githubusercontent.com/16109558/28381912-60574636-6c8a-11e7-90c3-c963f8be49a3.png">


## Testing Instructions

 * Go to a project's edit page.
 * Check if there is an "Annotation" section with an "Annotate project" button.
 * Click the "Annotate project" button to see if it goes to the annotation page, which should have a link to go back to edit project page, a button group for importing and exporting geojson annotations.

Closes #2276 
