### PR TITLE
Install openjdk 8 in airflow containers

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -99,6 +99,6 @@ node {
   } finally {
     // Pass or fail, ensure that the services and networks
     // created by Docker Compose are torn down.
-    sh 'docker-compose down -v'
+    sh 'docker-compose down -v --remove-orphans'
   }
 }

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/Main.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/Main.scala
@@ -2,6 +2,7 @@ package com.azavea.rf.batch
 
 import com.azavea.rf.batch.export.spark.Export
 import com.azavea.rf.batch.export.airflow.{CreateExportDef, DropboxCopy, S3Copy, CheckExportStatus}
+import com.azavea.rf.batch.healthcheck.HealthCheck
 import com.azavea.rf.batch.ingest.spark.Ingest
 import com.azavea.rf.batch.landsat8.airflow.{ImportLandsat8, ImportLandsat8C1}
 import com.azavea.rf.batch.sentinel2.airflow.ImportSentinel2
@@ -21,7 +22,8 @@ object Main {
     DropboxCopy.name       -> (DropboxCopy.main(_)),
     ImportLandsat8C1.name  -> (ImportLandsat8C1.main(_)),
     CheckExportStatus.name -> (CheckExportStatus.main(_)),
-    S3ToPostgres.name      -> (S3ToPostgres.main(_))
+    S3ToPostgres.name      -> (S3ToPostgres.main(_)),
+    HealthCheck.name       -> (HealthCheck.main(_))
   )
 
   def main(args: Array[String]): Unit = {

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/healthcheck/HealthCheck.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/healthcheck/HealthCheck.scala
@@ -1,0 +1,15 @@
+package com.azavea.rf.batch.healthcheck
+
+import com.typesafe.scalalogging.LazyLogging
+
+object HealthCheck extends LazyLogging {
+  val name = "healthcheck"
+
+  def run: Unit = {
+    logger.info("Airflow containers and the batch jar are friends")
+  }
+
+  def main(args: Array[String]): Unit = {
+    this.run
+  }
+}

--- a/app-tasks/Dockerfile
+++ b/app-tasks/Dockerfile
@@ -19,8 +19,8 @@ RUN set -ex \
        python-gdal/sid \
     ' \
     && javaDeps=' \
-       openjdk-8-jre/jessie-backports \
-       ca-certificates-java/jessie-backports \
+       openjdk-8-jre \
+       ca-certificates-java \
     ' \
     && echo 'deb http://deb.debian.org/debian jessie-backports main' > /etc/apt/sources.list.d/jessie-backports.list \
     && echo 'deb http://http.us.debian.org/debian sid main non-free contrib' > /etc/apt/sources.list.d/sid.list \

--- a/app-tasks/dags/ingest_project_scenes.py
+++ b/app-tasks/dags/ingest_project_scenes.py
@@ -230,7 +230,7 @@ def wait_for_status_op(*args, **kwargs):
     logger.info('Setting scene %s ingest status to %s', scene.id, scene.ingestStatus)
     scene.update()
     logger.info('Successfully updated scene %s\'s ingest status', scene.id)
-    
+
     if scene.ingestStatus == IngestStatus.FAILED:
         raise AirflowException('Failed to ingest {} for user {}'.format(scene_id, scene.owner))
 

--- a/app-tasks/dags/ingest_project_scenes.py
+++ b/app-tasks/dags/ingest_project_scenes.py
@@ -236,7 +236,11 @@ def wait_for_status_op(*args, **kwargs):
 
 @wrap_rollbar
 def metadataToPostgres(uri, scene_id):
-    bash_cmd = 'java -cp /opt/raster-foundry/jars/rf-batch.jar com.azavea.rf.batch.Main migration_s3_postgres {} layer_attributes {}'.format(uri, scene_id)
+    bash_cmd = (
+        'java -cp /opt/raster-foundry/jars/rf-batch.jar com.azavea.rf.batch.Main'
+        'migration_s3_postgres {} layer_attributes {}'
+    ).format(uri, scene_id)
+    logger.info('Bash command to store metadata: %s', bash_cmd)
     cmd = subprocess.Popen(bash_cmd, shell=True, stdout=subprocess.PIPE)
     step_id = ''
     for line in cmd.stdout:

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -56,10 +56,8 @@ services:
 
   airflow:
     image: raster-foundry-airflow:${GIT_COMMIT:-latest}
-    env_file: .env
     build:
       context: ./app-tasks
       dockerfile: Dockerfile
     volumes:
       - ./app-tasks/rf/:/opt/raster-foundry/app-tasks/rf/
-      - ./app-backend/batch/target/scala-2.11/rf-batch.jar:/opt/raster-foundry/jars/rf-batch.jar

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -56,8 +56,10 @@ services:
 
   airflow:
     image: raster-foundry-airflow:${GIT_COMMIT:-latest}
+    env_file: .env
     build:
       context: ./app-tasks
       dockerfile: Dockerfile
     volumes:
       - ./app-tasks/rf/:/opt/raster-foundry/app-tasks/rf/
+      - ./app-backend/batch/target/scala-2.11/rf-batch.jar:/opt/raster-foundry/jars/rf-batch.jar

--- a/scripts/cibuild
+++ b/scripts/cibuild
@@ -54,7 +54,7 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
                   -f "${DIR}/../docker-compose.yml" \
                   -f "${DIR}/../docker-compose.airflow.yml" \
                   -f "${DIR}/../docker-compose.test.yml" \
-                  build airflow
+                  build airflow airflow-worker
 
         echo "Running tests"
         GIT_COMMIT="${GIT_COMMIT}" ./scripts/test

--- a/scripts/cibuild
+++ b/scripts/cibuild
@@ -54,7 +54,7 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
                   -f "${DIR}/../docker-compose.yml" \
                   -f "${DIR}/../docker-compose.airflow.yml" \
                   -f "${DIR}/../docker-compose.test.yml" \
-                  build airflow airflow-worker
+                  build airflow
 
         echo "Running tests"
         GIT_COMMIT="${GIT_COMMIT}" ./scripts/test

--- a/scripts/test
+++ b/scripts/test
@@ -28,8 +28,8 @@ then
 
         echo "Verifying that Airflow containers can run the batch jar"
         docker-compose \
-            -f docker-compose.airflow.yml \
-            run --rm airflow-worker \
+            -f docker-compose.test.yml \
+            run --rm airflow \
             bash -c \
             "java -cp /opt/raster-foundry/jars/rf-batch.jar com.azavea.rf.batch.Main healthcheck"
 

--- a/scripts/test
+++ b/scripts/test
@@ -28,8 +28,8 @@ then
 
         echo "Verifying that Airflow containers can run the batch jar"
         docker-compose \
-            -f docker-compose.test.yml \
-            run --rm airflow \
+            -f docker-compose.airflow.yml \
+            run --rm airflow-worker \
             bash -c \
             "java -cp /opt/raster-foundry/jars/rf-batch.jar com.azavea.rf.batch.Main healthcheck"
 

--- a/scripts/test
+++ b/scripts/test
@@ -28,9 +28,8 @@ then
 
         echo "Verifying that Airflow containers can run the batch jar"
         docker-compose \
-            -f "${DIR}/../docker-compose.airflow.yml" \
-            run --rm \
-            airflow-worker \
+            -f docker-compose.airflow.yml \
+            run --rm airflow-worker \
             bash -c \
             "java -cp /opt/raster-foundry/jars/rf-batch.jar com.azavea.rf.batch.Main healthcheck"
 

--- a/scripts/test
+++ b/scripts/test
@@ -26,6 +26,14 @@ then
             find ./scripts -type f -print0 | xargs -0 -r shellcheck
         fi
 
+        echo "Verifying that Airflow containers can run the batch jar"
+        docker-compose \
+            -f "${DIR}/../docker-compose.airflow.yml" \
+            run --rm \
+            airflow-worker \
+            bash -c \
+            "java -cp /opt/raster-foundry/jars/rf-batch.jar com.azavea.rf.batch.Main healthcheck"
+
         echo "Validating swagger specification"
         docker-compose \
             -f docker-compose.test.yml \


### PR DESCRIPTION
## Overview

This PR reverts changes to the airflow Dockerfile that downgraded the openjdk version from 1.8 to 1.7. Also it adds logging to `ingest_project_scenes` so that you don't have to construct the metadata storage bash command yourself. _Also_ it adds a test to ci to make sure the batch jar can be run in airflow containers.

### Checklist

- ~Styleguide updated, if necessary~
- ~Swagger specification updated, if necessary~
- ~Symlinks from new migrations present or corrected for any new migrations~

## Testing Instructions

 * Ingest a scene
 * The metadata storage step should not fail
 * If jenkins continues to refuse to cooperate, run `cibuild`

Closes #2291 
