### PR TITLE
Add Memcached timeout and client mode settings

### DIFF
--- a/app-backend/common/src/main/resources/reference.conf
+++ b/app-backend/common/src/main/resources/reference.conf
@@ -23,6 +23,9 @@ memcached {
   port = 11211
   port = ${?MEMCACHED_PORT}
 
+  dynamicClientMode = false
+  dynamicClientMode = ${?MEMCACHED_DYNAMIC_CLIENT_MODE}
+
   timeout = 3000
   timeout = ${?MEMCACHED_TIMEOUT}
 

--- a/app-backend/common/src/main/resources/reference.conf
+++ b/app-backend/common/src/main/resources/reference.conf
@@ -19,14 +19,18 @@ airflow {
 memcached {
   host = "tile-cache.service.rasterfoundry.internal"
   host = ${?MEMCACHED_HOST}
+
   port = 11211
   port = ${?MEMCACHED_PORT}
 
-  enabled = true
-  enabled = ${?MEMCACHED_ENABLED}
+  timeout = 3000
+  timeout = ${?MEMCACHED_TIMEOUT}
 
   threads = 16
   threads = ${?MEMCACHED_THREADS}
+
+  enabled = true
+  enabled = ${?MEMCACHED_ENABLED}
 
   layerAttributes.enabled = true
   layerAttributes.enabled = ${?MEMCACHED_LAYER_ATTRIBUTES}

--- a/app-backend/common/src/main/scala/Config.scala
+++ b/app-backend/common/src/main/scala/Config.scala
@@ -3,6 +3,7 @@ package com.azavea.rf.common
 import java.util.concurrent.TimeUnit
 
 import com.typesafe.config.ConfigFactory
+import net.spy.memcached.ClientMode
 
 import scala.concurrent.duration._
 
@@ -24,6 +25,13 @@ object Config {
 
     lazy val port: Int =
       memcachedConfig.getInt("port")
+
+    lazy val clientMode: ClientMode =
+      if (memcachedConfig.getBoolean("dynamicClientMode")) {
+        ClientMode.Dynamic
+      } else {
+        ClientMode.Static
+      }
 
     lazy val timeout: Long = memcachedConfig.getLong("timeout")
 

--- a/app-backend/common/src/main/scala/Config.scala
+++ b/app-backend/common/src/main/scala/Config.scala
@@ -30,9 +30,6 @@ object Config {
     lazy val threads: Int =
       memcachedConfig.getInt("threads")
 
-    lazy val ttl: FiniteDuration =
-      FiniteDuration(memcachedConfig.getDuration("ttl").toNanos, TimeUnit.NANOSECONDS)
-
     lazy val enabled: Boolean =
       memcachedConfig.getBoolean("enabled")
 

--- a/app-backend/common/src/main/scala/Config.scala
+++ b/app-backend/common/src/main/scala/Config.scala
@@ -25,6 +25,8 @@ object Config {
     lazy val port: Int =
       memcachedConfig.getInt("port")
 
+    lazy val timeout: Long = memcachedConfig.getLong("timeout")
+
     lazy val threads: Int =
       memcachedConfig.getInt("threads")
 

--- a/app-backend/common/src/main/scala/cache/kryo/KryoConnectionFactory.scala
+++ b/app-backend/common/src/main/scala/cache/kryo/KryoConnectionFactory.scala
@@ -1,11 +1,14 @@
 package com.azavea.rf.common.cache.kryo
 
-import net.spy.memcached.transcoders.Transcoder
+import com.azavea.rf.common.Config
 import net.spy.memcached._
+import net.spy.memcached.transcoders.Transcoder
 
 /** Extends Memcached client configuration object to provide custom (kryo) transcoder. */
 class KryoConnectionFactory extends DefaultConnectionFactory(ClientMode.Static) {
   override def getDefaultTranscoder: Transcoder[AnyRef] = {
     new KryoTranscoder
   }
+
+  override def getOperationTimeout: Long = Config.memcached.timeout
 }

--- a/app-backend/common/src/main/scala/cache/kryo/KryoConnectionFactory.scala
+++ b/app-backend/common/src/main/scala/cache/kryo/KryoConnectionFactory.scala
@@ -4,8 +4,10 @@ import com.azavea.rf.common.Config
 import net.spy.memcached._
 import net.spy.memcached.transcoders.Transcoder
 
-/** Extends Memcached client configuration object to provide custom (kryo) transcoder. */
-class KryoConnectionFactory extends DefaultConnectionFactory(ClientMode.Static) {
+/** Extends Memcached connection factory configuration object to provide custom configuration. */
+class KryoConnectionFactory extends DefaultConnectionFactory() {
+  override def getClientMode: ClientMode = Config.memcached.clientMode
+
   override def getDefaultTranscoder: Transcoder[AnyRef] = {
     new KryoTranscoder
   }


### PR DESCRIPTION
## Overview

Add ability to override Memcached client timeout. The default of 2500ms was being tripped in staging. It now defaults to 3000 ms.

Also, add ability to override Memcached client mode. When set to static, the set of endpoints specified during initialization are used throughout the lifetime of the client object. This is what we want in development because our local Memcached instance does not support auto-discovery.

When set to dynamic (the DefaultConnectionFactory default) the set of cache node endpoints, and any updates to it, are dynamically managed. This is what we want in production because ElastiCache supports auto-discovery.

## Testing Instructions

- Launch the development environment using `server`
- Ensure that no `MemcachedClient` exceptions are thrown (when dynamic mode is enabled, it'll throw)
- Navigate to a project once the Hikari pool is stable and ensure that the tile server works