### PR TITLE
Add geocoded search to map controls

### DIFF
--- a/app-frontend/config/webpack/global.js
+++ b/app-frontend/config/webpack/global.js
@@ -16,6 +16,9 @@ const DEVELOPMENT = NODE_ENV === 'production' ? false : true;
 const stylesLoader = 'css-loader?sourceMap!postcss-loader!sass-loader?' +
         'outputStyle=expanded&sourceMap=true&sourceMapContents=true';
 
+const HERE_APP_ID = '\'mXP4DZFBZGyBmuZBKNeo\'';
+const HERE_APP_CODE = '\'kBWb6Z7ZLcuQanT_RoP60A\'';
+
 const basemaps = JSON.stringify({
     layers: {
         Light: {
@@ -43,8 +46,8 @@ const basemaps = JSON.stringify({
                 attribution: 'Map &copy; 1987-2014 <a href="http://developer.here.com">HERE</a>',
                 subdomains: '1234',
                 mapID: 'newest',
-                app_id: 'mXP4DZFBZGyBmuZBKNeo',
-                app_code: 'kBWb6Z7ZLcuQanT_RoP60A',
+                app_id: HERE_APP_ID,
+                app_code: HERE_APP_CODE,
                 base: 'aerial',
                 maxZoom: 30,
                 maxNativeZoom: 20,
@@ -59,8 +62,8 @@ const basemaps = JSON.stringify({
             properties: {
                 attribution: 'Map &copy; 1987-2014 <a href="http://developer.here.com">HERE</a>',
                 subdomains: '1234',
-                app_id: 'mXP4DZFBZGyBmuZBKNeo',
-                app_code: 'kBWb6Z7ZLcuQanT_RoP60A'
+                app_id: HERE_APP_ID,
+                app_code: HERE_APP_CODE
             }
         }
     },
@@ -259,7 +262,9 @@ module.exports = function (_path) {
                 'BUILDCONFIG': {
                     APP_NAME: '\'RasterFoundry\'',
                     BASEMAPS: basemaps,
-                    API_HOST: '\'\''
+                    API_HOST: '\'\'',
+                    HERE_APP_ID: HERE_APP_ID,
+                    HERE_APP_CODE: HERE_APP_CODE
                 }
             })
         ]

--- a/app-frontend/src/app/components/map/mapContainer/mapContainer.controller.js
+++ b/app-frontend/src/app/components/map/mapContainer/mapContainer.controller.js
@@ -2,16 +2,14 @@ import Map from 'es6-map';
 /* globals BUILDCONFIG */
 
 export default class MapContainerController {
-    constructor($log, $document, $element, $scope, $timeout, mapService,
-                $uibModal) {
+    constructor($document, $element, $scope, $timeout, $uibModal, mapService) {
         'ngInject';
         this.$document = $document;
         this.$element = $element;
-        this.$log = $log;
         this.$scope = $scope;
         this.$timeout = $timeout;
-        this.mapService = mapService;
         this.$uibModal = $uibModal;
+        this.mapService = mapService;
         this.getMap = () => this.mapService.getMap(this.mapId);
     }
 

--- a/app-frontend/src/app/components/map/mapContainer/mapContainer.controller.js
+++ b/app-frontend/src/app/components/map/mapContainer/mapContainer.controller.js
@@ -2,7 +2,8 @@ import Map from 'es6-map';
 /* globals BUILDCONFIG */
 
 export default class MapContainerController {
-    constructor($log, $document, $element, $scope, $timeout, mapService) {
+    constructor($log, $document, $element, $scope, $timeout, mapService,
+                $uibModal) {
         'ngInject';
         this.$document = $document;
         this.$element = $element;
@@ -10,6 +11,7 @@ export default class MapContainerController {
         this.$scope = $scope;
         this.$timeout = $timeout;
         this.mapService = mapService;
+        this.$uibModal = $uibModal;
         this.getMap = () => this.mapService.getMap(this.mapId);
     }
 
@@ -242,5 +244,25 @@ export default class MapContainerController {
             this.hasTileLoadingError =
                 Array.from(this.tileLoadingErrors.values()).reduce((acc, cur) => acc || cur, false);
         });
+    }
+
+    openMapSearchModal() {
+        if (this.activeModal) {
+            this.activeModal.dismiss();
+        }
+
+        this.activeModal = this.$uibModal.open({
+            component: 'rfMapSearchModal',
+            resolve: { }
+        });
+
+        this.activeModal.result.then(
+            location => {
+                const mapView = location.mapView;
+                this.map.fitBounds([
+                    [mapView.bottomRight.latitude, mapView.bottomRight.longitude],
+                    [mapView.topLeft.latitude, mapView.topLeft.longitude]
+                ]);
+            });
     }
 }

--- a/app-frontend/src/app/components/map/mapContainer/mapContainer.html
+++ b/app-frontend/src/app/components/map/mapContainer/mapContainer.html
@@ -15,6 +15,14 @@
   <div class="map-control">
     <button class="btn btn-default btn-square btn-small"
             title="Layers"
+            ng-click="$ctrl.openMapSearchModal()">
+      <i class="icon-search"></i>
+    </button>
+  </div>
+  <div class="filler"></div>
+  <div class="map-control">
+    <button class="btn btn-default btn-square btn-small"
+            title="Layers"
             ng-click="$ctrl.toggleLayerPicker($event)">
       <i class="icon-project"></i>
     </button>

--- a/app-frontend/src/app/components/map/mapSearchModal/mapSearchModal.component.js
+++ b/app-frontend/src/app/components/map/mapSearchModal/mapSearchModal.component.js
@@ -1,0 +1,15 @@
+// Component code
+import mapSearchModalTpl from './mapSearchModal.html';
+
+const MapSearchModalComponent = {
+    templateUrl: mapSearchModalTpl,
+    bindings: {
+        close: '&',
+        dismiss: '&',
+        modalInstance: '<',
+        resolve: '<'
+    },
+    controller: 'MapSearchModalController'
+};
+
+export default MapSearchModalComponent;

--- a/app-frontend/src/app/components/map/mapSearchModal/mapSearchModal.controller.js
+++ b/app-frontend/src/app/components/map/mapSearchModal/mapSearchModal.controller.js
@@ -1,0 +1,126 @@
+/* eslint-disable */
+export default class MapSearchModalController {
+
+    constructor($scope, $state, $element, $timeout, geocodeService) {
+        'ngInject';
+        this.$scope = $scope;
+        this.$state = $state;
+        this.$element = $element;
+        this.$timeout = $timeout;
+        this.geocodeService = geocodeService;
+    }
+
+    $onInit() {
+        this.isLoading = false;
+        this.isError = false;
+        this.query = '';
+        this.activeResultIndex = -1;
+
+    }
+
+    $postLink() {
+        this.$timeout(() => {
+            const el = $(this.$element[0]).find('input').get(0);
+            el.focus();
+            $(el).on('keydown', $.proxy(this.handleKeypress, this));
+        }, 0);
+    }
+
+    handleKeypress(e) {
+        if (e.which == 38) {
+            e.preventDefault();
+            this.incrementActiveResultIndex(-1);
+        } else if (e.which == 40 || e.which == 9) {
+            e.preventDefault();
+            this.incrementActiveResultIndex(1);
+        } else if (e.which == 13) {
+            e.preventDefault();
+            this.gotoActiveResult();
+        }
+    }
+
+    incrementActiveResultIndex(i) {
+        if (this.results) {
+            const numResults = this.results.suggestions.length;
+            this.$scope.$evalAsync(() => {
+                this.activeResultIndex += i;
+                if (this.activeResultIndex >= numResults) {
+                    this.activeResultIndex = 0;
+                } else if (this.activeResultIndex < 0) {
+                    this.activeResultIndex == numResults - 1;
+                }
+            });
+        }
+    }
+
+    selectLocation(i) {
+        this.activeResultIndex = i;
+        this.gotoActiveResult();
+    }
+
+    gotoActiveResult() {
+        if (
+            this.results &&
+            this.results.suggestions &&
+            this.results.suggestions.length > this.activeResultIndex &&
+            this.activeResultIndex >= 0
+        ) {
+            const locationId = this.results.suggestions[this.activeResultIndex].locationId;
+            this.geocodeService.getLocation(locationId).then(l => {
+                this.close({$value: l.response.view[0].result[0].location});
+            });
+        }
+    }
+
+    search() {
+        this.isLoading = true;
+        this.geocodeService.getLocationSuggestions(this.query).then(r => {
+            this.$scope.$evalAsync(() => {
+                this.results = r;
+                this.isLoading = false;
+                this.activateFirstResult();
+            });
+        });
+    }
+
+    activateFirstResult() {
+        if (
+            this.results &&
+            this.results.suggestions &&
+            this.results.suggestions.length
+        ) {
+            this.activeResultIndex = 0;
+        } else {
+            this.activeResultIndex = -1;
+        }
+    }
+
+    isActiveResultIndex(i) {
+        return i === this.activeResultIndex;
+    }
+
+    shouldShowSearchPrompt() {
+        return !this.query;
+    }
+
+    shouldShowResults() {
+        return this.query &&
+            this.results &&
+            this.results.suggestions &&
+            this.results.suggestions.length;
+    }
+
+    shouldShowLoadingMessage() {
+        return this.query &&
+            this.isLoading &&
+            !this.results;
+    }
+
+    shouldShowNoResultsMessage() {
+        return this.query &&
+            !this.isLoading &&
+            this.results &&
+            this.results.suggestions &&
+            !this.results.suggestions.length;
+    }
+}

--- a/app-frontend/src/app/components/map/mapSearchModal/mapSearchModal.controller.js
+++ b/app-frontend/src/app/components/map/mapSearchModal/mapSearchModal.controller.js
@@ -1,4 +1,10 @@
 /* eslint-disable */
+
+const UPARROW = 38;
+const DOWNARROW = 40;
+const TAB = 9;
+const ENTER = 13;
+
 export default class MapSearchModalController {
 
     constructor($scope, $state, $element, $timeout, geocodeService) {
@@ -27,13 +33,13 @@ export default class MapSearchModalController {
     }
 
     handleKeypress(e) {
-        if (e.which == 38) {
+        if (e.which === UPARROW) {
             e.preventDefault();
             this.incrementActiveResultIndex(-1);
-        } else if (e.which == 40 || e.which == 9) {
+        } else if (e.which === DOWNARROW || e.which === TAB) {
             e.preventDefault();
             this.incrementActiveResultIndex(1);
-        } else if (e.which == 13) {
+        } else if (e.which === ENTER) {
             e.preventDefault();
             this.gotoActiveResult();
         }
@@ -47,7 +53,7 @@ export default class MapSearchModalController {
                 if (this.activeResultIndex >= numResults) {
                     this.activeResultIndex = 0;
                 } else if (this.activeResultIndex < 0) {
-                    this.activeResultIndex == numResults - 1;
+                    this.activeResultIndex = numResults - 1;
                 }
             });
         }

--- a/app-frontend/src/app/components/map/mapSearchModal/mapSearchModal.html
+++ b/app-frontend/src/app/components/map/mapSearchModal/mapSearchModal.html
@@ -1,0 +1,25 @@
+<div class="modal-body">
+  <input class="form-control"
+         type="text"
+         placeholder="Search"
+         ng-model="$ctrl.query"
+         ng-model-options="{debounce: 250}"
+         ng-change="$ctrl.search()">
+  <div>
+    <ul class="map-search-results"
+        ng-if="$ctrl.shouldShowResults()">
+      <li class="map-search-results-item"
+          ng-repeat="location in $ctrl.results.suggestions"
+          ng-class="{ 'active': $ctrl.isActiveResultIndex($index) }"
+          ng-click="$ctrl.selectLocation($index)">
+        <div class="label">{{location.label}}</div>
+        <div class="info-text" ng-if="$ctrl.isActiveResultIndex($index)">
+          <div class="keyboard-shortcut-key">enter</div>
+        </div>
+      </li>
+    </ul>
+    <div class="map-search-prompt" ng-if="$ctrl.shouldShowLoadingMessage()">Searching...</div>
+    <div class="map-search-prompt" ng-if="$ctrl.shouldShowNoResultsMessage()">We can't find anything that matches what you're searching for</div>
+    <div class="map-search-prompt" ng-if="$ctrl.shouldShowSearchPrompt()">Search for a city, town, or address</div>
+  </div>
+</div>

--- a/app-frontend/src/app/components/map/mapSearchModal/mapSearchModal.module.js
+++ b/app-frontend/src/app/components/map/mapSearchModal/mapSearchModal.module.js
@@ -1,0 +1,14 @@
+import angular from 'angular';
+import MapSearchModalComponent from './mapSearchModal.component.js';
+import MapSearchModalController from './mapSearchModal.controller.js';
+
+const MapSearchModalModule = angular.module('components.map.mapSearchModal', []);
+
+MapSearchModalModule.controller(
+    'MapSearchModalController', MapSearchModalController
+);
+MapSearchModalModule.component(
+    'rfMapSearchModal', MapSearchModalComponent
+);
+
+export default MapSearchModalModule;

--- a/app-frontend/src/app/core/core.module.js
+++ b/app-frontend/src/app/core/core.module.js
@@ -28,6 +28,7 @@ require('./services/histogram.service')(shared);
 require('./services/dropbox.service')(shared);
 require('./services/aoi.service')(shared);
 require('./services/export.service')(shared);
+require('./services/geocode.service')(shared);
 
 require('./services/featureFlagOverrides.service')(shared);
 require('./services/featureFlags.provider')(shared);

--- a/app-frontend/src/app/core/services/geocode.service.js
+++ b/app-frontend/src/app/core/services/geocode.service.js
@@ -1,0 +1,34 @@
+/* global $ */
+/* eslint-disable camelcase */
+const appId = 'mXP4DZFBZGyBmuZBKNeo';
+const appCode = 'kBWb6Z7ZLcuQanT_RoP60A';
+
+export default (app) => {
+    class GeocodeService {
+        constructor() { }
+
+        getLocationSuggestions(query) {
+            const baseUrl = 'https://autocomplete.geocoder.cit.api.here.com/6.2/suggest.json';
+            const requestParams = {
+                app_id: appId,
+                app_code: appCode,
+                query: query
+            };
+            return $.get(baseUrl, requestParams);
+        }
+
+        getLocation(locationId) {
+            const baseUrl = 'https://geocoder.cit.api.here.com/6.2/geocode.json';
+            const requestParams = {
+                locationid: locationId,
+                gen: 9,
+                jsonattributes: 1,
+                app_id: appId,
+                app_code: appCode
+            };
+            return $.get(baseUrl, requestParams);
+        }
+    }
+
+    app.service('geocodeService', GeocodeService);
+};

--- a/app-frontend/src/app/core/services/geocode.service.js
+++ b/app-frontend/src/app/core/services/geocode.service.js
@@ -1,7 +1,5 @@
-/* global $ */
+/* global $, BUILDCONFIG */
 /* eslint-disable camelcase */
-const appId = 'mXP4DZFBZGyBmuZBKNeo';
-const appCode = 'kBWb6Z7ZLcuQanT_RoP60A';
 
 export default (app) => {
     class GeocodeService {
@@ -10,8 +8,8 @@ export default (app) => {
         getLocationSuggestions(query) {
             const baseUrl = 'https://autocomplete.geocoder.cit.api.here.com/6.2/suggest.json';
             const requestParams = {
-                app_id: appId,
-                app_code: appCode,
+                app_id: BUILDCONFIG.HERE_APP_ID,
+                app_code: BUILDCONFIG.HERE_APP_CODE,
                 query: query
             };
             return $.get(baseUrl, requestParams);
@@ -20,11 +18,11 @@ export default (app) => {
         getLocation(locationId) {
             const baseUrl = 'https://geocoder.cit.api.here.com/6.2/geocode.json';
             const requestParams = {
+                app_id: BUILDCONFIG.HERE_APP_ID,
+                app_code: BUILDCONFIG.HERE_APP_CODE,
                 locationid: locationId,
                 gen: 9,
-                jsonattributes: 1,
-                app_id: appId,
-                app_code: appCode
+                jsonattributes: 1
             };
             return $.get(baseUrl, requestParams);
         }

--- a/app-frontend/src/app/index.components.js
+++ b/app-frontend/src/app/index.components.js
@@ -36,6 +36,7 @@ export default angular.module('index.components', [
     require('./components/map/staticMap/staticMap.module.js').name,
     require('./components/map/drawToolbar/drawToolbar.module.js').name,
     require('./components/map/labMap/labMap.module.js').name,
+    require('./components/map/mapSearchModal/mapSearchModal.module.js').name,
 
     // settings components
     require('./components/settings/refreshTokenModal/refreshTokenModal.module.js').name,

--- a/app-frontend/src/assets/styles/sass/_shame.scss
+++ b/app-frontend/src/assets/styles/sass/_shame.scss
@@ -1988,9 +1988,7 @@ rf-operation-node {
   border-radius: $border-radius-base * 2;
   font-size: 1.2rem;
   letter-spacing: 0.00625rem;
-  // font-weight: bold;
   color: #999;
-  // font-family: Courier New, Courier, monospace;
 }
 
 .map-search-results-item {

--- a/app-frontend/src/assets/styles/sass/_shame.scss
+++ b/app-frontend/src/assets/styles/sass/_shame.scss
@@ -1968,3 +1968,54 @@ rf-operation-node {
   background-image: none;
   background: transparent;
 }
+.map-search-prompt {
+  text-align: center;
+  font-weight: bold;
+  padding: 2rem 1rem 1rem;
+}
+
+.map-search-results {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.keyboard-shortcut-key {
+  display: inline-block;
+  padding: 0.75rem 1.5rem;
+  background: $white;
+  border: 1px solid #ccc;
+  border-radius: $border-radius-base * 2;
+  font-size: 1.2rem;
+  letter-spacing: 0.00625rem;
+  // font-weight: bold;
+  color: #999;
+  // font-family: Courier New, Courier, monospace;
+}
+
+.map-search-results-item {
+  border-radius: $border-radius-base;
+  margin-top: 1rem;
+  display: flex;
+  align-items: center;
+  .label {
+    padding: 1.3rem 1rem;
+    flex: 1;
+  }
+  .info-text {
+    padding: 0 1rem;
+    text-align: right;
+    color: $off-white;
+  }
+  &:hover {
+    background: $shade-normal;
+    color: $white;
+    cursor: pointer;
+  }
+  &.active {
+    background: $brand-primary;
+    color: $white;
+  }
+}
+
+


### PR DESCRIPTION
## Overview

This PR adds a geocoded search to the map controls. We leverage [HERE](here.com)'s geocoding API to take a text based search and return a series of location suggestions and then use the API again to retrieve the bounding box of the selected location.

There are functioning keyboard controls:
- **enter** will select and goto  the currently highlighted location
- **up and down arrows and tab** will cycle through the locations

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~

### Demo

![image](https://user-images.githubusercontent.com/2442245/28399735-d866bbdc-6cdc-11e7-9f04-208191acff03.png)
![image](https://user-images.githubusercontent.com/2442245/28399741-e05b9aa6-6cdc-11e7-84c8-2e8cf2526e01.png)
![image](https://user-images.githubusercontent.com/2442245/28399746-e3910d32-6cdc-11e7-88e4-a8dabe8e1914.png)
![image](https://user-images.githubusercontent.com/2442245/28399754-f50681dc-6cdc-11e7-85c6-a6cc3c75387b.png)



### Notes

We had to use the raw jQuery`$get` method to avoid sending a preflight request to the HERE API. The API does not support `OPTION` requests and this preflight response would get a 40x error, which would prevent the actual request from happening. The preflight request was being sent because of the authorization headers, which are inserted into all `$http` based requests. For this reason, we had to avoid the use of `$http`.

We need to decide how to handle the API keys. We currently have them hardcoded in a few spots now (`global.js` and the `geocode.service.js`).

## Testing Instructions

 * Make sure there's now a search button on the map controls
 * Search, and make sure it acts as you would expect with various inputs

Closes #2233 
