### PR TITLE
Improve bash callout when setting layer metadata in ingest

### DIFF
--- a/app-tasks/dags/ingest_project_scenes.py
+++ b/app-tasks/dags/ingest_project_scenes.py
@@ -225,7 +225,7 @@ def wait_for_status_op(*args, **kwargs):
 
     if scene.ingestStatus != IngestStatus.FAILED:
         logger.info('Writing scene metadata into postgres.')
-        metadataToPostgres(s3_output_location, scene_id)
+        metadata_to_postgres(s3_output_location, scene_id)
 
     logger.info('Setting scene %s ingest status to %s', scene.id, scene.ingestStatus)
     scene.update()
@@ -235,27 +235,21 @@ def wait_for_status_op(*args, **kwargs):
         raise AirflowException('Failed to ingest {} for user {}'.format(scene_id, scene.owner))
 
 @wrap_rollbar
-def metadataToPostgres(uri, scene_id):
-    bash_cmd = (
-        'java -cp /opt/raster-foundry/jars/rf-batch.jar com.azavea.rf.batch.Main'
-        'migration_s3_postgres {} layer_attributes {}'
-    ).format(uri, scene_id)
-    logger.info('Bash command to store metadata: %s', bash_cmd)
-    cmd = subprocess.Popen(bash_cmd, shell=True, stdout=subprocess.PIPE)
-    step_id = ''
-    for line in cmd.stdout:
-        logger.info(line.strip())
-
-    # Wait until process terminates (without using cmd.wait())
-    while cmd.poll() is None:
-        time.sleep(0.5)
-
-    if cmd.returncode == 0:
-        logger.info('Successfully completed metadata postgres write for scene %s', scene_id)
-        return True
-    else:
-        logger.error('Something went wrong with %s', scene_id)
-        raise AirflowException('Metadata postgres write failed for {}'.format(scene_id))
+def metadata_to_postgres(uri, scene_id):
+    bash_cmd = [
+        'java',
+        '-cp'
+        '/opt/raster-foundry/jars/rf-batch.jar',
+        'com.azavea.rf.batch.Main',
+        'migration_s3_postgres',
+        uri,
+        'layer_attributes',
+        scene_id
+    ]
+    logger.info('Bash command to store metadata: %s', ' '.join(bash_cmd))
+    cmd = subprocess.check_call(bash_cmd, stdout=subprocess.PIPE)
+    logger.info('Successfully completed metadata postgres write for scene %s', scene_id)
+    return True
 
 ################################
 # Tasks                        #

--- a/app-tasks/dags/ingest_project_scenes.py
+++ b/app-tasks/dags/ingest_project_scenes.py
@@ -136,7 +136,7 @@ def wait_for_success(response, cluster_id):
             logger.info('Updating status of %s. Old Status: %s New Status: %s',
                         step_id, current_status, status)
             current_status = status
-        time.sleep(30)
+        time.sleep(5)
     is_success = (current_status == 'COMPLETED')
     if is_success:
         logger.info('Successfully completed ingest for %s', step_id)
@@ -238,7 +238,7 @@ def wait_for_status_op(*args, **kwargs):
 def metadata_to_postgres(uri, scene_id):
     bash_cmd = [
         'java',
-        '-cp'
+        '-cp',
         '/opt/raster-foundry/jars/rf-batch.jar',
         'com.azavea.rf.batch.Main',
         'migration_s3_postgres',


### PR DESCRIPTION
## Overview

This PR switches from opening a new process to using `subprocess.check_call` to shell out to the metadata scala process when setting layer metadata in the db after ingest. It in the process fixes a typo I introduced that mangled the bash command construction.

Also it decreases the polling delay for the response from EMR for creating the step, since that response is really fast and there's no reason to wait 30 seconds for something that's regularly ready in 3.

### Checklist

- ~Styleguide updated, if necessary~
- ~Swagger specification updated, if necessary~
- ~Symlinks from new migrations present or corrected for any new migrations~

## Testing Instructions

 * Bring up your server, airflow, and frontend
 * Upload a tif
 * Ingest shouldn't fail

Closes #2291 (again)
