### PR TITLE
Include StatusCodes with createFoo routes

### DIFF
--- a/app-backend/api/src/main/scala/datasource/Routes.scala
+++ b/app-backend/api/src/main/scala/datasource/Routes.scala
@@ -62,7 +62,7 @@ trait DatasourceRoutes extends Authentication
     entity(as[Datasource.Create]) { newDatasource =>
       authorize(user.isInRootOrSameOrganizationAs(newDatasource)) {
         onSuccess(write[Datasource](Datasources.insertDatasource(newDatasource, user))) { datasource =>
-          complete(datasource)
+          complete((StatusCodes.Created, datasource))
         }
       }
     }

--- a/app-backend/api/src/main/scala/exports/Routes.scala
+++ b/app-backend/api/src/main/scala/exports/Routes.scala
@@ -100,7 +100,7 @@ trait ExportRoutes extends Authentication
               val updateExport = user.updateDefaultExportSource(export)
               kickoffProjectExport(updateExport.id)
               update(Exports.updateExport(updateExport, updateExport.id, user))
-              complete(updateExport)
+              complete((StatusCodes.Created, updateExport))
             }
         }
       }

--- a/app-backend/api/src/main/scala/image/Routes.scala
+++ b/app-backend/api/src/main/scala/image/Routes.scala
@@ -51,7 +51,7 @@ trait ImageRoutes extends Authentication
     entity(as[Image.Banded]) { newImage =>
       authorize(user.isInRootOrSameOrganizationAs(newImage)) {
         onSuccess(Images.insertImage(newImage, user)) { image =>
-          complete(image)
+          complete((StatusCodes.Created, image))
         }
       }
     }

--- a/app-backend/api/src/main/scala/maptoken/Routes.scala
+++ b/app-backend/api/src/main/scala/maptoken/Routes.scala
@@ -51,7 +51,7 @@ trait MapTokenRoutes extends Authentication
     entity(as[MapToken.Create]) { newMapToken =>
       authorize(user.isInRootOrSameOrganizationAs(newMapToken)) {
         onSuccess(write[MapToken](MapTokens.insertMapToken(newMapToken, user))) { mapToken =>
-          complete(mapToken)
+          complete((StatusCodes.Created, mapToken))
         }
       }
     }

--- a/app-backend/api/src/main/scala/uploads/Routes.scala
+++ b/app-backend/api/src/main/scala/uploads/Routes.scala
@@ -86,7 +86,7 @@ trait UploadRoutes extends Authentication
           if (upload.uploadStatus == UploadStatus.Uploaded) {
             kickoffSceneImport(upload.id)
           }
-          complete(upload)
+          complete((StatusCodes.Created, upload))
         }
       }
     }


### PR DESCRIPTION
## Overview

Some of our create routes returned `200`s for "object created". That doesn't make any sense.

### Checklist

- ~Styleguide updated, if necessary~
- ~Swagger specification updated, if necessary~
- ~Symlinks from new migrations present or corrected for any new migrations~

### Notes

Sometimes this brings the routes into consistency with our spec (like with `Upload`s and `MapToken`s and `Export`s). Other times, it highlighted where the spec was weird. I'm creating issues for the other cases.

## Testing Instructions

 * ???
