### PR TITLE
Fix map loading text location to be centered on map

### DIFF
--- a/app-frontend/src/assets/styles/sass/components/_map.scss
+++ b/app-frontend/src/assets/styles/sass/components/_map.scss
@@ -82,6 +82,7 @@
  * safari fix for map not displaying
  */
 .main > rf-map-container {
+  position: relative;
   display: flex;
   flex: 1;
 


### PR DESCRIPTION
## Overview

See title

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~

### Demo
![image](https://user-images.githubusercontent.com/4392704/28528538-fa2d6cc0-705b-11e7-9474-7f9d5542ddaa.png)

## Testing Instructions

* Verify that the loading message is centered
* Verify that the new style doesn't break things on the map
Closes #2095
