### PR TITLE
Send metadata when importing

### DIFF
--- a/app-frontend/src/app/components/scenes/sceneImportModal/sceneImportModal.controller.js
+++ b/app-frontend/src/app/components/scenes/sceneImportModal/sceneImportModal.controller.js
@@ -93,7 +93,7 @@ export default class SceneImportModalController {
                 if (this.importType === 'S3') {
                     return 'S3_UPLOAD';
                 }
-                return 'UPLOAD_PROGRESS'
+                return 'UPLOAD_PROGRESS';
             },
             previous: () => 'IMPORT',
             allowNext: () => true,

--- a/app-frontend/src/app/components/scenes/sceneImportModal/sceneImportModal.controller.js
+++ b/app-frontend/src/app/components/scenes/sceneImportModal/sceneImportModal.controller.js
@@ -30,6 +30,7 @@ export default class SceneImportModalController {
             prefix: ''
         };
         this.selectedFiles = [];
+        this.sceneData = {};
         this.uploadProgressPct = {};
         this.uploadProgressFlexString = {};
         this.datasource = this.resolve.datasource || false;
@@ -62,7 +63,7 @@ export default class SceneImportModalController {
             allowPrevious: () => true,
             next: () => {
                 if (this.importType === 'S3') {
-                    return 'S3_UPLOAD';
+                    return 'METADATA';
                 }
                 return 'LOCAL_UPLOAD';
             },
@@ -83,8 +84,20 @@ export default class SceneImportModalController {
             },
             previous: () => 'IMPORT',
             allowPrevious: () => true,
-            next: () => 'UPLOAD_PROGRESS',
+            next: () => 'METADATA',
             allowNext: () => this.verifyFileCount(),
+            allowClose: () => true
+        }, {
+            name: 'METADATA',
+            next: () => {
+                if (this.importType === 'S3') {
+                    return 'S3_UPLOAD';
+                }
+                return 'UPLOAD_PROGRESS'
+            },
+            previous: () => 'IMPORT',
+            allowNext: () => true,
+            allowPrevious: () => true,
             allowClose: () => true
         }, {
             name: 'UPLOAD_PROGRESS',
@@ -93,8 +106,8 @@ export default class SceneImportModalController {
         }, {
             name: 'S3_UPLOAD',
             previous: () => 'IMPORT',
-            onEnter: () => this.startS3Upload(),
-            next: () => 'IMPORT_SUCCESS'
+            next: () => 'IMPORT_SUCCESS',
+            onEnter: () => this.startS3Upload()
         }, {
             name: 'IMPORT_SUCCESS',
             allowDone: () => true
@@ -252,7 +265,8 @@ export default class SceneImportModalController {
             uploadStatus: 'UPLOADING',
             visibility: 'PRIVATE',
             organizationId: user.organizationId,
-            metadata: {}
+            metadata: {acquisitionDate: this.sceneData.acquisitionDate,
+                       cloudCover: this.sceneData.cloudCover}
         };
 
         if (this.importType === 'local') {

--- a/app-frontend/src/app/components/scenes/sceneImportModal/sceneImportModal.html
+++ b/app-frontend/src/app/components/scenes/sceneImportModal/sceneImportModal.html
@@ -170,6 +170,30 @@
     </div>
   </div>
 
+  <!--Body for METADATA-->
+  <div class="modal-body" ng-if="$ctrl.currentStepIs('METADATA')">
+    <div class="content">
+      <h3 class="no-margin">Add optional metadata</h3>
+      <div>
+        <p>Enter metadata about the scenes in the files you're uploading</p>
+        <form>
+          <div class="form-group">
+            <div>
+              <label for="acquisitionDate">Acquisition Date</label>
+              <input id="acquisitionDate" type="date"
+                     class="form-control" ng-model="$ctrl.sceneData.acquisitionDate">
+            </div>
+            <div>
+              <label for="cloudCover">Cloud Cover</label>
+              <input id="cloudCover" type="number" placeholder=""
+                     class="form-control" ng-model="$ctrl.sceneData.cloudCover">
+            </div>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+
   <!--Body for UPLOAD_PROGRESS-->
   <div class="modal-body" ng-if="$ctrl.currentStepIs('UPLOAD_PROGRESS')">
     <div class="content">


### PR DESCRIPTION
## Overview

This PR adds a state to uploads to handle attaching metadata to scenes in an upload.

### Checklist

- ~Styleguide updated, if necessary~
- ~Swagger specification updated, if necessary~
- ~Symlinks from new migrations present or corrected for any new migrations~

## Testing Instructions

 * Bring up all ur stuff
 * Create an s3 and a local upload
 * Add some metadata to them
 * Verify that the `acquisitionDate` and `cloudCover` values are included in the request

Closes #2234 
