### PR TITLE
Add frontend parsing for many more local ops

### DIFF
--- a/app-frontend/src/app/components/tools/toolCreateModal/toolCreateModal.controller.js
+++ b/app-frontend/src/app/components/tools/toolCreateModal/toolCreateModal.controller.js
@@ -1,6 +1,18 @@
 /* global mathjs */
 
-const allowedOps = ['+', '-', '*', '/'];
+const allowedOps = [
+    '+', '-', '*', '/',
+    '==', '!=', '>', '<', '>=', '<=',
+    'and', 'or', 'xor',
+    '^',
+    'sqrt', 'log10',
+    'ceil', 'floor', 'round',
+    'abs',
+    'sin', 'cos', 'tan',
+    'asin', 'acos', 'atan',
+    'sinh', 'cosh', 'tanh',
+    'atan2'
+];
 
 export default class ToolCreateModalController {
     constructor(
@@ -69,11 +81,17 @@ export default class ToolCreateModalController {
             metadata: {}
         };
 
-        if (node.op && allowedOps.indexOf(node.op >= 0)) {
+        if (node.op && allowedOps.indexOf(node.op) >= 0) {
             // Op node
             builtNode.id = this.uuid4.generate();
             builtNode.apply = node.op;
             builtNode.metadata.label = node.fn;
+            builtNode.args = node.args.map(n => this.transformNode(n));
+        } else if (node.fn && node.fn.name && allowedOps.indexOf(node.fn.name) >= 0) {
+            // Function node; handle nearly the same as op node, for now
+            builtNode.id = this.uuid4.generate();
+            builtNode.apply = node.fn.name;
+            builtNode.metadata.label = node.fn.name;
             builtNode.args = node.args.map(n => this.transformNode(n));
         } else if (node.name) {
             // Symbol node

--- a/app-frontend/src/app/components/tools/toolCreateModal/toolCreateModal.html
+++ b/app-frontend/src/app/components/tools/toolCreateModal/toolCreateModal.html
@@ -34,7 +34,7 @@
           <p>
             Enter an algebraic expression that represents the operation the tool should compute. Here are some hints:
             <ul>
-              <li><strong>Allowed Operations</strong> - +, -, *, /</li>
+              <li><strong>Allowed Operations</strong> - Most standard arithmetic, comparison, and trigonometric operations are supported.</li>
               <li><strong>Raster Source</strong> - denoted by a symbol (e.g. <strong>NIR</strong> or <strong>SWIR</strong>)</li>
               <li><strong>Constant</strong> - denoted by a symbol prepended with an underscore (e.g. <strong>_G</strong> or <strong>_NF</strong>)</li>
               <li><strong>Constant with a default</strong> - denoted as above but with an added assignment, wrapped in parentheses (e.g. <strong>(_G=1)</strong> or <strong>(_NF=0.167)</strong>)</li>


### PR DESCRIPTION
## Overview

Adds parsing for all the new operations which have a direct correspondence to math.js operations, which is the most of them.

### Checklist

- [ ] ~Styleguide updated, if necessary~
- [ ] ~Swagger specification updated, if necessary~
- [ ] ~Symlinks from new migrations present or corrected for any new migrations~

### Demo

![threshold](https://user-images.githubusercontent.com/447977/28633335-71ea82e2-7201-11e7-82c4-90e6737ffb53.png)
Thresholding the blue band at all values > 192.

### Notes

- Many unary operations don't result in visible changes to the map because of the way color ramps are being calculated. Try some trigonometric functions for dramatic results.
- Not all functions have a direct correspondence to math.js functions. It looks like it's possible to define custom functions so this shouldn't be too hard to add.
- We can't add a documentation link for the operators while this is only in staging but we should add one before it is deployed.

## Testing Instructions

 * Make lots of new tools
 * Confirm they result in expected values.
