### PR TITLE
Kickoff ingests for scene creation and updating

### DIFF
--- a/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Scenes.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Scenes.scala
@@ -448,9 +448,11 @@ object Scenes extends TableQuery(tag => new Scenes(tag)) with LazyLogging {
       } yield (originalScene, updatedScene)
     } map {
       case (os, us) => {
-        val kickoffIngest =
-          os.head.statusFields.ingestStatus != IngestStatus.ToBeIngested &&
-          scene.statusFields.ingestStatus == IngestStatus.ToBeIngested
+        val kickoffIngest = os.headOption match {
+          case Some(s:Scene) => s.statusFields.ingestStatus != IngestStatus.ToBeIngested &&
+            scene.statusFields.ingestStatus == IngestStatus.ToBeIngested
+          case _ => false
+        }
         (1, kickoffIngest)
       }
       case _ => throw new IllegalStateException("Error while updating scene")


### PR DESCRIPTION
## Overview

This PR adds logic to the scene creation and update endpoints/methods to ensure ingests are kicked off at appropriate times. This should solve problems we were seeing when importing scenes without adding them to a project.

Namely, the changes make it so that:
- if a scene is created and it's ingest status is `TOBEINGESTED`, the ingest process will be kicked off
- if a scene is updated and it's previous status was not `TOBEINGESTED` but it's new status is `TOBEINGESTED`, the ingest process will be kicked off

We maintain the ingest trigger in the `addProjectScenes` endpoint as there should be not any interference.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~

## Testing Instructions
 * Make sure your server is running along with airflow
 * Upload a scene directly to a datasource and check that the ingest process proceeds as expected
 * Find a scene that is not `TOBEINGESTED` and post an update to the scenes endpoint, changing the status to `TOBEINGESTED` and check that the ingest process proceeds as expected

Closes #2099 
